### PR TITLE
fix: map createRun one-running UNIQUE races to retryable busy

### DIFF
--- a/internal/loops/failureclass/failureclass.go
+++ b/internal/loops/failureclass/failureclass.go
@@ -95,6 +95,12 @@ func Classify(err error, ctx Context) Kind {
 	if message == "" {
 		message = strings.ToLower(err.Error())
 	}
+	// Concurrent createRunContext races hit idx_runs_one_running_per_loop. The
+	// durable index is correct; treat a leaked UNIQUE as retryable so it cannot
+	// park the queue in manual_intervention (issue #634).
+	if isOneRunningRunPerLoopViolation(message) {
+		return RetryableTransient
+	}
 	if isManualWorktreeMessage(message) || ctx.Boundary == BoundaryLocalWorktree {
 		return ManualIntervention
 	}
@@ -126,6 +132,24 @@ func isInternalDeterministicBoundary(boundary Boundary) bool {
 	default:
 		return false
 	}
+}
+
+// IsOneRunningRunPerLoopViolation reports whether err is the partial unique
+// index on runs(loop_id) WHERE status='running'. Exported so runners can map
+// the conflict to a typed busy error without string-matching in three places.
+func IsOneRunningRunPerLoopViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	return isOneRunningRunPerLoopViolation(strings.ToLower(err.Error()))
+}
+
+func isOneRunningRunPerLoopViolation(message string) bool {
+	if !strings.Contains(message, "unique constraint failed") {
+		return false
+	}
+	return strings.Contains(message, "runs.loop_id") ||
+		strings.Contains(message, "idx_runs_one_running_per_loop")
 }
 
 func isManualWorktreeMessage(message string) bool {

--- a/internal/loops/failureclass/failureclass_test.go
+++ b/internal/loops/failureclass/failureclass_test.go
@@ -139,6 +139,29 @@ func TestClassifyGenericGitHub404StaysRetryable(t *testing.T) {
 	}
 }
 
