### PR TITLE
feat: advisory agent model catalog and dashboard combobox

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+!.slim/deepwork/
+!.slim/deepwork/**

--- a/docs/adr/0016-agent-model-catalog-is-advisory.md
+++ b/docs/adr/0016-agent-model-catalog-is-advisory.md
@@ -1,0 +1,117 @@
+# ADR-0016: Agent model catalog is advisory (static + probe); config identity unchanged
+
+## Context
+
+Coding roles already bind agent **identity** as vendor + model
+(`agent`, `agent.profiles.*`, `roles.{planner,worker,reviewer,fixer}.agent`) with
+resolve overlay, hot-reload for new claims, and per-run `agent_snapshot` freeze
+(ADR-0014). Dashboard and file config accept model as free text.
+
+Operators want to **override vendor-local defaults** (CLI home config / last-used
+model) so Looper stably launches with an explicit model. The missing piece is not
+a new identity field — it is **discoverability**: which model ids a given vendor
+CLI accepts on this machine, surfaced where vendor is already configurable.
+
+Vendor CLIs are heterogeneous (verified 2026-08-01):
+
+| Vendor | Scriptable model list |
+| --- | --- |
+| opencode | `opencode models` (line-oriented; strong) |
+| codex | `codex debug models [--bundled]` (JSON; experimental) |
+| cursor-cli | `cursor-agent models` (text; auth-scoped) |
+| grok-build | `grok models` (text; optional cache file) |
+| claude-code | **none** (interactive `/model` only) |
+
+Bare `agent` is ambiguous across installs (Cursor vs Grok). Looper must not treat
+a model directory as a gate over the agent CLI.
+
+## Decision
+
+1. **Catalog is advisory UX, not authority.**  
+   Config continues to store arbitrary model strings (including unset / explicit
+   empty → vendor default). Saving never requires membership in the catalog.
+   Runtime spawn authority remains: resolved/snapshot model → argv `--model`/`-m`
+   (and params model-flag strip) as today. The catalog does not validate runs.
+
+2. **Hybrid source: static baseline + on-demand CLI probe.**  
+   - Static: small embedded per-vendor id (and optional label) table shipped with
+     Looper — especially required for **claude-code**.  
+   - Probe: daemon invokes the **same resolved binary** used for spawn (including
+     `agent.params.command` when present), short timeout, **in-process TTL cache**
+     keyed by vendor + binary path. Probe failure → static only; never blocks
+     config load or save.  
+   - No Anthropic (or other cloud) Models HTTP API in v1 — identity is the local
+     agent vendor CLI, not a second credential plane.
+
+3. **Per-vendor probe policy (v1).**  
+   Probe where a non-interactive list exists (opencode, codex bundled debug JSON,
+   cursor-agent, grok). **claude-code: static only.** Prefer absolute resolved
+   paths; never discover via ambiguous bare `agent`.
+
+4. **API serves merged suggestions for dashboard (and any future clients).**  
+   One read endpoint parameterized by vendor (and using spawn-equivalent binary
+   resolution). Response may include ids, optional labels, and probe status
+   metadata for non-blocking UI hints. Implementation details live in the spec.
+
+5. **Configuration surface parity with vendor.**  
+   Wherever the product already allows configuring agent **vendor** (global,
+   named profiles, coding-role bindings), model keeps the same editability and
+   the same suggestion UX. No new project-scoped agent identity; coordinator
+   triage remains global-only. No IA push toward “profiles only” or “global only.”
+
+6. **Lifecycle unchanged.**  
+   Model (like vendor) is hot-safe for **new claims** only. In-flight runs and
+   sticky resume/retry keep frozen `agent_snapshot` identity (ADR-0014).
+
+7. **Strength of “stable model” for v1.**  
+   Product bar is **configuration reachability**: operators can find and set a
+   non-empty model so argv override applies. v1 does **not** require explicit
+   model to run, does not re-resolve model on sticky retry, and does not add
+   run-detail “actual model” observability (may be a later slice).
+
+## Trade-off
+
+**Prevents:** Operators guessing model ids; silent reliance on vendor home-config
+defaults when they intended a Looper-pinned model; blocking config on flaky CLI
+probe or stale hard gates; inventing cloud API identity parallel to CLI vendors.
+
+**Costs:** Static tables drift and need occasional refresh; probe adapters and
+text/JSON parsers per vendor; experimental Codex debug surface may change;
+long OpenCode lists need searchable UI; catalog never proves the child process
+honored the flag (CLI/session semantics remain outside Looper).
+
+**Why not simpler / stronger alternatives:**
+
+- **Static-only:** fails the “extract from vendor” goal where CLIs already list
+  models well (especially OpenCode/Codex).
+- **Probe-only:** Claude has no list command; unauthenticated Cursor returns empty;
+  dashboard would often be blank.
+- **Hard-validate model ∈ catalog:** rejects valid new models ahead of Looper
+  tables/CLIs; contradicts “agent CLI is the runner.”
+- **Require non-empty model to claim work:** breaks users who intentionally want
+  vendor default; large migration hammer for a discoverability feature.
+- **Anthropic HTTP for Claude models:** different auth than Claude Code OAuth;
+  list ≠ Code aliases/subscription set; second authority plane.
+- **Sticky retry adopts live config model:** undermines run-lineage stability
+  that snapshots exist to provide.
+
+## Authority
+
+| Question | Authority |
+| --- | --- |
+| What vendor/model identity a **new** claim uses | Config file overlay (global → profile → role) per existing resolve; ADR-0014 hot-safe publication |
+| What vendor/model an **in-flight / sticky** run uses | Durable `agent_snapshot` on the run |
+| Whether a model string is “allowed” | **Not Looper** — advisory catalog only; operator + vendor CLI |
+| Whether spawn passes `--model` | Non-empty resolved/snapshot model on the existing executor path |
+| Catalog contents | Looper static embed ∪ best-effort local CLI probe (non-authoritative) |
+
+## Consequences
+
+- New read API + probe/static merge in looperd; dashboard model fields become
+  searchable comboboxes with Inherit / Vendor default / id (tri-state preserved).
+- Spec: `specs/2026-08-01-agent-model-catalog/spec.md`.
+- Docs (`docs/configuration.md`) should describe catalog as suggestions and
+  restate model tri-state + snapshot freeze; no new gate language.
+- Follow-ups explicitly out of ADR scope: force-explicit-model policy, run-level
+  model observability, project agent bindings, Claude API catalog, sticky
+  re-resolve on retry.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,6 +276,16 @@ A role is runnable only when the overlay leaves a non-empty vendor. Missing glob
 
 After the full overlay, an empty-string model is kept as an explicit empty binding (not the same as unset): the vendor CLI uses its own default, and any global `agent.params` `--model`/`-m` flags are stripped so they cannot override the suppression.
 
+### Model suggestions
+
+Dashboard Config model fields offer searchable suggestions drawn from a built-in static list per vendor, optionally merged with a best-effort probe of the local vendor CLI. The same list is available via `GET /api/v1/agent/models?vendor=...`.
+
+The catalog is **advisory only** — not an allowlist. Arbitrary model IDs remain valid config values; save and claim never require membership in the catalog. See [ADR-0016](adr/0016-agent-model-catalog-is-advisory.md).
+
+Claude Code is static-only (no non-interactive list command). Other vendors may probe the same resolved local CLI binary used for spawn when available; probe failure falls back to the built-in list and does not block config load or save.
+
+Empty-string vs unset model semantics are unchanged (see [Model semantics](#model-semantics) above).
+
 ### Coordinator triage
 
 Coordinator triage LLM uses the **global** agent only (`agent.vendor` / `agent.model`, plus global params/env/timeouts). It does not read `roles.coordinator.agent` or coding-role profile bindings. If global `agent.vendor` is unset, triage LLM is skipped; coding roles that resolve via profile or role bindings can still run.

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -1965,6 +1965,14 @@ func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
+// ResolveCommand returns the agent binary used for spawn for vendor + params.
+// When params["command"] is a non-empty string it wins; otherwise vendor defaults
+// apply (claude, codex, opencode, agent for cursor-cli, grok for grok-build).
+// Same resolution as process spawn — callers may LookPath for an absolute path.
+func ResolveCommand(vendor config.AgentVendor, params map[string]any) string {
+	return resolveCommand(ExecutorConfig{Vendor: vendor, Params: params})
+}
+
 func resolveCommand(cfg ExecutorConfig) string {
 	if override, ok := cfg.Params["command"].(string); ok && strings.TrimSpace(override) != "" {
 		return override

--- a/internal/agent/modelcatalog/catalog.go
+++ b/internal/agent/modelcatalog/catalog.go
@@ -158,9 +158,18 @@ func (s *Service) List(ctx context.Context, opts ListOptions) (Result, error) {
 	s.inflight[cacheKey] = call
 	s.mu.Unlock()
 
-	result := s.listUncached(ctx, opts.Vendor, resolved)
+	// Shared probe work must outlive any single request cancel (popup close /
+	// AbortController). Tying listUncached to the leader's ctx would mark the
+	// probe as canceled, cache that failure for the full TTL, and poison every
+	// waiter coalesced behind this call even when their contexts are still live.
+	probeCtx := context.WithoutCancel(ctx)
+	result := s.listUncached(probeCtx, opts.Vendor, resolved)
 
-	s.cachePut(cacheKey, result)
+	// Defensive: never populate the shared cache with a cancel-sourced probe
+	// error (e.g. if a future caller re-introduces request cancel into probeCtx).
+	if !isCancelPoisonedProbe(result) {
+		s.cachePut(cacheKey, result)
+	}
 
 	s.mu.Lock()
 	call.result = result
@@ -170,6 +179,16 @@ func (s *Service) List(ctx context.Context, opts ListOptions) (Result, error) {
 	s.mu.Unlock()
 
 	return cloneResult(result), nil
+}
+
+// isCancelPoisonedProbe reports whether the result is a probe failure caused by
+// context cancellation. Those must not be cached or they starve later callers.
+func isCancelPoisonedProbe(result Result) bool {
+	if result.Sources.Probe != ProbeError {
+		return false
+	}
+	msg := result.Sources.ProbeError
+	return msg == "probe canceled" || msg == context.Canceled.Error()
 }
 
 func (s *Service) waitInflight(ctx context.Context, call *inflightCall) (Result, error) {

--- a/internal/agent/modelcatalog/catalog.go
+++ b/internal/agent/modelcatalog/catalog.go
@@ -167,6 +167,12 @@ func (s *Service) List(ctx context.Context, opts ListOptions) (Result, error) {
 	}
 
 	command := agent.ResolveCommand(opts.Vendor, opts.Params)
+	// ADR-0016: never discover via ambiguous bare `agent` (Cursor default
+	// ResolveCommand name; also excluded from takeover autodetection). Skip
+	// LookPath/probe unless the command path establishes Cursor identity.
+	if opts.Vendor == config.AgentVendorCursorCLI && isAmbiguousBareAgentCommand(command) {
+		return s.listAmbiguousCursorAgent(command), nil
+	}
 	// Relative path overrides (e.g. ./tools/codex-wrapper) resolve against each
 	// run's worktree at spawn time (executor sets cmd.Dir). Catalog probes have
 	// no worktree context; do not LookPath/run them from looperd's CWD.
@@ -364,6 +370,53 @@ func resolveBinaryPath(command string, lookPath func(string) (string, error)) st
 // relativeCommandProbeError is returned when agent.params.command is a
 // worktree-relative path. Probes cannot supply spawn's WorkingDirectory.
 const relativeCommandProbeError = "relative command override cannot be probed outside a run worktree"
+
+// ambiguousBareAgentProbeError is returned when cursor-cli would probe via the
+// default/unqualified bare name "agent" (ADR-0016).
+const ambiguousBareAgentProbeError = "cursor-cli command \"agent\" is ambiguous; set agent.params.command to an explicit cursor-agent path to enable probing"
+
+// listAmbiguousCursorAgent returns static suggestions only without LookPath or
+// running PATH's first "agent" binary.
+func (s *Service) listAmbiguousCursorAgent(command string) Result {
+	staticModels := append([]Model(nil), s.static[config.AgentVendorCursorCLI]...)
+	for i := range staticModels {
+		staticModels[i].Source = SourceStatic
+	}
+	result := Result{
+		Vendor: string(config.AgentVendorCursorCLI),
+		Models: staticModels,
+		Sources: Sources{
+			Static:     true,
+			Probe:      ProbeError,
+			ProbeError: ambiguousBareAgentProbeError,
+		},
+		ProbedAt: s.now().UTC().Format(time.RFC3339),
+	}
+	// Cache the skip so repeated combobox opens do not re-evaluate PATH.
+	cacheKey := string(config.AgentVendorCursorCLI) + "\x00" + command
+	s.cachePut(cacheKey, result)
+	return result
+}
+
+// isAmbiguousBareAgentCommand reports whether command is the unqualified bare
+// name "agent" (or agent.exe). Paths that include "cursor" (e.g. cursor-agent
+// or .../Cursor.app/.../agent) establish Cursor identity and may be probed.
+func isAmbiguousBareAgentCommand(command string) bool {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return false
+	}
+	base := filepath.Base(command)
+	base = strings.TrimSuffix(base, ".exe")
+	if !strings.EqualFold(base, "agent") {
+		return false
+	}
+	// Path or basename establishes Cursor identity (cursor-agent, Cursor.app, …).
+	if strings.Contains(strings.ToLower(command), "cursor") {
+		return false
+	}
+	return true
+}
 
 // isRelativePathCommand reports whether command is a path that agent spawn
 // resolves relative to the run worktree (cmd.Dir). Bare PATH names and

--- a/internal/agent/modelcatalog/catalog.go
+++ b/internal/agent/modelcatalog/catalog.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/processcontainment"
 )
 
 const (
@@ -49,10 +50,17 @@ type Result struct {
 
 // Options configures a Service. Zero values use defaults.
 type Options struct {
-	TTL      time.Duration
-	Timeout  time.Duration
-	Now      func() time.Time
-	Runner   Runner
+	TTL     time.Duration
+	Timeout time.Duration
+	Now     func() time.Time
+	Runner  Runner
+	// BaseContext bounds shared probe lifetime. Request cancel (popup close)
+	// must not cancel shared probes; BaseContext cancel (daemon BeginShutdown)
+	// must. Defaults to a service-owned cancelable background context.
+	BaseContext context.Context
+	// Tracker registers probe containment handles with the Supervisor for
+	// shutdown drain / retain-storage (ADR-0015 / #577). Optional.
+	Tracker  processcontainment.LiveTracker
 	LookPath func(string) (string, error)
 }
 
@@ -64,6 +72,11 @@ type Service struct {
 	runner   Runner
 	lookPath func(string) (string, error)
 	static   map[config.AgentVendor][]Model
+
+	// probeCtx is the daemon-owned parent for shared probes: independent of
+	// per-request cancel, canceled by Shutdown (BeginShutdown path).
+	probeCtx    context.Context
+	probeCancel context.CancelFunc
 
 	mu       sync.Mutex
 	cache    map[string]cacheEntry
@@ -97,30 +110,49 @@ func NewService(opts Options) *Service {
 	if now == nil {
 		now = time.Now
 	}
+	parent := opts.BaseContext
+	if parent == nil {
+		parent = context.Background()
+	}
+	probeCtx, probeCancel := context.WithCancel(parent)
+
 	runner := opts.Runner
 	if runner == nil {
-		runner = defaultRunner{}
+		runner = defaultRunner{tracker: opts.Tracker}
 	}
 	lookPath := opts.LookPath
 	if lookPath == nil {
 		lookPath = execLookPath
 	}
 	return &Service{
-		ttl:      ttl,
-		timeout:  timeout,
-		now:      now,
-		runner:   runner,
-		lookPath: lookPath,
-		static:   loadStaticCatalog(),
-		cache:    make(map[string]cacheEntry),
-		inflight: make(map[string]*inflightCall),
+		ttl:         ttl,
+		timeout:     timeout,
+		now:         now,
+		runner:      runner,
+		lookPath:    lookPath,
+		static:      loadStaticCatalog(),
+		probeCtx:    probeCtx,
+		probeCancel: probeCancel,
+		cache:       make(map[string]cacheEntry),
+		inflight:    make(map[string]*inflightCall),
 	}
+}
+
+// Shutdown cancels the daemon-owned shared probe parent so in-flight vendor
+// CLIs observe cancel and enter process-group Kill. Idempotent. Call from
+// BeginShutdown before non-agent drain waits so probes drain promptly.
+func (s *Service) Shutdown() {
+	if s == nil || s.probeCancel == nil {
+		return
+	}
+	s.probeCancel()
 }
 
 // ListOptions controls a single catalog request.
 type ListOptions struct {
 	Vendor  config.AgentVendor
-	Params  map[string]any // spawn-filtered agent.params (command override)
+	Params  map[string]any    // spawn-filtered agent.params (command override)
+	Env     map[string]string // configured agent.env (auth/config for vendor CLIs)
 	Refresh bool
 }
 
@@ -159,14 +191,16 @@ func (s *Service) List(ctx context.Context, opts ListOptions) (Result, error) {
 	s.mu.Unlock()
 
 	// Shared probe work must outlive any single request cancel (popup close /
-	// AbortController). Tying listUncached to the leader's ctx would mark the
-	// probe as canceled, cache that failure for the full TTL, and poison every
-	// waiter coalesced behind this call even when their contexts are still live.
-	probeCtx := context.WithoutCancel(ctx)
-	result := s.listUncached(probeCtx, opts.Vendor, resolved)
+	// AbortController) but must still observe daemon shutdown via probeCtx.
+	// Using WithoutCancel(request) would also ignore BeginShutdown/HTTP stop.
+	probeCtx := s.probeCtx
+	if probeCtx == nil {
+		probeCtx = context.Background()
+	}
+	result := s.listUncached(probeCtx, opts.Vendor, resolved, opts.Env)
 
 	// Defensive: never populate the shared cache with a cancel-sourced probe
-	// error (e.g. if a future caller re-introduces request cancel into probeCtx).
+	// error (e.g. daemon shutdown cancel during probe) so later Lists retry.
 	if !isCancelPoisonedProbe(result) {
 		s.cachePut(cacheKey, result)
 	}
@@ -212,7 +246,7 @@ func (s *Service) waitInflight(ctx context.Context, call *inflightCall) (Result,
 	}
 }
 
-func (s *Service) listUncached(ctx context.Context, vendor config.AgentVendor, resolvedBinary string) Result {
+func (s *Service) listUncached(ctx context.Context, vendor config.AgentVendor, resolvedBinary string, agentEnv map[string]string) Result {
 	staticModels := append([]Model(nil), s.static[vendor]...)
 	for i := range staticModels {
 		staticModels[i].Source = SourceStatic
@@ -236,7 +270,8 @@ func (s *Service) listUncached(ctx context.Context, vendor config.AgentVendor, r
 	probedAt := s.now().UTC()
 	result.ProbedAt = probedAt.Format(time.RFC3339)
 
-	probeModels, err := s.probe(ctx, vendor, resolvedBinary)
+	env := buildProbeEnv(agentEnv)
+	probeModels, err := s.probe(ctx, vendor, resolvedBinary, env)
 	if err != nil {
 		result.Sources.Probe = ProbeError
 		result.Sources.ProbeError = shortProbeError(err)

--- a/internal/agent/modelcatalog/catalog.go
+++ b/internal/agent/modelcatalog/catalog.go
@@ -4,6 +4,8 @@ package modelcatalog
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -165,7 +167,13 @@ func (s *Service) List(ctx context.Context, opts ListOptions) (Result, error) {
 	}
 
 	command := agent.ResolveCommand(opts.Vendor, opts.Params)
-	resolved := resolveBinaryPath(command, s.lookPath)
+	// Relative path overrides (e.g. ./tools/codex-wrapper) resolve against each
+	// run's worktree at spawn time (executor sets cmd.Dir). Catalog probes have
+	// no worktree context; do not LookPath/run them from looperd's CWD.
+	resolved := command
+	if !isRelativePathCommand(command) {
+		resolved = resolveBinaryPath(command, s.lookPath)
+	}
 	cacheKey := string(opts.Vendor) + "\x00" + resolved
 
 	if !opts.Refresh {
@@ -270,6 +278,15 @@ func (s *Service) listUncached(ctx context.Context, vendor config.AgentVendor, r
 	probedAt := s.now().UTC()
 	result.ProbedAt = probedAt.Format(time.RFC3339)
 
+	// Relative command overrides are not spawn-equivalent here: agent launch
+	// sets cmd.Dir to the run worktree; this endpoint has no such directory.
+	// Reject rather than resolving/running from looperd's current directory.
+	if isRelativePathCommand(resolvedBinary) {
+		result.Sources.Probe = ProbeError
+		result.Sources.ProbeError = relativeCommandProbeError
+		return result
+	}
+
 	env := buildProbeEnv(agentEnv)
 	probeModels, err := s.probe(ctx, vendor, resolvedBinary, env)
 	if err != nil {
@@ -342,4 +359,23 @@ func resolveBinaryPath(command string, lookPath func(string) (string, error)) st
 		return path
 	}
 	return command
+}
+
+// relativeCommandProbeError is returned when agent.params.command is a
+// worktree-relative path. Probes cannot supply spawn's WorkingDirectory.
+const relativeCommandProbeError = "relative command override cannot be probed outside a run worktree"
+
+// isRelativePathCommand reports whether command is a path that agent spawn
+// resolves relative to the run worktree (cmd.Dir). Bare PATH names and
+// absolute paths do not need a worktree to resolve and may be probed as-is.
+func isRelativePathCommand(command string) bool {
+	command = strings.TrimSpace(command)
+	if command == "" || filepath.IsAbs(command) {
+		return false
+	}
+	// PATH lookup names have no path separators.
+	if !strings.ContainsRune(command, '/') && (filepath.Separator == '/' || !strings.ContainsRune(command, filepath.Separator)) {
+		return false
+	}
+	return true
 }

--- a/internal/agent/modelcatalog/catalog.go
+++ b/internal/agent/modelcatalog/catalog.go
@@ -1,0 +1,290 @@
+// Package modelcatalog serves advisory agent model suggestions (static + CLI probe).
+// Catalog membership is never a config or runtime gate (ADR-0016).
+package modelcatalog
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/nexu-io/looper/internal/agent"
+	"github.com/nexu-io/looper/internal/config"
+)
+
+const (
+	defaultProbeTimeout = 5 * time.Second
+	defaultCacheTTL     = 60 * time.Second
+
+	SourceStatic = "static"
+	SourceProbe  = "probe"
+	SourceMerged = "merged"
+
+	ProbeOK          = "ok"
+	ProbeSkipped     = "skipped"
+	ProbeError       = "error"
+	ProbeUnsupported = "unsupported"
+)
+
+// Model is one suggested model id for a vendor CLI.
+type Model struct {
+	ID     string `json:"id"`
+	Label  string `json:"label"`
+	Source string `json:"source"`
+}
+
+// Sources describes how the model list was assembled.
+type Sources struct {
+	Static     bool   `json:"static"`
+	Probe      string `json:"probe"`
+	ProbeError string `json:"probeError,omitempty"`
+}
+
+// Result is the GET /api/v1/agent/models data payload.
+type Result struct {
+	Vendor   string  `json:"vendor"`
+	Models   []Model `json:"models"`
+	Sources  Sources `json:"sources"`
+	ProbedAt string  `json:"probedAt,omitempty"`
+}
+
+// Options configures a Service. Zero values use defaults.
+type Options struct {
+	TTL      time.Duration
+	Timeout  time.Duration
+	Now      func() time.Time
+	Runner   Runner
+	LookPath func(string) (string, error)
+}
+
+// Service merges static catalog entries with on-demand CLI probes.
+type Service struct {
+	ttl      time.Duration
+	timeout  time.Duration
+	now      func() time.Time
+	runner   Runner
+	lookPath func(string) (string, error)
+	static   map[config.AgentVendor][]Model
+
+	mu       sync.Mutex
+	cache    map[string]cacheEntry
+	inflight map[string]*inflightCall
+}
+
+type cacheEntry struct {
+	result    Result
+	expiresAt time.Time
+}
+
+// inflightCall coalesces concurrent cold Lists for the same cache key so only
+// one probe runs; waiters share the result.
+type inflightCall struct {
+	done   chan struct{}
+	result Result
+	err    error
+}
+
+// NewService constructs a catalog service with embedded static data.
+func NewService(opts Options) *Service {
+	ttl := opts.TTL
+	if ttl <= 0 {
+		ttl = defaultCacheTTL
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = defaultProbeTimeout
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	runner := opts.Runner
+	if runner == nil {
+		runner = defaultRunner{}
+	}
+	lookPath := opts.LookPath
+	if lookPath == nil {
+		lookPath = execLookPath
+	}
+	return &Service{
+		ttl:      ttl,
+		timeout:  timeout,
+		now:      now,
+		runner:   runner,
+		lookPath: lookPath,
+		static:   loadStaticCatalog(),
+		cache:    make(map[string]cacheEntry),
+		inflight: make(map[string]*inflightCall),
+	}
+}
+
+// ListOptions controls a single catalog request.
+type ListOptions struct {
+	Vendor  config.AgentVendor
+	Params  map[string]any // spawn-filtered agent.params (command override)
+	Refresh bool
+}
+
+// List returns merged model suggestions for vendor. Probe failures never error
+// when vendor is valid — callers always get static baseline + probe status.
+// Concurrent cold Lists for the same vendor+binary key share one in-flight probe.
+func (s *Service) List(ctx context.Context, opts ListOptions) (Result, error) {
+	if !isKnownVendor(opts.Vendor) {
+		return Result{}, ErrUnknownVendor
+	}
+
+	command := agent.ResolveCommand(opts.Vendor, opts.Params)
+	resolved := resolveBinaryPath(command, s.lookPath)
+	cacheKey := string(opts.Vendor) + "\x00" + resolved
+
+	if !opts.Refresh {
+		if hit, ok := s.cacheGet(cacheKey); ok {
+			return hit, nil
+		}
+	}
+
+	// Coalesce concurrent work for this key (singleflight-style).
+	s.mu.Lock()
+	if !opts.Refresh {
+		if entry, ok := s.cache[cacheKey]; ok && !s.now().After(entry.expiresAt) {
+			s.mu.Unlock()
+			return cloneResult(entry.result), nil
+		}
+	}
+	if call, ok := s.inflight[cacheKey]; ok {
+		s.mu.Unlock()
+		return s.waitInflight(ctx, call)
+	}
+	call := &inflightCall{done: make(chan struct{})}
+	s.inflight[cacheKey] = call
+	s.mu.Unlock()
+
+	result := s.listUncached(ctx, opts.Vendor, resolved)
+
+	s.cachePut(cacheKey, result)
+
+	s.mu.Lock()
+	call.result = result
+	// call.err stays nil: valid vendors never return a hard error from listUncached.
+	delete(s.inflight, cacheKey)
+	close(call.done)
+	s.mu.Unlock()
+
+	return cloneResult(result), nil
+}
+
+func (s *Service) waitInflight(ctx context.Context, call *inflightCall) (Result, error) {
+	select {
+	case <-call.done:
+		if call.err != nil {
+			return Result{}, call.err
+		}
+		return cloneResult(call.result), nil
+	case <-ctx.Done():
+		// Prefer a completed shared result if it races with cancellation.
+		select {
+		case <-call.done:
+			if call.err != nil {
+				return Result{}, call.err
+			}
+			return cloneResult(call.result), nil
+		default:
+			return Result{}, ctx.Err()
+		}
+	}
+}
+
+func (s *Service) listUncached(ctx context.Context, vendor config.AgentVendor, resolvedBinary string) Result {
+	staticModels := append([]Model(nil), s.static[vendor]...)
+	for i := range staticModels {
+		staticModels[i].Source = SourceStatic
+	}
+
+	result := Result{
+		Vendor: string(vendor),
+		Models: staticModels,
+		Sources: Sources{
+			Static: true,
+			Probe:  ProbeSkipped,
+		},
+	}
+
+	if !supportsProbe(vendor) {
+		result.Sources.Probe = ProbeUnsupported
+		// No probe attempt — leave probedAt empty.
+		return result
+	}
+
+	probedAt := s.now().UTC()
+	result.ProbedAt = probedAt.Format(time.RFC3339)
+
+	probeModels, err := s.probe(ctx, vendor, resolvedBinary)
+	if err != nil {
+		result.Sources.Probe = ProbeError
+		result.Sources.ProbeError = shortProbeError(err)
+		return result
+	}
+
+	result.Sources.Probe = ProbeOK
+	result.Models = mergeModels(staticModels, probeModels)
+	return result
+}
+
+func (s *Service) cacheGet(key string) (Result, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.cache[key]
+	if !ok || s.now().After(entry.expiresAt) {
+		return Result{}, false
+	}
+	return cloneResult(entry.result), true
+}
+
+func (s *Service) cachePut(key string, result Result) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cache[key] = cacheEntry{
+		result:    cloneResult(result),
+		expiresAt: s.now().Add(s.ttl),
+	}
+}
+
+func cloneResult(in Result) Result {
+	out := in
+	if in.Models != nil {
+		out.Models = append([]Model(nil), in.Models...)
+	}
+	return out
+}
+
+func isKnownVendor(vendor config.AgentVendor) bool {
+	switch vendor {
+	case config.AgentVendorClaudeCode, config.AgentVendorCodex, config.AgentVendorOpenCode,
+		config.AgentVendorCursorCLI, config.AgentVendorGrokBuild:
+		return true
+	default:
+		return false
+	}
+}
+
+func supportsProbe(vendor config.AgentVendor) bool {
+	switch vendor {
+	case config.AgentVendorCodex, config.AgentVendorOpenCode, config.AgentVendorCursorCLI, config.AgentVendorGrokBuild:
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveBinaryPath(command string, lookPath func(string) (string, error)) string {
+	if command == "" {
+		return command
+	}
+	// Absolute or explicit path overrides stay as-is.
+	if lookPath == nil {
+		return command
+	}
+	if path, err := lookPath(command); err == nil && path != "" {
+		return path
+	}
+	return command
+}

--- a/internal/agent/modelcatalog/catalog.go
+++ b/internal/agent/modelcatalog/catalog.go
@@ -274,7 +274,8 @@ func (s *Service) listUncached(ctx context.Context, vendor config.AgentVendor, r
 	probeModels, err := s.probe(ctx, vendor, resolvedBinary, env)
 	if err != nil {
 		result.Sources.Probe = ProbeError
-		result.Sources.ProbeError = shortProbeError(err)
+		// Redact agent.env values before caching / returning to API clients.
+		result.Sources.ProbeError = shortProbeError(err, agentEnv)
 		return result
 	}
 

--- a/internal/agent/modelcatalog/catalog.go
+++ b/internal/agent/modelcatalog/catalog.go
@@ -167,9 +167,10 @@ func (s *Service) List(ctx context.Context, opts ListOptions) (Result, error) {
 	}
 
 	command := agent.ResolveCommand(opts.Vendor, opts.Params)
-	// ADR-0016: never discover via ambiguous bare `agent` (Cursor default
-	// ResolveCommand name; also excluded from takeover autodetection). Skip
-	// LookPath/probe unless the command path establishes Cursor identity.
+	// ADR-0016: never discover via unqualified bare `agent` (Cursor default
+	// ResolveCommand name; also excluded from takeover autodetection). Explicit
+	// path overrides (absolute or with separators) are intentional and may be
+	// probed even when the basename is still "agent".
 	if opts.Vendor == config.AgentVendorCursorCLI && isAmbiguousBareAgentCommand(command) {
 		return s.listAmbiguousCursorAgent(command), nil
 	}
@@ -399,23 +400,23 @@ func (s *Service) listAmbiguousCursorAgent(command string) Result {
 }
 
 // isAmbiguousBareAgentCommand reports whether command is the unqualified bare
-// name "agent" (or agent.exe). Paths that include "cursor" (e.g. cursor-agent
-// or .../Cursor.app/.../agent) establish Cursor identity and may be probed.
+// PATH name "agent" (or agent.exe). Explicit path overrides — absolute paths
+// such as /usr/local/bin/agent, or any command with path separators — are not
+// ambiguous: the operator chose a specific binary, matching spawn behavior.
+// Only the bare default/unqualified name is rejected (ADR-0016).
 func isAmbiguousBareAgentCommand(command string) bool {
 	command = strings.TrimSpace(command)
 	if command == "" {
 		return false
 	}
+	// Explicit path overrides are intentional; do not require "cursor" in the path.
+	if filepath.IsAbs(command) || strings.ContainsRune(command, '/') ||
+		(filepath.Separator != '/' && strings.ContainsRune(command, filepath.Separator)) {
+		return false
+	}
 	base := filepath.Base(command)
 	base = strings.TrimSuffix(base, ".exe")
-	if !strings.EqualFold(base, "agent") {
-		return false
-	}
-	// Path or basename establishes Cursor identity (cursor-agent, Cursor.app, …).
-	if strings.Contains(strings.ToLower(command), "cursor") {
-		return false
-	}
-	return true
+	return strings.EqualFold(base, "agent")
 }
 
 // isRelativePathCommand reports whether command is a path that agent spawn

--- a/internal/agent/modelcatalog/catalog_test.go
+++ b/internal/agent/modelcatalog/catalog_test.go
@@ -647,6 +647,118 @@ func TestListUsesParamsCommand(t *testing.T) {
 	}
 }
 
+func TestListRelativeCommandOverrideSkipsProbe(t *testing.T) {
+	// Spawn resolves ./tools/... against the run worktree (cmd.Dir). Catalog
+	// probes have no worktree — must not LookPath/run against looperd CWD.
+	var runnerCalls atomic.Int32
+	var lookPathCalls atomic.Int32
+	svc := NewService(Options{
+		Runner: runnerFunc(func(context.Context, []string, string, ...string) ([]byte, error) {
+			runnerCalls.Add(1)
+			return []byte("should-not-run\n"), nil
+		}),
+		LookPath: func(s string) (string, error) {
+			lookPathCalls.Add(1)
+			// If this path were used, LookPath would wrongly pin to daemon CWD.
+			return "/wrong-daemon-cwd/" + s, nil
+		},
+		Now: func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	for _, command := range []string{"./tools/codex-wrapper", "tools/codex-wrapper", "../bin/codex"} {
+		got, err := svc.List(context.Background(), ListOptions{
+			Vendor:  config.AgentVendorCodex,
+			Params:  map[string]any{"command": command},
+			Refresh: true,
+		})
+		if err != nil {
+			t.Fatalf("List(%q) error = %v", command, err)
+		}
+		if got.Sources.Probe != ProbeError {
+			t.Fatalf("List(%q) probe = %q, want error", command, got.Sources.Probe)
+		}
+		if got.Sources.ProbeError != relativeCommandProbeError {
+			t.Fatalf("List(%q) probeError = %q, want %q", command, got.Sources.ProbeError, relativeCommandProbeError)
+		}
+		if !got.Sources.Static || len(got.Models) == 0 {
+			t.Fatalf("List(%q) expected static models, got %#v", command, got)
+		}
+		if got.ProbedAt != "2026-08-01T12:00:00Z" {
+			t.Fatalf("List(%q) probedAt = %q", command, got.ProbedAt)
+		}
+		for _, m := range got.Models {
+			if m.Source != SourceStatic {
+				t.Fatalf("List(%q) model source = %q, want static only", command, m.Source)
+			}
+		}
+	}
+	if runnerCalls.Load() != 0 {
+		t.Fatalf("runner calls = %d, want 0", runnerCalls.Load())
+	}
+	if lookPathCalls.Load() != 0 {
+		t.Fatalf("LookPath calls = %d, want 0 (must not resolve relative against daemon CWD)", lookPathCalls.Load())
+	}
+}
+
+func TestListBareAndAbsoluteCommandsStillProbe(t *testing.T) {
+	var saw []string
+	svc := NewService(Options{
+		Runner: runnerFunc(func(_ context.Context, _ []string, name string, _ ...string) ([]byte, error) {
+			saw = append(saw, name)
+			return []byte(`{"models":[{"id":"gpt-5.4","name":"GPT-5.4","visibility":"list"}]}`), nil
+		}),
+		LookPath: func(s string) (string, error) {
+			if s == "codex" {
+				return "/usr/bin/codex", nil
+			}
+			return s, nil
+		},
+	})
+
+	if _, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorCodex}); err != nil {
+		t.Fatalf("bare List() error = %v", err)
+	}
+	if _, err := svc.List(context.Background(), ListOptions{
+		Vendor: config.AgentVendorCodex,
+		Params: map[string]any{"command": "/opt/custom-codex"},
+	}); err != nil {
+		t.Fatalf("absolute List() error = %v", err)
+	}
+	if !reflect.DeepEqual(saw, []string{"/usr/bin/codex", "/opt/custom-codex"}) {
+		t.Fatalf("probed binaries = %#v, want bare resolved + absolute", saw)
+	}
+}
+
+func TestIsRelativePathCommand(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"codex", false},
+		{"my.codex-wrapper", false},
+		{"/opt/custom-codex", false},
+		{"./tools/codex-wrapper", true},
+		{"tools/codex-wrapper", true},
+		{"../bin/codex", true},
+	}
+	for _, tc := range cases {
+		if got := isRelativePathCommand(tc.in); got != tc.want {
+			t.Fatalf("isRelativePathCommand(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDefaultRunnerRejectsRelativeCommand(t *testing.T) {
+	_, err := defaultRunner{}.Run(context.Background(), nil, "./tools/codex-wrapper", "debug", "models")
+	if err == nil {
+		t.Fatal("expected error for relative command")
+	}
+	if !strings.Contains(err.Error(), relativeCommandProbeError) {
+		t.Fatalf("error = %q, want %q", err, relativeCommandProbeError)
+	}
+}
+
 func TestListProbeOutputOverflowIsError(t *testing.T) {
 	// Fake runner simulates defaultRunner overflow failure.
 	svc := NewService(Options{

--- a/internal/agent/modelcatalog/catalog_test.go
+++ b/internal/agent/modelcatalog/catalog_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/processcontainment"
 )
 
 func TestLoadStaticCatalog(t *testing.T) {
@@ -167,7 +168,7 @@ func TestParseLineModelsRejectsLoggedOutWarning(t *testing.T) {
 func TestListClaudeCodeUnsupportedProbeStaticOnly(t *testing.T) {
 	var calls atomic.Int32
 	svc := NewService(Options{
-		Runner: runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		Runner: runnerFunc(func(context.Context, []string, string, ...string) ([]byte, error) {
 			calls.Add(1)
 			return nil, errors.New("should not probe")
 		}),
@@ -199,7 +200,7 @@ func TestListClaudeCodeUnsupportedProbeStaticOnly(t *testing.T) {
 
 func TestListProbeFailureReturnsStaticAndError(t *testing.T) {
 	svc := NewService(Options{
-		Runner: runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		Runner: runnerFunc(func(context.Context, []string, string, ...string) ([]byte, error) {
 			return nil, errors.New("exit status 1: not logged in")
 		}),
 		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
@@ -229,7 +230,7 @@ func TestListProbeOKMergesAndCaches(t *testing.T) {
 	var calls atomic.Int32
 	svc := NewService(Options{
 		TTL: 60 * time.Second,
-		Runner: runnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		Runner: runnerFunc(func(_ context.Context, _ []string, name string, args ...string) ([]byte, error) {
 			calls.Add(1)
 			if name != "/usr/bin/opencode" {
 				t.Fatalf("binary = %q, want resolved path", name)
@@ -320,7 +321,7 @@ func TestListCoalescesInflightSameKey(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	svc := NewService(Options{
-		Runner: runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		Runner: runnerFunc(func(context.Context, []string, string, ...string) ([]byte, error) {
 			n := calls.Add(1)
 			if n == 1 {
 				close(started)
@@ -386,7 +387,7 @@ func TestListCanceledCallerDoesNotPoisonCache(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	svc := NewService(Options{
-		Runner: runnerFunc(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		Runner: runnerFunc(func(ctx context.Context, _ []string, _ string, _ ...string) ([]byte, error) {
 			calls.Add(1)
 			close(started)
 			select {
@@ -460,7 +461,7 @@ func TestListCanceledLeaderDoesNotPoisonLiveWaiters(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	svc := NewService(Options{
-		Runner: runnerFunc(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		Runner: runnerFunc(func(ctx context.Context, _ []string, _ string, _ ...string) ([]byte, error) {
 			calls.Add(1)
 			close(started)
 			select {
@@ -532,7 +533,7 @@ func TestListUnknownVendor(t *testing.T) {
 func TestListUsesParamsCommand(t *testing.T) {
 	var saw string
 	svc := NewService(Options{
-		Runner: runnerFunc(func(_ context.Context, name string, _ ...string) ([]byte, error) {
+		Runner: runnerFunc(func(_ context.Context, _ []string, name string, _ ...string) ([]byte, error) {
 			saw = name
 			return []byte("custom-model\n"), nil
 		}),
@@ -553,7 +554,7 @@ func TestListUsesParamsCommand(t *testing.T) {
 func TestListProbeOutputOverflowIsError(t *testing.T) {
 	// Fake runner simulates defaultRunner overflow failure.
 	svc := NewService(Options{
-		Runner: runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		Runner: runnerFunc(func(context.Context, []string, string, ...string) ([]byte, error) {
 			return nil, fmt.Errorf("probe output exceeded %d bytes", maxProbeOutputBytes)
 		}),
 		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
@@ -594,7 +595,7 @@ func TestDefaultRunnerTimeoutKillsProcessGroup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
 	start := time.Now()
-	_, err := defaultRunner{}.Run(ctx, "bash", "-c", `
+	_, err := defaultRunner{}.Run(ctx, nil, "bash", "-c", `
 trap '' TERM
 sleep 60 &
 sleep 60
@@ -622,7 +623,7 @@ func TestDefaultRunnerBoundsHugeOutput(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	_, err := defaultRunner{}.Run(ctx, "bash", "-c", script)
+	_, err := defaultRunner{}.Run(ctx, nil, "bash", "-c", script)
 	if err == nil {
 		t.Fatal("expected overflow error")
 	}
@@ -656,10 +657,182 @@ func TestBoundedBufferDiscardsAfterCap(t *testing.T) {
 	}
 }
 
-type runnerFunc func(ctx context.Context, name string, args ...string) ([]byte, error)
+func TestListShutdownCancelsSharedProbeNotRequestCancel(t *testing.T) {
+	// Daemon Shutdown must cancel shared probes; request cancel must not.
+	var calls atomic.Int32
+	started := make(chan struct{})
+	sawCancel := make(chan struct{})
+	svc := NewService(Options{
+		Runner: runnerFunc(func(ctx context.Context, _ []string, _ string, _ ...string) ([]byte, error) {
+			calls.Add(1)
+			close(started)
+			<-ctx.Done()
+			close(sawCancel)
+			return nil, ctx.Err()
+		}),
+		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
 
-func (f runnerFunc) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return f(ctx, name, args...)
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	done := make(chan Result, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		got, err := svc.List(reqCtx, ListOptions{Vendor: config.AgentVendorOpenCode})
+		errCh <- err
+		done <- got
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("probe did not start")
+	}
+	// Request cancel (popup) must not abort the shared probe.
+	reqCancel()
+	select {
+	case <-sawCancel:
+		t.Fatal("probe observed cancel after request cancel; want daemon-owned lifetime")
+	case <-time.After(80 * time.Millisecond):
+	}
+
+	// Daemon shutdown cancels probeCtx → runner sees cancel.
+	svc.Shutdown()
+	select {
+	case <-sawCancel:
+	case <-time.After(3 * time.Second):
+		t.Fatal("probe did not observe Shutdown cancel")
+	}
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("List() error = %v, want soft probe error result", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("List() did not return after Shutdown")
+	}
+	got := <-done
+	if got.Sources.Probe != ProbeError {
+		t.Fatalf("probe = %q, want error after shutdown cancel", got.Sources.Probe)
+	}
+	if got.Sources.ProbeError != "probe canceled" && !strings.Contains(got.Sources.ProbeError, "canceled") {
+		t.Fatalf("probeError = %q, want cancel", got.Sources.ProbeError)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestListPassesAgentEnvToRunner(t *testing.T) {
+	var sawEnv []string
+	svc := NewService(Options{
+		Runner: runnerFunc(func(_ context.Context, env []string, _ string, _ ...string) ([]byte, error) {
+			sawEnv = append([]string(nil), env...)
+			return []byte("from-env-model\n"), nil
+		}),
+		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+	got, err := svc.List(context.Background(), ListOptions{
+		Vendor: config.AgentVendorOpenCode,
+		Env:    map[string]string{"OPENCODE_API_KEY": "secret-from-agent-env", "CUSTOM_PROBE": "1"},
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got.Sources.Probe != ProbeOK {
+		t.Fatalf("probe = %q err=%q", got.Sources.Probe, got.Sources.ProbeError)
+	}
+	envMap := envSliceToMap(sawEnv)
+	if envMap["OPENCODE_API_KEY"] != "secret-from-agent-env" {
+		t.Fatalf("OPENCODE_API_KEY = %q, want agent.env value", envMap["OPENCODE_API_KEY"])
+	}
+	if envMap["CUSTOM_PROBE"] != "1" {
+		t.Fatalf("CUSTOM_PROBE = %q", envMap["CUSTOM_PROBE"])
+	}
+	// Ambient secrets must not be inherited wholesale: require allowlist shape
+	// (PATH may be present; arbitrary LOOPER_TEST_SECRET must not unless configured).
+	if _, ok := envMap["LOOPER_TEST_SECRET_SHOULD_NOT_LEAK"]; ok {
+		t.Fatal("ambient secret leaked into probe env")
+	}
+}
+
+func TestDefaultRunnerUsesSanitizedEnvNotAmbient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess env sanitization test")
+	}
+	t.Setenv("LOOPER_PROBE_AMBIENT_SECRET", "daemon-credential-must-not-leak")
+	t.Setenv("OPENCODE_API_KEY", "ambient-key-must-not-leak")
+
+	// Child prints whether ambient secret is visible and whether configured key is.
+	script := `python3 -c 'import os; print("ambient="+("yes" if os.environ.get("LOOPER_PROBE_AMBIENT_SECRET") else "no")); print("cfg="+os.environ.get("OPENCODE_API_KEY",""))'`
+	if _, err := exec.LookPath("python3"); err != nil {
+		script = `sh -c 'if [ -n "$LOOPER_PROBE_AMBIENT_SECRET" ]; then echo ambient=yes; else echo ambient=no; fi; echo cfg=$OPENCODE_API_KEY'`
+	}
+	env := buildProbeEnv(map[string]string{"OPENCODE_API_KEY": "from-agent-env"})
+	out, err := defaultRunner{}.Run(context.Background(), env, "bash", "-c", script)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, "ambient=no") {
+		t.Fatalf("ambient secret leaked into probe; output=%q", text)
+	}
+	if !strings.Contains(text, "cfg=from-agent-env") {
+		t.Fatalf("configured agent.env not present; output=%q", text)
+	}
+	// Double-check ambient OPENCODE_API_KEY was replaced by agent.env, not ambient.
+	if strings.Contains(text, "ambient-key-must-not-leak") {
+		t.Fatalf("ambient OPENCODE_API_KEY leaked; output=%q", text)
+	}
+}
+
+func TestDefaultRunnerTracksHandleWithLiveTracker(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess tracker test")
+	}
+	tracker := &recordingTracker{}
+	runner := defaultRunner{tracker: tracker}
+	_, err := runner.Run(context.Background(), buildProbeEnv(nil), "bash", "-c", "echo ok")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if tracker.tracks.Load() != 1 {
+		t.Fatalf("Track calls = %d, want 1", tracker.tracks.Load())
+	}
+	if tracker.releases.Load() != 1 {
+		t.Fatalf("release calls = %d, want 1", tracker.releases.Load())
+	}
+}
+
+func envSliceToMap(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+	for _, e := range env {
+		k, v, ok := strings.Cut(e, "=")
+		if !ok || k == "" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+type recordingTracker struct {
+	tracks   atomic.Int32
+	releases atomic.Int32
+}
+
+func (t *recordingTracker) Track(handle *processcontainment.Handle) (release func()) {
+	t.tracks.Add(1)
+	return func() { t.releases.Add(1) }
+}
+
+func (t *recordingTracker) ReportDrainFailure(error) {}
+
+type runnerFunc func(ctx context.Context, env []string, name string, args ...string) ([]byte, error)
+
+func (f runnerFunc) Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
+	return f(ctx, env, name, args...)
 }
 
 func readTestdata(t *testing.T, name string) []byte {

--- a/internal/agent/modelcatalog/catalog_test.go
+++ b/internal/agent/modelcatalog/catalog_test.go
@@ -729,6 +729,125 @@ func TestListBareAndAbsoluteCommandsStillProbe(t *testing.T) {
 	}
 }
 
+func TestListCursorCLISkipsAmbiguousBareAgent(t *testing.T) {
+	// Default ResolveCommand for cursor-cli is bare "agent" — must not LookPath
+	// or execute whatever is first on PATH (ADR-0016 / takeover exclusion).
+	var runnerCalls atomic.Int32
+	var lookPathCalls atomic.Int32
+	svc := NewService(Options{
+		Runner: runnerFunc(func(context.Context, []string, string, ...string) ([]byte, error) {
+			runnerCalls.Add(1)
+			return []byte("should-not-run\n"), nil
+		}),
+		LookPath: func(s string) (string, error) {
+			lookPathCalls.Add(1)
+			return "/evil/path/" + s, nil
+		},
+		Now: func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	got, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorCursorCLI})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got.Sources.Probe != ProbeError {
+		t.Fatalf("probe = %q, want error", got.Sources.Probe)
+	}
+	if got.Sources.ProbeError != ambiguousBareAgentProbeError {
+		t.Fatalf("probeError = %q, want %q", got.Sources.ProbeError, ambiguousBareAgentProbeError)
+	}
+	if !got.Sources.Static || len(got.Models) == 0 {
+		t.Fatalf("expected static models, got %#v", got)
+	}
+	for _, m := range got.Models {
+		if m.Source != SourceStatic {
+			t.Fatalf("model source = %q, want static only", m.Source)
+		}
+	}
+	if runnerCalls.Load() != 0 {
+		t.Fatalf("runner calls = %d, want 0", runnerCalls.Load())
+	}
+	if lookPathCalls.Load() != 0 {
+		t.Fatalf("LookPath calls = %d, want 0", lookPathCalls.Load())
+	}
+
+	// Explicit bare "agent" override is still ambiguous.
+	got, err = svc.List(context.Background(), ListOptions{
+		Vendor:  config.AgentVendorCursorCLI,
+		Params:  map[string]any{"command": "agent"},
+		Refresh: true,
+	})
+	if err != nil {
+		t.Fatalf("List(explicit agent) error = %v", err)
+	}
+	if got.Sources.ProbeError != ambiguousBareAgentProbeError {
+		t.Fatalf("explicit agent probeError = %q", got.Sources.ProbeError)
+	}
+	if runnerCalls.Load() != 0 || lookPathCalls.Load() != 0 {
+		t.Fatalf("explicit agent still probed (runner=%d lookPath=%d)", runnerCalls.Load(), lookPathCalls.Load())
+	}
+}
+
+func TestListCursorCLIProbesWhenIdentityEstablished(t *testing.T) {
+	var saw []string
+	svc := NewService(Options{
+		Runner: runnerFunc(func(_ context.Context, _ []string, name string, args ...string) ([]byte, error) {
+			saw = append(saw, name)
+			return []byte("composer-1\ngpt-5\n"), nil
+		}),
+		LookPath: func(s string) (string, error) {
+			if s == "cursor-agent" {
+				return "/usr/local/bin/cursor-agent", nil
+			}
+			return s, nil
+		},
+	})
+
+	// Explicit cursor-agent binary name.
+	if _, err := svc.List(context.Background(), ListOptions{
+		Vendor: config.AgentVendorCursorCLI,
+		Params: map[string]any{"command": "cursor-agent"},
+	}); err != nil {
+		t.Fatalf("List(cursor-agent) error = %v", err)
+	}
+	// Path containing "cursor" even when basename is agent.
+	if _, err := svc.List(context.Background(), ListOptions{
+		Vendor: config.AgentVendorCursorCLI,
+		Params: map[string]any{"command": "/Applications/Cursor.app/Contents/Resources/app/bin/agent"},
+	}); err != nil {
+		t.Fatalf("List(Cursor.app agent) error = %v", err)
+	}
+	want := []string{
+		"/usr/local/bin/cursor-agent",
+		"/Applications/Cursor.app/Contents/Resources/app/bin/agent",
+	}
+	if !reflect.DeepEqual(saw, want) {
+		t.Fatalf("probed binaries = %#v, want %#v", saw, want)
+	}
+}
+
+func TestIsAmbiguousBareAgentCommand(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"agent", true},
+		{"agent.exe", true},
+		{"AGENT", true},
+		{"cursor-agent", false},
+		{"/usr/local/bin/cursor-agent", false},
+		{"/usr/local/bin/agent", true},
+		{"/Applications/Cursor.app/bin/agent", false},
+		{"codex", false},
+	}
+	for _, tc := range cases {
+		if got := isAmbiguousBareAgentCommand(tc.in); got != tc.want {
+			t.Fatalf("isAmbiguousBareAgentCommand(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestIsRelativePathCommand(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/internal/agent/modelcatalog/catalog_test.go
+++ b/internal/agent/modelcatalog/catalog_test.go
@@ -817,9 +817,18 @@ func TestListCursorCLIProbesWhenIdentityEstablished(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("List(Cursor.app agent) error = %v", err)
 	}
+	// Explicit absolute path named "agent" without "cursor" in any component —
+	// still an intentional override (spawn uses it); must probe, not treat as bare.
+	if _, err := svc.List(context.Background(), ListOptions{
+		Vendor: config.AgentVendorCursorCLI,
+		Params: map[string]any{"command": "/usr/local/bin/agent"},
+	}); err != nil {
+		t.Fatalf("List(/usr/local/bin/agent) error = %v", err)
+	}
 	want := []string{
 		"/usr/local/bin/cursor-agent",
 		"/Applications/Cursor.app/Contents/Resources/app/bin/agent",
+		"/usr/local/bin/agent",
 	}
 	if !reflect.DeepEqual(saw, want) {
 		t.Fatalf("probed binaries = %#v, want %#v", saw, want)
@@ -837,8 +846,10 @@ func TestIsAmbiguousBareAgentCommand(t *testing.T) {
 		{"AGENT", true},
 		{"cursor-agent", false},
 		{"/usr/local/bin/cursor-agent", false},
-		{"/usr/local/bin/agent", true},
+		// Explicit absolute path is not bare, even without "cursor" in the path.
+		{"/usr/local/bin/agent", false},
 		{"/Applications/Cursor.app/bin/agent", false},
+		{"./bin/agent", false},
 		{"codex", false},
 	}
 	for _, tc := range cases {

--- a/internal/agent/modelcatalog/catalog_test.go
+++ b/internal/agent/modelcatalog/catalog_test.go
@@ -379,6 +379,148 @@ func TestListCoalescesInflightSameKey(t *testing.T) {
 	}
 }
 
+func TestListCanceledCallerDoesNotPoisonCache(t *testing.T) {
+	// Request cancel (popup close) must not abort the shared probe or cache a
+	// "probe canceled" failure that later Lists would serve for the full TTL.
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	svc := NewService(Options{
+		Runner: runnerFunc(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+			calls.Add(1)
+			close(started)
+			select {
+			case <-release:
+				return []byte("good-model\n"), nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}),
+		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan Result, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		got, err := svc.List(ctx, ListOptions{Vendor: config.AgentVendorOpenCode})
+		errCh <- err
+		done <- got
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("probe did not start")
+	}
+	cancel()
+	// Give the leader a chance to observe cancel if it still used the request ctx.
+	time.Sleep(30 * time.Millisecond)
+	close(release)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("List() after cancel error = %v (probe should outlive request cancel)", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("List() did not return")
+	}
+	leader := <-done
+	if leader.Sources.Probe != ProbeOK {
+		t.Fatalf("leader probe = %q err=%q, want ok", leader.Sources.Probe, leader.Sources.ProbeError)
+	}
+
+	// Cache must hold the successful probe, not a cancel failure.
+	second, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorOpenCode})
+	if err != nil {
+		t.Fatalf("second List() error = %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("runner calls = %d, want 1 (cached success)", calls.Load())
+	}
+	if second.Sources.Probe != ProbeOK {
+		t.Fatalf("cached probe = %q err=%q, want ok", second.Sources.Probe, second.Sources.ProbeError)
+	}
+	found := false
+	for _, m := range second.Models {
+		if m.ID == "good-model" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected good-model in cached result %#v", second.Models)
+	}
+}
+
+func TestListCanceledLeaderDoesNotPoisonLiveWaiters(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	svc := NewService(Options{
+		Runner: runnerFunc(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+			calls.Add(1)
+			close(started)
+			select {
+			case <-release:
+				return []byte("shared-model\n"), nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}),
+		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	leaderCtx, leaderCancel := context.WithCancel(context.Background())
+	leaderDone := make(chan struct{})
+	go func() {
+		defer close(leaderDone)
+		_, _ = svc.List(leaderCtx, ListOptions{Vendor: config.AgentVendorOpenCode})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("probe did not start")
+	}
+
+	// Waiter joins while probe is in flight; leader cancel must not poison it.
+	waiterErr := make(chan error, 1)
+	waiterResult := make(chan Result, 1)
+	go func() {
+		got, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorOpenCode})
+		waiterErr <- err
+		waiterResult <- got
+	}()
+	time.Sleep(30 * time.Millisecond)
+	leaderCancel()
+	close(release)
+
+	select {
+	case <-leaderDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("leader List() did not return")
+	}
+	select {
+	case err := <-waiterErr:
+		if err != nil {
+			t.Fatalf("waiter List() error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("waiter List() did not return")
+	}
+	got := <-waiterResult
+	if got.Sources.Probe != ProbeOK {
+		t.Fatalf("waiter probe = %q err=%q, want ok", got.Sources.Probe, got.Sources.ProbeError)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("runner calls = %d, want 1", calls.Load())
+	}
+}
+
 func TestListUnknownVendor(t *testing.T) {
 	svc := NewService(Options{})
 	_, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendor("nope")})

--- a/internal/agent/modelcatalog/catalog_test.go
+++ b/internal/agent/modelcatalog/catalog_test.go
@@ -224,6 +224,102 @@ func TestListProbeFailureReturnsStaticAndError(t *testing.T) {
 	}
 }
 
+func TestListProbeErrorRedactsConfiguredEnvValues(t *testing.T) {
+	// Mirrors the write-only agent.env contract: config API exposes envKeys only;
+	// probe diagnostics must not re-surface credential values via probeError.
+	const secret = "sk-super-secret-token-value-xyz"
+	svc := NewService(Options{
+		Runner: runnerFunc(func(context.Context, []string, string, ...string) ([]byte, error) {
+			return nil, fmt.Errorf("authentication failed: invalid token %s for user", secret)
+		}),
+		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+	got, err := svc.List(context.Background(), ListOptions{
+		Vendor: config.AgentVendorCodex,
+		Env:    map[string]string{"OPENAI_API_KEY": secret, "EMPTY": ""},
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got.Sources.Probe != ProbeError {
+		t.Fatalf("probe = %q, want error", got.Sources.Probe)
+	}
+	if strings.Contains(got.Sources.ProbeError, secret) {
+		t.Fatalf("probeError leaked agent.env value: %q", got.Sources.ProbeError)
+	}
+	if !strings.Contains(got.Sources.ProbeError, "[REDACTED]") {
+		t.Fatalf("probeError = %q, want [REDACTED] placeholder", got.Sources.ProbeError)
+	}
+	if !strings.Contains(got.Sources.ProbeError, "authentication failed") {
+		t.Fatalf("probeError = %q, want non-secret diagnostic preserved", got.Sources.ProbeError)
+	}
+
+	// Cached response must also stay redacted (listUncached redacts before cachePut).
+	cached, err := svc.List(context.Background(), ListOptions{
+		Vendor: config.AgentVendorCodex,
+		Env:    map[string]string{"OPENAI_API_KEY": secret},
+	})
+	if err != nil {
+		t.Fatalf("cached List() error = %v", err)
+	}
+	if strings.Contains(cached.Sources.ProbeError, secret) {
+		t.Fatalf("cached probeError leaked agent.env value: %q", cached.Sources.ProbeError)
+	}
+}
+
+func TestShortProbeErrorRedactsLongestSecretsFirst(t *testing.T) {
+	err := errors.New("token=abc-longer-secret and short=abc")
+	got := shortProbeError(err, map[string]string{
+		"LONG":  "abc-longer-secret",
+		"SHORT": "abc",
+	})
+	if strings.Contains(got, "abc-longer-secret") || strings.Contains(got, "token=abc") {
+		t.Fatalf("shortProbeError = %q, secrets still present", got)
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("shortProbeError = %q, want redaction", got)
+	}
+}
+
+func TestDefaultRunnerStderrRedactedInListProbeError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess stderr redaction test")
+	}
+	const secret = "probe-stderr-secret-must-not-leak-42"
+	// Resolve a real bash so defaultRunner runs; override vendor command via params.
+	// Probe always passes vendor-specific args; use a wrapper script that ignores
+	// args and prints the secret on stderr then exits nonzero.
+	dir := t.TempDir()
+	wrapper := filepath.Join(dir, "fake-cli")
+	script := "#!/bin/sh\necho \"auth error: bad key " + secret + "\" >&2\nexit 1\n"
+	if err := os.WriteFile(wrapper, []byte(script), 0o755); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+	svc := NewService(Options{
+		// Production defaultRunner path (no fake Runner).
+		LookPath: func(string) (string, error) { return wrapper, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+	got, err := svc.List(context.Background(), ListOptions{
+		Vendor: config.AgentVendorOpenCode,
+		Params: map[string]any{"command": wrapper},
+		Env:    map[string]string{"OPENCODE_API_KEY": secret},
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got.Sources.Probe != ProbeError {
+		t.Fatalf("probe = %q err=%q, want error", got.Sources.Probe, got.Sources.ProbeError)
+	}
+	if strings.Contains(got.Sources.ProbeError, secret) {
+		t.Fatalf("probeError leaked stderr secret: %q", got.Sources.ProbeError)
+	}
+	if !strings.Contains(got.Sources.ProbeError, "[REDACTED]") {
+		t.Fatalf("probeError = %q, want [REDACTED]", got.Sources.ProbeError)
+	}
+}
+
 func TestListProbeOKMergesAndCaches(t *testing.T) {
 	var now atomic.Value
 	now.Store(time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC))

--- a/internal/agent/modelcatalog/catalog_test.go
+++ b/internal/agent/modelcatalog/catalog_test.go
@@ -797,6 +797,9 @@ func TestDefaultRunnerTracksHandleWithLiveTracker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
+	if tracker.begins.Load() != 1 {
+		t.Fatalf("BeginTrack calls = %d, want 1", tracker.begins.Load())
+	}
 	if tracker.tracks.Load() != 1 {
 		t.Fatalf("Track calls = %d, want 1", tracker.tracks.Load())
 	}
@@ -818,8 +821,14 @@ func envSliceToMap(env []string) map[string]string {
 }
 
 type recordingTracker struct {
+	begins   atomic.Int32
 	tracks   atomic.Int32
 	releases atomic.Int32
+}
+
+func (t *recordingTracker) BeginTrack() (end func(), err error) {
+	t.begins.Add(1)
+	return func() {}, nil
 }
 
 func (t *recordingTracker) Track(handle *processcontainment.Handle) (release func()) {

--- a/internal/agent/modelcatalog/catalog_test.go
+++ b/internal/agent/modelcatalog/catalog_test.go
@@ -1,0 +1,538 @@
+package modelcatalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestLoadStaticCatalog(t *testing.T) {
+	catalog := loadStaticCatalog()
+	claude := catalog[config.AgentVendorClaudeCode]
+	if len(claude) < 3 {
+		t.Fatalf("claude-code static models = %d, want at least sonnet/opus/haiku", len(claude))
+	}
+	ids := map[string]bool{}
+	for _, m := range claude {
+		ids[m.ID] = true
+		if m.Label == "" {
+			t.Fatalf("empty label for %q", m.ID)
+		}
+	}
+	for _, want := range []string{"sonnet", "opus", "haiku"} {
+		if !ids[want] {
+			t.Fatalf("claude-code missing alias %q", want)
+		}
+	}
+	for _, vendor := range []config.AgentVendor{
+		config.AgentVendorCodex,
+		config.AgentVendorOpenCode,
+		config.AgentVendorCursorCLI,
+		config.AgentVendorGrokBuild,
+	} {
+		if len(catalog[vendor]) == 0 {
+			t.Fatalf("static catalog empty for %s", vendor)
+		}
+	}
+}
+
+func TestMergeModelsStaticFirstProbeLabelWinsDedupe(t *testing.T) {
+	static := []Model{
+		{ID: "gpt-5.4", Label: "Static GPT", Source: SourceStatic},
+		{ID: "o3", Label: "o3", Source: SourceStatic},
+	}
+	probe := []Model{
+		{ID: "gpt-5.4", Label: "Probe GPT-5.4", Source: SourceProbe},
+		{ID: "gpt-4.1", Label: "GPT-4.1", Source: SourceProbe},
+		{ID: "alpha-only", Label: "Alpha", Source: SourceProbe},
+		{ID: "gpt-4.1", Label: "dup", Source: SourceProbe},
+	}
+	got := mergeModels(static, probe)
+	want := []Model{
+		{ID: "gpt-5.4", Label: "Probe GPT-5.4", Source: SourceMerged},
+		{ID: "o3", Label: "o3", Source: SourceStatic},
+		{ID: "alpha-only", Label: "Alpha", Source: SourceProbe},
+		{ID: "gpt-4.1", Label: "GPT-4.1", Source: SourceProbe},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mergeModels() = %#v, want %#v", got, want)
+	}
+}
+
+func TestMergeModelsBareProbeIDPreservesStaticLabel(t *testing.T) {
+	static := []Model{
+		{ID: "composer-1", Label: "Composer 1", Source: SourceStatic},
+		{ID: "gpt-5", Label: "GPT-5", Source: SourceStatic},
+	}
+	// Bare probe ids: empty Label means "no label from probe".
+	probe := []Model{
+		{ID: "composer-1", Source: SourceProbe},
+		{ID: "gpt-5", Label: "", Source: SourceProbe},
+		{ID: "new-only", Source: SourceProbe},
+	}
+	got := mergeModels(static, probe)
+	want := []Model{
+		{ID: "composer-1", Label: "Composer 1", Source: SourceMerged},
+		{ID: "gpt-5", Label: "GPT-5", Source: SourceMerged},
+		{ID: "new-only", Label: "new-only", Source: SourceProbe},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mergeModels() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseOpenCodeModelsFixture(t *testing.T) {
+	raw := readTestdata(t, "opencode_models.txt")
+	got := parseOpenCodeModels(raw)
+	wantIDs := []string{
+		"anthropic/claude-sonnet-4-5",
+		"anthropic/claude-opus-4-5",
+		"openai/gpt-5.4",
+		"openai/gpt-4.1",
+		"google/gemini-2.5-pro",
+	}
+	if len(got) != len(wantIDs) {
+		t.Fatalf("len = %d, want %d (%#v)", len(got), len(wantIDs), got)
+	}
+	for i, id := range wantIDs {
+		if got[i].ID != id || got[i].Source != SourceProbe {
+			t.Fatalf("got[%d] = %#v, want id=%q source=probe", i, got[i], id)
+		}
+		if got[i].Label != "" {
+			t.Fatalf("got[%d].Label = %q, want empty bare-id label", i, got[i].Label)
+		}
+	}
+}
+
+func TestParseOpenCodeRejectsMultiwordDiagnostics(t *testing.T) {
+	raw := []byte("Not logged in\nanthropic/claude-sonnet-4-5\nPlease run opencode auth\nopenai/gpt-4.1\n")
+	got := parseOpenCodeModels(raw)
+	if !reflect.DeepEqual(modelIDs(got), []string{"anthropic/claude-sonnet-4-5", "openai/gpt-4.1"}) {
+		t.Fatalf("ids = %#v", modelIDs(got))
+	}
+}
+
+func TestParseCodexModelsFixtureFiltersVisibility(t *testing.T) {
+	raw := readTestdata(t, "codex_models.json")
+	got, err := parseCodexModels(raw)
+	if err != nil {
+		t.Fatalf("parseCodexModels() error = %v", err)
+	}
+	ids := modelIDs(got)
+	if reflect.DeepEqual(ids, []string{"gpt-5.4", "gpt-5.3-codex", "o3"}) == false {
+		t.Fatalf("ids = %#v, want list-visible only (no experimental-hidden)", ids)
+	}
+	if got[0].Label != "GPT-5.4" {
+		t.Fatalf("label = %q, want GPT-5.4", got[0].Label)
+	}
+}
+
+func TestParseCursorAndGrokFixtures(t *testing.T) {
+	cursor := parseCursorModels(readTestdata(t, "cursor_models.txt"))
+	if got := modelIDs(cursor); !reflect.DeepEqual(got, []string{"auto", "sonnet-4", "gpt-5", "composer-1"}) {
+		t.Fatalf("cursor ids = %#v", got)
+	}
+	if cursor[0].Label != "Auto" {
+		t.Fatalf("cursor label = %q, want Auto", cursor[0].Label)
+	}
+	// Bare id line: no fabricated label.
+	if cursor[3].ID != "composer-1" || cursor[3].Label != "" {
+		t.Fatalf("composer-1 entry = %#v, want empty label", cursor[3])
+	}
+	grok := parseGrokModels(readTestdata(t, "grok_models.txt"))
+	if got := modelIDs(grok); !reflect.DeepEqual(got, []string{"grok-4", "grok-3", "grok-code-fast-1"}) {
+		t.Fatalf("grok ids = %#v", got)
+	}
+}
+
+func TestParseLineModelsRejectsLoggedOutWarning(t *testing.T) {
+	raw := []byte("Not logged in\nPlease authenticate first\nauto - Auto\n")
+	got := parseLineModels(raw)
+	if !reflect.DeepEqual(modelIDs(got), []string{"auto"}) {
+		t.Fatalf("ids = %#v, want only table row", modelIDs(got))
+	}
+}
+
+func TestListClaudeCodeUnsupportedProbeStaticOnly(t *testing.T) {
+	var calls atomic.Int32
+	svc := NewService(Options{
+		Runner: runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+			calls.Add(1)
+			return nil, errors.New("should not probe")
+		}),
+		LookPath: func(s string) (string, error) { return "/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+	got, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorClaudeCode})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("probe calls = %d, want 0", calls.Load())
+	}
+	if got.Sources.Probe != ProbeUnsupported {
+		t.Fatalf("probe = %q, want unsupported", got.Sources.Probe)
+	}
+	if !got.Sources.Static || len(got.Models) == 0 {
+		t.Fatalf("expected static models, got %#v", got)
+	}
+	if got.ProbedAt != "" {
+		t.Fatalf("probedAt = %q, want empty when unsupported", got.ProbedAt)
+	}
+	for _, m := range got.Models {
+		if m.Source != SourceStatic {
+			t.Fatalf("model source = %q, want static", m.Source)
+		}
+	}
+}
+
+func TestListProbeFailureReturnsStaticAndError(t *testing.T) {
+	svc := NewService(Options{
+		Runner: runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+			return nil, errors.New("exit status 1: not logged in")
+		}),
+		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+	got, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorCodex})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got.Sources.Probe != ProbeError {
+		t.Fatalf("probe = %q, want error", got.Sources.Probe)
+	}
+	if !strings.Contains(got.Sources.ProbeError, "not logged in") {
+		t.Fatalf("probeError = %q", got.Sources.ProbeError)
+	}
+	if !got.Sources.Static || len(got.Models) == 0 {
+		t.Fatalf("expected static fallback, got %#v", got)
+	}
+	if got.ProbedAt != "2026-08-01T12:00:00Z" {
+		t.Fatalf("probedAt = %q", got.ProbedAt)
+	}
+}
+
+func TestListProbeOKMergesAndCaches(t *testing.T) {
+	var now atomic.Value
+	now.Store(time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC))
+	var calls atomic.Int32
+	svc := NewService(Options{
+		TTL: 60 * time.Second,
+		Runner: runnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+			calls.Add(1)
+			if name != "/usr/bin/opencode" {
+				t.Fatalf("binary = %q, want resolved path", name)
+			}
+			if !reflect.DeepEqual(args, []string{"models"}) {
+				t.Fatalf("args = %#v", args)
+			}
+			return readTestdata(t, "opencode_models.txt"), nil
+		}),
+		LookPath: func(s string) (string, error) {
+			if s == "opencode" {
+				return "/usr/bin/opencode", nil
+			}
+			return "", errors.New("not found")
+		},
+		Now: func() time.Time { return now.Load().(time.Time) },
+	})
+
+	first, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorOpenCode})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if first.Sources.Probe != ProbeOK {
+		t.Fatalf("probe = %q, want ok", first.Sources.Probe)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d after first list", calls.Load())
+	}
+	// Static entries first; probe-only after.
+	if first.Models[0].Source != SourceMerged && first.Models[0].Source != SourceStatic {
+		t.Fatalf("first model source = %q", first.Models[0].Source)
+	}
+	// Bare probe id overlapping static must keep static label.
+	for _, m := range first.Models {
+		if m.ID == "anthropic/claude-sonnet-4-5" {
+			if m.Label != "Anthropic Claude Sonnet 4.5" {
+				t.Fatalf("overlapping bare probe overwrote static label: %#v", m)
+			}
+			if m.Source != SourceMerged {
+				t.Fatalf("source = %q, want merged", m.Source)
+			}
+		}
+	}
+	foundProbeOnly := false
+	for _, m := range first.Models {
+		if m.ID == "openai/gpt-4.1" && m.Source == SourceProbe {
+			foundProbeOnly = true
+		}
+	}
+	if !foundProbeOnly {
+		t.Fatalf("expected probe-only openai/gpt-4.1 in %#v", first.Models)
+	}
+
+	// Cache hit — no second probe.
+	second, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorOpenCode})
+	if err != nil {
+		t.Fatalf("List() cache error = %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d after cache hit, want 1", calls.Load())
+	}
+	if second.ProbedAt != first.ProbedAt {
+		t.Fatalf("cached probedAt changed: %q vs %q", second.ProbedAt, first.ProbedAt)
+	}
+
+	// refresh bypasses cache.
+	_, err = svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorOpenCode, Refresh: true})
+	if err != nil {
+		t.Fatalf("List(refresh) error = %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("calls = %d after refresh, want 2", calls.Load())
+	}
+
+	// TTL expiry.
+	now.Store(now.Load().(time.Time).Add(61 * time.Second))
+	_, err = svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorOpenCode})
+	if err != nil {
+		t.Fatalf("List() after TTL error = %v", err)
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("calls = %d after TTL, want 3", calls.Load())
+	}
+}
+
+func TestListCoalescesInflightSameKey(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	svc := NewService(Options{
+		Runner: runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+			n := calls.Add(1)
+			if n == 1 {
+				close(started)
+			}
+			<-release
+			return []byte("probe-only-model\n"), nil
+		}),
+		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	results := make(chan Result, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorOpenCode})
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- got
+		}()
+	}
+
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("probe did not start")
+	}
+	// Let waiters pile up on the in-flight call.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+	close(errs)
+	close(results)
+
+	for err := range errs {
+		t.Fatalf("List() error = %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("runner calls = %d, want 1 (coalesced)", calls.Load())
+	}
+	count := 0
+	for got := range results {
+		count++
+		if got.Sources.Probe != ProbeOK {
+			t.Fatalf("probe = %q, want ok", got.Sources.Probe)
+		}
+	}
+	if count != n {
+		t.Fatalf("results = %d, want %d", count, n)
+	}
+}
+
+func TestListUnknownVendor(t *testing.T) {
+	svc := NewService(Options{})
+	_, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendor("nope")})
+	if !errors.Is(err, ErrUnknownVendor) {
+		t.Fatalf("err = %v, want ErrUnknownVendor", err)
+	}
+}
+
+func TestListUsesParamsCommand(t *testing.T) {
+	var saw string
+	svc := NewService(Options{
+		Runner: runnerFunc(func(_ context.Context, name string, _ ...string) ([]byte, error) {
+			saw = name
+			return []byte("custom-model\n"), nil
+		}),
+		LookPath: func(s string) (string, error) { return s, nil },
+	})
+	_, err := svc.List(context.Background(), ListOptions{
+		Vendor: config.AgentVendorCodex,
+		Params: map[string]any{"command": "/opt/custom-codex"},
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if saw != "/opt/custom-codex" {
+		t.Fatalf("command = %q, want /opt/custom-codex", saw)
+	}
+}
+
+func TestListProbeOutputOverflowIsError(t *testing.T) {
+	// Fake runner simulates defaultRunner overflow failure.
+	svc := NewService(Options{
+		Runner: runnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+			return nil, fmt.Errorf("probe output exceeded %d bytes", maxProbeOutputBytes)
+		}),
+		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+	got, err := svc.List(context.Background(), ListOptions{Vendor: config.AgentVendorOpenCode})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if got.Sources.Probe != ProbeError {
+		t.Fatalf("probe = %q, want error", got.Sources.Probe)
+	}
+	if !strings.Contains(got.Sources.ProbeError, "exceeded") {
+		t.Fatalf("probeError = %q", got.Sources.ProbeError)
+	}
+	if len(got.Models) == 0 {
+		t.Fatal("expected static models on overflow")
+	}
+}
+
+func TestParseCodexWithoutVisibilityIncludesAll(t *testing.T) {
+	raw := []byte(`{"models":[{"id":"a","name":"A"},{"id":"b","name":"B"}]}`)
+	got, err := parseCodexModels(raw)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if !reflect.DeepEqual(modelIDs(got), []string{"a", "b"}) {
+		t.Fatalf("ids = %#v", modelIDs(got))
+	}
+}
+
+func TestDefaultRunnerTimeoutKillsProcessGroup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess group-kill test")
+	}
+	// Leader spawns a same-group descendant that ignores SIGTERM and holds the
+	// process group alive; timeout must still return via group Kill+drain.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := defaultRunner{}.Run(ctx, "bash", "-c", `
+trap '' TERM
+sleep 60 &
+sleep 60
+wait
+`)
+	elapsed := time.Since(start)
+	if elapsed > 4*time.Second {
+		t.Fatalf("Run hung for %v; expected process-group kill to bound return", elapsed)
+	}
+	if err == nil {
+		t.Fatal("expected timeout/cancel error")
+	}
+}
+
+func TestDefaultRunnerBoundsHugeOutput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess output-bound test")
+	}
+	// Emit more than maxProbeOutputBytes on stdout; runner must fail (not OOM)
+	// and return promptly while still draining the writer.
+	script := fmt.Sprintf(`python3 -c 'import sys; sys.stdout.write("x"*%d)'`, maxProbeOutputBytes+64*1024)
+	if _, lookErr := exec.LookPath("python3"); lookErr != nil {
+		// Fallback without python.
+		script = fmt.Sprintf(`dd if=/dev/zero bs=1024 count=%d 2>/dev/null | tr '\0' 'x'`, (maxProbeOutputBytes/1024)+64)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := defaultRunner{}.Run(ctx, "bash", "-c", script)
+	if err == nil {
+		t.Fatal("expected overflow error")
+	}
+	if !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("err = %v, want exceeded", err)
+	}
+}
+
+func TestBoundedBufferDiscardsAfterCap(t *testing.T) {
+	b := newBoundedBuffer(8)
+	n, err := b.Write([]byte("hello world!!!"))
+	if err != nil {
+		t.Fatalf("Write error = %v", err)
+	}
+	if n != 14 {
+		t.Fatalf("Write n = %d, want 14 (full accept)", n)
+	}
+	if !b.Truncated() {
+		t.Fatal("expected truncated")
+	}
+	if got := b.String(); got != "hello wo" {
+		t.Fatalf("retained = %q, want %q", got, "hello wo")
+	}
+	// Further writes still succeed (drain) without growing.
+	n, err = b.Write([]byte("more"))
+	if err != nil || n != 4 {
+		t.Fatalf("second Write n=%d err=%v", n, err)
+	}
+	if len(b.Bytes()) != 8 {
+		t.Fatalf("len after discard = %d", len(b.Bytes()))
+	}
+}
+
+type runnerFunc func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+func (f runnerFunc) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return f(ctx, name, args...)
+}
+
+func readTestdata(t *testing.T, name string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read testdata/%s: %v", name, err)
+	}
+	return raw
+}
+
+func modelIDs(models []Model) []string {
+	out := make([]string, len(models))
+	for i, m := range models {
+		out[i] = m.ID
+	}
+	return out
+}

--- a/internal/agent/modelcatalog/errors.go
+++ b/internal/agent/modelcatalog/errors.go
@@ -1,0 +1,6 @@
+package modelcatalog
+
+import "errors"
+
+// ErrUnknownVendor is returned when List is called with a non-enum vendor.
+var ErrUnknownVendor = errors.New("unknown agent vendor")

--- a/internal/agent/modelcatalog/merge.go
+++ b/internal/agent/modelcatalog/merge.go
@@ -1,0 +1,78 @@
+package modelcatalog
+
+import "sort"
+
+// mergeModels unions static then probe by id.
+// Probe label wins on conflict only when the probe entry has a non-empty label;
+// bare probe ids keep the static label when one exists.
+// Ordering: static recommendations first (stable input order), then probe-only
+// ids sorted alphabetically. Empty labels default to id for API consumers.
+func mergeModels(staticModels, probeModels []Model) []Model {
+	byID := make(map[string]Model, len(staticModels)+len(probeModels))
+	staticOrder := make([]string, 0, len(staticModels))
+	fromStatic := make(map[string]struct{}, len(staticModels))
+
+	for _, m := range staticModels {
+		id := m.ID
+		if id == "" {
+			continue
+		}
+		if _, ok := fromStatic[id]; ok {
+			continue
+		}
+		fromStatic[id] = struct{}{}
+		staticOrder = append(staticOrder, id)
+		cp := m
+		if cp.Source == "" {
+			cp.Source = SourceStatic
+		}
+		if cp.Label == "" {
+			cp.Label = id
+		}
+		byID[id] = cp
+	}
+
+	probeOnly := make([]string, 0)
+	seenProbe := make(map[string]struct{})
+	for _, m := range probeModels {
+		id := m.ID
+		if id == "" {
+			continue
+		}
+		if _, ok := seenProbe[id]; ok {
+			// Keep first probe occurrence.
+			continue
+		}
+		seenProbe[id] = struct{}{}
+		probeLabel := m.Label // empty means "no label from probe"
+		if _, ok := fromStatic[id]; ok {
+			existing := byID[id]
+			if probeLabel != "" {
+				existing.Label = probeLabel
+			}
+			existing.Source = SourceMerged
+			if existing.Label == "" {
+				existing.Label = id
+			}
+			byID[id] = existing
+			continue
+		}
+		label := probeLabel
+		if label == "" {
+			label = id
+		}
+		probeOnly = append(probeOnly, id)
+		byID[id] = Model{ID: id, Label: label, Source: SourceProbe}
+	}
+
+	sort.Strings(probeOnly)
+
+	out := make([]Model, 0, len(staticOrder)+len(probeOnly))
+	for _, id := range staticOrder {
+		out = append(out, byID[id])
+	}
+	for _, id := range probeOnly {
+		out = append(out, byID[id])
+	}
+	return out
+}

--- a/internal/agent/modelcatalog/parse.go
+++ b/internal/agent/modelcatalog/parse.go
@@ -1,0 +1,211 @@
+package modelcatalog
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func parseOpenCodeModels(stdout []byte) []Model {
+	// OpenCode prints one bare id per line (provider/model). Reject multiword
+	// diagnostic lines such as "Not logged in".
+	return parseStrictIDLines(stdout)
+}
+
+func parseCursorModels(stdout []byte) []Model {
+	return parseTableOrIDLines(stdout)
+}
+
+func parseGrokModels(stdout []byte) []Model {
+	return parseTableOrIDLines(stdout)
+}
+
+// parseLineModels is the shared text parser used by cursor/grok-style output.
+// Kept as an alias for tests and call sites that want the table-tolerant path.
+func parseLineModels(stdout []byte) []Model {
+	return parseTableOrIDLines(stdout)
+}
+
+// parseStrictIDLines accepts only a single model-id token per non-empty line.
+func parseStrictIDLines(stdout []byte) []Model {
+	lines := strings.Split(string(stdout), "\n")
+	out := make([]Model, 0, len(lines))
+	seen := make(map[string]struct{})
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || shouldSkipDecorLine(line) {
+			continue
+		}
+		// Multiword lines are diagnostics/warnings, not model ids.
+		if strings.ContainsAny(line, " \t") {
+			continue
+		}
+		id := strings.TrimRight(line, ",;:")
+		if id == "" || !looksLikeModelID(id) {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		// Leave Label empty when probe has no separate label so merge can keep
+		// a better static label (probe label wins only when present).
+		out = append(out, Model{ID: id, Source: SourceProbe})
+	}
+	return out
+}
+
+// parseTableOrIDLines accepts bare ids or recognized table rows:
+// "id - label", "id — label", "id\tlabel". Multiword lines without those
+// separators (e.g. "Not logged in") are rejected.
+func parseTableOrIDLines(stdout []byte) []Model {
+	lines := strings.Split(string(stdout), "\n")
+	out := make([]Model, 0, len(lines))
+	seen := make(map[string]struct{})
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || shouldSkipDecorLine(line) {
+			continue
+		}
+		id, label, ok := parseModelLine(line)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, Model{ID: id, Label: label, Source: SourceProbe})
+	}
+	return out
+}
+
+func shouldSkipDecorLine(line string) bool {
+	lower := strings.ToLower(line)
+	if strings.HasPrefix(line, "#") || strings.HasPrefix(line, "─") || strings.HasPrefix(line, "━") {
+		return true
+	}
+	if lower == "models" || lower == "model" || strings.HasPrefix(lower, "available model") {
+		return true
+	}
+	return false
+}
+
+func parseModelLine(line string) (id, label string, ok bool) {
+	// Prefer explicit table separators over whitespace splitting so diagnostic
+	// sentences are not partially accepted as model ids.
+	for _, sep := range []string{" - ", " — ", "\t"} {
+		if i := strings.Index(line, sep); i > 0 {
+			id = strings.TrimSpace(line[:i])
+			label = strings.TrimSpace(line[i+len(sep):])
+			id = strings.TrimRight(id, ",;:")
+			if id == "" || !looksLikeModelID(id) {
+				return "", "", false
+			}
+			return id, label, true
+		}
+	}
+	fields := strings.Fields(line)
+	if len(fields) != 1 {
+		// Multiword without recognized separator → diagnostic, not a model.
+		return "", "", false
+	}
+	id = strings.TrimRight(fields[0], ",;:")
+	if id == "" || !looksLikeModelID(id) {
+		return "", "", false
+	}
+	// Bare id: no separate label from probe.
+	return id, "", true
+}
+
+func looksLikeModelID(id string) bool {
+	if id == "" {
+		return false
+	}
+	// Reject pure decoration / table borders.
+	if strings.Trim(id, "-─━=|*+") == "" {
+		return false
+	}
+	// Must start with alphanumeric.
+	r := id[0]
+	if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+		return true
+	}
+	return false
+}
+
+type codexModelsPayload struct {
+	Models []codexModelEntry `json:"models"`
+}
+
+type codexModelEntry struct {
+	ID         string `json:"id"`
+	Slug       string `json:"slug"`
+	Name       string `json:"name"`
+	Model      string `json:"model"`
+	Visibility string `json:"visibility"`
+	// Some builds nest identity differently.
+	Label string `json:"label"`
+}
+
+func parseCodexModels(stdout []byte) ([]Model, error) {
+	trimmed := bytesTrimSpace(stdout)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	var payload codexModelsPayload
+	if err := json.Unmarshal(trimmed, &payload); err != nil {
+		// Some builds may print a bare array.
+		var arr []codexModelEntry
+		if err2 := json.Unmarshal(trimmed, &arr); err2 != nil {
+			return nil, err
+		}
+		payload.Models = arr
+	}
+
+	hasVisibility := false
+	for _, e := range payload.Models {
+		if strings.TrimSpace(e.Visibility) != "" {
+			hasVisibility = true
+			break
+		}
+	}
+
+	out := make([]Model, 0, len(payload.Models))
+	seen := make(map[string]struct{})
+	for _, e := range payload.Models {
+		if hasVisibility {
+			vis := strings.ToLower(strings.TrimSpace(e.Visibility))
+			// Prefer visibility=list when the field exists; still include
+			// experimental entries that are list-visible.
+			if vis != "" && vis != "list" {
+				continue
+			}
+		}
+		id := firstNonEmpty(e.ID, e.Slug, e.Model)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		// Do not fall back to id: empty means "no label from probe" so merge
+		// can preserve a better static label.
+		label := firstNonEmpty(e.Label, e.Name)
+		out = append(out, Model{ID: id, Label: label, Source: SourceProbe})
+	}
+	return out, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if s := strings.TrimSpace(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func bytesTrimSpace(b []byte) []byte {
+	return []byte(strings.TrimSpace(string(b)))
+}

--- a/internal/agent/modelcatalog/probe.go
+++ b/internal/agent/modelcatalog/probe.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -301,11 +302,16 @@ func (s *Service) probe(ctx context.Context, vendor config.AgentVendor, binary s
 	}
 }
 
-func shortProbeError(err error) string {
+// shortProbeError turns a probe failure into a short, client-safe hint for
+// sources.probeError. Configured agent.env values are write-only in the config
+// API (envKeys only); redact them here so CLI stderr that echoes credentials
+// cannot leak those values into cached API responses.
+func shortProbeError(err error, agentEnv map[string]string) string {
 	if err == nil {
 		return ""
 	}
 	msg := strings.TrimSpace(err.Error())
+	msg = redactConfiguredEnvValues(msg, agentEnv)
 	// Collapse multi-line noise; keep a short operator-facing hint.
 	if i := strings.IndexByte(msg, '\n'); i >= 0 {
 		msg = msg[:i]
@@ -316,6 +322,36 @@ func shortProbeError(err error) string {
 	}
 	if msg == "" {
 		return "probe failed"
+	}
+	return msg
+}
+
+// redactConfiguredEnvValues replaces every non-empty agent.env value that
+// appears in msg with [REDACTED]. Longer values are applied first so a secret
+// that is a substring of another is fully covered. Empty values are skipped.
+func redactConfiguredEnvValues(msg string, agentEnv map[string]string) string {
+	if msg == "" || len(agentEnv) == 0 {
+		return msg
+	}
+	vals := make([]string, 0, len(agentEnv))
+	seen := make(map[string]struct{}, len(agentEnv))
+	for _, v := range agentEnv {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		vals = append(vals, v)
+	}
+	sort.Slice(vals, func(i, j int) bool {
+		return len(vals[i]) > len(vals[j])
+	})
+	for _, v := range vals {
+		if strings.Contains(msg, v) {
+			msg = strings.ReplaceAll(msg, v, "[REDACTED]")
+		}
 	}
 	return msg
 }

--- a/internal/agent/modelcatalog/probe.go
+++ b/internal/agent/modelcatalog/probe.go
@@ -56,18 +56,17 @@ func (r defaultRunner) Run(ctx context.Context, env []string, name string, args 
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
-	handle, err := processcontainment.Start(cmd, processcontainment.Options{
+	// BeginTrack before Start so BeginShutdown cannot snapshot an empty handle
+	// set while Start→Track is in flight (admission-closed refuse kills in Track).
+	handle, release, err := processcontainment.StartTracked(r.tracker, cmd, processcontainment.Options{
 		GracePeriod:  probeGracePeriod,
 		DrainTimeout: probeGracePeriod + probeCleanupSlack,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("start probe: %w", err)
 	}
-	if r.tracker != nil {
-		release := r.tracker.Track(handle)
-		if release != nil {
-			defer release()
-		}
+	if release != nil {
+		defer release()
 	}
 
 	waitDone := make(chan error, 1)

--- a/internal/agent/modelcatalog/probe.go
+++ b/internal/agent/modelcatalog/probe.go
@@ -1,0 +1,284 @@
+package modelcatalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/processcontainment"
+)
+
+const (
+	// maxProbeOutputBytes caps retained stdout and stderr independently.
+	// Writers keep draining after the cap (discard excess) so pipe-full cannot
+	// stall the child; overflow is treated as probe failure.
+	maxProbeOutputBytes = 2 << 20 // 2 MiB per stream
+
+	probeGracePeriod  = 500 * time.Millisecond
+	probeCleanupSlack = 2 * time.Second
+)
+
+// Runner executes a short-lived CLI probe. Tests inject fakes; production uses
+// defaultRunner (exec with timeout + process group kill).
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) (stdout []byte, err error)
+}
+
+type defaultRunner struct{}
+
+func (defaultRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command(name, args...)
+	stdout := newBoundedBuffer(maxProbeOutputBytes)
+	stderr := newBoundedBuffer(maxProbeOutputBytes)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	handle, err := processcontainment.Start(cmd, processcontainment.Options{
+		GracePeriod:  probeGracePeriod,
+		DrainTimeout: probeGracePeriod + probeCleanupSlack,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start probe: %w", err)
+	}
+
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- handle.Wait(ctx) }()
+
+	waitErr, killErr, drainErr := awaitProbeCommand(handle, ctx, waitDone)
+
+	if stdout.Truncated() || stderr.Truncated() {
+		return nil, fmt.Errorf("probe output exceeded %d bytes", maxProbeOutputBytes)
+	}
+
+	out := stdout.Bytes()
+	if waitErr != nil && isContextError(waitErr) {
+		msg := "probe timed out"
+		if errors.Is(waitErr, context.Canceled) {
+			msg = "probe canceled"
+		}
+		if killErr != nil {
+			return out, errors.Join(fmt.Errorf("%s", msg), killErr)
+		}
+		return out, fmt.Errorf("%s", msg)
+	}
+	if waitErr != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = waitErr.Error()
+		}
+		if drainErr != nil {
+			return out, errors.Join(fmt.Errorf("%s", msg), drainErr)
+		}
+		return out, fmt.Errorf("%s", msg)
+	}
+	if drainErr != nil {
+		return out, drainErr
+	}
+	if killErr != nil {
+		return out, killErr
+	}
+	return out, nil
+}
+
+// awaitProbeCommand finishes a contained probe without hanging on cmd.Wait's
+// pipe-copy phase. On cancel/timeout: Kill the process group with an independent
+// cleanup context. After normal leader exit: Drain descendants. When the leader
+// is reaped but Wait is stuck on a pipe-holding descendant, Drain unblocks it.
+func awaitProbeCommand(
+	handle *processcontainment.Handle,
+	ctx context.Context,
+	waitDone <-chan error,
+) (waitErr error, killErr error, drainErr error) {
+	cleanupTimeout := probeGracePeriod + probeCleanupSlack
+	poll := time.NewTicker(10 * time.Millisecond)
+	defer poll.Stop()
+
+	var alreadyDrained bool
+	for {
+		select {
+		case waitErr = <-waitDone:
+			if waitErr != nil && isContextError(waitErr) {
+				killCtx, killCancel := context.WithTimeout(context.Background(), cleanupTimeout)
+				killErr = handle.Kill(killCtx)
+				killCancel()
+				return waitErr, killErr, nil
+			}
+			if !alreadyDrained {
+				drainCtx, drainCancel := context.WithTimeout(context.Background(), cleanupTimeout)
+				drainErr = handle.Drain(drainCtx)
+				drainCancel()
+			}
+			return waitErr, nil, drainErr
+
+		case <-poll.C:
+			if alreadyDrained || !processPIDGone(handle.PID()) {
+				continue
+			}
+			// Leader reaped but pipe copy still blocks Wait — Drain kills
+			// pipe-holding descendants so Wait can finish.
+			drainCtx, drainCancel := context.WithTimeout(context.Background(), cleanupTimeout)
+			drainErr = handle.Drain(drainCtx)
+			drainCancel()
+			alreadyDrained = true
+			select {
+			case waitErr = <-waitDone:
+				return waitErr, nil, drainErr
+			case <-time.After(cleanupTimeout):
+				if waitErr == nil {
+					if drainErr != nil {
+						waitErr = drainErr
+					} else {
+						waitErr = fmt.Errorf("probe wait did not complete after drain")
+					}
+				}
+				return waitErr, nil, drainErr
+			}
+		}
+	}
+}
+
+func processPIDGone(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return errors.Is(err, syscall.ESRCH)
+}
+
+func isContextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// boundedBuffer retains up to limit bytes then discards the rest while still
+// accepting Writes (so the child is not blocked on a full pipe).
+type boundedBuffer struct {
+	mu        sync.Mutex
+	data      []byte
+	limit     int
+	truncated bool
+}
+
+func newBoundedBuffer(limit int) *boundedBuffer {
+	if limit <= 0 {
+		limit = maxProbeOutputBytes
+	}
+	return &boundedBuffer{limit: limit}
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	originalLen := len(p)
+	if len(b.data) >= b.limit {
+		if originalLen > 0 {
+			b.truncated = true
+		}
+		return originalLen, nil
+	}
+	remaining := b.limit - len(b.data)
+	if len(p) > remaining {
+		b.truncated = true
+		p = p[:remaining]
+	}
+	b.data = append(b.data, p...)
+	return originalLen, nil
+}
+
+func (b *boundedBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.data) == 0 {
+		return nil
+	}
+	out := make([]byte, len(b.data))
+	copy(out, b.data)
+	return out
+}
+
+func (b *boundedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.data)
+}
+
+func (b *boundedBuffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.truncated
+}
+
+func execLookPath(file string) (string, error) {
+	return exec.LookPath(file)
+}
+
+func (s *Service) probe(ctx context.Context, vendor config.AgentVendor, binary string) ([]Model, error) {
+	timeout := s.timeout
+	if timeout <= 0 {
+		timeout = defaultProbeTimeout
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	switch vendor {
+	case config.AgentVendorOpenCode:
+		out, err := s.runner.Run(runCtx, binary, "models")
+		if err != nil {
+			return nil, err
+		}
+		return parseOpenCodeModels(out), nil
+	case config.AgentVendorCodex:
+		out, err := s.runner.Run(runCtx, binary, "debug", "models", "--bundled")
+		if err != nil {
+			return nil, err
+		}
+		return parseCodexModels(out)
+	case config.AgentVendorCursorCLI:
+		out, err := s.runner.Run(runCtx, binary, "models")
+		if err != nil {
+			// Fallback flag used by some cursor-agent builds.
+			out2, err2 := s.runner.Run(runCtx, binary, "--list-models")
+			if err2 != nil {
+				return nil, err
+			}
+			return parseCursorModels(out2), nil
+		}
+		return parseCursorModels(out), nil
+	case config.AgentVendorGrokBuild:
+		out, err := s.runner.Run(runCtx, binary, "models")
+		if err != nil {
+			return nil, err
+		}
+		return parseGrokModels(out), nil
+	default:
+		return nil, errors.New("probe unsupported")
+	}
+}
+
+func shortProbeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.TrimSpace(err.Error())
+	// Collapse multi-line noise; keep a short operator-facing hint.
+	if i := strings.IndexByte(msg, '\n'); i >= 0 {
+		msg = msg[:i]
+	}
+	const max = 240
+	if len(msg) > max {
+		msg = msg[:max] + "…"
+	}
+	if msg == "" {
+		return "probe failed"
+	}
+	return msg
+}

--- a/internal/agent/modelcatalog/probe.go
+++ b/internal/agent/modelcatalog/probe.go
@@ -44,6 +44,12 @@ func (r defaultRunner) Run(ctx context.Context, env []string, name string, args 
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	// Defense in depth: relative path commands need a worktree Dir (spawn sets
+	// cmd.Dir). Catalog List rejects these before probe; refuse here too so a
+	// direct Run cannot resolve them from looperd's CWD.
+	if isRelativePathCommand(name) {
+		return nil, fmt.Errorf("%s", relativeCommandProbeError)
+	}
 
 	cmd := exec.Command(name, args...)
 	// Always set Env so ambient daemon credentials cannot leak into vendor CLIs.

--- a/internal/agent/modelcatalog/probe.go
+++ b/internal/agent/modelcatalog/probe.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/processcontainment"
 )
@@ -25,19 +26,31 @@ const (
 )
 
 // Runner executes a short-lived CLI probe. Tests inject fakes; production uses
-// defaultRunner (exec with timeout + process group kill).
+// defaultRunner (exec with timeout + process group kill + sanitized env).
+// env is the full sanitized process environment (KEY=value entries), never nil
+// for production probes — use buildProbeEnv.
 type Runner interface {
-	Run(ctx context.Context, name string, args ...string) (stdout []byte, err error)
+	Run(ctx context.Context, env []string, name string, args ...string) (stdout []byte, err error)
 }
 
-type defaultRunner struct{}
+// defaultRunner spawns vendor CLIs under process containment with an allowlisted
+// environment matching agent spawn (not the daemon ambient environment).
+type defaultRunner struct {
+	tracker processcontainment.LiveTracker
+}
 
-func (defaultRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+func (r defaultRunner) Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
 	cmd := exec.Command(name, args...)
+	// Always set Env so ambient daemon credentials cannot leak into vendor CLIs.
+	// Empty env still means "explicit empty" rather than inherit (exec default).
+	if env == nil {
+		env = buildProbeEnv(nil)
+	}
+	cmd.Env = env
 	stdout := newBoundedBuffer(maxProbeOutputBytes)
 	stderr := newBoundedBuffer(maxProbeOutputBytes)
 	cmd.Stdout = stdout
@@ -50,11 +63,18 @@ func (defaultRunner) Run(ctx context.Context, name string, args ...string) ([]by
 	if err != nil {
 		return nil, fmt.Errorf("start probe: %w", err)
 	}
+	if r.tracker != nil {
+		release := r.tracker.Track(handle)
+		if release != nil {
+			defer release()
+		}
+	}
 
 	waitDone := make(chan error, 1)
 	go func() { waitDone <- handle.Wait(ctx) }()
 
 	waitErr, killErr, drainErr := awaitProbeCommand(handle, ctx, waitDone)
+	reportProbeContainmentFailure(r.tracker, killErr, drainErr)
 
 	if stdout.Truncated() || stderr.Truncated() {
 		return nil, fmt.Errorf("probe output exceeded %d bytes", maxProbeOutputBytes)
@@ -88,6 +108,24 @@ func (defaultRunner) Run(ctx context.Context, name string, args ...string) ([]by
 		return out, killErr
 	}
 	return out, nil
+}
+
+func reportProbeContainmentFailure(tracker processcontainment.LiveTracker, errs ...error) {
+	if tracker == nil {
+		return
+	}
+	for _, err := range errs {
+		if err != nil {
+			tracker.ReportDrainFailure(err)
+		}
+	}
+}
+
+// buildProbeEnv builds the sanitized environment for a model catalog probe,
+// matching agent spawn allowlisting (BuildCommandEnv) and merging configured
+// agent.env. Working directory and prompt are empty: probes are not agents.
+func buildProbeEnv(agentEnv map[string]string) []string {
+	return agent.BuildCommandEnv("", "", agentEnv)
 }
 
 // awaitProbeCommand finishes a contained probe without hanging on cmd.Wait's
@@ -221,7 +259,7 @@ func execLookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
 
-func (s *Service) probe(ctx context.Context, vendor config.AgentVendor, binary string) ([]Model, error) {
+func (s *Service) probe(ctx context.Context, vendor config.AgentVendor, binary string, env []string) ([]Model, error) {
 	timeout := s.timeout
 	if timeout <= 0 {
 		timeout = defaultProbeTimeout
@@ -231,22 +269,22 @@ func (s *Service) probe(ctx context.Context, vendor config.AgentVendor, binary s
 
 	switch vendor {
 	case config.AgentVendorOpenCode:
-		out, err := s.runner.Run(runCtx, binary, "models")
+		out, err := s.runner.Run(runCtx, env, binary, "models")
 		if err != nil {
 			return nil, err
 		}
 		return parseOpenCodeModels(out), nil
 	case config.AgentVendorCodex:
-		out, err := s.runner.Run(runCtx, binary, "debug", "models", "--bundled")
+		out, err := s.runner.Run(runCtx, env, binary, "debug", "models", "--bundled")
 		if err != nil {
 			return nil, err
 		}
 		return parseCodexModels(out)
 	case config.AgentVendorCursorCLI:
-		out, err := s.runner.Run(runCtx, binary, "models")
+		out, err := s.runner.Run(runCtx, env, binary, "models")
 		if err != nil {
 			// Fallback flag used by some cursor-agent builds.
-			out2, err2 := s.runner.Run(runCtx, binary, "--list-models")
+			out2, err2 := s.runner.Run(runCtx, env, binary, "--list-models")
 			if err2 != nil {
 				return nil, err
 			}
@@ -254,7 +292,7 @@ func (s *Service) probe(ctx context.Context, vendor config.AgentVendor, binary s
 		}
 		return parseCursorModels(out), nil
 	case config.AgentVendorGrokBuild:
-		out, err := s.runner.Run(runCtx, binary, "models")
+		out, err := s.runner.Run(runCtx, env, binary, "models")
 		if err != nil {
 			return nil, err
 		}

--- a/internal/agent/modelcatalog/static.go
+++ b/internal/agent/modelcatalog/static.go
@@ -1,0 +1,39 @@
+package modelcatalog
+
+import (
+	_ "embed"
+	"encoding/json"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+//go:embed static_catalog.json
+var staticCatalogJSON []byte
+
+type staticEntry struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+func loadStaticCatalog() map[config.AgentVendor][]Model {
+	var raw map[string][]staticEntry
+	if err := json.Unmarshal(staticCatalogJSON, &raw); err != nil {
+		panic("modelcatalog: invalid static_catalog.json: " + err.Error())
+	}
+	out := make(map[config.AgentVendor][]Model, len(raw))
+	for vendor, entries := range raw {
+		models := make([]Model, 0, len(entries))
+		for _, e := range entries {
+			if e.ID == "" {
+				continue
+			}
+			label := e.Label
+			if label == "" {
+				label = e.ID
+			}
+			models = append(models, Model{ID: e.ID, Label: label, Source: SourceStatic})
+		}
+		out[config.AgentVendor(vendor)] = models
+	}
+	return out
+}

--- a/internal/agent/modelcatalog/static_catalog.json
+++ b/internal/agent/modelcatalog/static_catalog.json
@@ -1,0 +1,34 @@
+{
+  "claude-code": [
+    { "id": "sonnet", "label": "Sonnet" },
+    { "id": "opus", "label": "Opus" },
+    { "id": "haiku", "label": "Haiku" },
+    { "id": "claude-sonnet-4-5", "label": "Claude Sonnet 4.5" },
+    { "id": "claude-opus-4-5", "label": "Claude Opus 4.5" },
+    { "id": "claude-haiku-4-5", "label": "Claude Haiku 4.5" }
+  ],
+  "codex": [
+    { "id": "gpt-5.4", "label": "GPT-5.4" },
+    { "id": "gpt-5.3-codex", "label": "GPT-5.3 Codex" },
+    { "id": "gpt-5.2", "label": "GPT-5.2" },
+    { "id": "o3", "label": "o3" },
+    { "id": "o4-mini", "label": "o4-mini" }
+  ],
+  "opencode": [
+    { "id": "anthropic/claude-sonnet-4-5", "label": "Anthropic Claude Sonnet 4.5" },
+    { "id": "anthropic/claude-opus-4-5", "label": "Anthropic Claude Opus 4.5" },
+    { "id": "openai/gpt-5.4", "label": "OpenAI GPT-5.4" },
+    { "id": "google/gemini-2.5-pro", "label": "Google Gemini 2.5 Pro" }
+  ],
+  "cursor-cli": [
+    { "id": "auto", "label": "Auto" },
+    { "id": "sonnet-4", "label": "Sonnet 4" },
+    { "id": "gpt-5", "label": "GPT-5" },
+    { "id": "composer-1", "label": "Composer 1" }
+  ],
+  "grok-build": [
+    { "id": "grok-4", "label": "Grok 4" },
+    { "id": "grok-3", "label": "Grok 3" },
+    { "id": "grok-code-fast-1", "label": "Grok Code Fast 1" }
+  ]
+}

--- a/internal/agent/modelcatalog/testdata/codex_models.json
+++ b/internal/agent/modelcatalog/testdata/codex_models.json
@@ -1,0 +1,24 @@
+{
+  "models": [
+    {
+      "id": "gpt-5.4",
+      "name": "GPT-5.4",
+      "visibility": "list"
+    },
+    {
+      "id": "gpt-5.3-codex",
+      "name": "GPT-5.3 Codex",
+      "visibility": "list"
+    },
+    {
+      "id": "experimental-hidden",
+      "name": "Hidden Experimental",
+      "visibility": "hidden"
+    },
+    {
+      "slug": "o3",
+      "name": "o3",
+      "visibility": "list"
+    }
+  ]
+}

--- a/internal/agent/modelcatalog/testdata/cursor_models.txt
+++ b/internal/agent/modelcatalog/testdata/cursor_models.txt
@@ -1,0 +1,5 @@
+Available models
+auto - Auto
+sonnet-4 - Sonnet 4
+gpt-5	GPT-5
+composer-1

--- a/internal/agent/modelcatalog/testdata/grok_models.txt
+++ b/internal/agent/modelcatalog/testdata/grok_models.txt
@@ -1,0 +1,3 @@
+grok-4
+grok-3
+grok-code-fast-1

--- a/internal/agent/modelcatalog/testdata/opencode_models.txt
+++ b/internal/agent/modelcatalog/testdata/opencode_models.txt
@@ -1,0 +1,5 @@
+anthropic/claude-sonnet-4-5
+anthropic/claude-opus-4-5
+openai/gpt-5.4
+openai/gpt-4.1
+google/gemini-2.5-pro

--- a/internal/api/agent_models_test.go
+++ b/internal/api/agent_models_test.go
@@ -1,0 +1,278 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/agent/modelcatalog"
+	"github.com/nexu-io/looper/internal/config"
+	pkgapi "github.com/nexu-io/looper/pkg/api"
+)
+
+func TestHandlerAgentModelsMissingVendor(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/models", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	body := parseJSONMap(t, rec.Body.Bytes())
+	assertEqual(t, body["ok"], false)
+	errObj := body["error"].(map[string]any)
+	assertEqual(t, errObj["code"], string(pkgapi.ErrorCodeValidationFailed))
+}
+
+func TestHandlerAgentModelsUnknownVendor(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/models?vendor=not-a-vendor", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	body := parseJSONMap(t, rec.Body.Bytes())
+	errObj := body["error"].(map[string]any)
+	assertEqual(t, errObj["code"], string(pkgapi.ErrorCodeValidationFailed))
+}
+
+func TestHandlerAgentModelsClaudeCodeStaticUnsupported(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
+		Runner: modelCatalogRunnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+			t.Fatal("claude-code must not probe")
+			return nil, nil
+		}),
+		LookPath: func(s string) (string, error) { return "/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/models?vendor=claude-code", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	data := parseJSONMap(t, rec.Body.Bytes())["data"].(map[string]any)
+	assertEqual(t, data["vendor"], "claude-code")
+	sources := data["sources"].(map[string]any)
+	assertEqual(t, sources["static"], true)
+	assertEqual(t, sources["probe"], "unsupported")
+	models := data["models"].([]any)
+	if len(models) == 0 {
+		t.Fatal("expected static models")
+	}
+	ids := map[string]bool{}
+	for _, raw := range models {
+		m := raw.(map[string]any)
+		ids[m["id"].(string)] = true
+		assertEqual(t, m["source"], "static")
+	}
+	for _, want := range []string{"sonnet", "opus", "haiku"} {
+		if !ids[want] {
+			t.Fatalf("missing static alias %q in %#v", want, ids)
+		}
+	}
+}
+
+func TestHandlerAgentModelsProbeFailureStill200(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
+		Runner: modelCatalogRunnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+			return nil, errors.New("codex: command failed")
+		}),
+		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/models?vendor=codex", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	data := parseJSONMap(t, rec.Body.Bytes())["data"].(map[string]any)
+	sources := data["sources"].(map[string]any)
+	assertEqual(t, sources["static"], true)
+	assertEqual(t, sources["probe"], "error")
+	if sources["probeError"] == nil || sources["probeError"] == "" {
+		t.Fatalf("expected probeError, got %#v", sources)
+	}
+	models := data["models"].([]any)
+	if len(models) == 0 {
+		t.Fatal("expected static models on probe error")
+	}
+	assertEqual(t, data["probedAt"], "2026-08-01T12:00:00Z")
+}
+
+func TestHandlerAgentModelsProbeOK(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
+		Runner: modelCatalogRunnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if name != "/usr/bin/opencode" {
+				t.Fatalf("name = %q", name)
+			}
+			if len(args) != 1 || args[0] != "models" {
+				t.Fatalf("args = %#v", args)
+			}
+			return []byte("openai/gpt-4.1\nanthropic/claude-sonnet-4-5\n"), nil
+		}),
+		LookPath: func(s string) (string, error) {
+			if s == "opencode" {
+				return "/usr/bin/opencode", nil
+			}
+			return s, nil
+		},
+		Now: func() time.Time { return time.Date(2026, 8, 1, 15, 0, 0, 0, time.UTC) },
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/models?vendor=opencode", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	data := parseJSONMap(t, rec.Body.Bytes())["data"].(map[string]any)
+	sources := data["sources"].(map[string]any)
+	assertEqual(t, sources["probe"], "ok")
+	assertEqual(t, data["probedAt"], "2026-08-01T15:00:00Z")
+
+	// Ensure response JSON shape matches envelope + payload fields.
+	var envelope struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Vendor string `json:"vendor"`
+			Models []struct {
+				ID     string `json:"id"`
+				Label  string `json:"label"`
+				Source string `json:"source"`
+			} `json:"models"`
+			Sources struct {
+				Static bool   `json:"static"`
+				Probe  string `json:"probe"`
+			} `json:"sources"`
+			ProbedAt string `json:"probedAt"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !envelope.OK || envelope.Data.Vendor != "opencode" || len(envelope.Data.Models) == 0 {
+		t.Fatalf("envelope = %#v", envelope)
+	}
+	foundProbeOnly := false
+	for _, m := range envelope.Data.Models {
+		if m.ID == "openai/gpt-4.1" && m.Source == "probe" {
+			foundProbeOnly = true
+		}
+	}
+	if !foundProbeOnly {
+		t.Fatalf("expected probe-only model in %#v", envelope.Data.Models)
+	}
+}
+
+func TestHandlerAgentModelsMethodNotAllowed(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agent/models?vendor=codex", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestHandlerAgentModelsSameVendorUsesParamsCommand(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	vendor := config.AgentVendorCodex
+	cfg.Agent.Vendor = &vendor
+	cfg.Agent.Params = map[string]any{"command": "/opt/custom-codex"}
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+
+	var saw string
+	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
+		Runner: modelCatalogRunnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+			saw = name
+			if len(args) < 1 || args[0] != "debug" {
+				t.Fatalf("args = %#v, want codex debug models", args)
+			}
+			return []byte(`{"models":[{"id":"gpt-5.4","name":"GPT-5.4","visibility":"list"}]}`), nil
+		}),
+		LookPath: func(s string) (string, error) { return s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/models?vendor=codex", nil)
+	rec := httptest.NewRecorder()
+	// serveHTTP (not ServeHTTP): avoid Runtime.Config() overwriting the mutated
+	// fixture agent.params used for spawn-equivalent command resolution.
+	h.serveHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if saw != "/opt/custom-codex" {
+		t.Fatalf("probed command = %q, want /opt/custom-codex (same-vendor wrapper kept)", saw)
+	}
+}
+
+func TestHandlerAgentModelsCrossVendorStripsParamsCommand(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	global := config.AgentVendorCodex
+	cfg.Agent.Vendor = &global
+	cfg.Agent.Params = map[string]any{"command": "/opt/custom-codex-wrapper"}
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+
+	var saw string
+	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
+		Runner: modelCatalogRunnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+			saw = name
+			if len(args) != 1 || args[0] != "models" {
+				t.Fatalf("args = %#v, want opencode models", args)
+			}
+			return []byte("openai/gpt-4.1\n"), nil
+		}),
+		LookPath: func(s string) (string, error) {
+			if s == "opencode" {
+				return "/usr/bin/opencode", nil
+			}
+			// If wrapper leaked through, LookPath would return it as-is below.
+			return s, nil
+		},
+		Now: func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/models?vendor=opencode", nil)
+	rec := httptest.NewRecorder()
+	h.serveHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if saw == "/opt/custom-codex-wrapper" {
+		t.Fatal("cross-vendor probe used global codex wrapper command")
+	}
+	if saw != "/usr/bin/opencode" {
+		t.Fatalf("probed command = %q, want /usr/bin/opencode (default after strip)", saw)
+	}
+}
+
+type modelCatalogRunnerFunc func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+func (f modelCatalogRunnerFunc) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return f(ctx, name, args...)
+}

--- a/internal/api/agent_models_test.go
+++ b/internal/api/agent_models_test.go
@@ -51,7 +51,7 @@ func TestHandlerAgentModelsClaudeCodeStaticUnsupported(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	h := NewHandler(Context{Config: cfg, Runtime: rt})
 	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
-		Runner: modelCatalogRunnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		Runner: modelCatalogRunnerFunc(func(context.Context, []string, string, ...string) ([]byte, error) {
 			t.Fatal("claude-code must not probe")
 			return nil, nil
 		}),
@@ -92,7 +92,7 @@ func TestHandlerAgentModelsProbeFailureStill200(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	h := NewHandler(Context{Config: cfg, Runtime: rt})
 	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
-		Runner: modelCatalogRunnerFunc(func(context.Context, string, ...string) ([]byte, error) {
+		Runner: modelCatalogRunnerFunc(func(context.Context, []string, string, ...string) ([]byte, error) {
 			return nil, errors.New("codex: command failed")
 		}),
 		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
@@ -124,7 +124,7 @@ func TestHandlerAgentModelsProbeOK(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	h := NewHandler(Context{Config: cfg, Runtime: rt})
 	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
-		Runner: modelCatalogRunnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		Runner: modelCatalogRunnerFunc(func(_ context.Context, _ []string, name string, args ...string) ([]byte, error) {
 			if name != "/usr/bin/opencode" {
 				t.Fatalf("name = %q", name)
 			}
@@ -207,7 +207,7 @@ func TestHandlerAgentModelsSameVendorUsesParamsCommand(t *testing.T) {
 
 	var saw string
 	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
-		Runner: modelCatalogRunnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		Runner: modelCatalogRunnerFunc(func(_ context.Context, _ []string, name string, args ...string) ([]byte, error) {
 			saw = name
 			if len(args) < 1 || args[0] != "debug" {
 				t.Fatalf("args = %#v, want codex debug models", args)
@@ -231,6 +231,56 @@ func TestHandlerAgentModelsSameVendorUsesParamsCommand(t *testing.T) {
 	}
 }
 
+func TestHandlerAgentModelsPassesAgentEnvToCatalog(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.Agent.Env = map[string]string{
+		"OPENCODE_API_KEY": "handler-agent-env-secret",
+		"GROK_API_KEY":     "also-present",
+	}
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+
+	var sawEnv []string
+	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
+		Runner: modelCatalogRunnerFunc(func(_ context.Context, env []string, name string, args ...string) ([]byte, error) {
+			sawEnv = append([]string(nil), env...)
+			return []byte("openai/gpt-4.1\n"), nil
+		}),
+		LookPath: func(s string) (string, error) {
+			if s == "opencode" {
+				return "/usr/bin/opencode", nil
+			}
+			return s, nil
+		},
+		Now: func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/models?vendor=opencode", nil)
+	rec := httptest.NewRecorder()
+	h.serveHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(sawEnv) == 0 {
+		t.Fatal("runner received empty env; want sanitized env with agent.env")
+	}
+	foundKey := false
+	foundGrok := false
+	for _, e := range sawEnv {
+		if e == "OPENCODE_API_KEY=handler-agent-env-secret" {
+			foundKey = true
+		}
+		if e == "GROK_API_KEY=also-present" {
+			foundGrok = true
+		}
+	}
+	if !foundKey {
+		t.Fatalf("OPENCODE_API_KEY from agent.env missing in probe env: %#v", sawEnv)
+	}
+	if !foundGrok {
+		t.Fatalf("GROK_API_KEY from agent.env missing in probe env: %#v", sawEnv)
+	}
+}
+
 func TestHandlerAgentModelsCrossVendorStripsParamsCommand(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	global := config.AgentVendorCodex
@@ -240,7 +290,7 @@ func TestHandlerAgentModelsCrossVendorStripsParamsCommand(t *testing.T) {
 
 	var saw string
 	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
-		Runner: modelCatalogRunnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		Runner: modelCatalogRunnerFunc(func(_ context.Context, _ []string, name string, args ...string) ([]byte, error) {
 			saw = name
 			if len(args) != 1 || args[0] != "models" {
 				t.Fatalf("args = %#v, want opencode models", args)
@@ -271,8 +321,8 @@ func TestHandlerAgentModelsCrossVendorStripsParamsCommand(t *testing.T) {
 	}
 }
 
-type modelCatalogRunnerFunc func(ctx context.Context, name string, args ...string) ([]byte, error)
+type modelCatalogRunnerFunc func(ctx context.Context, env []string, name string, args ...string) ([]byte, error)
 
-func (f modelCatalogRunnerFunc) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return f(ctx, name, args...)
+func (f modelCatalogRunnerFunc) Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
+	return f(ctx, env, name, args...)
 }

--- a/internal/api/agent_models_test.go
+++ b/internal/api/agent_models_test.go
@@ -198,6 +198,87 @@ func TestHandlerAgentModelsMethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestHandlerAgentModelsRefreshRejectedForCrossSite(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	var probes int
+	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
+		Runner: modelCatalogRunnerFunc(func(context.Context, []string, string, ...string) ([]byte, error) {
+			probes++
+			return []byte(`{"models":[{"id":"gpt-5.4","name":"GPT-5.4","visibility":"list"}]}`), nil
+		}),
+		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/models?vendor=codex&refresh=1", nil)
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	if probes != 0 {
+		t.Fatalf("probes = %d, want 0 for cross-site refresh", probes)
+	}
+	body := parseJSONMap(t, rec.Body.Bytes())
+	errObj := body["error"].(map[string]any)
+	assertEqual(t, errObj["code"], string(pkgapi.ErrorCodeUnauthorized))
+}
+
+func TestHandlerAgentModelsRefreshAllowedSameOriginAndCLI(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	var probes int
+	h.modelCatalog = modelcatalog.NewService(modelcatalog.Options{
+		Runner: modelCatalogRunnerFunc(func(context.Context, []string, string, ...string) ([]byte, error) {
+			probes++
+			return []byte(`{"models":[{"id":"gpt-5.4","name":"GPT-5.4","visibility":"list"}]}`), nil
+		}),
+		LookPath: func(s string) (string, error) { return "/usr/bin/" + s, nil },
+		Now:      func() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) },
+	})
+
+	// CLI / non-browser: no Sec-Fetch-Site.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/models?vendor=codex&refresh=1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("CLI refresh status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Same-origin dashboard fetch.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/agent/models?vendor=codex&refresh=1", nil)
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("same-origin refresh status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if probes != 2 {
+		t.Fatalf("probes = %d, want 2", probes)
+	}
+}
+
+func TestAllowForcedModelCatalogRefresh(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/models?refresh=1", nil)
+	if !allowForcedModelCatalogRefresh(req) {
+		t.Fatal("CLI without Sec-Fetch-Site must allow forced refresh")
+	}
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	if !allowForcedModelCatalogRefresh(req) {
+		t.Fatal("same-origin must allow forced refresh")
+	}
+	req.Header.Set("Sec-Fetch-Site", "none")
+	if !allowForcedModelCatalogRefresh(req) {
+		t.Fatal("Sec-Fetch-Site none must allow forced refresh")
+	}
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	if allowForcedModelCatalogRefresh(req) {
+		t.Fatal("cross-site must reject forced refresh")
+	}
+}
+
 func TestHandlerAgentModelsSameVendorUsesParamsCommand(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	vendor := config.AgentVendorCodex

--- a/internal/api/browser_guard.go
+++ b/internal/api/browser_guard.go
@@ -18,6 +18,19 @@ import (
 // binaries leave this false so a real Host: example.com is not rewritten.
 var rewriteHTTPtestDefaultHost bool
 
+// allowForcedModelCatalogRefresh reports whether GET .../agent/models?refresh=1
+// may bypass the probe cache and launch a vendor CLI. Cross-site browser
+// requests (Sec-Fetch-Site: cross-site), including originless no-CORS loads such
+// as <img>, must not force repeated probes under authMode=none loopback Host
+// acceptance. CLI and same-origin dashboard fetches are allowed.
+func allowForcedModelCatalogRefresh(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	site := strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")))
+	return site != "cross-site"
+}
+
 // validateBrowserRequest enforces Host allowlisting and Origin matching for
 // browser requests, including safe methods (GET/HEAD) that expose dashboard
 // state.

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/agent"
+	"github.com/nexu-io/looper/internal/agent/modelcatalog"
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/domain"
 	"github.com/nexu-io/looper/internal/eventlog"
@@ -161,6 +162,7 @@ type Handler struct {
 	recoverySummary  func() any
 	webhookForwarder webhookforward.Forwarder
 	bootstrap        *bootstrapCodes
+	modelCatalog     *modelcatalog.Service
 	// discardBeforeGitHook is test-only: invoked after discard preflight recheck
 	// and immediately before git reset/clean so tests can inject a requeue race
 	// that bypasses LockLoopRequeue (defense-in-depth for the pre-git recheck).
@@ -220,6 +222,7 @@ func NewHandler(context Context) *Handler {
 		recoverySummary:  recoverySummary,
 		webhookForwarder: forwarder,
 		bootstrap:        bootstrap,
+		modelCatalog:     modelcatalog.NewService(modelcatalog.Options{Now: now}),
 	}
 }
 
@@ -359,6 +362,9 @@ func (h *Handler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case apiBasePath + "/config":
 		h.handleConfigRoute(w, r, requestID)
+		return
+	case apiBasePath + "/agent/models":
+		h.handleAgentModelsRoute(w, r, requestID)
 		return
 	case apiBasePath + "/webhook/status":
 		if !assertMethod(r.Method, http.MethodGet, path, w, requestID, h.writeError) {
@@ -1117,6 +1123,65 @@ type statusTools struct {
 	Git       bool `json:"git"`
 	GH        bool `json:"gh"`
 	Osascript bool `json:"osascript"`
+}
+
+func (h *Handler) handleAgentModelsRoute(w http.ResponseWriter, r *http.Request, requestID string) {
+	if !assertMethod(r.Method, http.MethodGet, apiBasePath+"/agent/models", w, requestID, h.writeError) {
+		return
+	}
+	vendorRaw := strings.TrimSpace(r.URL.Query().Get("vendor"))
+	if vendorRaw == "" {
+		h.writeError(w, requestID, apiError{
+			code:    pkgapi.ErrorCodeValidationFailed,
+			status:  http.StatusBadRequest,
+			message: "vendor query parameter is required",
+		})
+		return
+	}
+	vendor := config.AgentVendor(vendorRaw)
+	switch vendor {
+	case config.AgentVendorClaudeCode, config.AgentVendorCodex, config.AgentVendorOpenCode,
+		config.AgentVendorCursorCLI, config.AgentVendorGrokBuild:
+	default:
+		h.writeError(w, requestID, apiError{
+			code:    pkgapi.ErrorCodeValidationFailed,
+			status:  http.StatusBadRequest,
+			message: "vendor must be one of: claude-code, codex, opencode, cursor-cli, grok-build",
+		})
+		return
+	}
+
+	refreshRaw := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("refresh")))
+	refresh := refreshRaw == "1" || refreshRaw == "true" || refreshRaw == "yes"
+
+	cfg := h.effectiveConfig()
+	// Spawn-equivalent params ownership: when global agent.vendor owns
+	// agent.params and the catalog vendor diverges, strip command/args so a
+	// Codex wrapper is never used to probe OpenCode (or vice versa).
+	params := agent.ParamsForRoleVendor(cfg.Agent.Params, cfg.Agent.Vendor, vendor, nil)
+
+	svc := h.modelCatalog
+	if svc == nil {
+		svc = modelcatalog.NewService(modelcatalog.Options{Now: h.now})
+	}
+	result, err := svc.List(r.Context(), modelcatalog.ListOptions{
+		Vendor:  vendor,
+		Params:  params,
+		Refresh: refresh,
+	})
+	if err != nil {
+		if errors.Is(err, modelcatalog.ErrUnknownVendor) {
+			h.writeError(w, requestID, apiError{
+				code:    pkgapi.ErrorCodeValidationFailed,
+				status:  http.StatusBadRequest,
+				message: "vendor must be one of: claude-code, codex, opencode, cursor-cli, grok-build",
+			})
+			return
+		}
+		h.writeError(w, requestID, internalServerError(err))
+		return
+	}
+	h.writeSuccess(w, requestID, result)
 }
 
 func (h *Handler) handleConfigRoute(w http.ResponseWriter, r *http.Request, requestID string) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/loops"
 	networkclient "github.com/nexu-io/looper/internal/network/client"
+	"github.com/nexu-io/looper/internal/processcontainment"
 	"github.com/nexu-io/looper/internal/projects"
 	"github.com/nexu-io/looper/internal/reviewer"
 	looperdruntime "github.com/nexu-io/looper/internal/runtime"
@@ -216,13 +217,32 @@ func NewHandler(context Context) *Handler {
 	bootstrap := newBootstrapCodes()
 	bootstrap.now = now
 
+	// Model catalog probes are Supervisor-owned non-agent work: track handles
+	// for shutdown drain and cancel shared probe lifetime on BeginShutdown
+	// (independent of popup/request AbortController cancel).
+	var tracker processcontainment.LiveTracker
+	if context.Runtime != nil {
+		if ae := context.Runtime.Services().ActiveExecutions; ae != nil {
+			tracker = ae
+		}
+	}
+	modelCatalog := modelcatalog.NewService(modelcatalog.Options{
+		Now:     now,
+		Tracker: tracker,
+	})
+	if register, ok := any(context.Runtime).(interface {
+		OnBeginShutdown(func())
+	}); ok {
+		register.OnBeginShutdown(modelCatalog.Shutdown)
+	}
+
 	return &Handler{
 		context:          context,
 		now:              now,
 		recoverySummary:  recoverySummary,
 		webhookForwarder: forwarder,
 		bootstrap:        bootstrap,
-		modelCatalog:     modelcatalog.NewService(modelcatalog.Options{Now: now}),
+		modelCatalog:     modelCatalog,
 	}
 }
 
@@ -1164,9 +1184,12 @@ func (h *Handler) handleAgentModelsRoute(w http.ResponseWriter, r *http.Request,
 	if svc == nil {
 		svc = modelcatalog.NewService(modelcatalog.Options{Now: h.now})
 	}
+	// Pass agent.env so vendor CLIs that authenticate via configured env
+	// (OpenCode/Grok API keys, etc.) probe with the same credentials as spawn.
 	result, err := svc.List(r.Context(), modelcatalog.ListOptions{
 		Vendor:  vendor,
 		Params:  params,
+		Env:     cfg.Agent.Env,
 		Refresh: refresh,
 	})
 	if err != nil {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1173,6 +1173,18 @@ func (h *Handler) handleAgentModelsRoute(w http.ResponseWriter, r *http.Request,
 
 	refreshRaw := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("refresh")))
 	refresh := refreshRaw == "1" || refreshRaw == "true" || refreshRaw == "yes"
+	// refresh=1 bypasses the probe cache and launches the vendor CLI. Under
+	// authMode=none, originless no-CORS GETs to loopback are Host-allowed; a
+	// cross-site page could therefore force repeated probes. Reject forced
+	// refresh when browser fetch metadata marks the request cross-site.
+	if refresh && !allowForcedModelCatalogRefresh(r) {
+		h.writeError(w, requestID, apiError{
+			code:    pkgapi.ErrorCodeUnauthorized,
+			status:  http.StatusForbidden,
+			message: "forced model catalog refresh is not allowed for cross-site requests",
+		})
+		return
+	}
 
 	cfg := h.effectiveConfig()
 	// Spawn-equivalent params ownership: when global agent.vendor owns

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -278,7 +278,22 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 	stderr := newTrustedReviewBoundedBuffer(maxTrustedReviewProxyOutputBytes)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	// BeginTrack before Start so BeginShutdown waits across Start→Bind→Track.
+	var endTrack func()
+	if tracker != nil {
+		end, trackErr := tracker.BeginTrack()
+		if trackErr != nil {
+			_ = configReader.Close()
+			_ = configWriter.Close()
+			_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: trackErr.Error()})
+			return
+		}
+		endTrack = end
+	}
 	if err := cmd.Start(); err != nil {
+		if endTrack != nil {
+			endTrack()
+		}
 		_ = configReader.Close()
 		_ = configWriter.Close()
 		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: err.Error()})
@@ -289,6 +304,9 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 		DrainTimeout: 20 * time.Second,
 	})
 	if bindErr != nil {
+		if endTrack != nil {
+			endTrack()
+		}
 		_ = configReader.Close()
 		_ = configWriter.Close()
 		// Bind failed after Start: force-kill the orphaned process group so it
@@ -299,6 +317,9 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 	}
 	if tracker != nil {
 		release := tracker.Track(handle)
+		if endTrack != nil {
+			endTrack()
+		}
 		if release != nil {
 			defer release()
 		}

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -299,19 +299,20 @@ func handleTrustedReviewProxyConn(ctx context.Context, conn net.Conn, realLooper
 		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: err.Error()})
 		return
 	}
-	handle, bindErr := processcontainment.Bind(cmd, processcontainment.Options{
+	handle, bindErr := bindTrustedReviewCmd(cmd, processcontainment.Options{
 		GracePeriod:  2 * time.Second,
 		DrainTimeout: 20 * time.Second,
 	})
 	if bindErr != nil {
+		_ = configReader.Close()
+		_ = configWriter.Close()
+		// Bind failed after Start: force-kill and reap the orphaned process
+		// group before endTrack so BeginShutdown cannot observe a closed
+		// reservation while emergency cleanup is still running.
+		killTrustedReviewStartedWithoutHandle(cmd)
 		if endTrack != nil {
 			endTrack()
 		}
-		_ = configReader.Close()
-		_ = configWriter.Close()
-		// Bind failed after Start: force-kill the orphaned process group so it
-		// does not outlive the proxy request (same emergency path as shell bind).
-		killTrustedReviewStartedWithoutHandle(cmd)
 		_ = json.NewEncoder(conn).Encode(trustedReviewProxyResponse{ExitCode: 1, Error: "bind trusted review containment handle: " + bindErr.Error()})
 		return
 	}
@@ -496,11 +497,21 @@ func mergeTrustedReviewTruncationError(existing string) string {
 	return existing + "; " + trustedReviewOutputTruncatedMsg
 }
 
+// bindTrustedReviewCmd attaches a containment Handle after cmd.Start. Tests may
+// override to force post-Start Bind failures without relying on rare getpgid
+// errors (same seam as processcontainment.startBind).
+var bindTrustedReviewCmd = processcontainment.Bind
+
+// afterTrustedReviewEmergencyKill is invoked after the Bind-failure emergency
+// kill/reap finishes (tests assert endTrack ordering against this hook).
+var afterTrustedReviewEmergencyKill = func(*exec.Cmd) {}
+
 // killTrustedReviewStartedWithoutHandle is only used when Bind fails after
 // Start so the orphaned process group is not left live. Production stop paths
 // use Handle.Kill. Mirrors shell.killStartedWithoutHandle: SIGKILL the group
 // first, then fall back to Process.Kill + Wait on the leader.
 func killTrustedReviewStartedWithoutHandle(cmd *exec.Cmd) {
+	defer afterTrustedReviewEmergencyKill(cmd)
 	if cmd == nil || cmd.Process == nil {
 		return
 	}

--- a/internal/forge/trusted_review_proxy_test.go
+++ b/internal/forge/trusted_review_proxy_test.go
@@ -2,13 +2,18 @@ package forge
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/processcontainment"
 )
 
 func TestValidateTrustedReviewProxyArgv(t *testing.T) {
@@ -537,3 +542,152 @@ func TestTrustedReviewProxyKeepsRunConfigWhenLiveFileChanges(t *testing.T) {
 		t.Fatalf("trusted child retained named config path %q; want descriptor-only snapshot", strings.TrimSpace(string(childConfigPath)))
 	}
 }
+
+// Contract (PR #630 review): on Bind failure after Start, emergency kill/reap
+// must finish before endTrack so BeginShutdown cannot observe a closed
+// BeginTrack reservation while cleanup is still running.
+func TestTrustedReviewBindFailureEndsTrackAfterEmergencyKill(t *testing.T) {
+	dir := t.TempDir()
+	realLooper := filepath.Join(dir, "real-looper")
+	// Long sleep so a reordered endTrack-before-kill would leave a live child
+	// and reverse the recorded event order under the delayed-kill hook.
+	script := trustedReviewProxyStubScript("sleep 60\n")
+	if err := os.WriteFile(realLooper, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(realLooper) error = %v", err)
+	}
+
+	oldBind := bindTrustedReviewCmd
+	bindTrustedReviewCmd = func(cmd *exec.Cmd, opts processcontainment.Options) (*processcontainment.Handle, error) {
+		return nil, errors.New("forced bind failure")
+	}
+	t.Cleanup(func() { bindTrustedReviewCmd = oldBind })
+
+	var mu sync.Mutex
+	var events []string
+	record := func(e string) {
+		mu.Lock()
+		events = append(events, e)
+		mu.Unlock()
+	}
+
+	// Hold kill completion so concurrent BeginShutdown-style observers would
+	// race if endTrack ran first; release only after recording kill_done.
+	killHold := make(chan struct{})
+	oldAfter := afterTrustedReviewEmergencyKill
+	afterTrustedReviewEmergencyKill = func(*exec.Cmd) {
+		record("kill_done")
+		<-killHold
+	}
+	t.Cleanup(func() { afterTrustedReviewEmergencyKill = oldAfter })
+
+	tracker := &orderRecordingTracker{onEnd: func() { record("endTrack") }}
+
+	sockPath, cleanup, err := StartTrustedReviewProxy(realLooper, nil, "acme/looper#1", dir, config.Config{}, testTrustedReviewPolicy(), tracker)
+	if err != nil {
+		t.Fatalf("StartTrustedReviewProxy() error = %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	t.Setenv(TrustedReviewSockEnv, sockPath)
+	t.Setenv(trustedReviewProxySkipEnv, "")
+
+	submitDone := make(chan error, 1)
+	go func() {
+		submitDone <- ProxyReviewSubmit([]string{"review", "submit", "acme/looper#1", "--event", "COMMENT"}, []byte(`{"body":"x"}`), dir)
+	}()
+
+	// Wait until emergency kill finished (still holding so endTrack cannot race
+	// ahead without being recorded after kill_done).
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		mu.Lock()
+		n := len(events)
+		snapshot := append([]string(nil), events...)
+		mu.Unlock()
+		if n > 0 {
+			if snapshot[0] != "kill_done" {
+				close(killHold)
+				t.Fatalf("first event = %v, want kill_done before endTrack", snapshot)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			close(killHold)
+			t.Fatalf("timed out waiting for emergency kill; events=%v", snapshot)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// While kill holds, endTrack must not have run yet.
+	mu.Lock()
+	if len(events) != 1 || events[0] != "kill_done" {
+		snapshot := append([]string(nil), events...)
+		mu.Unlock()
+		close(killHold)
+		t.Fatalf("events while kill held = %v, want only [kill_done]", snapshot)
+	}
+	mu.Unlock()
+
+	close(killHold)
+
+	select {
+	case err := <-submitDone:
+		if err == nil {
+			t.Fatal("ProxyReviewSubmit() error = nil, want bind failure")
+		}
+		if !strings.Contains(err.Error(), "forced bind failure") && !strings.Contains(err.Error(), "bind trusted review") {
+			t.Fatalf("ProxyReviewSubmit() error = %v, want bind failure", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("ProxyReviewSubmit hung after bind failure")
+	}
+
+	mu.Lock()
+	got := append([]string(nil), events...)
+	mu.Unlock()
+	want := []string{"kill_done", "endTrack"}
+	if len(got) != len(want) {
+		t.Fatalf("events = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("events = %v, want %v", got, want)
+		}
+	}
+	if tracker.begins != 1 {
+		t.Fatalf("BeginTrack calls = %d, want 1", tracker.begins)
+	}
+	if tracker.tracks != 0 {
+		t.Fatalf("Track calls = %d, want 0 on Bind failure", tracker.tracks)
+	}
+}
+
+type orderRecordingTracker struct {
+	mu     sync.Mutex
+	begins int
+	tracks int
+	onEnd  func()
+}
+
+func (t *orderRecordingTracker) BeginTrack() (end func(), err error) {
+	t.mu.Lock()
+	t.begins++
+	t.mu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			if t.onEnd != nil {
+				t.onEnd()
+			}
+		})
+	}, nil
+}
+
+func (t *orderRecordingTracker) Track(*processcontainment.Handle) (release func()) {
+	t.mu.Lock()
+	t.tracks++
+	t.mu.Unlock()
+	return func() {}
+}
+
+func (t *orderRecordingTracker) ReportDrainFailure(error) {}

--- a/internal/infra/shell/runner.go
+++ b/internal/infra/shell/runner.go
@@ -161,12 +161,28 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	stdoutBuffer := newBoundedBuffer(maxCapturedBytes)
 	stderrBuffer := newBoundedBuffer(maxCapturedBytes)
 
+	// BeginTrack before Start so BeginShutdown waits across the Start→Track
+	// window (and Track refuse-kills if admission closed mid-start).
+	var endTrack func()
+	if options.Tracker != nil {
+		end, trackErr := options.Tracker.BeginTrack()
+		if trackErr != nil {
+			return Result{}, fmt.Errorf("start command: %w", trackErr)
+		}
+		endTrack = end
+	}
 	handle, err := startContainedCommand(ctx, options, gracefulShutdown, stdoutBuffer, stderrBuffer)
 	if err != nil {
+		if endTrack != nil {
+			endTrack()
+		}
 		return Result{}, fmt.Errorf("start command: %w", err)
 	}
 	if options.Tracker != nil {
 		release := options.Tracker.Track(handle)
+		if endTrack != nil {
+			endTrack()
+		}
 		if release != nil {
 			defer release()
 		}

--- a/internal/processcontainment/containment.go
+++ b/internal/processcontainment/containment.go
@@ -142,6 +142,10 @@ func Bind(cmd *exec.Cmd, opts Options) (*Handle, error) {
 // Start is Configure + cmd.Start + Bind. Wait is not armed before Start
 // returns, so short-lived producers that use StdoutPipe/StderrPipe can begin
 // draining before the reaper closes the pipes.
+//
+// When cmd.Start succeeds but Bind fails, Start force-kills and reaps the
+// orphaned process group so the child cannot outlive the caller without a
+// Handle (StartTracked probes, short-lived tools, etc.).
 func Start(cmd *exec.Cmd, opts Options) (*Handle, error) {
 	if cmd == nil {
 		return nil, fmt.Errorf("process containment: command is required")
@@ -150,7 +154,35 @@ func Start(cmd *exec.Cmd, opts Options) (*Handle, error) {
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("process containment: start: %w", err)
 	}
-	return Bind(cmd, opts)
+	handle, err := startBind(cmd, opts)
+	if err != nil {
+		// Process is live without a Handle: emergency group kill + reap.
+		// Production stop paths use Handle.Kill once Bind succeeds.
+		killStartedWithoutHandle(cmd)
+		return nil, err
+	}
+	return handle, nil
+}
+
+// startBind attaches a Handle after a successful cmd.Start. Production always
+// uses Bind; tests may override to force post-Start Bind failures without
+// relying on rare getpgid errors.
+var startBind = Bind
+
+// killStartedWithoutHandle is only used when Bind fails after Start so the
+// orphaned process group is not left live. Production stop paths use Handle.Kill.
+// Configure guarantees the child is (or was) its process-group leader, so
+// SIGKILL -pid targets the owned group first; Process.Kill + Wait reaps the leader.
+func killStartedWithoutHandle(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pid := cmd.Process.Pid
+	if pid > 0 {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	}
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
 }
 
 func newHandle(cmd *exec.Cmd, pid, pgid int, opts Options) *Handle {

--- a/internal/processcontainment/live_tracker.go
+++ b/internal/processcontainment/live_tracker.go
@@ -1,18 +1,109 @@
 package processcontainment
 
+import (
+	"errors"
+	"os/exec"
+)
+
+// ErrTrackerAdmissionClosed is returned by LiveTracker.BeginTrack when the
+// Supervisor has already closed spawn admission (BeginShutdown). Callers must
+// not Start/Bind a process after this error — there is no shutdown-wait slot.
+var ErrTrackerAdmissionClosed = errors.New("containment tracker: admission closed")
+
 // LiveTracker is the optional Supervisor hook for non-agent containment handles
 // (ADR-0015 / #577). Supervisor-owned spawn boundaries (validation/shell,
-// trusted review-submit children) register live handles so daemon shutdown can
-// wait for confirmed drain and record Kill/Drain failures for retain-storage.
+// trusted review-submit children, model-catalog probes) register live handles
+// so daemon shutdown can wait for confirmed drain and record Kill/Drain
+// failures for retain-storage.
 //
 // Independently lifecycle-owned shell users (git/gh/tea gateways, osascript)
 // leave Tracker nil.
+//
+// Spawn boundary contract (closes Start→Track vs BeginShutdown races):
+//
+//  1. BeginTrack before processcontainment.Start/Bind — reserves a wait slot
+//     so BeginShutdown cannot return while Start→Track is in flight.
+//  2. On Start/Bind failure, call the end func from BeginTrack.
+//  3. On success, Track the handle, then call end (Track does not end the
+//     reservation; callers own end so refuse-path Kill can finish first).
+//  4. Track after admission is closed confirmed-drains the handle (like agent
+//     BindHandle refuse) and returns a no-op release.
+//
+// Use StartTracked / BindTracked helpers to enforce this order.
 type LiveTracker interface {
+	// BeginTrack reserves a shutdown-wait slot before Start/Bind. Returns
+	// ErrTrackerAdmissionClosed when admission is already closed. The end
+	// func is idempotent and must be called when the window closes (after
+	// Track, or on Start/Bind failure without Track).
+	BeginTrack() (end func(), err error)
 	// Track registers a live handle until release is called. release is
 	// idempotent and safe after Kill/Drain completes (success or failure).
+	// When admission is closed, Track confirmed-drains the handle and returns
+	// a no-op release so a just-started process cannot outlive shutdown.
 	Track(handle *Handle) (release func())
 	// ReportDrainFailure records a Kill/Drain failure observed on the caller's
 	// ownership path so Runtime.Stop can retain SQLite instead of reporting a
 	// clean stop with undrained ownership.
 	ReportDrainFailure(err error)
+}
+
+// StartTracked admits a tracker window (when tracker != nil), Starts the
+// command, Tracks the handle, then ends the admit window. On Start failure the
+// admit window is ended without Track. When tracker is nil this is Start with
+// a no-op release.
+func StartTracked(tracker LiveTracker, cmd *exec.Cmd, opts Options) (*Handle, func(), error) {
+	end, err := beginTrackOptional(tracker)
+	if err != nil {
+		return nil, nil, err
+	}
+	handle, err := Start(cmd, opts)
+	if err != nil {
+		end()
+		return nil, nil, err
+	}
+	release := trackOptional(tracker, handle)
+	end()
+	return handle, release, nil
+}
+
+// BindTracked is StartTracked for an already-started command (Configure+Start
+// done by the caller). On Bind failure the admit window is ended without Track.
+func BindTracked(tracker LiveTracker, cmd *exec.Cmd, opts Options) (*Handle, func(), error) {
+	end, err := beginTrackOptional(tracker)
+	if err != nil {
+		return nil, nil, err
+	}
+	handle, err := Bind(cmd, opts)
+	if err != nil {
+		end()
+		return nil, nil, err
+	}
+	release := trackOptional(tracker, handle)
+	end()
+	return handle, release, nil
+}
+
+func beginTrackOptional(tracker LiveTracker) (end func(), err error) {
+	if tracker == nil {
+		return func() {}, nil
+	}
+	end, err = tracker.BeginTrack()
+	if err != nil {
+		return nil, err
+	}
+	if end == nil {
+		return func() {}, nil
+	}
+	return end, nil
+}
+
+func trackOptional(tracker LiveTracker, handle *Handle) func() {
+	if tracker == nil {
+		return func() {}
+	}
+	release := tracker.Track(handle)
+	if release == nil {
+		return func() {}
+	}
+	return release
 }

--- a/internal/processcontainment/live_tracker.go
+++ b/internal/processcontainment/live_tracker.go
@@ -49,8 +49,10 @@ type LiveTracker interface {
 
 // StartTracked admits a tracker window (when tracker != nil), Starts the
 // command, Tracks the handle, then ends the admit window. On Start failure the
-// admit window is ended without Track. When tracker is nil this is Start with
-// a no-op release.
+// admit window is ended without Track; Start itself kills/reaps the process
+// group when Bind fails after a successful cmd.Start, so the child cannot
+// outlive the admission window without a tracked Handle. When tracker is nil
+// this is Start with a no-op release.
 func StartTracked(tracker LiveTracker, cmd *exec.Cmd, opts Options) (*Handle, func(), error) {
 	end, err := beginTrackOptional(tracker)
 	if err != nil {
@@ -58,6 +60,7 @@ func StartTracked(tracker LiveTracker, cmd *exec.Cmd, opts Options) (*Handle, fu
 	}
 	handle, err := Start(cmd, opts)
 	if err != nil {
+		// Start already cleaned up any orphaned process group on Bind failure.
 		end()
 		return nil, nil, err
 	}

--- a/internal/processcontainment/start_bind_fail_test.go
+++ b/internal/processcontainment/start_bind_fail_test.go
@@ -1,0 +1,88 @@
+package processcontainment
+
+import (
+	"errors"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+)
+
+// TestStartCleansUpProcessGroupOnBindFailure covers the Start→Bind failure
+// boundary: cmd.Start succeeded, Bind failed, the child must not outlive the
+// caller without a Handle (orphaned from LiveTracker and request timeouts).
+func TestStartCleansUpProcessGroupOnBindFailure(t *testing.T) {
+	requireUnixProcessGroup(t)
+
+	old := startBind
+	startBind = func(cmd *exec.Cmd, opts Options) (*Handle, error) {
+		return nil, errors.New("forced bind failure")
+	}
+	t.Cleanup(func() { startBind = old })
+
+	cmd := exec.Command("/bin/sh", "-c", "sleep 60")
+	handle, err := Start(cmd, Options{})
+	if handle != nil {
+		t.Fatalf("Start() handle = %#v, want nil on Bind failure", handle)
+	}
+	if err == nil {
+		t.Fatal("Start() error = nil, want forced bind failure")
+	}
+	if cmd.Process == nil {
+		t.Fatal("cmd.Process = nil after Start failure, want Process for pid check")
+	}
+	assertProcessDead(t, cmd.Process.Pid)
+}
+
+// TestStartTrackedCleansUpOnBindFailure ensures StartTracked ends the admit
+// window without Track and that the orphaned process group is reaped when
+// Bind fails after Start (same boundary as probes using StartTracked).
+func TestStartTrackedCleansUpOnBindFailure(t *testing.T) {
+	requireUnixProcessGroup(t)
+
+	old := startBind
+	startBind = func(cmd *exec.Cmd, opts Options) (*Handle, error) {
+		return nil, errors.New("forced bind failure")
+	}
+	t.Cleanup(func() { startBind = old })
+
+	tracker := &countingTracker{}
+	cmd := exec.Command("/bin/sh", "-c", "sleep 60")
+	handle, release, err := StartTracked(tracker, cmd, Options{})
+	if handle != nil || release != nil {
+		t.Fatalf("StartTracked() handle/release non-nil on Bind failure (handle=%v release_set=%v)", handle, release != nil)
+	}
+	if err == nil {
+		t.Fatal("StartTracked() error = nil, want forced bind failure")
+	}
+	if tracker.begins.Load() != 1 {
+		t.Fatalf("BeginTrack calls = %d, want 1", tracker.begins.Load())
+	}
+	if tracker.ends.Load() != 1 {
+		t.Fatalf("end calls = %d, want 1 (admit window closed on failure)", tracker.ends.Load())
+	}
+	if tracker.tracks.Load() != 0 {
+		t.Fatalf("Track calls = %d, want 0 on Bind failure", tracker.tracks.Load())
+	}
+	if cmd.Process == nil {
+		t.Fatal("cmd.Process = nil after StartTracked failure")
+	}
+	assertProcessDead(t, cmd.Process.Pid)
+}
+
+type countingTracker struct {
+	begins atomic.Int32
+	ends   atomic.Int32
+	tracks atomic.Int32
+}
+
+func (t *countingTracker) BeginTrack() (end func(), err error) {
+	t.begins.Add(1)
+	return func() { t.ends.Add(1) }, nil
+}
+
+func (t *countingTracker) Track(*Handle) (release func()) {
+	t.tracks.Add(1)
+	return func() {}
+}
+
+func (t *countingTracker) ReportDrainFailure(error) {}

--- a/internal/runtime/active_executions.go
+++ b/internal/runtime/active_executions.go
@@ -30,11 +30,18 @@ type ownedExecution struct {
 }
 
 // nonAgentTracked is one Supervisor-owned non-agent containment handle
-// (shell validation, trusted review child). Owners register while the handle
-// is live and release after their confirmed Kill/Drain path finishes.
+// (shell validation, trusted review child, model-catalog probe). Owners
+// register while the handle is live and release after their confirmed
+// Kill/Drain path finishes.
 type nonAgentTracked struct {
 	handle *processcontainment.Handle
 	done   chan struct{}
+}
+
+// nonAgentAdmit is a BeginTrack reservation: BeginShutdown waits on done so
+// Start→Track cannot race past an empty nonAgentHandles snapshot.
+type nonAgentAdmit struct {
+	done chan struct{}
 }
 
 // ActiveExecutionRegistry is the in-process Supervisor registry for live agent
@@ -87,6 +94,11 @@ type ActiveExecutionRegistry struct {
 	// registered via Track (processcontainment.LiveTracker).
 	nonAgentHandles map[uint64]*nonAgentTracked
 	nextNonAgentID  uint64
+	// nonAgentPending holds BeginTrack reservations until end is called.
+	// BeginShutdown waits on these so Start→Track cannot orphan a just-started
+	// process after an empty handle snapshot.
+	nonAgentPending   map[uint64]*nonAgentAdmit
+	nextNonAgentAdmit uint64
 	// nonAgentDrainErr accumulates ReportDrainFailure and force-kill failures
 	// from non-agent handles so Runtime.Stop can retain SQLite.
 	nonAgentDrainErr error
@@ -122,6 +134,7 @@ func NewActiveExecutionRegistry() *ActiveExecutionRegistry {
 		boundOps:         make(map[uint64]*operationLease),
 		boundByQueueItem: make(map[string]uint64),
 		nonAgentHandles:  make(map[uint64]*nonAgentTracked),
+		nonAgentPending:  make(map[uint64]*nonAgentAdmit),
 	}
 }
 
@@ -810,14 +823,55 @@ func (r *ActiveExecutionRegistry) LoopStopActive(loopID string) bool {
 // not reach confirmed-dead. Callers must retain storage and fail loud (#577).
 var errShutdownDrainTimeout = errors.New("shutdown: containment drain timed out or failed")
 
+// BeginTrack implements processcontainment.LiveTracker. Reserves a shutdown-wait
+// slot before Start/Bind so BeginShutdown cannot miss a Start→Track window.
+func (r *ActiveExecutionRegistry) BeginTrack() (end func(), err error) {
+	if r == nil {
+		return nil, processcontainment.ErrTrackerAdmissionClosed
+	}
+	r.mu.Lock()
+	if r.admissionClosed {
+		r.mu.Unlock()
+		return nil, processcontainment.ErrTrackerAdmissionClosed
+	}
+	if r.nonAgentPending == nil {
+		r.nonAgentPending = make(map[uint64]*nonAgentAdmit)
+	}
+	r.nextNonAgentAdmit++
+	id := r.nextNonAgentAdmit
+	admit := &nonAgentAdmit{done: make(chan struct{})}
+	r.nonAgentPending[id] = admit
+	r.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.mu.Lock()
+			if _, ok := r.nonAgentPending[id]; ok {
+				delete(r.nonAgentPending, id)
+			}
+			r.mu.Unlock()
+			close(admit.done)
+		})
+	}, nil
+}
+
 // Track implements processcontainment.LiveTracker for Supervisor-owned non-agent
-// handles (validation/shell, trusted review). release is idempotent.
+// handles (validation/shell, trusted review, model-catalog probes). release is
+// idempotent. When admission is already closed, Track confirmed-drains the
+// handle (agent BindHandle refuse shape) and returns a no-op release so a
+// just-started process cannot outlive BeginShutdown's pending-admit wait.
 func (r *ActiveExecutionRegistry) Track(handle *processcontainment.Handle) (release func()) {
 	if r == nil || handle == nil {
 		return func() {}
 	}
-	entry := &nonAgentTracked{handle: handle, done: make(chan struct{})}
 	r.mu.Lock()
+	if r.admissionClosed {
+		r.mu.Unlock()
+		r.killUntrackedNonAgent(handle)
+		return func() {}
+	}
+	entry := &nonAgentTracked{handle: handle, done: make(chan struct{})}
 	if r.nonAgentHandles == nil {
 		r.nonAgentHandles = make(map[uint64]*nonAgentTracked)
 	}
@@ -836,6 +890,20 @@ func (r *ActiveExecutionRegistry) Track(handle *processcontainment.Handle) (rele
 			r.mu.Unlock()
 			close(entry.done)
 		})
+	}
+}
+
+// killUntrackedNonAgent confirmed-drains a handle that lost the Track race with
+// BeginShutdown (admission already closed). Failures feed retain-storage.
+func (r *ActiveExecutionRegistry) killUntrackedNonAgent(handle *processcontainment.Handle) {
+	if r == nil || handle == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), r.killBudget())
+	err := handle.Kill(ctx)
+	cancel()
+	if err != nil {
+		r.ReportDrainFailure(err)
 	}
 }
 
@@ -905,6 +973,14 @@ func (r *ActiveExecutionRegistry) BeginShutdown(reason string) error {
 			rebindWait = append(rebindWait, lease.rebindDone)
 		}
 	}
+	// Non-agent BeginTrack windows: wait before handle drain so Track refuse
+	// Kill (or successful Track registration) cannot race past an empty snapshot.
+	nonAgentAdmitWait := make([]<-chan struct{}, 0, len(r.nonAgentPending))
+	for _, admit := range r.nonAgentPending {
+		if admit != nil && admit.done != nil {
+			nonAgentAdmitWait = append(nonAgentAdmitWait, admit.done)
+		}
+	}
 	entries := make([]*ownedExecution, 0, len(r.executions))
 	for _, entry := range r.executions {
 		entries = append(entries, entry)
@@ -927,10 +1003,11 @@ func (r *ActiveExecutionRegistry) BeginShutdown(reason string) error {
 		}
 	}
 	budget := r.killBudget()
-	waitChans := make([]<-chan struct{}, 0, len(spawnWait)+len(rebindWait)+len(opWait))
+	waitChans := make([]<-chan struct{}, 0, len(spawnWait)+len(rebindWait)+len(opWait)+len(nonAgentAdmitWait))
 	waitChans = append(waitChans, spawnWait...)
 	waitChans = append(waitChans, rebindWait...)
 	waitChans = append(waitChans, opWait...)
+	waitChans = append(waitChans, nonAgentAdmitWait...)
 	for _, done := range waitChans {
 		if done == nil {
 			continue
@@ -966,6 +1043,8 @@ func (r *ActiveExecutionRegistry) BeginShutdown(reason string) error {
 	// Non-agent Supervisor-owned handles: prefer owner cancel path (shell.Run /
 	// trusted-review Kill) so we do not race concurrent Kill. Wait for release,
 	// then force-kill stragglers and join reported drain failures.
+	// Snapshot is after BeginTrack waits so Track that registered during the
+	// admit window is visible here.
 	if err := r.drainNonAgentHandles(budget); err != nil {
 		drainErr = errors.Join(drainErr, err)
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -196,15 +196,18 @@ type Runtime struct {
 	humanAttentionNotifyWG     sync.WaitGroup
 	humanAttentionNotifyDone   chan struct{}
 	activeExecutions           *ActiveExecutionRegistry
-	projectCatalog             *projects.Catalog
-	githubGateway              *githubinfra.Gateway
-	webhook                    *webhookRuntime
-	webhookDaemonLock          *daemonLock
-	webhookForwarder           WebhookForwarder
-	networkManager             runtimeNetworkManager
-	schedulerDisabled          bool
-	startupReadyOnce           sync.Once
-	startupReadyErr            error
+	// beginShutdownHooks run during BeginShutdown after admission flips to
+	// stopping and before non-agent drain waits (cancel producers first).
+	beginShutdownHooks []func()
+	projectCatalog     *projects.Catalog
+	githubGateway      *githubinfra.Gateway
+	webhook            *webhookRuntime
+	webhookDaemonLock  *daemonLock
+	webhookForwarder   WebhookForwarder
+	networkManager     runtimeNetworkManager
+	schedulerDisabled  bool
+	startupReadyOnce   sync.Once
+	startupReadyErr    error
 	// ownershipAcquired remains true after CompleteStartup succeeds so stop
 	// still writes looperd.stopped. Admission is the sole ready Authority;
 	// this flag is not a mutation/claim gate.
@@ -477,7 +480,15 @@ func (r *Runtime) BeginShutdown(reason string) {
 	// cancels under admission.mu. Do not take r.mu while holding admission.mu
 	// (other paths lock r.mu then read admission — that order would deadlock).
 	cancels := r.snapshotWorkProducerCancels()
-	_ = r.admission.BeginShutdownThen(reason, cancels.invokeForShutdown)
+	hooks := r.snapshotBeginShutdownHooks()
+	_ = r.admission.BeginShutdownThen(reason, func() {
+		cancels.invokeForShutdown()
+		for _, hook := range hooks {
+			if hook != nil {
+				hook()
+			}
+		}
+	})
 	// Close agent spawn admission and confirmed-drain live handles — agents and
 	// tracked Supervisor-owned non-agents (#576/#577). Agent leases cancel via
 	// registry; non-agent owners were canceled above.
@@ -488,6 +499,34 @@ func (r *Runtime) BeginShutdown(reason string) {
 			r.mu.Unlock()
 		}
 	}
+}
+
+// OnBeginShutdown registers a hook invoked during BeginShutdown after admission
+// flips to stopping and work-producer cancels run, but before the registry
+// waits on tracked non-agent handles. Used for Supervisor-owned non-agent
+// work that is not scheduler/recovery (e.g. model catalog shared probes).
+// Hooks must be safe to call more than once (idempotent cancel).
+func (r *Runtime) OnBeginShutdown(hook func()) {
+	if r == nil || hook == nil {
+		return
+	}
+	r.mu.Lock()
+	r.beginShutdownHooks = append(r.beginShutdownHooks, hook)
+	r.mu.Unlock()
+}
+
+func (r *Runtime) snapshotBeginShutdownHooks() []func() {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.beginShutdownHooks) == 0 {
+		return nil
+	}
+	out := make([]func(), len(r.beginShutdownHooks))
+	copy(out, r.beginShutdownHooks)
+	return out
 }
 
 // workProducerCancels is a lock-free snapshot of cancel targets so

--- a/internal/runtime/shutdown_order_test.go
+++ b/internal/runtime/shutdown_order_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -400,5 +401,113 @@ func TestActiveExecutionRegistryBeginShutdownReturnsDrainFailure(t *testing.T) {
 	}
 	if !errors.Is(err, errShutdownDrainTimeout) && !errors.Is(err, force) && !strings.Contains(err.Error(), force.Error()) {
 		t.Fatalf("BeginShutdown() = %v, want wrapped drain failure", err)
+	}
+}
+
+// Contract (PR #630): BeginTrack + Track refuse closes the Start→Track race
+// where BeginShutdown snapshots an empty nonAgentHandles set and returns before
+// Track registers a just-started process. Without the admit window, a short
+// shutdown budget can exit while the probe/shell cleanup still runs.
+func TestActiveExecutionRegistryBeginTrackStartTrackShutdownInterleaving(t *testing.T) {
+	t.Parallel()
+
+	reg := NewActiveExecutionRegistry()
+	reg.killTimeout = 2 * time.Second
+
+	// Hold the BeginTrack window open across Start, then interleave BeginShutdown
+	// before Track — the exact gap the review called out.
+	end, err := reg.BeginTrack()
+	if err != nil {
+		t.Fatalf("BeginTrack: %v", err)
+	}
+
+	cmd := exec.Command("sleep", "60")
+	handle, err := processcontainment.Start(cmd, processcontainment.Options{
+		GracePeriod:  50 * time.Millisecond,
+		DrainTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		end()
+		t.Fatalf("Start: %v", err)
+	}
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownDone <- reg.BeginShutdown("interleave start/track")
+	}()
+
+	// Give BeginShutdown time to close admission and begin waiting on the admit slot.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		reg.mu.Lock()
+		closed := reg.admissionClosed
+		reg.mu.Unlock()
+		if closed {
+			break
+		}
+		if time.Now().After(deadline) {
+			end()
+			_ = handle.Kill(context.Background())
+			t.Fatal("timed out waiting for admissionClosed")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Track after admission closed: must refuse-kill (not register a handle that
+	// BeginShutdown already missed in its initial snapshot).
+	release := reg.Track(handle)
+	if release == nil {
+		t.Fatal("Track returned nil release")
+	}
+	// end unblocks BeginShutdown's non-agent admit wait after refuse Kill.
+	end()
+	release()
+
+	select {
+	case err := <-shutdownDone:
+		if err != nil {
+			// Refuse-path kill failure would retain storage; success is ideal.
+			t.Fatalf("BeginShutdown() error = %v, want nil after refuse-kill", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("BeginShutdown did not return; pending BeginTrack window likely not waited")
+	}
+
+	// Process group must be dead — otherwise we orphaned across shutdown.
+	if err := syscall.Kill(handle.PID(), 0); err == nil {
+		t.Fatalf("probe pid %d still live after refuse Track + BeginShutdown", handle.PID())
+	} else if !errors.Is(err, syscall.ESRCH) {
+		// ESRCH is confirmed gone; other errors are acceptable (e.g. EPERM on some hosts).
+		t.Logf("Kill(0) after shutdown: %v (pid=%d)", err, handle.PID())
+	}
+
+	reg.mu.Lock()
+	pending := len(reg.nonAgentPending)
+	handles := len(reg.nonAgentHandles)
+	reg.mu.Unlock()
+	if pending != 0 {
+		t.Fatalf("nonAgentPending = %d, want 0", pending)
+	}
+	if handles != 0 {
+		t.Fatalf("nonAgentHandles = %d, want 0 after refuse Track", handles)
+	}
+}
+
+// Contract (PR #630): BeginTrack after admission closed refuses Start entirely.
+func TestActiveExecutionRegistryBeginTrackRefusesAfterShutdown(t *testing.T) {
+	t.Parallel()
+	reg := NewActiveExecutionRegistry()
+	if err := reg.BeginShutdown("already stopping"); err != nil {
+		t.Fatalf("BeginShutdown: %v", err)
+	}
+	end, err := reg.BeginTrack()
+	if !errors.Is(err, processcontainment.ErrTrackerAdmissionClosed) {
+		if end != nil {
+			end()
+		}
+		t.Fatalf("BeginTrack() err = %v, want ErrTrackerAdmissionClosed", err)
+	}
+	if end != nil {
+		t.Fatal("BeginTrack() end != nil on admission-closed error")
 	}
 }

--- a/internal/runtime/shutdown_order_test.go
+++ b/internal/runtime/shutdown_order_test.go
@@ -191,6 +191,89 @@ func TestShutdownRetainsStorageWhenNonAgentDrainFailureReported(t *testing.T) {
 	}
 }
 
+// Contract (PR #630): model catalog shared probes are Supervisor-owned non-agent
+// work. BeginShutdown must cancel their daemon-owned parent (OnBeginShutdown)
+// before waiting on tracked handles so HTTP-stop's short budget cannot leave
+// vendor CLI descendants orphaned after process exit.
+func TestBeginShutdownCancelsModelCatalogProbeBeforeNonAgentDrain(t *testing.T) {
+	t.Parallel()
+
+	reg := NewActiveExecutionRegistry()
+	reg.killTimeout = 3 * time.Second
+
+	hookFired := make(chan struct{})
+	rt := &Runtime{
+		admission:        NewAdmission(),
+		activeExecutions: reg,
+		shutdownCh:       make(chan struct{}),
+	}
+	if err := rt.admission.MarkReady("test"); err != nil {
+		t.Fatalf("MarkReady: %v", err)
+	}
+	rt.OnBeginShutdown(func() { close(hookFired) })
+
+	// Simulate a model-catalog probe: long sleep tracked as non-agent, canceled
+	// only when OnBeginShutdown runs (same shape as probeCtx cancel → Kill).
+	probeCtx, probeCancel := context.WithCancel(context.Background())
+	rt.OnBeginShutdown(probeCancel)
+
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		_, err := shell.Run(probeCtx, shell.Options{
+			Command:          "/bin/sh",
+			Args:             []string{"-c", "sleep 60"},
+			GracefulShutdown: 100 * time.Millisecond,
+			Tracker:          reg,
+		})
+		done <- err
+	}()
+	<-started
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		reg.mu.Lock()
+		n := len(reg.nonAgentHandles)
+		reg.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			probeCancel()
+			t.Fatal("timed out waiting for probe handle Track")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	start := time.Now()
+	rt.BeginShutdown("test model-catalog probe cancel")
+	elapsed := time.Since(start)
+
+	select {
+	case <-hookFired:
+	default:
+		t.Fatal("OnBeginShutdown hook did not fire")
+	}
+	if elapsed >= reg.killTimeout {
+		t.Fatalf("BeginShutdown took %v (>= killTimeout %v); probe cancel likely after non-agent wait", elapsed, reg.killTimeout)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("BeginShutdown took %v, want prompt cancel/drain well under 1s", elapsed)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			if !strings.Contains(err.Error(), context.Canceled.Error()) {
+				t.Fatalf("probe shell.Run error = %v, want context.Canceled", err)
+			}
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("probe did not finish after BeginShutdown")
+	}
+}
+
 // Contract (#590 review): BeginShutdown cancels producer contexts before
 // waiting on tracked non-agent handles. Validation shell.Run only Kill/Drains
 // after its owner ctx is canceled; waiting first would burn killBudget then

--- a/specs/2026-08-01-agent-model-catalog/spec.md
+++ b/specs/2026-08-01-agent-model-catalog/spec.md
@@ -1,0 +1,257 @@
+# Agent model catalog (dashboard suggestions + vendor probe)
+
+## 1. Background
+
+Looper already supports per-binding agent **vendor** and **model**:
+
+- Global: `agent.vendor`, `agent.model`
+- Profiles: `agent.profiles.<id>.{vendor,model}`
+- Coding roles: `roles.{planner,worker,reviewer,fixer}.agent.{profile,vendor,model}`
+
+Resolve order, empty-string suppress → vendor default, params `--model` strip,
+hot-reload for new claims, and sticky `agent_snapshot` freeze are implemented
+(see `docs/configuration.md`, ADR-0014, ADR-0016).
+
+Dashboard Config today uses a **vendor select** and a **free-text model** field.
+Operators who want Looper to **override vendor-local CLI defaults** and run a
+chosen model stably often do not know valid ids, or leave model unset and
+silently inherit home-config defaults.
+
+**Product intent:** make explicit model configuration easy and aligned with
+vendor configuration surfaces — not introduce a new identity model or a
+validation gate.
+
+Formal decisions: **[ADR-0016](../../docs/adr/0016-agent-model-catalog-is-advisory.md)**.
+
+## 2. Goals
+
+1. Expose a **suggested model list** per agent vendor, merged from:
+   - a small **static** embedded catalog, and
+   - **on-demand CLI probe** when the vendor supports non-interactive listing.
+2. Let the **dashboard** configure model wherever vendor is configurable
+   (global, profiles, four coding roles) via a **searchable combobox**, while
+   **still allowing arbitrary hand-entered ids**.
+3. Keep existing identity semantics: tri-state model (`unset` / `""` / id),
+   ResolveAgent overlay, snapshot freeze, argv override strength.
+4. Fail soft: probe errors never block config read/write or daemon work.
+
+## 3. Non-goals (kill list)
+
+1. Hard-require model ∈ catalog on save or claim
+2. Require non-empty model to run coding roles
+3. Project-scoped agent vendor/model
+4. Coordinator-specific agent binding (remains global-only)
+5. Anthropic / OpenAI / other **cloud Models HTTP** as catalog source
+6. Changing sticky resume/retry to re-resolve live config model
+7. Run detail / execution record “actual model used” observability (later)
+8. User-editable `~/.looper/models.json` override files (later if needed)
+9. Rewriting config IA to push profiles-only or global-only workflows
+10. Proving per-vendor that CLI flag always beats home config (document assumption only)
+11. Interactive TUI scraping (`claude` `/model`, Codex `/model`)
+12. Dashboard editing of `agent.params` (still file/restart-bound)
+
+## 4. Decisions (locked)
+
+| Topic | Decision |
+| --- | --- |
+| Authority of list | **Advisory only** (ADR-0016) |
+| Sources | Static embed + on-demand probe; probe failure → static |
+| Claude Code | **Static only** (no list CLI) |
+| Other vendors | Probe when possible: opencode, codex, cursor-cli, grok-build |
+| Codex probe | Prefer `codex debug models --bundled` (stable/offline); treat as experimental surface |
+| Binary resolution | **Same as spawn** (default name or `agent.params.command`); absolute path; never bare ambiguous `agent` |
+| Cache | In-process memory, short TTL, key = vendor + resolved binary path |
+| When probe runs | On demand when UI/API requests models for a vendor (not full five-vendor startup sweep) |
+| Validation | None on save; free text always allowed |
+| UI control | Searchable combobox; full list (including long OpenCode output) |
+| Special values | **Inherit** (unset) where overlay applies; **Vendor default** (explicit `""`); concrete ids |
+| Which vendor for list | **Effective vendor** after same overlay as ResolveAgent for that control |
+| Config surfaces | Parity with vendor: global + profiles + planner/worker/reviewer/fixer |
+| Apply timing | New claims only; in-flight + sticky keep snapshot |
+| Strength bar | Configuration reachability — not force-explicit, not run observability |
+| IA / narrative | No preferred path; same logic as vendor fields |
+
+## 5. Model tri-state (unchanged; UI must map explicitly)
+
+| Binding | Meaning |
+| --- | --- |
+| Field absent / unset (`nil`) | Inherit previous layer (role → profile → global → vendor CLI default) |
+| Explicit empty string `""` | Suppress inherit; force vendor CLI default; strip params `--model`/`-m` |
+| Non-empty string | Explicit model id passed to CLI |
+
+Global has no Inherit (top of overlay). Profile/role show Inherit when unset.
+
+Custom values not present in the catalog remain selectable/displayable once set.
+
+## 6. Effective vendor for catalog requests
+
+When the operator edits model on a control, the catalog vendor is the **resolved**
+vendor for that binding — not only the leaf `vendor` field:
+
+1. Inline `vendor` on that binding if set
+2. Else profile’s vendor if `profile` set
+3. Else global `agent.vendor`
+
+If no vendor resolves: return static empty or vendor-agnostic message; do not
+probe; UI prompts to select a vendor first.
+
+## 7. HTTP API (looperd)
+
+### 7.1 Endpoint
+
+```
+GET /api/v1/agent/models?vendor=<AgentVendor>
+```
+
+- `vendor` required; must be a known `AgentVendor` enum value.
+- Auth: same as other `/api/v1/*` (loopback / local-token).
+- Not a config mutation; read-only; safe to poll subject to server-side cache.
+
+### 7.2 Response shape (normative intent)
+
+```json
+{
+  "vendor": "codex",
+  "models": [
+    { "id": "gpt-5.4", "label": "GPT-5.4", "source": "probe" }
+  ],
+  "sources": {
+    "static": true,
+    "probe": "ok"
+  },
+  "probedAt": "2026-08-01T12:00:00Z"
+}
+```
+
+| Field | Notes |
+| --- | --- |
+| `models[].id` | String passed through as config model / CLI flag value |
+| `models[].label` | Optional display string; may equal id |
+| `models[].source` | `static` \| `probe` (or `merged` if both); UI may ignore |
+| `sources.probe` | `ok` \| `skipped` \| `error` \| `unsupported` |
+| `sources.probeError` | Optional short message when `error` (never fatal to client) |
+| `probedAt` | Set when probe attempted or served from cache |
+
+Merge rules:
+
+- Union by `id`; probe label wins on conflict when present.
+- Stable-enough ordering: static recommendations first, then probe-only ids
+  (implementation may sort alpha within buckets).
+- Deduplicate exact ids.
+
+### 7.3 Probe behavior
+
+| Vendor | Command / source (v1 intent) | Notes |
+| --- | --- | --- |
+| `opencode` | `opencode models` | One id per line (`provider/model`) |
+| `codex` | `codex debug models --bundled` | Parse JSON `models[]`; prefer `visibility=list` when field exists |
+| `cursor-cli` | resolved `cursor-agent`/`agent` binary `models` or `--list-models` | Text parse; empty if logged out |
+| `grok-build` | `grok models` | Text parse; optional fallback read of well-known cache only if needed |
+| `claude-code` | none | `probe: unsupported`; static only |
+
+Shared rules:
+
+- Timeout short (seconds); kill process group on expiry.
+- Do not pass the operator prompt or start an agent session.
+- Inherit env only as required for CLI auth (same machine user as looperd).
+- Cache hit skips subprocess until TTL expires; optional `?refresh=1` may bypass cache (nice-to-have).
+
+### 7.4 Static catalog
+
+- Embedded in the binary (Go embed JSON or equivalent).
+- Per vendor: small set of common ids/aliases (Claude aliases like `sonnet` /
+  `opus` / `haiku` are high value).
+- Not aiming for completeness; probe supplies breadth where available.
+- Updating the table is a normal code change / release, not a runtime user file.
+
+## 8. Dashboard UX
+
+### 8.1 Surfaces
+
+Replace free-text model inputs on Config for:
+
+- Global agent model
+- Each agent profile model
+- Each coding role agent model
+
+Vendor controls unchanged in meaning; switching vendor keeps existing
+clear/pair guards in `configForm` and reloads suggestions for the new effective
+vendor.
+
+### 8.2 Combobox
+
+- Searchable filter over `id` and `label`.
+- Always include special rows where applicable: Inherit, Vendor default.
+- Always allow commit of a custom string (create option / free entry).
+- If current saved value ∉ list, still show it as the selected value.
+- Loading: show static or previous list immediately if cached; probe may populate
+  asynchronously without blocking the form.
+- Probe error: optional non-blocking hint (“Using built-in list; CLI probe
+  failed”) — must not use modal blockers or disable Save.
+
+### 8.3 OpenCode scale
+
+Return and search the **full** probed list. No magic provider filter in v1.
+Native `<select>` is insufficient; use a combobox/command palette pattern
+consistent with dashboard component library.
+
+## 9. Runtime override (existing; no behavior change required for v1)
+
+When resolved/snapshot model is non-empty, executor strips conflicting params
+model flags and prepends vendor model flags. Catalog work must **not** weaken
+this path.
+
+Unset model continues to defer to vendor local defaults — by design for v1
+strength bar (reachability, not mandate).
+
+## 10. Docs
+
+- `docs/configuration.md`: note model suggestions API/dashboard; restate
+  advisory nature; link ADR-0016.
+- Do not document the catalog as a allowlist.
+
+## 11. Verification
+
+Minimum credible evidence for implementation PRs:
+
+| Check | Intent |
+| --- | --- |
+| Unit: static catalog load + merge/dedupe | Pure logic |
+| Unit: per-vendor probe parsers with fixtures | No live CLI in CI required |
+| Unit/API: unknown vendor → 4xx; missing vendor → 4xx | Contract |
+| Unit/API: probe subprocess failure → 200 + static + `probe=error` | Fail soft |
+| Config form: tri-state still patches unset vs `""` vs id | No regression |
+| Manual or component: combobox custom value + search | UX |
+| `go test` for touched packages; dashboard typecheck/build as today | CI |
+
+Out of scope for mandatory CI: live `codex`/`opencode`/`claude` on runners.
+
+## 12. Ship shape
+
+Suggested slices (flexible):
+
+1. **ADR + this spec** (docs only)
+2. **Backend:** static catalog + probe adapters + `GET .../agent/models` + tests
+3. **Dashboard:** combobox wired to API on all vendor-parity model fields
+4. **Docs:** configuration.md touch-up
+
+## 13. Done bar
+
+- [ ] ADR-0016 merged
+- [ ] API returns merged suggestions per vendor; claude static-only; fail soft
+- [ ] Dashboard model fields are searchable suggestions with free entry + tri-state
+- [ ] Effective vendor drives the list for profile/role controls
+- [ ] No new validation rejecting unknown models
+- [ ] Snapshot / hot-reload / resolve semantics unchanged (regression tests green)
+- [ ] configuration.md updated
+
+## 14. Open implementation choices (not product locks)
+
+Left to implementer unless they force a product change:
+
+- Exact TTL duration and `refresh` query
+- JSON field names beyond §7.2 intent
+- Combobox component choice within existing design system
+- Whether Grok reads `~/.grok/models_cache.json` as secondary
+- Codex filter on `visibility`
+- Static file format (JSON vs Go literals)

--- a/web/dashboard/src/components/ModelCombobox.test.tsx
+++ b/web/dashboard/src/components/ModelCombobox.test.tsx
@@ -86,15 +86,27 @@ describe("ModelCombobox", () => {
     expect(onCommit).toHaveBeenCalledWith("gpt-5");
   });
 
-  it("commits a custom typed id", () => {
+  it("commits a custom typed id on Enter (keystrokes stay local)", () => {
     const onCommit = vi.fn();
     const props = { ...commonProps, value: "", onCommitValue: onCommit };
     render(<ModelCombobox {...props} />);
     const input = screen.getByLabelText("agent.model");
     fireEvent.change(input, { target: { value: "custom-id" } });
-    // Every keystroke stages the draft so the tri-state contract is preserved
-    // even without hitting Enter — the last call carries the full string.
+    // Typing is local until commit so Escape can cancel without a parent draft.
+    expect(onCommit).not.toHaveBeenCalled();
+    fireEvent.keyDown(input, { key: "Enter" });
     expect(onCommit).toHaveBeenLastCalledWith("custom-id");
+  });
+
+  it("commits free-entry text on blur without Enter", () => {
+    const onCommit = vi.fn();
+    const props = { ...commonProps, value: "", onCommitValue: onCommit };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model");
+    fireEvent.change(input, { target: { value: "blur-commit" } });
+    expect(onCommit).not.toHaveBeenCalled();
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenLastCalledWith("blur-commit");
   });
 
   it("Inherit special row calls onInherit; Vendor default commits empty", async () => {
@@ -120,14 +132,17 @@ describe("ModelCombobox", () => {
   });
 
   it("does not fetch when vendor is null; prompts to select a vendor", async () => {
-    const props = { ...commonProps, value: "", vendor: null };
+    const onCommit = vi.fn();
+    const props = { ...commonProps, value: "", vendor: null, onCommitValue: onCommit };
     render(<ModelCombobox {...props} />);
     const input = screen.getByLabelText("agent.model");
     fireEvent.focus(input);
     expect(await screen.findByText(/Select a vendor first/i)).toBeTruthy();
-    // Free entry still works.
+    // Free entry still works (commit on Enter when no vendor).
     fireEvent.change(input, { target: { value: "custom" } });
-    expect(commonProps.onCommitValue).toHaveBeenLastCalledWith("custom");
+    expect(onCommit).not.toHaveBeenCalled();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onCommit).toHaveBeenLastCalledWith("custom");
   });
 
   it("keyboard navigation: ArrowDown starts at the current-state row", async () => {
@@ -157,9 +172,8 @@ describe("ModelCombobox", () => {
     render(<ModelCombobox {...props} />);
     const input = screen.getByLabelText("agent.model");
     fireEvent.change(input, { target: { value: "my-model" } });
-    // Keystrokes stage the draft; the last onCommitValue is the typed value.
-    expect(onCommit).toHaveBeenLastCalledWith("my-model");
-    onCommit.mockClear();
+    // Keystrokes stay local; only Enter/pick/blur/Tab stage the draft.
+    expect(onCommit).not.toHaveBeenCalled();
     fireEvent.keyDown(input, { key: "Enter" });
     // Untouched Enter must not select Inherit (row 0) — it commits the typed
     // value (or falls back to no-op) so custom ids are not overwritten.
@@ -185,7 +199,7 @@ describe("ModelCombobox", () => {
     expect(onInherit).not.toHaveBeenCalled();
   });
 
-  it("closes on Escape and restores parent value (clears stale query)", async () => {
+  it("closes on Escape without staging, restoring parent value", async () => {
     const onCommit = vi.fn();
     const props = {
       ...commonProps,
@@ -197,10 +211,13 @@ describe("ModelCombobox", () => {
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "typing…" } });
     expect(input.value).toBe("typing…");
+    expect(onCommit).not.toHaveBeenCalled();
     fireEvent.keyDown(input, { key: "Escape" });
-    // Popup dismissed; input reverts to controlled parent value.
+    // Popup dismissed; input reverts to controlled parent value and Escape
+    // must not leave a half-edited draft on the parent.
     expect(screen.queryByTestId("model-combobox-popup")).toBeNull();
     expect(input.value).toBe("gpt-5");
+    expect(onCommit).not.toHaveBeenCalled();
   });
 
   it("shows the vendor-default placeholder when value is empty and not unset", () => {
@@ -280,5 +297,75 @@ describe("ModelCombobox", () => {
     render(<ModelCombobox {...props} />);
     const input = screen.getByLabelText("agent.model") as HTMLInputElement;
     expect(input.placeholder).toBe("Vendor default");
+  });
+
+  it("keeps cached suggestions when switching back to a fresh vendor while open", async () => {
+    const codexModels = {
+      vendor: "codex",
+      models: [
+        { id: "gpt-5", label: "GPT-5", source: "static" as const },
+        { id: "o4", label: "O4", source: "probe" as const },
+      ],
+      sources: { static: true, probe: "ok" as const },
+      probedAt: "2026-08-01T00:00:00Z",
+    };
+    const opencodeModels = {
+      vendor: "opencode",
+      models: [
+        { id: "big-pickle", label: "Big Pickle", source: "static" as const },
+      ],
+      sources: { static: true, probe: "ok" as const },
+      probedAt: "2026-08-01T00:00:00Z",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const path = String(input);
+        if (path.includes("vendor=codex")) return jsonEnvelope(codexModels);
+        if (path.includes("vendor=opencode")) return jsonEnvelope(opencodeModels);
+        throw new Error(`unexpected: ${path}`);
+      }),
+    );
+
+    const onCommit = vi.fn();
+    const { rerender } = render(
+      <ModelCombobox
+        {...commonProps}
+        value=""
+        vendor="codex"
+        onCommitValue={onCommit}
+      />,
+    );
+    const input = screen.getByLabelText("agent.model");
+    fireEvent.focus(input);
+    await screen.findByText("GPT-5");
+
+    // Visit opencode so both vendors are warm in the module cache.
+    rerender(
+      <ModelCombobox
+        {...commonProps}
+        value=""
+        vendor="opencode"
+        onCommitValue={onCommit}
+      />,
+    );
+    await screen.findByText("Big Pickle");
+    expect(screen.queryByText("GPT-5")).toBeNull();
+
+    // Switch back to codex while still open. Fresh cache must be restored and
+    // must not be wiped by a later vendor-clear effect (only specials left).
+    rerender(
+      <ModelCombobox
+        {...commonProps}
+        value=""
+        vendor="codex"
+        onCommitValue={onCommit}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("GPT-5")).toBeTruthy();
+    });
+    expect(screen.getByText("O4")).toBeTruthy();
+    expect(screen.queryByText("Big Pickle")).toBeNull();
   });
 });

--- a/web/dashboard/src/components/ModelCombobox.test.tsx
+++ b/web/dashboard/src/components/ModelCombobox.test.tsx
@@ -218,4 +218,39 @@ describe("ModelCombobox", () => {
     expect(input.placeholder).toBe("Inherit");
     expect(input.disabled).toBe(true);
   });
+
+  it("treats null value as Inherit (absent leaf) without locking the control", async () => {
+    const onCommit = vi.fn();
+    const onInherit = vi.fn();
+    const props = {
+      ...commonProps,
+      value: null as string | null,
+      onCommitValue: onCommit,
+      onInherit,
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    expect(input.placeholder).toBe("Inherit");
+    expect(input.disabled).toBe(false);
+
+    fireEvent.focus(input);
+    await screen.findByText("GPT-5");
+    // ArrowDown starts on Inherit (current state); Enter calls onInherit, not "".
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onInherit).toHaveBeenCalledTimes(1);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("treats null value as Vendor default when inherit is not allowed", () => {
+    const props = {
+      ...commonProps,
+      value: null as string | null,
+      allowInherit: false,
+      onInherit: undefined,
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    expect(input.placeholder).toBe("Vendor default");
+  });
 });

--- a/web/dashboard/src/components/ModelCombobox.test.tsx
+++ b/web/dashboard/src/components/ModelCombobox.test.tsx
@@ -307,29 +307,54 @@ describe("ModelCombobox", () => {
 
   it("keeps global absence distinct from explicit Vendor default suppress", async () => {
     const onCommit = vi.fn();
+    const onUnbound = vi.fn();
     const props = {
       ...commonProps,
       value: null as string | null,
       allowInherit: false,
       onInherit: undefined,
+      onUnbound,
       onCommitValue: onCommit,
-      placeholder: "Model id (empty = inherit CLI default)",
+      placeholder: "Model id (empty = vendor default / suppress)",
     };
     render(<ModelCombobox {...props} />);
     const input = screen.getByLabelText("agent.model") as HTMLInputElement;
     // Absent global model is unbound (params --model may still apply), not
     // the Vendor default suppress row.
-    expect(input.placeholder).toBe("Model id (empty = inherit CLI default)");
+    expect(input.placeholder).toBe("Unbound");
     expect(input.placeholder).not.toBe("Vendor default");
 
     fireEvent.focus(input);
     await screen.findByText("GPT-5");
-    // No current-state row: Vendor default is not aria-selected as current.
+    // Unbound is the current-state row; Vendor default is not.
+    const unbound = screen.getByText("Unbound").closest("[role='option']");
+    expect(unbound?.getAttribute("aria-selected")).toBe("true");
     const vendorDefault = screen.getByText("Vendor default").closest("[role='option']");
     expect(vendorDefault?.getAttribute("aria-selected")).toBe("false");
 
     // Untouched Enter must not stage explicit "" suppress.
     fireEvent.keyDown(input, { key: "Enter" });
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onUnbound).not.toHaveBeenCalled();
+  });
+
+  it("offers Unbound restore for global scope and calls onUnbound", async () => {
+    const onCommit = vi.fn();
+    const onUnbound = vi.fn();
+    const props = {
+      ...commonProps,
+      value: "gpt-5",
+      allowInherit: false,
+      onInherit: undefined,
+      onUnbound,
+      onCommitValue: onCommit,
+      placeholder: "Model id (empty = vendor default / suppress)",
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model");
+    fireEvent.focus(input);
+    fireEvent.mouseDown(await screen.findByText("Unbound"));
+    expect(onUnbound).toHaveBeenCalledTimes(1);
     expect(onCommit).not.toHaveBeenCalled();
   });
 
@@ -339,6 +364,7 @@ describe("ModelCombobox", () => {
       value: "",
       allowInherit: false,
       onInherit: undefined,
+      onUnbound: vi.fn(),
     };
     render(<ModelCombobox {...props} />);
     const input = screen.getByLabelText("agent.model") as HTMLInputElement;

--- a/web/dashboard/src/components/ModelCombobox.test.tsx
+++ b/web/dashboard/src/components/ModelCombobox.test.tsx
@@ -249,6 +249,65 @@ describe("ModelCombobox", () => {
     );
   });
 
+  it("keyboard navigation: preserves active option by identity when catalog replaces custom row", async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      ),
+    );
+
+    const onCommit = vi.fn();
+    const onInherit = vi.fn();
+    // Saved binding that will appear in the catalog once the probe returns.
+    // While loading it is shown as a temporary custom row; ArrowDown lands on
+    // it by index. After load the custom row collapses into a model entry at a
+    // different index — active must follow identity, not the old numeric slot.
+    const props = {
+      ...commonProps,
+      vendor: "identity-remap-vendor",
+      value: "gpt-5-mini",
+      onCommitValue: onCommit,
+      onInherit,
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    fireEvent.focus(input);
+
+    expect(await screen.findByText(/Loading suggestions/i)).toBeTruthy();
+    expect(screen.getByText('Use "gpt-5-mini"')).toBeTruthy();
+
+    // Activate the temporary custom row (index after Inherit + Vendor default).
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    const customOpt = screen
+      .getByText('Use "gpt-5-mini"')
+      .closest("[role='option']");
+    expect(customOpt?.getAttribute("aria-selected")).toBe("true");
+
+    resolveFetch?.(
+      jsonEnvelope({
+        ...MODELS,
+        vendor: "identity-remap-vendor",
+      }),
+    );
+
+    // Catalog includes gpt-5-mini; custom row is gone. Active should still
+    // highlight that model (now a catalog row), not the next row at the old index.
+    await waitFor(() => {
+      expect(screen.queryByText('Use "gpt-5-mini"')).toBeNull();
+    });
+    const modelOpt = screen.getByText("GPT-5 mini").closest("[role='option']");
+    expect(modelOpt?.getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onInherit).not.toHaveBeenCalled();
+    expect(onCommit).toHaveBeenLastCalledWith("gpt-5-mini");
+  });
+
   it("keyboard navigation: with a filter, ArrowDown starts at the first matching suggestion", async () => {
     const onCommit = vi.fn();
     const onInherit = vi.fn();

--- a/web/dashboard/src/components/ModelCombobox.test.tsx
+++ b/web/dashboard/src/components/ModelCombobox.test.tsx
@@ -1,0 +1,221 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ModelCombobox } from "./ModelCombobox";
+
+function jsonEnvelope(data: unknown) {
+  return new Response(JSON.stringify({ ok: true, data }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const MODELS = {
+  vendor: "codex",
+  models: [
+    { id: "gpt-5", label: "GPT-5", source: "static" as const },
+    { id: "gpt-5-mini", label: "GPT-5 mini", source: "probe" as const },
+    { id: "o4", label: "O4", source: "probe" as const },
+  ],
+  sources: { static: true, probe: "ok" as const },
+  probedAt: "2026-08-01T00:00:00Z",
+};
+
+describe("ModelCombobox", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const path = String(input);
+        if (path.startsWith("/api/v1/agent/models")) {
+          return jsonEnvelope(MODELS);
+        }
+        throw new Error(`unexpected: ${path}`);
+      }),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    cleanup();
+  });
+
+  const commonProps = {
+    ariaLabel: "agent.model",
+    vendor: "codex",
+    disabled: false,
+    unset: false,
+    allowInherit: true,
+    onCommitValue: vi.fn(),
+    onInherit: vi.fn(),
+  };
+
+  it("shows special rows and filters by id / label", async () => {
+    const props = { ...commonProps, value: "" };
+    render(<ModelCombobox {...props} />);
+
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    fireEvent.focus(input);
+
+    // Special rows present.
+    expect(await screen.findByText("Inherit")).toBeTruthy();
+    expect(screen.getByText("Vendor default")).toBeTruthy();
+
+    // Suggestions rendered.
+    await waitFor(() => {
+      expect(screen.getByText("GPT-5")).toBeTruthy();
+    });
+    expect(screen.getByText("GPT-5 mini")).toBeTruthy();
+
+    // Filter by id substring.
+    fireEvent.change(input, { target: { value: "mini" } });
+    await waitFor(() => {
+      expect(screen.queryByText("GPT-5")).toBeNull();
+    });
+    expect(screen.getByText("GPT-5 mini")).toBeTruthy();
+  });
+
+  it("commits a picked suggestion via onCommitValue", async () => {
+    const onCommit = vi.fn();
+    const props = { ...commonProps, value: "", onCommitValue: onCommit };
+    render(<ModelCombobox {...props} />);
+
+    const input = screen.getByLabelText("agent.model");
+    fireEvent.focus(input);
+
+    const opt = await screen.findByText("GPT-5");
+    fireEvent.mouseDown(opt);
+    expect(onCommit).toHaveBeenCalledWith("gpt-5");
+  });
+
+  it("commits a custom typed id", () => {
+    const onCommit = vi.fn();
+    const props = { ...commonProps, value: "", onCommitValue: onCommit };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model");
+    fireEvent.change(input, { target: { value: "custom-id" } });
+    // Every keystroke stages the draft so the tri-state contract is preserved
+    // even without hitting Enter — the last call carries the full string.
+    expect(onCommit).toHaveBeenLastCalledWith("custom-id");
+  });
+
+  it("Inherit special row calls onInherit; Vendor default commits empty", async () => {
+    const onCommit = vi.fn();
+    const onInherit = vi.fn();
+    const props = {
+      ...commonProps,
+      value: "gpt-5",
+      onCommitValue: onCommit,
+      onInherit,
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model");
+    fireEvent.focus(input);
+
+    fireEvent.mouseDown(await screen.findByText("Inherit"));
+    expect(onInherit).toHaveBeenCalledTimes(1);
+    expect(onCommit).not.toHaveBeenCalled();
+
+    fireEvent.focus(input);
+    fireEvent.mouseDown(await screen.findByText("Vendor default"));
+    expect(onCommit).toHaveBeenLastCalledWith("");
+  });
+
+  it("does not fetch when vendor is null; prompts to select a vendor", async () => {
+    const props = { ...commonProps, value: "", vendor: null };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model");
+    fireEvent.focus(input);
+    expect(await screen.findByText(/Select a vendor first/i)).toBeTruthy();
+    // Free entry still works.
+    fireEvent.change(input, { target: { value: "custom" } });
+    expect(commonProps.onCommitValue).toHaveBeenLastCalledWith("custom");
+  });
+
+  it("keyboard navigation: ArrowDown starts at the current-state row", async () => {
+    const onCommit = vi.fn();
+    const props = { ...commonProps, value: "", onCommitValue: onCommit };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    fireEvent.focus(input);
+    // Wait for options.
+    await screen.findByText("GPT-5");
+    // value="" → Vendor default is the current-state row. First ArrowDown
+    // lands on it (rather than blindly on row 0); Enter commits "".
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onCommit).toHaveBeenLastCalledWith("");
+  });
+
+  it("untouched Enter with a typed custom id commits the typed value, not row zero", async () => {
+    const onCommit = vi.fn();
+    const onInherit = vi.fn();
+    const props = {
+      ...commonProps,
+      value: "",
+      onCommitValue: onCommit,
+      onInherit,
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model");
+    fireEvent.change(input, { target: { value: "my-model" } });
+    // Keystrokes stage the draft; the last onCommitValue is the typed value.
+    expect(onCommit).toHaveBeenLastCalledWith("my-model");
+    onCommit.mockClear();
+    fireEvent.keyDown(input, { key: "Enter" });
+    // Untouched Enter must not select Inherit (row 0) — it commits the typed
+    // value (or falls back to no-op) so custom ids are not overwritten.
+    expect(onInherit).not.toHaveBeenCalled();
+    expect(onCommit).toHaveBeenLastCalledWith("my-model");
+  });
+
+  it("untouched Enter without a typed value keeps the parent value (no commit)", async () => {
+    const onCommit = vi.fn();
+    const onInherit = vi.fn();
+    const props = {
+      ...commonProps,
+      value: "gpt-5",
+      onCommitValue: onCommit,
+      onInherit,
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model");
+    fireEvent.focus(input);
+    await screen.findByText("GPT-5");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onInherit).not.toHaveBeenCalled();
+  });
+
+  it("closes on Escape and restores parent value (clears stale query)", async () => {
+    const onCommit = vi.fn();
+    const props = {
+      ...commonProps,
+      value: "gpt-5",
+      onCommitValue: onCommit,
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "typing…" } });
+    expect(input.value).toBe("typing…");
+    fireEvent.keyDown(input, { key: "Escape" });
+    // Popup dismissed; input reverts to controlled parent value.
+    expect(screen.queryByTestId("model-combobox-popup")).toBeNull();
+    expect(input.value).toBe("gpt-5");
+  });
+
+  it("shows the vendor-default placeholder when value is empty and not unset", () => {
+    const props = { ...commonProps, value: "" };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    expect(input.value).toBe("");
+    expect(input.placeholder).toBe("Vendor default");
+  });
+
+  it("shows the inherit placeholder when unset", () => {
+    const props = { ...commonProps, value: "", unset: true };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    expect(input.placeholder).toBe("Inherit");
+    expect(input.disabled).toBe(true);
+  });
+});

--- a/web/dashboard/src/components/ModelCombobox.test.tsx
+++ b/web/dashboard/src/components/ModelCombobox.test.tsx
@@ -242,10 +242,38 @@ describe("ModelCombobox", () => {
     expect(onCommit).not.toHaveBeenCalled();
   });
 
-  it("treats null value as Vendor default when inherit is not allowed", () => {
+  it("keeps global absence distinct from explicit Vendor default suppress", async () => {
+    const onCommit = vi.fn();
     const props = {
       ...commonProps,
       value: null as string | null,
+      allowInherit: false,
+      onInherit: undefined,
+      onCommitValue: onCommit,
+      placeholder: "Model id (empty = inherit CLI default)",
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    // Absent global model is unbound (params --model may still apply), not
+    // the Vendor default suppress row.
+    expect(input.placeholder).toBe("Model id (empty = inherit CLI default)");
+    expect(input.placeholder).not.toBe("Vendor default");
+
+    fireEvent.focus(input);
+    await screen.findByText("GPT-5");
+    // No current-state row: Vendor default is not aria-selected as current.
+    const vendorDefault = screen.getByText("Vendor default").closest("[role='option']");
+    expect(vendorDefault?.getAttribute("aria-selected")).toBe("false");
+
+    // Untouched Enter must not stage explicit "" suppress.
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("explicit empty string still shows Vendor default when inherit is not allowed", () => {
+    const props = {
+      ...commonProps,
+      value: "",
       allowInherit: false,
       onInherit: undefined,
     };

--- a/web/dashboard/src/components/ModelCombobox.test.tsx
+++ b/web/dashboard/src/components/ModelCombobox.test.tsx
@@ -98,6 +98,22 @@ describe("ModelCombobox", () => {
     expect(onCommit).toHaveBeenLastCalledWith("custom-id");
   });
 
+  it("commits an empty clear on Enter when the query was edited to blank", () => {
+    const onCommit = vi.fn();
+    const props = {
+      ...commonProps,
+      value: "gpt-5",
+      onCommitValue: onCommit,
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    // Operator deletes the bound id then presses Enter — same clear as blur/Tab.
+    fireEvent.change(input, { target: { value: "" } });
+    expect(onCommit).not.toHaveBeenCalled();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onCommit).toHaveBeenLastCalledWith("");
+  });
+
   it("commits free-entry text on blur without Enter", () => {
     const onCommit = vi.fn();
     const props = { ...commonProps, value: "", onCommitValue: onCommit };
@@ -158,6 +174,36 @@ describe("ModelCombobox", () => {
     fireEvent.keyDown(input, { key: "ArrowDown" });
     fireEvent.keyDown(input, { key: "Enter" });
     expect(onCommit).toHaveBeenLastCalledWith("");
+  });
+
+  it("keyboard navigation: with a filter, ArrowDown starts at the first matching suggestion", async () => {
+    const onCommit = vi.fn();
+    const onInherit = vi.fn();
+    const props = {
+      ...commonProps,
+      // Bound model is not in the filtered set, so stateRowIndex is null.
+      value: "gpt-5",
+      onCommitValue: onCommit,
+      onInherit,
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    fireEvent.focus(input);
+    await screen.findByText("O4");
+
+    // Exact id match so no free-entry custom row precedes the model suggestion.
+    fireEvent.change(input, { target: { value: "o4" } });
+    await waitFor(() => {
+      expect(screen.queryByText("GPT-5")).toBeNull();
+    });
+    expect(screen.getByText("O4")).toBeTruthy();
+
+    // Must not land on Inherit (row 0) and commit unset — start on the first
+    // custom/model choice in the filtered list.
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onInherit).not.toHaveBeenCalled();
+    expect(onCommit).toHaveBeenLastCalledWith("o4");
   });
 
   it("untouched Enter with a typed custom id commits the typed value, not row zero", async () => {

--- a/web/dashboard/src/components/ModelCombobox.test.tsx
+++ b/web/dashboard/src/components/ModelCombobox.test.tsx
@@ -176,6 +176,79 @@ describe("ModelCombobox", () => {
     expect(onCommit).toHaveBeenLastCalledWith("");
   });
 
+  it("keyboard navigation: out-of-catalog binding is a current-state row, not Inherit", async () => {
+    const onCommit = vi.fn();
+    const onInherit = vi.fn();
+    const props = {
+      ...commonProps,
+      // Free-typed id absent from the advisory catalog.
+      value: "my-custom-model",
+      onCommitValue: onCommit,
+      onInherit,
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    fireEvent.focus(input);
+    await screen.findByText("GPT-5");
+
+    // Synthetic custom row represents the current binding so aria-selected
+    // and first ArrowDown land on it rather than special row 0 (Inherit).
+    const custom = screen
+      .getByText('Use "my-custom-model"')
+      .closest("[role='option']");
+    expect(custom?.getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onInherit).not.toHaveBeenCalled();
+    expect(onCommit).toHaveBeenLastCalledWith("my-custom-model");
+  });
+
+  it("keyboard navigation: while catalog is loading, ArrowDown does not clear a concrete binding", async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      ),
+    );
+
+    const onCommit = vi.fn();
+    const onInherit = vi.fn();
+    // Distinct vendor so the module-level suggestion cache from earlier tests
+    // cannot short-circuit the hanging fetch into a warm hit.
+    const props = {
+      ...commonProps,
+      vendor: "loading-vendor",
+      value: "still-loading-model",
+      onCommitValue: onCommit,
+      onInherit,
+    };
+    render(<ModelCombobox {...props} />);
+    const input = screen.getByLabelText("agent.model") as HTMLInputElement;
+    fireEvent.focus(input);
+
+    expect(await screen.findByText(/Loading suggestions/i)).toBeTruthy();
+    // Before models arrive there is no catalog row for the binding; the
+    // synthetic custom row must still be the current-state target so
+    // ArrowDown+Enter re-commits the id instead of Inherit (row 0).
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onInherit).not.toHaveBeenCalled();
+    expect(onCommit).toHaveBeenLastCalledWith("still-loading-model");
+
+    // Unblock the hanging fetch so the effect cleanup does not leak.
+    resolveFetch?.(
+      jsonEnvelope({
+        ...MODELS,
+        vendor: "loading-vendor",
+      }),
+    );
+  });
+
   it("keyboard navigation: with a filter, ArrowDown starts at the first matching suggestion", async () => {
     const onCommit = vi.fn();
     const onInherit = vi.fn();

--- a/web/dashboard/src/components/ModelCombobox.tsx
+++ b/web/dashboard/src/components/ModelCombobox.tsx
@@ -89,18 +89,34 @@ export function ModelCombobox({
   const listRef = useRef<HTMLUListElement | null>(null);
 
   // Single close path: clear popup, transient query, and navigation state.
-  // Parent `value` is authoritative once closed.
+  // Parent `value` is authoritative once closed. Escape uses this path without
+  // staging, so discarded keystrokes never reach the draft.
   const close = useCallback(() => {
     setOpen(false);
     setQuery(null);
     setActive(null);
   }, []);
 
+  // Commit free-entry text (or empty clear) then close. Used by Enter, Tab,
+  // and blur — not Escape, which cancels without staging.
+  const commitTypedAndClose = useCallback(() => {
+    if (query !== null) {
+      onCommitValue(query.trim());
+    }
+    close();
+  }, [query, onCommitValue, close]);
+
   // Load / refresh suggestions when the popup opens (or vendor changes while
-  // open). Fresh cache serves synchronously; stale cache is shown while a
-  // background probe refreshes it.
+  // open). Clear prior UI state first, then restore from the module cache or
+  // fetch — a separate vendor-clear effect used to run *after* a fresh cache
+  // hit and wipe the restored list for the rest of the open session.
   useEffect(() => {
+    setEntries(null);
+    setProbeError(null);
+    setLoading(false);
+
     if (!open || !vendor) return;
+
     const cached = cache.get(vendor);
     if (cached) setEntries(cached.data.models);
     if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
@@ -143,23 +159,17 @@ export function ModelCombobox({
     };
   }, [open, vendor]);
 
-  // Vendor change: drop stale suggestions immediately.
-  useEffect(() => {
-    setEntries(null);
-    setProbeError(null);
-    setLoading(false);
-  }, [vendor]);
-
-  // Close on outside click via the unified close path.
+  // Outside click stages free-entry text then closes (not cancel). Escape is
+  // the only path that discards the local query without committing.
   useEffect(() => {
     if (!open) return;
     const handler = (event: MouseEvent) => {
       if (!rootRef.current) return;
-      if (!rootRef.current.contains(event.target as Node)) close();
+      if (!rootRef.current.contains(event.target as Node)) commitTypedAndClose();
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
-  }, [open, close]);
+  }, [open, commitTypedAndClose]);
 
   const rows = useMemo<Row[]>(() => {
     const specials: Row[] = [];
@@ -313,20 +323,21 @@ export function ModelCombobox({
         commitRow(rows[active]);
       } else if (query !== null && query.trim() !== "") {
         event.preventDefault();
-        onCommitValue(query.trim());
-        close();
+        commitTypedAndClose();
       } else if (open) {
         event.preventDefault();
         close();
       }
     } else if (event.key === "Escape") {
+      // Cancel: discard local query without staging. Parent draft stays at
+      // the pre-edit value because keystrokes no longer call onCommitValue.
       if (open) {
         event.preventDefault();
         close();
       }
     } else if (event.key === "Tab") {
-      // Tab commits nothing but exits cleanly.
-      if (open) close();
+      // Tab away stages free-entry text (same as blur) but does not pick a row.
+      if (open) commitTypedAndClose();
     }
   };
 
@@ -376,16 +387,20 @@ export function ModelCombobox({
           ) {
             return;
           }
-          close();
+          // Stage free-entry text on leave so Save without Enter still works;
+          // Escape uses close() only and never reaches here with a pending query
+          // that should be discarded (Escape closes first without blur commit
+          // when the input keeps focus).
+          commitTypedAndClose();
         }}
         onChange={(event) => {
           const next = event.currentTarget.value;
-          // Preserve tri-state: stage typed text as-is (free entry). Empty text
-          // is legitimate — caller decides how "" maps to buildConfigPatch.
+          // Keep typing local until commit (Enter / pick / Tab / blur). Staging
+          // every keystroke made Escape unable to cancel: parent draft already
+          // held the half-edited id, so closing only cleared the local query.
           setQuery(next);
           setOpen(true);
           setActive(null);
-          onCommitValue(next);
         }}
         onKeyDown={onKeyDown}
       />

--- a/web/dashboard/src/components/ModelCombobox.tsx
+++ b/web/dashboard/src/components/ModelCombobox.tsx
@@ -38,7 +38,9 @@ export type ModelComboboxProps = {
   vendor: string | null;
   /**
    * Current draft (or published) binding:
-   * - `null` = persisted absence (inherits previous layer; not the same as `""`)
+   * - `null` = persisted absence (not the same as `""`)
+   *   - with allowInherit: Inherit from previous layer
+   *   - without (global): unbound — params/CLI model may still apply
    * - `""` = explicit vendor-default suppress
    * - non-empty = model id
    */