+func TestClassifyOneRunningRunPerLoopUniqueIsRetryable(t *testing.T) {
+	// Leaked SQLite UNIQUE from idx_runs_one_running_per_loop must never become
+	// non_retryable/MI when createRun race mapping is skipped (issue #634).
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{name: "wrapped upsert", message: "upsert run: UNIQUE constraint failed: runs.loop_id"},
+		{name: "index name", message: "UNIQUE constraint failed: idx_runs_one_running_per_loop"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Classify(errors.New(tt.message), Context{Runner: RunnerReviewer, Boundary: BoundaryStorage})
+			if got != RetryableTransient {
+				t.Fatalf("Classify() = %s, want %s", got, RetryableTransient)
+			}
+			if !IsOneRunningRunPerLoopViolation(errors.New(tt.message)) {
+				t.Fatalf("IsOneRunningRunPerLoopViolation(%q) = false, want true", tt.message)
+			}
+		})
+	}
+}
+
 // typedHTTPStatusError mirrors provider errors such as forge.ForgejoHTTPError
 // that expose the original HTTP status without importing provider packages.
 type typedHTTPStatusError struct {

--- a/internal/planner/runner.go
+++ b/internal/planner/runner.go
@@ -1495,6 +1495,12 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	if err != nil {
 		return resumedRunContext{}, err
 	}
+	if latestRun != nil && latestRun.Status == "running" {
+		return resumedRunContext{}, &loopError{
+			message: fmt.Sprintf("loop %s already has a running planner run %s", loop.ID, latestRun.ID),
+			kind:    FailureRetryableTransient,
+		}
+	}
 	check := parseCheckpoint(nil)
 	lastCompleted := PlannerStep("")
 	if latestRun != nil {
@@ -1532,6 +1538,18 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	encoded := mustMarshalJSON(initialCheckpoint)
 	run.CheckpointJSON = &encoded
 	if err := r.repos.Runs.Upsert(ctx, run); err != nil {
+		if hasRunning, checkErr := r.repos.Runs.HasRunningByLoopID(ctx, loop.ID); checkErr == nil && hasRunning {
+			return resumedRunContext{}, &loopError{
+				message: fmt.Sprintf("loop %s already has a running planner run", loop.ID),
+				kind:    FailureRetryableTransient,
+			}
+		}
+		if failureclass.IsOneRunningRunPerLoopViolation(err) {
+			return resumedRunContext{}, &loopError{
+				message: fmt.Sprintf("loop %s already has a running planner run", loop.ID),
+				kind:    FailureRetryableTransient,
+			}
+		}
 		return resumedRunContext{}, err
 	}
 	return resumedRunContext{Run: run, StartStep: startStep, Checkpoint: initialCheckpoint, Resumed: resumed}, nil

--- a/internal/reviewer/create_run_context_race_test.go
+++ b/internal/reviewer/create_run_context_race_test.go
@@ -1,0 +1,176 @@
+package reviewer
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestCreateRunContextConcurrentDoubleCreateOneRunning(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{
+		ID: "loop_reviewer_create_race", Seq: 1, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "queued",
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	const workers = 8
+	var wg sync.WaitGroup
+	results := make(chan error, workers)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := runner.createRunContext(context.Background(), loop)
+			results <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var successes int
+	var busy int
+	for err := range results {
+		if err == nil {
+			successes++
+			continue
+		}
+		var loopErr *loopError
+		if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+			t.Fatalf("createRunContext() unexpected error = %v", err)
+		}
+		if strings.Contains(strings.ToLower(err.Error()), "unique constraint failed") {
+			t.Fatalf("createRunContext leaked UNIQUE constraint error: %v", err)
+		}
+		busy++
+	}
+	if successes != 1 {
+		t.Fatalf("successes = %d, want exactly 1", successes)
+	}
+	if busy != workers-1 {
+		t.Fatalf("busy losers = %d, want %d", busy, workers-1)
+	}
+	hasRunning, err := fixture.repos.Runs.HasRunningByLoopID(context.Background(), loop.ID)
+	if err != nil || !hasRunning {
+		t.Fatalf("HasRunningByLoopID() = %v, %v; want true, nil", hasRunning, err)
+	}
+}
+
+func TestCreateRunContextTreatsActiveRunningRunAsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loop := storage.LoopRecord{
+		ID: "loop_reviewer_active_run", Seq: 1, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running",
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	active := storage.RunRecord{
+		ID: "run_reviewer_active", LoopID: loop.ID, Status: "running",
+		CurrentStep: stringPtr(string(stepDiscover)), StartedAt: nowISO, LastHeartbeatAt: &nowISO,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), active); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+
+	_, err := runner.createRunContext(context.Background(), loop)
+	if err == nil {
+		t.Fatal("createRunContext() error = nil, want retryable active-run error")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("createRunContext() error = %#v, want retryable_transient loopError", err)
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "unique constraint failed") {
+		t.Fatalf("createRunContext leaked UNIQUE constraint error: %v", err)
+	}
+	preserved, err := fixture.repos.Runs.GetByID(context.Background(), active.ID)
+	if err != nil || preserved == nil || preserved.Status != "running" {
+		t.Fatalf("active run = (%#v, %v), want still running", preserved, err)
+	}
+}
+
+func TestProcessClaimedQueueItemMapsActiveRunConflictToRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	loopID := "loop_reviewer_active_claim"
+	queueID := "queue_reviewer_active_claim"
+	targetID := "pr:acme/looper:42"
+	loop := storage.LoopRecord{
+		ID: loopID, Seq: 2, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "running",
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	active := storage.RunRecord{
+		ID: "run_reviewer_claim_active", LoopID: loopID, Status: "running",
+		CurrentStep: stringPtr(string(stepReview)), StartedAt: nowISO, LastHeartbeatAt: &nowISO,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Runs.Upsert(context.Background(), active); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	queueItem := storage.QueueItemRecord{
+		ID: queueID, ProjectID: stringPtr("project_1"), LoopID: &loopID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: "reviewer:" + loopID, Priority: storage.QueuePriorityReviewer,
+		Status: "running", AvailableAt: nowISO, Attempts: 0, MaxAttempts: 5,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), queueItem); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	_, err := runner.ProcessClaimedQueueItem(context.Background(), queueItem)
+	if err == nil {
+		t.Fatal("ProcessClaimedQueueItem() error = nil, want active-run setup failure")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("ProcessClaimedQueueItem() error = %#v, want retryable_transient", err)
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "unique constraint failed") {
+		t.Fatalf("ProcessClaimedQueueItem leaked UNIQUE constraint: %v", err)
+	}
+
+	updatedQueue, err := fixture.repos.Queue.GetByID(context.Background(), queueID)
+	if err != nil || updatedQueue == nil {
+		t.Fatalf("Queue.GetByID() = (%#v, %v)", updatedQueue, err)
+	}
+	// Normal setup-failure path requeues retryable_transient (may burn one attempt).
+	// Must not land in manual_intervention on the UNIQUE race fingerprint.
+	if updatedQueue.Status == "manual_intervention" || updatedQueue.Status == "failed" {
+		t.Fatalf("queue status = %s kind=%v, want requeued not terminal MI/failed", updatedQueue.Status, updatedQueue.LastErrorKind)
+	}
+	if updatedQueue.LastErrorKind != nil && *updatedQueue.LastErrorKind == string(FailureNonRetryable) {
+		t.Fatalf("queue last_error_kind = non_retryable, want retryable_transient")
+	}
+	if updatedQueue.LastErrorKind != nil && *updatedQueue.LastErrorKind != string(FailureRetryableTransient) && updatedQueue.Status == "queued" {
+		t.Fatalf("queue last_error_kind = %v, want retryable_transient", *updatedQueue.LastErrorKind)
+	}
+}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4633,6 +4633,15 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	if err != nil {
 		return resumedRunContext{}, err
 	}
+	if latestRun != nil && latestRun.Status == "running" {
+		// Another processor already owns the running slot for this loop. Do not
+		// insert a second running run; map to retryable_transient (issue #634).
+		// Stale orphans are ReconcileStaleRuns' job — this path only refuses the race.
+		return resumedRunContext{}, &loopError{
+			message: fmt.Sprintf("loop %s already has a running reviewer run %s", loop.ID, latestRun.ID),
+			kind:    FailureRetryableTransient,
+		}
+	}
 	checkpoint := parseCheckpoint(nil)
 	lastCompleted := ReviewerStep("")
 	failedStep := ReviewerStep("")
@@ -4699,6 +4708,18 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		run.LastCompletedStep = stringPtr(string(lastCompleted))
 	}
 	if err := r.repos.Runs.Upsert(ctx, run); err != nil {
+		if hasRunning, checkErr := r.repos.Runs.HasRunningByLoopID(ctx, loop.ID); checkErr == nil && hasRunning {
+			return resumedRunContext{}, &loopError{
+				message: fmt.Sprintf("loop %s already has a running reviewer run", loop.ID),
+				kind:    FailureRetryableTransient,
+			}
+		}
+		if failureclass.IsOneRunningRunPerLoopViolation(err) {
+			return resumedRunContext{}, &loopError{
+				message: fmt.Sprintf("loop %s already has a running reviewer run", loop.ID),
+				kind:    FailureRetryableTransient,
+			}
+		}
 		return resumedRunContext{}, err
 	}
 	return resumedRunContext{Run: run, StartStep: startStep, Checkpoint: initialCheckpoint, Resumed: resumed}, nil

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -2486,6 +2486,12 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 	if err != nil {
 		return resumedRunContext{}, err
 	}
+	if latestRun != nil && latestRun.Status == "running" {
+		return resumedRunContext{}, &loopError{
+			message: fmt.Sprintf("loop %s already has a running worker run %s", loop.ID, latestRun.ID),
+			kind:    FailureRetryableTransient,
+		}
+	}
 	checkpoint := workerCheckpoint{}
 	var lastCompletedStep WorkerStep
 	var failedStep WorkerStep
@@ -2543,6 +2549,18 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		}
 	}
 	if err := r.repos.Runs.Upsert(ctx, run); err != nil {
+		if hasRunning, checkErr := r.repos.Runs.HasRunningByLoopID(ctx, loop.ID); checkErr == nil && hasRunning {
+			return resumedRunContext{}, &loopError{
+				message: fmt.Sprintf("loop %s already has a running worker run", loop.ID),
+				kind:    FailureRetryableTransient,
+			}
+		}
+		if failureclass.IsOneRunningRunPerLoopViolation(err) {
+			return resumedRunContext{}, &loopError{
+				message: fmt.Sprintf("loop %s already has a running worker run", loop.ID),
+				kind:    FailureRetryableTransient,
+			}
+		}
 		return resumedRunContext{}, err
 	}
 	parsedCheckpoint, err := parseCheckpoint(run.CheckpointJSON)