@@ -223,12 +225,17 @@ export function ModelCombobox({
     }
   }, [active, open]);
 
-  // Absent leaf (null) is inherit when Inherit is offered; without allowInherit
-  // (global model) absence collapses to vendor/CLI default like explicit "".
+  // Tri-state binding:
+  // - null = persisted absence (not the same as explicit "")
+  // - ""   = explicit vendor-default suppress
+  // - id   = model id
+  // When Inherit is offered (profile/role), absence is Inherit. For global
+  // (!allowInherit), absence stays unbound: agent.params.args --model/-m may
+  // still apply. Only explicit "" is Vendor default; collapsing null → ""
+  // would reaffirm as suppress and strip params model flags on save.
   const inheritsByAbsence = value === null && allowInherit;
   const isInheritState = unset || inheritsByAbsence;
-  const isVendorDefaultState =
-    !unset && (value === "" || (value === null && !allowInherit));
+  const isVendorDefaultState = !unset && value === "";
   const boundValue = value ?? "";
 
   // What to render inside the input. When closed, defer to the controlled

--- a/web/dashboard/src/components/ModelCombobox.tsx
+++ b/web/dashboard/src/components/ModelCombobox.tsx
@@ -1,0 +1,469 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  fetchAgentModels,
+  type AgentModelEntry,
+  type AgentModelsData,
+} from "@/lib/api";
+
+const controlClass =
+  "w-full rounded border border-[var(--border)] bg-[var(--bg)] px-2 py-1 text-[12px] text-[var(--text)] disabled:cursor-not-allowed disabled:opacity-60";
+
+/**
+ * Advisory suggestion cache. Backend already caches ~60s per vendor; this just
+ * avoids extra round trips on repeated focus and keeps the previous list on
+ * screen while a refresh probe is in flight. Cache freshness (timestamp) is
+ * the sole authority for whether we skip a fetch — no separate "fetched"
+ * ref that could strand the control after an aborted request.
+ */
+const CACHE_TTL_MS = 60_000;
+const cache = new Map<string, { at: number; data: AgentModelsData }>();
+
+type SpecialKind = "inherit" | "vendor-default";
+type Row =
+  | { kind: "special"; special: SpecialKind; label: string; hint?: string }
+  | { kind: "model"; entry: AgentModelEntry }
+  | { kind: "custom"; value: string };
+
+export type ModelComboboxProps = {
+  id?: string;
+  ariaLabel?: string;
+  /** Effective vendor resolved by the caller (nullable). */
+  vendor: string | null;
+  /** Current draft (or published) string. Empty string = vendor default. */
+  value: string;
+  /** True when caller has staged an unset (inherit). Displayed as read-only. */
+  unset: boolean;
+  disabled: boolean;
+  /** True to include an "Inherit" row (profile / role scopes). */
+  allowInherit: boolean;
+  placeholder?: string;
+  /**
+   * Stage a value as free entry / id pick / vendor default. Caller decides how
+   * to map "" (vendor default suppress vs no-op) based on scope semantics — see
+   * buildConfigPatch tri-state rules.
+   */
+  onCommitValue: (value: string) => void;
+  /**
+   * Stage an inherit (unset). Required when allowInherit=true.
+   */
+  onInherit?: () => void;
+};
+
+export function ModelCombobox({
+  id,
+  ariaLabel,
+  vendor,
+  value,
+  unset,
+  disabled,
+  allowInherit,
+  placeholder,
+  onCommitValue,
+  onInherit,
+}: ModelComboboxProps) {
+  const generatedId = useId();
+  const listboxId = `${id ?? generatedId}-listbox`;
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState<string | null>(null);
+  // null = no keyboard navigation yet. Enter with null commits the typed
+  // value (or does nothing) rather than blindly selecting row zero.
+  const [active, setActive] = useState<number | null>(null);
+  const [entries, setEntries] = useState<AgentModelEntry[] | null>(null);
+  const [probeError, setProbeError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
+
+  // Single close path: clear popup, transient query, and navigation state.
+  // Parent `value` is authoritative once closed.
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery(null);
+    setActive(null);
+  }, []);
+
+  // Load / refresh suggestions when the popup opens (or vendor changes while
+  // open). Fresh cache serves synchronously; stale cache is shown while a
+  // background probe refreshes it.
+  useEffect(() => {
+    if (!open || !vendor) return;
+    const cached = cache.get(vendor);
+    if (cached) setEntries(cached.data.models);
+    if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+      setProbeError(
+        cached.data.sources.probe === "error"
+          ? cached.data.sources.probeError ??
+              "Using built-in list; CLI probe failed"
+          : null,
+      );
+      return;
+    }
+    const controller = new AbortController();
+    setLoading(true);
+    fetchAgentModels(vendor, { signal: controller.signal })
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        cache.set(vendor, { at: Date.now(), data });
+        setEntries(data.models);
+        setProbeError(
+          data.sources.probe === "error"
+            ? data.sources.probeError ??
+                "Using built-in list; CLI probe failed"
+            : null,
+        );
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setProbeError(
+          err instanceof Error
+            ? `Model suggestions unavailable (${err.message})`
+            : "Model suggestions unavailable",
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => {
+      controller.abort();
+      setLoading(false);
+    };
+  }, [open, vendor]);
+
+  // Vendor change: drop stale suggestions immediately.
+  useEffect(() => {
+    setEntries(null);
+    setProbeError(null);
+    setLoading(false);
+  }, [vendor]);
+
+  // Close on outside click via the unified close path.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (event: MouseEvent) => {
+      if (!rootRef.current) return;
+      if (!rootRef.current.contains(event.target as Node)) close();
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open, close]);
+
+  const rows = useMemo<Row[]>(() => {
+    const specials: Row[] = [];
+    if (allowInherit) {
+      specials.push({
+        kind: "special",
+        special: "inherit",
+        label: "Inherit",
+        hint: "Fall back to the previous layer (profile / global / vendor default).",
+      });
+    }
+    specials.push({
+      kind: "special",
+      special: "vendor-default",
+      label: "Vendor default",
+      hint: "Suppress inherited model; use the vendor CLI default.",
+    });
+
+    const q = (query ?? "").trim().toLowerCase();
+    const source = entries ?? [];
+    const filtered = q
+      ? source.filter(
+          (m) =>
+            m.id.toLowerCase().includes(q) ||
+            m.label.toLowerCase().includes(q),
+        )
+      : source;
+
+    const modelRows: Row[] = filtered.map((entry) => ({
+      kind: "model",
+      entry,
+    }));
+
+    // Custom / free-entry row when the current query is a novel id.
+    let customRow: Row | null = null;
+    if (
+      q &&
+      !filtered.some((m) => m.id.toLowerCase() === q) &&
+      // Skip "custom" when the query happens to equal a special label.
+      q !== "inherit" &&
+      q !== "vendor default"
+    ) {
+      customRow = { kind: "custom", value: (query ?? "").trim() };
+    }
+
+    return customRow ? [...specials, customRow, ...modelRows] : [...specials, ...modelRows];
+  }, [entries, query, allowInherit]);
+
+  // Keep active index in range as rows change. Null (untouched) stays null.
+  useEffect(() => {
+    if (active !== null && active >= rows.length) {
+      setActive(rows.length > 0 ? rows.length - 1 : null);
+    }
+  }, [rows.length, active]);
+
+  // Scroll the active option into view on keyboard navigation.
+  useEffect(() => {
+    if (!open || active === null || !listRef.current) return;
+    const el = listRef.current.children[active] as HTMLElement | undefined;
+    // scrollIntoView is a browser API; jsdom stubs it out — guard for tests.
+    if (typeof el?.scrollIntoView === "function") {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  }, [active, open]);
+
+  // What to render inside the input. When closed, defer to the controlled
+  // `value` so a discarded/rebased parent draft never leaves stale query
+  // text on screen. When open, show the current query (or fall back to value).
+  const displayValue = open ? query ?? value : unset ? "" : value;
+
+  // Which row represents the current parent state (for aria-selected when the
+  // operator hasn't navigated yet).
+  const stateRowIndex = useMemo<number | null>(() => {
+    if (unset) {
+      const idx = rows.findIndex(
+        (r) => r.kind === "special" && r.special === "inherit",
+      );
+      return idx >= 0 ? idx : null;
+    }
+    if (value === "") {
+      const idx = rows.findIndex(
+        (r) => r.kind === "special" && r.special === "vendor-default",
+      );
+      return idx >= 0 ? idx : null;
+    }
+    const idx = rows.findIndex(
+      (r) => r.kind === "model" && r.entry.id === value,
+    );
+    return idx >= 0 ? idx : null;
+  }, [rows, value, unset]);
+
+  const commitRow = useCallback(
+    (row: Row) => {
+      if (row.kind === "special") {
+        if (row.special === "inherit") {
+          if (onInherit) onInherit();
+        } else {
+          onCommitValue("");
+        }
+      } else if (row.kind === "model") {
+        onCommitValue(row.entry.id);
+      } else {
+        onCommitValue(row.value);
+      }
+      close();
+    },
+    [onCommitValue, onInherit, close],
+  );
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setOpen(true);
+      setActive((idx) => {
+        // First arrow press: start navigation from the row that reflects
+        // current parent state (Inherit when unset, Vendor default when "",
+        // or the matching model), falling back to row 0.
+        if (idx === null) return stateRowIndex ?? 0;
+        return Math.min(rows.length - 1, idx + 1);
+      });
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setOpen(true);
+      setActive((idx) => {
+        if (idx === null) return stateRowIndex ?? 0;
+        return Math.max(0, idx - 1);
+      });
+    } else if (event.key === "Enter") {
+      // Only commit a row when the operator has explicitly arrow-navigated
+      // to it. An untouched Enter with typed text commits the typed value;
+      // with no typed text it does nothing (keeps the current parent value).
+      if (open && active !== null && rows[active]) {
+        event.preventDefault();
+        commitRow(rows[active]);
+      } else if (query !== null && query.trim() !== "") {
+        event.preventDefault();
+        onCommitValue(query.trim());
+        close();
+      } else if (open) {
+        event.preventDefault();
+        close();
+      }
+    } else if (event.key === "Escape") {
+      if (open) {
+        event.preventDefault();
+        close();
+      }
+    } else if (event.key === "Tab") {
+      // Tab commits nothing but exits cleanly.
+      if (open) close();
+    }
+  };
+
+  // aria-activedescendant: prefer explicit keyboard-navigated active row.
+  // When the operator has not navigated, expose the row that reflects current
+  // parent state (if any) so screen readers announce the current selection.
+  const ariaActiveIdx = active ?? stateRowIndex;
+  const activeId =
+    open && ariaActiveIdx !== null && rows[ariaActiveIdx]
+      ? `${listboxId}-opt-${ariaActiveIdx}`
+      : undefined;
+
+  // Placeholder reflects tri-state when the input renders empty and closed.
+  const closedPlaceholder = unset
+    ? "Inherit"
+    : value === ""
+      ? "Vendor default"
+      : placeholder;
+
+  return (
+    <div ref={rootRef} className="relative min-w-0">
+      <input
+        id={id}
+        aria-label={ariaLabel}
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-activedescendant={activeId}
+        className={`${controlClass} mono ${unset ? "opacity-50" : ""}`}
+        type="text"
+        spellCheck={false}
+        autoComplete="off"
+        placeholder={open ? placeholder : closedPlaceholder}
+        disabled={disabled || unset}
+        value={displayValue}
+        onFocus={() => setOpen(true)}
+        onClick={() => setOpen(true)}
+        onBlur={(event) => {
+          // Ignore blur when focus moves to our own popup (listbox mousedown).
+          if (
+            rootRef.current &&
+            event.relatedTarget instanceof Node &&
+            rootRef.current.contains(event.relatedTarget)
+          ) {
+            return;
+          }
+          close();
+        }}
+        onChange={(event) => {
+          const next = event.currentTarget.value;
+          // Preserve tri-state: stage typed text as-is (free entry). Empty text
+          // is legitimate — caller decides how "" maps to buildConfigPatch.
+          setQuery(next);
+          setOpen(true);
+          setActive(null);
+          onCommitValue(next);
+        }}
+        onKeyDown={onKeyDown}
+      />
+      {open && !disabled && !unset ? (
+        <div
+          className="absolute left-0 right-0 z-30 mt-1 max-h-64 overflow-auto rounded border border-[var(--border)] bg-[var(--bg-elevated)] shadow-lg"
+          data-testid="model-combobox-popup"
+        >
+          {!vendor ? (
+            <p className="m-0 px-2 py-1.5 text-[11px] text-[var(--text-muted)]">
+              Select a vendor first — suggestions will load automatically. You
+              can still type any model id.
+            </p>
+          ) : null}
+          {probeError ? (
+            <p
+              className="m-0 border-b border-[var(--border)] px-2 py-1 text-[10px] text-[var(--warn)]"
+              role="status"
+            >
+              {probeError}
+            </p>
+          ) : null}
+          {loading && (!entries || entries.length === 0) ? (
+            <p className="m-0 px-2 py-1.5 text-[11px] text-[var(--text-muted)]">
+              Loading suggestions…
+            </p>
+          ) : null}
+          <ul
+            id={listboxId}
+            ref={listRef}
+            role="listbox"
+            className="m-0 list-none p-0"
+          >
+            {rows.map((row, idx) => {
+              const isActive = idx === active;
+              const isCurrent = active === null && idx === stateRowIndex;
+              const label =
+                row.kind === "special"
+                  ? row.label
+                  : row.kind === "model"
+                    ? row.entry.label || row.entry.id
+                    : `Use "${row.value}"`;
+              const sub =
+                row.kind === "special"
+                  ? row.hint
+                  : row.kind === "model"
+                    ? row.entry.id !== label
+                      ? row.entry.id
+                      : row.entry.source
+                    : "Custom model id";
+              return (
+                <li
+                  key={
+                    row.kind === "special"
+                      ? `sp-${row.special}`
+                      : row.kind === "model"
+                        ? `m-${row.entry.id}`
+                        : `c-${row.value}`
+                  }
+                  id={`${listboxId}-opt-${idx}`}
+                  role="option"
+                  aria-selected={isActive || isCurrent}
+                  className={`flex cursor-pointer flex-col gap-0.5 px-2 py-1 text-[12px] ${
+                    isActive
+                      ? "bg-[color-mix(in_srgb,var(--accent)_20%,transparent)]"
+                      : isCurrent
+                        ? "bg-[color-mix(in_srgb,var(--accent)_10%,transparent)]"
+                        : "hover:bg-[var(--bg-muted)]"
+                  }`}
+                  // Use mousedown so the input's blur does not close first.
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    commitRow(row);
+                  }}
+                  onMouseEnter={() => setActive(idx)}
+                >
+                  <span
+                    className={
+                      row.kind === "model" ? "mono" : "font-medium"
+                    }
+                  >
+                    {label}
+                  </span>
+                  {sub ? (
+                    <span className="text-[10px] text-[var(--text-muted)]">
+                      {sub}
+                    </span>
+                  ) : null}
+                </li>
+              );
+            })}
+            {rows.length === 0 && vendor && !loading ? (
+              <li
+                role="option"
+                aria-selected={false}
+                aria-disabled
+                className="px-2 py-1.5 text-[11px] text-[var(--text-muted)]"
+              >
+                No suggestions. Type a model id to use it directly.
+              </li>
+            ) : null}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/dashboard/src/components/ModelCombobox.tsx
+++ b/web/dashboard/src/components/ModelCombobox.tsx
@@ -178,6 +178,24 @@ export function ModelCombobox({
     return () => document.removeEventListener("mousedown", handler);
   }, [open, commitTypedAndClose]);
 
+  // Tri-state binding:
+  // - null = persisted absence (not the same as explicit "")
+  // - ""   = explicit vendor-default suppress
+  // - id   = model id
+  // When Inherit is offered (profile/role), absence is Inherit. For global
+  // (!allowInherit), absence stays unbound: agent.params.args --model/-m may
+  // still apply. Only explicit "" is Vendor default; collapsing null → ""
+  // would reaffirm as suppress and strip params model flags on save.
+  // Computed before `rows` so a concrete binding missing from the catalog
+  // can still be represented as a current-state custom row.
+  const absenceState = unset || value === null;
+  const isInheritState = allowInherit && absenceState;
+  const isUnboundState = !allowInherit && absenceState;
+  const isVendorDefaultState = !unset && value === "";
+  const boundValue = value ?? "";
+  const hasConcreteBinding =
+    !isInheritState && !isUnboundState && !isVendorDefaultState && boundValue !== "";
+
   const rows = useMemo<Row[]>(() => {
     const specials: Row[] = [];
     if (allowInherit) {
@@ -219,21 +237,37 @@ export function ModelCombobox({
       entry,
     }));
 
-    // Custom / free-entry row when the current query is a novel id.
+    // Custom / free-entry row when the typed query is a novel id, or when the
+    // parent already binds a concrete id that is absent from the (possibly
+    // still-loading) catalog. Without the latter, stateRowIndex is null and
+    // first ArrowDown falls through to special row 0 (Inherit/Unbound).
     let customRow: Row | null = null;
-    if (
-      q &&
-      !filtered.some((m) => m.id.toLowerCase() === q) &&
-      // Skip "custom" when the query happens to equal a special label.
-      q !== "inherit" &&
-      q !== "unbound" &&
-      q !== "vendor default"
+    if (q) {
+      if (
+        !filtered.some((m) => m.id.toLowerCase() === q) &&
+        // Skip "custom" when the query happens to equal a special label.
+        q !== "inherit" &&
+        q !== "unbound" &&
+        q !== "vendor default"
+      ) {
+        customRow = { kind: "custom", value: (query ?? "").trim() };
+      }
+    } else if (
+      hasConcreteBinding &&
+      !source.some((m) => m.id === boundValue)
     ) {
-      customRow = { kind: "custom", value: (query ?? "").trim() };
+      customRow = { kind: "custom", value: boundValue };
     }
 
     return customRow ? [...specials, customRow, ...modelRows] : [...specials, ...modelRows];
-  }, [entries, query, allowInherit, onUnbound]);
+  }, [
+    entries,
+    query,
+    allowInherit,
+    onUnbound,
+    hasConcreteBinding,
+    boundValue,
+  ]);
 
   // Keep active index in range as rows change. Null (untouched) stays null.
   useEffect(() => {
@@ -252,20 +286,6 @@ export function ModelCombobox({
     }
   }, [active, open]);
 
-  // Tri-state binding:
-  // - null = persisted absence (not the same as explicit "")
-  // - ""   = explicit vendor-default suppress
-  // - id   = model id
-  // When Inherit is offered (profile/role), absence is Inherit. For global
-  // (!allowInherit), absence stays unbound: agent.params.args --model/-m may
-  // still apply. Only explicit "" is Vendor default; collapsing null → ""
-  // would reaffirm as suppress and strip params model flags on save.
-  const absenceState = unset || value === null;
-  const isInheritState = allowInherit && absenceState;
-  const isUnboundState = !allowInherit && absenceState;
-  const isVendorDefaultState = !unset && value === "";
-  const boundValue = value ?? "";
-
   // What to render inside the input. When closed, defer to the controlled
   // `value` so a discarded/rebased parent draft never leaves stale query
   // text on screen. When open, show the current query (or fall back to value).
@@ -276,7 +296,8 @@ export function ModelCombobox({
       : boundValue;
 
   // Which row represents the current parent state (for aria-selected when the
-  // operator hasn't navigated yet).
+  // operator hasn't navigated yet). Matches model suggestions and the
+  // synthetic custom row for out-of-catalog / still-loading bindings.
   const stateRowIndex = useMemo<number | null>(() => {
     if (isInheritState) {
       const idx = rows.findIndex(
@@ -297,7 +318,9 @@ export function ModelCombobox({
       return idx >= 0 ? idx : null;
     }
     const idx = rows.findIndex(
-      (r) => r.kind === "model" && r.entry.id === value,
+      (r) =>
+        (r.kind === "model" && r.entry.id === value) ||
+        (r.kind === "custom" && r.value === value),
     );
     return idx >= 0 ? idx : null;
   }, [rows, value, isInheritState, isUnboundState, isVendorDefaultState]);
@@ -322,21 +345,27 @@ export function ModelCombobox({
     [onCommitValue, onInherit, onUnbound, close],
   );
 
+  // First non-special row (custom free-entry or model suggestion). Used when
+  // a filter is active or when a concrete binding has no state row yet.
+  const firstChoiceIndex = (): number => {
+    const idx = rows.findIndex((r) => r.kind === "model" || r.kind === "custom");
+    return idx >= 0 ? idx : 0;
+  };
+
   // First keyboard step when the operator has not arrow-navigated yet.
   // With a typed filter, start on the first custom/model suggestion so
   // ArrowDown+Enter does not land on Inherit / Vendor default (specials
   // always precede filtered rows, and stateRowIndex is often null once the
   // current binding is filtered out). Without a filter, start on the row
-  // that reflects parent state.
+  // that reflects parent state; if that is still missing for a concrete
+  // binding, prefer the first non-special row over special row 0 so Enter
+  // cannot unexpectedly clear the binding to Inherit/Unbound.
   const initialNavIndex = (): number => {
     const hasFilter = query !== null && query.trim() !== "";
-    if (hasFilter) {
-      const firstChoice = rows.findIndex(
-        (r) => r.kind === "model" || r.kind === "custom",
-      );
-      if (firstChoice >= 0) return firstChoice;
-    }
-    return stateRowIndex ?? 0;
+    if (hasFilter) return firstChoiceIndex();
+    if (stateRowIndex !== null) return stateRowIndex;
+    if (hasConcreteBinding) return firstChoiceIndex();
+    return 0;
   };
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/web/dashboard/src/components/ModelCombobox.tsx
+++ b/web/dashboard/src/components/ModelCombobox.tsx
@@ -31,6 +31,18 @@ type Row =
   | { kind: "model"; entry: AgentModelEntry }
   | { kind: "custom"; value: string };
 
+/**
+ * Stable logical identity for a listbox row. Custom free-entry rows and catalog
+ * model rows that share the same id map to the same key so keyboard `active`
+ * can be remapped when a temporary custom binding row is replaced by the real
+ * catalog entry (or vice versa) without retaining a stale numeric index.
+ */
+function rowIdentity(row: Row): string {
+  if (row.kind === "special") return `special:${row.special}`;
+  if (row.kind === "model") return `value:${row.entry.id}`;
+  return `value:${row.value}`;
+}
+
 export type ModelComboboxProps = {
   id?: string;
   ariaLabel?: string;
@@ -94,6 +106,9 @@ export function ModelCombobox({
   const [loading, setLoading] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLUListElement | null>(null);
+  // Previous row snapshot for remapping `active` by identity when the list
+  // changes under an open popup (catalog load, filter, custom-row collapse).
+  const prevRowsRef = useRef<Row[]>([]);
 
   // Single close path: clear popup, transient query, and navigation state.
   // Parent `value` is authoritative once closed. Escape uses this path without
@@ -269,12 +284,39 @@ export function ModelCombobox({
     boundValue,
   ]);
 
-  // Keep active index in range as rows change. Null (untouched) stays null.
+  // Keep keyboard `active` on the same logical option when the row set
+  // changes. Range-only clamping is insufficient: while the catalog loads we
+  // may insert a temporary custom row for the saved binding; ArrowDown can
+  // land on it by index, then the real catalog entry replaces that custom
+  // row and the same numeric index points at a different model. Remap by
+  // identity (custom value ≡ model id); if the option disappeared, clear
+  // navigation so Enter does not commit an unrelated row.
   useEffect(() => {
-    if (active !== null && active >= rows.length) {
-      setActive(rows.length > 0 ? rows.length - 1 : null);
+    const prevRows = prevRowsRef.current;
+    prevRowsRef.current = rows;
+    if (active === null) return;
+
+    if (prevRows === rows) {
+      // Rows unchanged (e.g. pure active update): only clamp out-of-range.
+      if (active >= rows.length) {
+        setActive(rows.length > 0 ? rows.length - 1 : null);
+      }
+      return;
     }
-  }, [rows.length, active]);
+
+    const prev = prevRows[active];
+    if (prev) {
+      const id = rowIdentity(prev);
+      const nextIdx = rows.findIndex((r) => rowIdentity(r) === id);
+      if (nextIdx >= 0) {
+        if (nextIdx !== active) setActive(nextIdx);
+        return;
+      }
+    }
+
+    // Previously active option is gone — reset rather than keep a stale index.
+    setActive(null);
+  }, [rows, active]);
 
   // Scroll the active option into view on keyboard navigation.
   useEffect(() => {

--- a/web/dashboard/src/components/ModelCombobox.tsx
+++ b/web/dashboard/src/components/ModelCombobox.tsx
@@ -296,32 +296,47 @@ export function ModelCombobox({
     [onCommitValue, onInherit, close],
   );
 
+  // First keyboard step when the operator has not arrow-navigated yet.
+  // With a typed filter, start on the first custom/model suggestion so
+  // ArrowDown+Enter does not land on Inherit / Vendor default (specials
+  // always precede filtered rows, and stateRowIndex is often null once the
+  // current binding is filtered out). Without a filter, start on the row
+  // that reflects parent state.
+  const initialNavIndex = (): number => {
+    const hasFilter = query !== null && query.trim() !== "";
+    if (hasFilter) {
+      const firstChoice = rows.findIndex(
+        (r) => r.kind === "model" || r.kind === "custom",
+      );
+      if (firstChoice >= 0) return firstChoice;
+    }
+    return stateRowIndex ?? 0;
+  };
+
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "ArrowDown") {
       event.preventDefault();
       setOpen(true);
       setActive((idx) => {
-        // First arrow press: start navigation from the row that reflects
-        // current parent state (Inherit when unset/absent, Vendor default
-        // when "", or the matching model), falling back to row 0.
-        if (idx === null) return stateRowIndex ?? 0;
+        if (idx === null) return initialNavIndex();
         return Math.min(rows.length - 1, idx + 1);
       });
     } else if (event.key === "ArrowUp") {
       event.preventDefault();
       setOpen(true);
       setActive((idx) => {
-        if (idx === null) return stateRowIndex ?? 0;
+        if (idx === null) return initialNavIndex();
         return Math.max(0, idx - 1);
       });
     } else if (event.key === "Enter") {
       // Only commit a row when the operator has explicitly arrow-navigated
-      // to it. An untouched Enter with typed text commits the typed value;
-      // with no typed text it does nothing (keeps the current parent value).
+      // to it. An untouched Enter commits any edited query — including an
+      // empty clear (same as blur/Tab). query === null means no edit, so
+      // keep the parent value.
       if (open && active !== null && rows[active]) {
         event.preventDefault();
         commitRow(rows[active]);
-      } else if (query !== null && query.trim() !== "") {
+      } else if (query !== null) {
         event.preventDefault();
         commitTypedAndClose();
       } else if (open) {

--- a/web/dashboard/src/components/ModelCombobox.tsx
+++ b/web/dashboard/src/components/ModelCombobox.tsx
@@ -25,7 +25,7 @@ const controlClass =
 const CACHE_TTL_MS = 60_000;
 const cache = new Map<string, { at: number; data: AgentModelsData }>();
 
-type SpecialKind = "inherit" | "vendor-default";
+type SpecialKind = "inherit" | "unbound" | "vendor-default";
 type Row =
   | { kind: "special"; special: SpecialKind; label: string; hint?: string }
   | { kind: "model"; entry: AgentModelEntry }
@@ -61,6 +61,12 @@ export type ModelComboboxProps = {
    * Stage an inherit (unset). Required when allowInherit=true.
    */
   onInherit?: () => void;
+  /**
+   * Restore global absence (null). Required for the global scope where Inherit
+   * is not offered: clears a draft back to published null, or stages unset when
+   * a binding exists. Distinct from Vendor default (`""` suppress).
+   */
+  onUnbound?: () => void;
 };
 
 export function ModelCombobox({
@@ -74,6 +80,7 @@ export function ModelCombobox({
   placeholder,
   onCommitValue,
   onInherit,
+  onUnbound,
 }: ModelComboboxProps) {
   const generatedId = useId();
   const listboxId = `${id ?? generatedId}-listbox`;
@@ -180,6 +187,15 @@ export function ModelCombobox({
         label: "Inherit",
         hint: "Fall back to the previous layer (profile / global / vendor default).",
       });
+    } else if (onUnbound) {
+      // Global scope: restore absence (null), not layer inherit. Needed when
+      // the published leaf is default-sourced so FieldFrame has no Unset.
+      specials.push({
+        kind: "special",
+        special: "unbound",
+        label: "Unbound",
+        hint: "No agent.model binding; agent.params.args --model/-m may still apply.",
+      });
     }
     specials.push({
       kind: "special",
@@ -210,13 +226,14 @@ export function ModelCombobox({
       !filtered.some((m) => m.id.toLowerCase() === q) &&
       // Skip "custom" when the query happens to equal a special label.
       q !== "inherit" &&
+      q !== "unbound" &&
       q !== "vendor default"
     ) {
       customRow = { kind: "custom", value: (query ?? "").trim() };
     }
 
     return customRow ? [...specials, customRow, ...modelRows] : [...specials, ...modelRows];
-  }, [entries, query, allowInherit]);
+  }, [entries, query, allowInherit, onUnbound]);
 
   // Keep active index in range as rows change. Null (untouched) stays null.
   useEffect(() => {
@@ -243,8 +260,9 @@ export function ModelCombobox({
   // (!allowInherit), absence stays unbound: agent.params.args --model/-m may
   // still apply. Only explicit "" is Vendor default; collapsing null → ""
   // would reaffirm as suppress and strip params model flags on save.
-  const inheritsByAbsence = value === null && allowInherit;
-  const isInheritState = unset || inheritsByAbsence;
+  const absenceState = unset || value === null;
+  const isInheritState = allowInherit && absenceState;
+  const isUnboundState = !allowInherit && absenceState;
   const isVendorDefaultState = !unset && value === "";
   const boundValue = value ?? "";
 
@@ -253,7 +271,7 @@ export function ModelCombobox({
   // text on screen. When open, show the current query (or fall back to value).
   const displayValue = open
     ? (query ?? boundValue)
-    : isInheritState
+    : isInheritState || isUnboundState
       ? ""
       : boundValue;
 
@@ -263,6 +281,12 @@ export function ModelCombobox({
     if (isInheritState) {
       const idx = rows.findIndex(
         (r) => r.kind === "special" && r.special === "inherit",
+      );
+      return idx >= 0 ? idx : null;
+    }
+    if (isUnboundState) {
+      const idx = rows.findIndex(
+        (r) => r.kind === "special" && r.special === "unbound",
       );
       return idx >= 0 ? idx : null;
     }
@@ -276,13 +300,15 @@ export function ModelCombobox({
       (r) => r.kind === "model" && r.entry.id === value,
     );
     return idx >= 0 ? idx : null;
-  }, [rows, value, isInheritState, isVendorDefaultState]);
+  }, [rows, value, isInheritState, isUnboundState, isVendorDefaultState]);
 
   const commitRow = useCallback(
     (row: Row) => {
       if (row.kind === "special") {
         if (row.special === "inherit") {
           if (onInherit) onInherit();
+        } else if (row.special === "unbound") {
+          if (onUnbound) onUnbound();
         } else {
           onCommitValue("");
         }
@@ -293,7 +319,7 @@ export function ModelCombobox({
       }
       close();
     },
-    [onCommitValue, onInherit, close],
+    [onCommitValue, onInherit, onUnbound, close],
   );
 
   // First keyboard step when the operator has not arrow-navigated yet.
@@ -366,13 +392,15 @@ export function ModelCombobox({
       : undefined;
 
   // Placeholder reflects tri-state when the input renders empty and closed.
-  // Staged unset locks the control; natural absence still shows Inherit but
-  // remains editable so operators can pick a model without an Undo first.
+  // Staged unset locks the control; natural absence still shows Inherit /
+  // Unbound but remains editable so operators can pick a model without Undo.
   const closedPlaceholder = isInheritState
     ? "Inherit"
-    : isVendorDefaultState
-      ? "Vendor default"
-      : placeholder;
+    : isUnboundState
+      ? "Unbound"
+      : isVendorDefaultState
+        ? "Vendor default"
+        : placeholder;
 
   return (
     <div ref={rootRef} className="relative min-w-0">

--- a/web/dashboard/src/components/ModelCombobox.tsx
+++ b/web/dashboard/src/components/ModelCombobox.tsx
@@ -36,8 +36,13 @@ export type ModelComboboxProps = {
   ariaLabel?: string;
   /** Effective vendor resolved by the caller (nullable). */
   vendor: string | null;
-  /** Current draft (or published) string. Empty string = vendor default. */
-  value: string;
+  /**
+   * Current draft (or published) binding:
+   * - `null` = persisted absence (inherits previous layer; not the same as `""`)
+   * - `""` = explicit vendor-default suppress
+   * - non-empty = model id
+   */
+  value: string | null;
   /** True when caller has staged an unset (inherit). Displayed as read-only. */
   unset: boolean;
   disabled: boolean;
@@ -218,21 +223,33 @@ export function ModelCombobox({
     }
   }, [active, open]);
 
+  // Absent leaf (null) is inherit when Inherit is offered; without allowInherit
+  // (global model) absence collapses to vendor/CLI default like explicit "".
+  const inheritsByAbsence = value === null && allowInherit;
+  const isInheritState = unset || inheritsByAbsence;
+  const isVendorDefaultState =
+    !unset && (value === "" || (value === null && !allowInherit));
+  const boundValue = value ?? "";
+
   // What to render inside the input. When closed, defer to the controlled
   // `value` so a discarded/rebased parent draft never leaves stale query
   // text on screen. When open, show the current query (or fall back to value).
-  const displayValue = open ? query ?? value : unset ? "" : value;
+  const displayValue = open
+    ? (query ?? boundValue)
+    : isInheritState
+      ? ""
+      : boundValue;
 
   // Which row represents the current parent state (for aria-selected when the
   // operator hasn't navigated yet).
   const stateRowIndex = useMemo<number | null>(() => {
-    if (unset) {
+    if (isInheritState) {
       const idx = rows.findIndex(
         (r) => r.kind === "special" && r.special === "inherit",
       );
       return idx >= 0 ? idx : null;
     }
-    if (value === "") {
+    if (isVendorDefaultState) {
       const idx = rows.findIndex(
         (r) => r.kind === "special" && r.special === "vendor-default",
       );
@@ -242,7 +259,7 @@ export function ModelCombobox({
       (r) => r.kind === "model" && r.entry.id === value,
     );
     return idx >= 0 ? idx : null;
-  }, [rows, value, unset]);
+  }, [rows, value, isInheritState, isVendorDefaultState]);
 
   const commitRow = useCallback(
     (row: Row) => {
@@ -268,8 +285,8 @@ export function ModelCombobox({
       setOpen(true);
       setActive((idx) => {
         // First arrow press: start navigation from the row that reflects
-        // current parent state (Inherit when unset, Vendor default when "",
-        // or the matching model), falling back to row 0.
+        // current parent state (Inherit when unset/absent, Vendor default
+        // when "", or the matching model), falling back to row 0.
         if (idx === null) return stateRowIndex ?? 0;
         return Math.min(rows.length - 1, idx + 1);
       });
@@ -316,9 +333,11 @@ export function ModelCombobox({
       : undefined;
 
   // Placeholder reflects tri-state when the input renders empty and closed.
-  const closedPlaceholder = unset
+  // Staged unset locks the control; natural absence still shows Inherit but
+  // remains editable so operators can pick a model without an Undo first.
+  const closedPlaceholder = isInheritState
     ? "Inherit"
-    : value === ""
+    : isVendorDefaultState
       ? "Vendor default"
       : placeholder;
 

--- a/web/dashboard/src/lib/api.ts
+++ b/web/dashboard/src/lib/api.ts
@@ -461,6 +461,43 @@ export function fetchConfig(signal?: AbortSignal): Promise<ConfigData> {
   return apiFetch<ConfigData>("/api/v1/config", { signal });
 }
 
+export type AgentModelSource = "static" | "probe" | "merged";
+export type AgentModelProbeStatus = "ok" | "skipped" | "error" | "unsupported";
+
+export type AgentModelEntry = {
+  id: string;
+  label: string;
+  source: AgentModelSource;
+};
+
+export type AgentModelsData = {
+  vendor: string;
+  models: AgentModelEntry[];
+  sources: {
+    static: boolean;
+    probe: AgentModelProbeStatus;
+    probeError?: string;
+  };
+  probedAt?: string;
+};
+
+/**
+ * Read the agent model suggestion catalog for a vendor. Advisory — never blocks
+ * config save. Backend serves a merged static+probe list with a short cache;
+ * pass `refresh: true` to bypass it.
+ */
+export function fetchAgentModels(
+  vendor: string,
+  opts?: { refresh?: boolean; signal?: AbortSignal },
+): Promise<AgentModelsData> {
+  const params = new URLSearchParams({ vendor });
+  if (opts?.refresh) params.set("refresh", "1");
+  return apiFetch<AgentModelsData>(
+    `/api/v1/agent/models?${params.toString()}`,
+    { signal: opts?.signal },
+  );
+}
+
 export function patchConfig(
   body: PatchConfigBody,
   signal?: AbortSignal,

--- a/web/dashboard/src/lib/configForm.test.ts
+++ b/web/dashboard/src/lib/configForm.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 import { ApiError, type ConfigData } from "./api";
 import {
   AGENT_VENDOR_OPTIONS,
+  agentModelScope,
   buildConfigPatch,
   CONFIG_GROUPS,
   configFieldErrors,
   configFieldPaths,
   configSelectOptions,
   draftStagesConfigChange,
+  effectiveAgentVendor,
   highImpactChanges,
   profileLeafUnsetWouldEmpty,
   roleAgentPath,
@@ -327,6 +329,31 @@ describe("config form contract", () => {
       "roles.worker.agent.model": "",
     });
     expect(result.body.unset).toEqual([]);
+  });
+
+  it("stages a suppress binding for absent global agent.model when the draft is blank", () => {
+    const data = fixture();
+    // Fixture has no agent.model published — absent. Selecting "Vendor
+    // default" from the combobox drafts "" and must persist as an explicit
+    // suppress binding rather than a silent no-op.
+    expect((data.agent as { model?: unknown }).model).toBeUndefined();
+    const result = buildConfigPatch(data, { "agent.model": "" }, []);
+    expect(result.errors).toEqual({});
+    expect(result.body.set).toEqual({ "agent.model": "" });
+    expect(result.body.unset).toEqual([]);
+    // draftStagesConfigChange must observe the same staging so the Config
+    // form does not immediately drop the draft.
+    expect(draftStagesConfigChange(data, "agent.model", "")).toBe(true);
+  });
+
+  it("does not restage suppress when agent.model is already explicit \"\"", () => {
+    const data = fixture();
+    (data.agent as { model?: unknown }).model = "";
+    const result = buildConfigPatch(data, { "agent.model": "" }, []);
+    expect(result.errors).toEqual({});
+    expect(result.body.set).toEqual({});
+    expect(result.body.unset).toEqual([]);
+    expect(draftStagesConfigChange(data, "agent.model", "")).toBe(false);
   });
 
   it("stages blank profile/role model drafts as suppress when the leaf is absent", () => {
@@ -707,5 +734,144 @@ describe("config form contract", () => {
     expect(configFieldErrors(error)).toEqual({
       "scheduler.maxConcurrentRuns": "must be greater than zero",
     });
+  });
+});
+
+describe("agentModelScope", () => {
+  it("classifies model paths", () => {
+    expect(agentModelScope("agent.model")).toEqual({ kind: "global" });
+    expect(agentModelScope("agent.profiles.fast.model")).toEqual({
+      kind: "profile",
+      id: "fast",
+    });
+    expect(agentModelScope("roles.worker.agent.model")).toEqual({
+      kind: "role",
+      role: "worker",
+    });
+    expect(agentModelScope("agent.vendor")).toBeNull();
+    expect(agentModelScope("roles.worker.agent.vendor")).toBeNull();
+    expect(agentModelScope("agent.profiles.fast.vendor")).toBeNull();
+  });
+});
+
+describe("effectiveAgentVendor", () => {
+  it("returns the global vendor for the global scope", () => {
+    const data = fixture();
+    expect(
+      effectiveAgentVendor(data, {}, [], { kind: "global" }),
+    ).toBe("codex");
+  });
+
+  it("returns null when the global vendor is unset", () => {
+    const data = fixture();
+    expect(
+      effectiveAgentVendor(data, {}, ["agent.vendor"], { kind: "global" }),
+    ).toBeNull();
+  });
+
+  it("prefers a draft vendor over the published value", () => {
+    const data = fixture();
+    expect(
+      effectiveAgentVendor(
+        data,
+        { "agent.vendor": "claude-code" },
+        [],
+        { kind: "global" },
+      ),
+    ).toBe("claude-code");
+  });
+
+  it("resolves profile scope via own vendor, then global", () => {
+    const data = fixture();
+    // Published fast profile has vendor=codex; global also codex.
+    expect(
+      effectiveAgentVendor(data, {}, [], { kind: "profile", id: "fast" }),
+    ).toBe("codex");
+
+    // Unset the profile vendor → falls back to global.
+    expect(
+      effectiveAgentVendor(
+        data,
+        {},
+        ["agent.profiles.fast.vendor"],
+        { kind: "profile", id: "fast" },
+      ),
+    ).toBe("codex");
+
+    // Global vendor draft overrides.
+    expect(
+      effectiveAgentVendor(
+        data,
+        { "agent.vendor": "opencode" },
+        ["agent.profiles.fast.vendor"],
+        { kind: "profile", id: "fast" },
+      ),
+    ).toBe("opencode");
+  });
+
+  it("treats whole-profile unset as no profile vendor", () => {
+    const data = fixture();
+    expect(
+      effectiveAgentVendor(
+        data,
+        {},
+        ["agent.profiles.fast"],
+        { kind: "profile", id: "fast" },
+      ),
+    ).toBe("codex");
+  });
+
+  it("resolves role scope inline vendor first, then profile, then global", () => {
+    const data = fixture();
+    // Fixture role worker: profile=fast, vendor=claude-code → inline wins.
+    expect(
+      effectiveAgentVendor(data, {}, [], { kind: "role", role: "worker" }),
+    ).toBe("claude-code");
+
+    // Unset role vendor → profile "fast" (vendor=codex) resolves.
+    expect(
+      effectiveAgentVendor(
+        data,
+        {},
+        ["roles.worker.agent.vendor"],
+        { kind: "role", role: "worker" },
+      ),
+    ).toBe("codex");
+
+    // Unset role profile too → falls back to global.
+    expect(
+      effectiveAgentVendor(
+        data,
+        {},
+        ["roles.worker.agent.vendor", "roles.worker.agent.profile"],
+        { kind: "role", role: "worker" },
+      ),
+    ).toBe("codex");
+
+    // Global draft override wins once role/profile vendors are gone.
+    expect(
+      effectiveAgentVendor(
+        data,
+        { "agent.vendor": "opencode" },
+        [
+          "roles.worker.agent.vendor",
+          "roles.worker.agent.profile",
+          "agent.profiles.fast.vendor",
+        ],
+        { kind: "role", role: "worker" },
+      ),
+    ).toBe("opencode");
+  });
+
+  it("empty-string draft vendor counts as absent for overlay", () => {
+    const data = fixture();
+    expect(
+      effectiveAgentVendor(
+        data,
+        { "roles.worker.agent.vendor": "" },
+        [],
+        { kind: "role", role: "worker" },
+      ),
+    ).toBe("codex"); // profile fast still resolves
   });
 });

--- a/web/dashboard/src/lib/configForm.ts
+++ b/web/dashboard/src/lib/configForm.ts
@@ -82,6 +82,117 @@ export function isValidAgentProfileId(id: string): boolean {
   return /^[A-Za-z0-9_-]+$/.test(id);
 }
 
+export type AgentModelScope =
+  | { kind: "global" }
+  | { kind: "profile"; id: string }
+  | { kind: "role"; role: CodingRole };
+
+const agentProfileModelPath = /^agent\.profiles\.([A-Za-z0-9_-]+)\.model$/;
+const roleAgentModelPath =
+  /^roles\.(planner|worker|reviewer|fixer)\.agent\.model$/;
+
+/** Which model binding (if any) this dotted path represents, for combobox wiring. */
+export function agentModelScope(path: string): AgentModelScope | null {
+  if (path === "agent.model") return { kind: "global" };
+  const profile = agentProfileModelPath.exec(path);
+  if (profile) return { kind: "profile", id: profile[1] };
+  const role = roleAgentModelPath.exec(path);
+  if (role) return { kind: "role", role: role[1] as CodingRole };
+  return null;
+}
+
+function readOverlayVendor(
+  data: ConfigData,
+  drafts: Record<string, ConfigDraft>,
+  unset: Set<string>,
+  path: string,
+): string | null {
+  if (unset.has(path)) return null;
+  if (Object.hasOwn(drafts, path)) {
+    const draft = drafts[path];
+    if (typeof draft !== "string") return null;
+    const trimmed = draft.trim();
+    return trimmed === "" ? null : trimmed;
+  }
+  const value = getConfigValue(data, path);
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * Effective agent vendor for a model binding, mirroring ResolveAgent overlay
+ * but using current form state (published + drafts + unsetPaths). Returns null
+ * when no vendor resolves — the combobox should still allow free entry and
+ * prompt the operator to pick a vendor before requesting suggestions.
+ *
+ * Order (per ADR-0016 / spec §6):
+ *   1. Inline vendor on the binding (if set and not pending unset).
+ *   2. For role scope, the selected profile's vendor (if any and not removed).
+ *   3. Global agent.vendor.
+ */
+export function effectiveAgentVendor(
+  data: ConfigData,
+  drafts: Record<string, ConfigDraft>,
+  unsetPaths: Iterable<string>,
+  scope: AgentModelScope,
+): string | null {
+  const unset =
+    unsetPaths instanceof Set
+      ? unsetPaths
+      : new Set<string>(unsetPaths as Iterable<string>);
+  const global = () => readOverlayVendor(data, drafts, unset, "agent.vendor");
+
+  if (scope.kind === "global") return global();
+
+  if (scope.kind === "profile") {
+    if (unset.has(`agent.profiles.${scope.id}`)) return global();
+    const own = readOverlayVendor(
+      data,
+      drafts,
+      unset,
+      agentProfilePath(scope.id, "vendor"),
+    );
+    return own ?? global();
+  }
+
+  // role
+  const roleVendor = readOverlayVendor(
+    data,
+    drafts,
+    unset,
+    roleAgentPath(scope.role, "vendor"),
+  );
+  if (roleVendor) return roleVendor;
+
+  // Resolve selected profile through the same overlay.
+  const profileFieldPath = roleAgentPath(scope.role, "profile");
+  let profileId: string | null = null;
+  if (!unset.has(profileFieldPath)) {
+    if (Object.hasOwn(drafts, profileFieldPath)) {
+      const draft = drafts[profileFieldPath];
+      if (typeof draft === "string" && draft.trim() !== "") {
+        profileId = draft.trim();
+      }
+    } else {
+      const value = getConfigValue(data, profileFieldPath);
+      if (typeof value === "string" && value.trim() !== "") {
+        profileId = value.trim();
+      }
+    }
+  }
+  if (profileId && !unset.has(`agent.profiles.${profileId}`)) {
+    const pv = readOverlayVendor(
+      data,
+      drafts,
+      unset,
+      agentProfilePath(profileId, "vendor"),
+    );
+    if (pv) return pv;
+  }
+  return global();
+}
+
 /**
  * Curated common-operator settings shown in the Essentials section, in the
  * intended display order. Anything else falls under Advanced. Role agent
@@ -547,13 +658,13 @@ export function buildConfigPatch(
       continue;
     }
     // Model empty draft: stage explicit vendor-default suppress (non-nil "").
-    // Profile/role empty models are distinct from unset (inherit) in
-    // overlayAgentIdentity, so a blank draft stages set "" even when the leaf
-    // is currently absent — operators can create suppress without first saving
-    // a non-empty model. Global agent.model only stages "" when replacing a
-    // non-empty published value (absent already means no model). Use Unset to
-    // go from suppress/value back to inherit. Vendor-switch companion logic may
-    // still set "" itself.
+    // Global agent.model, profile models, and role models all treat "" as an
+    // explicit suppress binding distinct from absent/unset (inherit). A blank
+    // draft therefore stages set "" even when the leaf is currently absent —
+    // operators can create suppress from the "Vendor default" combobox row
+    // without first saving a non-empty model. Skip only when the published
+    // value is already explicit "". Use Unset to go from suppress/value back
+    // to inherit. Vendor-switch companion logic may still set "" itself.
     if (
       parsed.value === "" &&
       (path === "agent.model" ||
@@ -561,17 +672,7 @@ export function buildConfigPatch(
           path.endsWith(".model"))
     ) {
       const current = getConfigValue(data, path);
-      if (current === "") {
-        // Already an explicit suppress binding.
-        continue;
-      }
-      if (path === "agent.model") {
-        if (typeof current === "string" && current !== "") {
-          set[path] = "";
-        }
-        continue;
-      }
-      // Profile / role model: create or replace with suppress even if absent.
+      if (current === "") continue; // already suppress
       set[path] = "";
       continue;
     }

--- a/web/dashboard/src/pages/Config.test.tsx
+++ b/web/dashboard/src/pages/Config.test.tsx
@@ -1246,9 +1246,12 @@ describe("ConfigPage", () => {
     vi.stubGlobal("fetch", fetchMock);
     renderPage();
 
-    fireEvent.change(await screen.findByLabelText("agent.profiles.fast.model"), {
+    const modelInput = await screen.findByLabelText("agent.profiles.fast.model");
+    fireEvent.change(modelInput, {
       target: { value: "gpt-5" },
     });
+    // ModelCombobox keeps keystrokes local until commit (blur / Enter / pick).
+    fireEvent.blur(modelInput);
     clickSaveChanges();
     fireEvent.click(
       await screen.findByRole("button", {
@@ -1385,9 +1388,11 @@ describe("ConfigPage", () => {
     expect(screen.queryByLabelText(/params/i)).toBeNull();
     expect(screen.queryByText(/params map/i)).toBeNull();
 
-    fireEvent.change(screen.getByLabelText("agent.profiles.fast.model"), {
+    const profileModel = screen.getByLabelText("agent.profiles.fast.model");
+    fireEvent.change(profileModel, {
       target: { value: "gpt-5" },
     });
+    fireEvent.blur(profileModel);
     fireEvent.change(screen.getByLabelText("New profile id"), {
       target: { value: "cheap" },
     });
@@ -1545,6 +1550,7 @@ describe("ConfigPage", () => {
     ) as HTMLInputElement;
     expect(modelInput.disabled).toBe(false);
     fireEvent.change(modelInput, { target: { value: "gpt-5" } });
+    fireEvent.blur(modelInput);
 
     fireEvent.change(screen.getByLabelText("New profile id"), {
       target: { value: "cheap" },

--- a/web/dashboard/src/pages/Config.test.tsx
+++ b/web/dashboard/src/pages/Config.test.tsx
@@ -1575,4 +1575,133 @@ describe("ConfigPage", () => {
     expect(body.set["agent.profiles.fast.model"]).toBe("gpt-5");
     expect(body.set["agent.profiles.cheap.vendor"]).toBe("opencode");
   });
+
+  it("restores absent global agent.model via Unbound without Discard", async () => {
+    // Published agent.model is absent (default-sourced): Unset is hidden and
+    // Inherit is not offered. After drafting a concrete id, Unbound must clear
+    // the draft back to null so Save does not set agent.model.
+    const { model: _drop, ...agentWithoutModel } = configFixture().agent!;
+    void _drop;
+    const initial = configFixture({
+      agent: {
+        ...agentWithoutModel,
+        vendor: "codex",
+        envKeys: ["OPENAI_API_KEY"],
+      },
+      metadata: {
+        ...configFixture().metadata,
+        fields: {
+          ...configFixture().metadata.fields,
+          "agent.model": {
+            source: "default",
+            editable: true,
+            applyMode: "hot",
+          },
+        },
+      },
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input);
+      if (path.startsWith("/api/v1/agent/models")) {
+        return response({
+          vendor: "codex",
+          models: [{ id: "gpt-5", label: "GPT-5", source: "static" }],
+          sources: { static: true, probe: "skipped" },
+          probedAt: null,
+        });
+      }
+      if (path !== "/api/v1/config") {
+        throw new Error(`unexpected request: ${path}`);
+      }
+      if (init?.method === "PATCH") return response(initial);
+      return response(initial);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    const modelInput = (await screen.findByLabelText(
+      "agent.model",
+    )) as HTMLInputElement;
+    // Absent → closed placeholder is Unbound, not Vendor default.
+    expect(modelInput.placeholder).toBe("Unbound");
+    expect(modelInput.value).toBe("");
+
+    fireEvent.focus(modelInput);
+    fireEvent.change(modelInput, { target: { value: "gpt-5" } });
+    fireEvent.blur(modelInput);
+    expect(modelInput.value).toBe("gpt-5");
+    expect(screen.getAllByText(/1\s*unsaved/i).length).toBeGreaterThan(0);
+
+    // Field-local restore: Unbound clears the draft (no full Discard).
+    fireEvent.focus(modelInput);
+    fireEvent.mouseDown(await screen.findByText("Unbound"));
+    expect(modelInput.value).toBe("");
+    expect(modelInput.placeholder).toBe("Unbound");
+    // No remaining dirty state for this field alone — dock may disappear.
+    expect(screen.queryByText(/unsaved/i)).toBeNull();
+
+    // Open placeholder documents empty = vendor default suppress, not inherit.
+    fireEvent.focus(modelInput);
+    expect(modelInput.placeholder).toMatch(/vendor default/i);
+    expect(modelInput.placeholder).not.toMatch(/inherit CLI/i);
+  });
+
+  it("stages explicit vendor-default suppress for empty global agent.model clear", async () => {
+    const { model: _drop, ...agentWithoutModel } = configFixture().agent!;
+    void _drop;
+    const initial = configFixture({
+      agent: {
+        ...agentWithoutModel,
+        vendor: "codex",
+        envKeys: ["OPENAI_API_KEY"],
+      },
+      metadata: {
+        ...configFixture().metadata,
+        fields: {
+          ...configFixture().metadata.fields,
+          "agent.model": {
+            source: "default",
+            editable: true,
+            applyMode: "hot",
+          },
+        },
+      },
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input);
+      if (path.startsWith("/api/v1/agent/models")) {
+        return response({
+          vendor: "codex",
+          models: [{ id: "gpt-5", label: "GPT-5", source: "static" }],
+          sources: { static: true, probe: "skipped" },
+          probedAt: null,
+        });
+      }
+      if (path !== "/api/v1/config") {
+        throw new Error(`unexpected request: ${path}`);
+      }
+      if (init?.method === "PATCH") return response(initial);
+      return response(initial);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    const modelInput = (await screen.findByLabelText(
+      "agent.model",
+    )) as HTMLInputElement;
+    fireEvent.focus(modelInput);
+    fireEvent.mouseDown(await screen.findByText("Vendor default"));
+    expect(modelInput.placeholder).toBe("Vendor default");
+    clickSaveChanges();
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH")).toBe(
+        true,
+      );
+    });
+    const patchCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PATCH");
+    const body = JSON.parse(String(patchCall?.[1]?.body));
+    expect(body.set["agent.model"]).toBe("");
+    expect(body.unset).toEqual([]);
+  });
 });

--- a/web/dashboard/src/pages/Config.tsx
+++ b/web/dashboard/src/pages/Config.tsx
@@ -499,13 +499,16 @@ function AgentProfiles({
                 : published?.vendor == null
                   ? ""
                   : String(published.vendor);
-          const modelValue =
+          // null = persisted absence (Inherit); "" = explicit vendor-default
+          // suppress. Do not collapse absence to "" — that mis-highlights
+          // Vendor default and ArrowDown+Enter would stage set model:"".
+          const modelValue: string | null =
             modelUnset || pendingRemoval
-              ? ""
+              ? null
               : Object.hasOwn(drafts, modelPath)
                 ? String(drafts[modelPath] ?? "")
                 : published?.model == null
-                  ? ""
+                  ? null
                   : String(published.model);
           const canUnsetVendor =
             vendorEditable &&
@@ -1577,6 +1580,15 @@ export function ConfigPage() {
     const dirty = Object.hasOwn(drafts, path);
     const unset = unsetPaths.has(path);
     const modelScope = agentModelScope(path);
+    // Model leaves: keep absence (null) distinct from explicit "" suppress so
+    // profile/role comboboxes show Inherit rather than Vendor default.
+    const modelValue: string | null = unset
+      ? null
+      : Object.hasOwn(drafts, path)
+        ? String(drafts[path] ?? "")
+        : effective == null
+          ? null
+          : String(effective);
     return (
       <FieldFrame
         key={path}
@@ -1594,7 +1606,7 @@ export function ConfigPage() {
             id={`config-${path}`}
             ariaLabel={path}
             vendor={effectiveAgentVendor(data, drafts, unsetPaths, modelScope)}
-            value={String(value ?? "")}
+            value={modelValue}
             unset={unset}
             disabled={editorLocked || !metaIsEditable(meta)}
             allowInherit={modelScope.kind !== "global"}

--- a/web/dashboard/src/pages/Config.tsx
+++ b/web/dashboard/src/pages/Config.tsx
@@ -1383,6 +1383,35 @@ export function ConfigPage() {
     [clearPathError, retireLoad],
   );
 
+  // Global agent.model: restore absence (null). When the leaf is already
+  // absent/default-sourced, FieldFrame has no Unset and Inherit is disabled —
+  // clearing the draft is the only field-local path back to unbound (so
+  // params/CLI --model may still apply). When a binding is published, stage
+  // unset instead of set "".
+  const onRestoreModelAbsence = useCallback(
+    (path: string) => {
+      retireLoad();
+      const published = data ? getConfigValue(data, path) : undefined;
+      setDrafts((current) => {
+        if (!Object.hasOwn(current, path)) return current;
+        const next = { ...current };
+        delete next[path];
+        return next;
+      });
+      setUnsetPaths((current) => {
+        const next = new Set(current);
+        if (published == null) {
+          next.delete(path);
+        } else {
+          next.add(path);
+        }
+        return next;
+      });
+      clearPathError(path);
+    },
+    [clearPathError, data, retireLoad],
+  );
+
   const onSecretSet = useCallback(
     (key: string, value: string) => {
       retireLoad();
@@ -1613,12 +1642,17 @@ export function ConfigPage() {
             allowInherit={modelScope.kind !== "global"}
             placeholder={
               modelScope.kind === "global"
-                ? "Model id (empty = inherit CLI default)"
+                ? "Model id (empty = vendor default / suppress)"
                 : "Model id (empty = vendor default; Inherit = previous layer)"
             }
             onCommitValue={(next) => onDraft(path, next)}
             onInherit={
               modelScope.kind === "global" ? undefined : () => onToggleUnset(path)
+            }
+            onUnbound={
+              modelScope.kind === "global"
+                ? () => onRestoreModelAbsence(path)
+                : undefined
             }
           />
         ) : (

--- a/web/dashboard/src/pages/Config.tsx
+++ b/web/dashboard/src/pages/Config.tsx
@@ -1580,8 +1580,9 @@ export function ConfigPage() {
     const dirty = Object.hasOwn(drafts, path);
     const unset = unsetPaths.has(path);
     const modelScope = agentModelScope(path);
-    // Model leaves: keep absence (null) distinct from explicit "" suppress so
-    // profile/role comboboxes show Inherit rather than Vendor default.
+    // Model leaves: keep absence (null) distinct from explicit "" suppress.
+    // Profile/role: null → Inherit. Global: null → unbound (params/CLI may
+    // still supply --model); only "" is Vendor default suppress.
     const modelValue: string | null = unset
       ? null
       : Object.hasOwn(drafts, path)

--- a/web/dashboard/src/pages/Config.tsx
+++ b/web/dashboard/src/pages/Config.tsx
@@ -8,11 +8,13 @@ import {
 } from "react";
 import { RefreshCw, Settings } from "lucide-react";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { ModelCombobox } from "@/components/ModelCombobox";
 import { PanelError } from "@/components/PanelError";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
   ApiError,
+  fetchAgentModels,
   fetchConfig,
   patchConfig,
   type ConfigData,
@@ -21,6 +23,7 @@ import {
 } from "@/lib/api";
 import {
   AGENT_VENDOR_OPTIONS,
+  agentModelScope,
   agentProfilePath,
   buildConfigPatch,
   CODING_ROLES,
@@ -32,6 +35,7 @@ import {
   configSelectOptions,
   draftFromValue,
   draftStagesConfigChange,
+  effectiveAgentVendor,
   ESSENTIAL_PATHS,
   getConfigValue,
   highImpactChanges,
@@ -328,6 +332,38 @@ function ConfigControl({
   );
 }
 
+function NewProfileModelSuggestions({ vendor }: { vendor: string }) {
+  const [entries, setEntries] = useState<
+    Array<{ id: string; label: string }>
+  >([]);
+  useEffect(() => {
+    // Drop the previous vendor's suggestions immediately so the datalist
+    // does not offer stale ids while the next probe is in flight or fails.
+    setEntries([]);
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const data = await fetchAgentModels(vendor, {
+          signal: controller.signal,
+        });
+        if (!controller.signal.aborted) setEntries(data.models);
+      } catch {
+        // Advisory only — silent. Do not restore previous vendor's entries.
+      }
+    })();
+    return () => controller.abort();
+  }, [vendor]);
+  return (
+    <datalist id="new-profile-model-suggestions">
+      {entries.map((entry) => (
+        <option key={entry.id} value={entry.id}>
+          {entry.label && entry.label !== entry.id ? entry.label : ""}
+        </option>
+      ))}
+    </datalist>
+  );
+}
+
 function AgentProfiles({
   data,
   drafts,
@@ -606,23 +642,29 @@ function AgentProfiles({
                 </div>
                 <div className="min-w-0">
                   <div className="flex items-start gap-1.5">
-                    <label className="min-w-0 flex-1 text-[11px]">
+                    <div className="min-w-0 flex-1 text-[11px]">
                       <span className="text-[var(--text-muted)]">Model</span>
-                      <input
-                        aria-label={modelPath}
-                        className={`${controlClass} mt-0.5 mono ${modelUnset ? "opacity-50" : ""}`}
-                        value={modelValue}
-                        disabled={
-                          !modelEditable || pendingRemoval || modelUnset
-                        }
-                        placeholder="optional (empty = vendor default; Unset = inherit)"
-                        onChange={(event) => {
-                          // Empty draft stages model:"" (vendor default suppress).
-                          // Use Unset for inheritance. Do not auto-unset on clear.
-                          onDraft(modelPath, event.currentTarget.value);
-                        }}
-                      />
-                    </label>
+                      <div className="mt-0.5">
+                        <ModelCombobox
+                          ariaLabel={modelPath}
+                          vendor={effectiveAgentVendor(data, drafts, unsetPaths, {
+                            kind: "profile",
+                            id,
+                          })}
+                          value={modelValue}
+                          unset={modelUnset}
+                          disabled={!modelEditable || pendingRemoval}
+                          allowInherit
+                          placeholder="Model id (empty = vendor default; Inherit = previous layer)"
+                          onCommitValue={(next) => {
+                            // Empty draft stages model:"" (vendor default suppress).
+                            // Use Unset for inheritance. Do not auto-unset on clear.
+                            onDraft(modelPath, next);
+                          }}
+                          onInherit={() => toggleProfileLeafUnset("model")}
+                        />
+                      </div>
+                    </div>
                     {canUnsetModel ? (
                       <Button
                         variant="ghost"
@@ -700,9 +742,17 @@ function AgentProfiles({
           className={`${controlClass} mono`}
           value={newModel}
           disabled={!canEdit}
-          placeholder="Model (optional)"
+          placeholder={
+            newVendor
+              ? "Model (optional; type or pick from suggestions)"
+              : "Model (optional)"
+          }
+          list={newVendor ? "new-profile-model-suggestions" : undefined}
           onChange={(event) => setNewModel(event.currentTarget.value)}
         />
+        {newVendor ? (
+          <NewProfileModelSuggestions vendor={newVendor} />
+        ) : null}
         <Button variant="ghost" size="sm" disabled={!canEdit} onClick={stageNew}>
           Add profile
         </Button>
@@ -1526,6 +1576,7 @@ export function ConfigPage() {
     const meta = resolveFieldMeta(data, path);
     const dirty = Object.hasOwn(drafts, path);
     const unset = unsetPaths.has(path);
+    const modelScope = agentModelScope(path);
     return (
       <FieldFrame
         key={path}
@@ -1538,15 +1589,36 @@ export function ConfigPage() {
         disabled={editorLocked}
         onUnset={() => onToggleUnset(path)}
       >
-        <ConfigControl
-          path={path}
-          kind={kind}
-          value={value}
-          options={configSelectOptions(path)}
-          disabled={editorLocked || !metaIsEditable(meta)}
-          unset={unset}
-          onChange={(next) => onDraft(path, next)}
-        />
+        {modelScope ? (
+          <ModelCombobox
+            id={`config-${path}`}
+            ariaLabel={path}
+            vendor={effectiveAgentVendor(data, drafts, unsetPaths, modelScope)}
+            value={String(value ?? "")}
+            unset={unset}
+            disabled={editorLocked || !metaIsEditable(meta)}
+            allowInherit={modelScope.kind !== "global"}
+            placeholder={
+              modelScope.kind === "global"
+                ? "Model id (empty = inherit CLI default)"
+                : "Model id (empty = vendor default; Inherit = previous layer)"
+            }
+            onCommitValue={(next) => onDraft(path, next)}
+            onInherit={
+              modelScope.kind === "global" ? undefined : () => onToggleUnset(path)
+            }
+          />
+        ) : (
+          <ConfigControl
+            path={path}
+            kind={kind}
+            value={value}
+            options={configSelectOptions(path)}
+            disabled={editorLocked || !metaIsEditable(meta)}
+            unset={unset}
+            onChange={(next) => onDraft(path, next)}
+          />
+        )}
       </FieldFrame>
     );
   };


### PR DESCRIPTION
## Summary

- Add advisory agent model catalog (`internal/agent/modelcatalog`): embedded static suggestions + on-demand CLI probe (opencode/codex/cursor/grok; Claude Code static-only), in-process TTL cache, fail-soft probe errors.
- Expose `GET /api/v1/agent/models?vendor=…` (optional `refresh`) using spawn-equivalent binary resolution (`ResolveCommand` + `ParamsForRoleVendor`).
- Dashboard Config: searchable free-entry `ModelCombobox` on global / profile / coding-role model fields, driven by effective vendor overlay; tri-state Inherit / Vendor default / id preserved.
- Docs: ADR-0016 + `configuration.md` model-suggestions note (explicitly not an allowlist). Spec: `specs/2026-08-01-agent-model-catalog/`.

## Design notes

- Catalog is **advisory only** — never validates save/claim; free-text model IDs remain valid.
- Probe uses process-group kill, bounded I/O, and in-flight coalesce per vendor+binary.
- ResolveAgent / agent_snapshot / hot-reload restart guards unchanged.

## Test plan

- [x] `go test ./internal/agent/modelcatalog/ ./internal/agent/ ./internal/api/ -count=1`
- [x] `pnpm test` / `pnpm build` in `web/dashboard` (169 tests)
- [ ] Manual: open Config, pick vendor, open model combobox — suggestions load; custom id + Inherit / Vendor default still patch correctly
- [ ] Manual: probe-capable vendor with CLI missing → static list + non-blocking probe hint; Save still works