### PR DESCRIPTION
## Summary

Minimal fix for #634 only.

- Guard `createRunContext` in reviewer / planner / worker: if a running run already exists for the loop, or upsert hits `idx_runs_one_running_per_loop`, return a typed `retryable_transient` `loopError` instead of leaking SQLite UNIQUE.
- Harden `failureclass.Classify` so any remaining `UNIQUE constraint failed: runs.loop_id` / index-name leak cannot classify as non-retryable MI.
- Focused regression tests for concurrent double-create, active-run busy, and claim setup mapping.

Closes #634

## Authority

Durable `runs.status='running'` (enforced by partial unique index `idx_runs_one_running_per_loop`) is the admission gate for inserting a second run for the same loop. Agent structured lifecycle output cannot authorize a concurrent second running run; the index is the authority, and this PR only maps a lost race against that authority to typed busy instead of non-retryable MI.

## Trade-off (what this PR adds)

**Failure prevented:** concurrent `createRunContext` losers leak `UNIQUE constraint failed: runs.loop_id`, which `failureclass` treated as non-retryable → queue `manual_intervention` even when a sibling run later succeeds (#634 production fingerprint).

**What it costs:**
- Busy losers still flow through generic setup recovery (`failQueueItem` / `MarkRetry`), which can burn an attempt and does not status-guard against a winner that already `Complete`d the shared claim.
- `failureclass` gains a narrow UNIQUE-message safety net (string fingerprint) so any remaining leak cannot become MI; runner-local typed mapping is the primary path.
- Planner/worker get the same gate without separate concurrent lifecycle tests in this PR (reviewer covers the race shape).

**Why simpler alternatives are insufficient for this bug:**
- Doing nothing leaves the production MI fingerprint.
- Deleting the unique index would allow two running runs per loop (worse).
- Full claim↔run ownership / leave-alone / atomic run+claim terminalization is the right long-term design but is explicitly out of scope here — it previously blew up this PR's surface.

Residual claim-ownership TOCTOU (winner Complete then loser MarkRetry, attempt burn under long sibling runs) needs a separate design issue, not stacked patches on #634.

## Non-goals (explicitly cut)

This PR previously drifted into claim ownership / leave-alone / scheduler finalize / atomic run+claim terminalization / contention requeue protocol. **All of that was force-pushed out.**

Not in this PR:

- no `ErrLeaveClaimRunning` or other new cross-component lifecycle signals
- no `recoverActiveRunConflict` leave-claim path
- no orphan invent beyond refusing a live running slot (stale orphans stay `ReconcileStaleRuns`)
- no scheduler `ensureClaimFinalized` special cases
- no planner/worker claim ownership redesign
- no status-guarded contention recovery that avoids generic `MarkRetry`

Those need a separate design (real claim↔run authority), not stacked race patches on this bug.

## Root cause

After head-change interrupt → requeue, two concurrent `createRunContext` calls can race the partial unique index. The loser hit:

```text
upsert run: UNIQUE constraint failed: runs.loop_id
```

`failureclass` treated that as non-retryable → `manual_intervention`, even when a sibling run published successfully.

## Test plan

- [x] `go test ./internal/loops/failureclass/ -run TestClassifyOneRunningRunPerLoop`
- [x] `go test ./internal/reviewer/ -run 'TestCreateRunContextConcurrent|TestCreateRunContextTreatsActive|TestProcessClaimedQueueItemMapsActive'`
- [x] `go vet` on touched packages

## Note to reviewers / fixer

Please **decline** follow-ups that re-introduce claim leave-alone, new sentinels, or multi-window TOCTOU hardening beyond the typed busy mapping above. File a new issue if ownership redesign is required.
