### PR TITLE
feat: add pi and omp agent vendors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The loops compose: planner hands off to reviewer↔fixer, reviewer↔fixer hands
 - 🐙 **The forge is the source of truth.** Issues, PRs, labels, reviews, and assignees *are* the workflow — no external task tracker, no YAML pipeline. GitHub is fully supported; Forgejo supports planner, worker, native reviewer requests/reviews, and summary-comment compatibility flows.
 - 🛰️ **Many repos, one daemon.** Register your projects once — Looper watches them together and runs loops across repos in parallel.
 - 🌳 **Parallel-safe by design.** Every loop runs in its own git worktree, so agents work across issues and repos without stepping on each other.
-- 🤖 **Bring your own agent.** Pluggable vendor layer (`opencode`, `claude-code`, `codex`, `cursor-cli`, `grok-build`) so you're not locked into one model or CLI.
+- 🤖 **Bring your own agent.** Pluggable vendor layer (`opencode`, `claude-code`, `codex`, `cursor-cli`, `grok-build`, `pi`, `omp`) so you're not locked into one model or CLI.
 - 🧰 **Local, inspectable, stoppable.** Daemon on your machine, thin CLI to drive it. `looper ps`, `looper logs`, `looper stop` — no hosted control plane.
 
 ## Quick start
@@ -120,7 +120,7 @@ looper takeover acme/repo#42
 - starts a continuous **reviewer** loop and **fixer** loop on the PR, which ping-pong until the review comes back clean;
 - with `--merge`, lets the reviewer enable GitHub auto-merge so the PR merges itself once it's approved and green.
 
-It picks your coding agent automatically when exactly one of `claude` / `codex` / `grok` / `opencode` is on `PATH`, prompts when it's ambiguous, and accepts `--agent-vendor` / `--yes` for non-interactive (agent-driven) runs:
+It picks your coding agent automatically when exactly one of `claude` / `codex` / `grok` / `opencode` / `pi` / `omp` is on `PATH`, prompts when it's ambiguous, and accepts `--agent-vendor` / `--yes` for non-interactive (agent-driven) runs:
 
 ```bash
 looper takeover acme/repo#42 --merge --agent-vendor claude-code
@@ -135,7 +135,7 @@ looper takeover stop acme/repo#42    # stop this takeover's reviewer + fixer loo
 looper takeover stop --all
 ```
 
-Requirements: `git`, an authenticated `gh`, and one supported agent CLI installed locally (the agent runs on your machine with your own credentials). Grok Build from xAI uses `agent.vendor = "grok-build"` and the `grok` executable; see [Grok Build configuration](docs/configuration.md#grok-build-xai) for daemon authentication and automation limits.
+Requirements: `git`, an authenticated `gh`, and one supported agent CLI installed locally (the agent runs on your machine with your own credentials). Grok Build from xAI uses `agent.vendor = "grok-build"` and the `grok` executable; see [Grok Build configuration](docs/configuration.md#grok-build-xai). Pi uses `agent.vendor = "pi"` (`pi` binary); Oh My Pi uses `agent.vendor = "omp"` (`omp` binary)—see [Pi](docs/configuration.md#pi) and [Oh My Pi](docs/configuration.md#oh-my-pi-omp).
 
 ### One-liner for not-yet-installed users
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -369,6 +369,36 @@ For fresh unattended runs, Looper supplies `--always-approve` and `--sandbox off
 
 Grok Build support is fresh-run only. Daemon native resume and interactive takeover through `looper resume` are unsupported. A retry uses a fresh checkpoint prompt, and Looper never uses Grok Build's ambient `--continue`.
 
+## Pi
+
+Use `pi` as the `agent.vendor` identifier. Looper invokes the [Pi](https://pi.dev) coding agent executable as `pi`:
+
+```toml
+[agent]
+vendor = "pi"
+```
+
+Authenticate via Pi's own login/config (project-local `.pi` and vendor credentials). Prefer vendor authentication over storing secrets in Looper configuration.
+
+For fresh unattended runs, Looper supplies `-p` with the generated task prompt and `--approve` (trusts project-local `.pi` for the run). Configured `agent.params.args` override these defaults: if `-p`/`--print` is already present, Looper does not append its prompt (operator owns print/prompt); if any of `-a`/`--approve`/`-na`/`--no-approve` is present, Looper does not add `--approve`. There is no `--cwd` flag—Looper sets the process working directory to the worktree.
+
+Pi support is fresh-run only. Daemon native resume and interactive takeover through `looper resume` are unsupported. A retry uses a fresh checkpoint prompt.
+
+## Oh My Pi (omp)
+
+Use `omp` as the `agent.vendor` identifier (not `oh-my-pi`). Looper invokes the [Oh My Pi](https://omp.sh) executable as `omp`:
+
+```toml
+[agent]
+vendor = "omp"
+```
+
+Authenticate via omp's own login/config. Prefer vendor authentication over storing secrets in Looper configuration.
+
+For fresh unattended runs, Looper supplies `-p` with the generated task prompt, `--cwd <worktree>` when the workdir is non-empty, and `--auto-approve`. Configured arguments override defaults: if `-p`/`--print` is already present, Looper does not append its prompt; if `--cwd` is present, Looper does not add workdir; if `--auto-approve` or `--approval-mode` (including `--approval-mode=...`) is present, Looper does not add `--auto-approve`.
+
+Oh My Pi support is fresh-run only. Daemon native resume and interactive takeover through `looper resume` are unsupported. A retry uses a fresh checkpoint prompt.
+
 ## Provider support
 
 Looper supports three provider kinds:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -45,6 +45,14 @@ For xAI Grok Build, configure `agent.vendor = "grok-build"`; Looper runs the `gr
 
 Configured Grok arguments take precedence: `--permission-mode` can prompt or fail unattended work, a non-`plain` `--output-format` can break direct completion-marker parsing, and `-p`/`--single` replaces Looper's generated task prompt. Grok Build has no daemon native resume or interactive `looper resume` takeover. Retries start with a fresh checkpoint prompt; Looper never uses ambient `--continue`.
 
+### Pi
+
+For Pi ([pi.dev](https://pi.dev)), configure `agent.vendor = "pi"`; Looper runs the `pi` executable. Authenticate with Pi's own login/config (project-local `.pi`). Looper defaults to `-p <prompt> --approve` for unattended fresh runs. Configured `-p`/`--print` means you own the prompt; any of `-a`/`--approve`/`-na`/`--no-approve` skips the default approve flag. Pi has no daemon native resume or interactive `looper resume` takeover.
+
+### Oh My Pi (omp)
+
+For Oh My Pi ([omp.sh](https://omp.sh)), configure `agent.vendor = "omp"` (not `oh-my-pi`); Looper runs the `omp` executable. Authenticate with omp's own login/config. Looper defaults to `-p <prompt> --cwd <worktree> --auto-approve`. Configured print, cwd, or approval flags (`--auto-approve` / `--approval-mode`) override those defaults. Oh My Pi has no daemon native resume or interactive `looper resume` takeover.
+
 ## 1a. Local-only vs Routed projects
 
 Looper supports two project modes:
@@ -562,7 +570,7 @@ looper takeover owner/repo#42 --merge   # also auto-merge once approved + green
 3. starts a continuous reviewer loop and fixer loop on the target PR (skip the fixer with `--no-fix`);
 4. with `--merge`, sets `roles.reviewer.autoMerge.enabled` for the project so the reviewer enables GitHub auto-merge once the PR is approved and checks are green.
 
-Agent selection: `takeover` reuses the vendor already in your config; otherwise it auto-detects an installed `claude` / `codex` / `grok` / `opencode` CLI, prompts when the choice is ambiguous, and accepts `--agent-vendor` plus `--yes` for non-interactive runs. Auto-merge still depends on the repository allowing it (and, by default, on branch protection with required checks); when GitHub refuses, the reviewer keeps reviewing and reports why instead.
+Agent selection: `takeover` reuses the vendor already in your config; otherwise it auto-detects an installed `claude` / `codex` / `grok` / `opencode` / `pi` / `omp` CLI, prompts when the choice is ambiguous, and accepts `--agent-vendor` plus `--yes` for non-interactive runs. Auto-merge still depends on the repository allowing it (and, by default, on branch protection with required checks); when GitHub refuses, the reviewer keeps reviewing and reports why instead.
 
 Manage and stop takeovers:
 

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -1967,7 +1967,8 @@ func shellSingleQuote(s string) string {
 
 // ResolveCommand returns the agent binary used for spawn for vendor + params.
 // When params["command"] is a non-empty string it wins; otherwise vendor defaults
-// apply (claude, codex, opencode, agent for cursor-cli, grok for grok-build).
+// apply (claude, codex, opencode, agent for cursor-cli, grok for grok-build,
+// pi for pi, omp for omp).
 // Same resolution as process spawn — callers may LookPath for an absolute path.
 func ResolveCommand(vendor config.AgentVendor, params map[string]any) string {
 	return resolveCommand(ExecutorConfig{Vendor: vendor, Params: params})
@@ -1985,6 +1986,7 @@ func resolveCommand(cfg ExecutorConfig) string {
 	case config.AgentVendorGrokBuild:
 		return "grok"
 	default:
+		// pi, omp, codex, opencode, and any future vendor whose id matches the binary.
 		return string(cfg.Vendor)
 	}
 }
@@ -2002,6 +2004,10 @@ func resolveArgs(cfg ExecutorConfig, workingDirectory string, prompt string) []s
 		return resolveCursorArgs(cfg, resolvedArgs, prompt)
 	case config.AgentVendorGrokBuild:
 		return resolveGrokArgs(cfg, resolvedArgs, workingDirectory, prompt)
+	case config.AgentVendorPi:
+		return resolvePiArgs(cfg, resolvedArgs, prompt)
+	case config.AgentVendorOmp:
+		return resolveOmpArgs(cfg, resolvedArgs, workingDirectory, prompt)
 	default:
 		return append([]string{}, resolvedArgs...)
 	}
@@ -2075,6 +2081,38 @@ func resolveGrokArgs(cfg ExecutorConfig, args []string, workingDirectory string,
 	}
 	if !hasAnyFlag(resolved, []string{"--no-auto-update"}) {
 		resolved = append(resolved, "--no-auto-update")
+	}
+	return resolved
+}
+
+// resolvePiArgs builds argv for the Pi coding agent (https://pi.dev).
+// -p/--print is boolean; the prompt is a positional message. No --cwd flag —
+// Looper already sets process cmd.Dir to the worktree. Fresh-run only.
+func resolvePiArgs(cfg ExecutorConfig, args []string, prompt string) []string {
+	resolved := prependModelFlag(args, cfg.Model, "--model", []string{"--model"})
+	if !hasAnyFlag(resolved, []string{"-p", "--print"}) {
+		// Operator-owned print/prompt: when -p/--print is already configured,
+		// do not append Looper's generated prompt (matches claude-code).
+		resolved = append(resolved, "-p", prompt)
+	}
+	if !hasAnyFlag(resolved, []string{"-a", "--approve", "-na", "--no-approve"}) {
+		resolved = append(resolved, "--approve")
+	}
+	return resolved
+}
+
+// resolveOmpArgs builds argv for Oh My Pi / omp (https://omp.sh).
+// Print mode matches pi (-p/--print boolean + positional prompt). Fresh-run only.
+func resolveOmpArgs(cfg ExecutorConfig, args []string, workingDirectory string, prompt string) []string {
+	resolved := prependModelFlag(args, cfg.Model, "--model", []string{"--model"})
+	if !hasAnyFlag(resolved, []string{"-p", "--print"}) {
+		resolved = append(resolved, "-p", prompt)
+	}
+	if strings.TrimSpace(workingDirectory) != "" && !hasAnyFlag(resolved, []string{"--cwd"}) {
+		resolved = append(resolved, "--cwd", workingDirectory)
+	}
+	if !hasAnyFlag(resolved, []string{"--auto-approve", "--approval-mode"}) {
+		resolved = append(resolved, "--auto-approve")
 	}
 	return resolved
 }

--- a/internal/agent/modelcatalog/catalog.go
+++ b/internal/agent/modelcatalog/catalog.go
@@ -338,7 +338,7 @@ func cloneResult(in Result) Result {
 func isKnownVendor(vendor config.AgentVendor) bool {
 	switch vendor {
 	case config.AgentVendorClaudeCode, config.AgentVendorCodex, config.AgentVendorOpenCode,
-		config.AgentVendorCursorCLI, config.AgentVendorGrokBuild:
+		config.AgentVendorCursorCLI, config.AgentVendorGrokBuild, config.AgentVendorPi, config.AgentVendorOmp:
 		return true
 	default:
 		return false
@@ -347,7 +347,8 @@ func isKnownVendor(vendor config.AgentVendor) bool {
 
 func supportsProbe(vendor config.AgentVendor) bool {
 	switch vendor {
-	case config.AgentVendorCodex, config.AgentVendorOpenCode, config.AgentVendorCursorCLI, config.AgentVendorGrokBuild:
+	case config.AgentVendorCodex, config.AgentVendorOpenCode, config.AgentVendorCursorCLI, config.AgentVendorGrokBuild,
+		config.AgentVendorPi, config.AgentVendorOmp:
 		return true
 	default:
 		return false

--- a/internal/agent/modelcatalog/catalog_test.go
+++ b/internal/agent/modelcatalog/catalog_test.go
@@ -173,9 +173,17 @@ func TestParsePiModelsFixture(t *testing.T) {
 }
 
 func TestParsePiModelsSkipsHeaderAndNoise(t *testing.T) {
-	raw := []byte("provider model context\nNot logged in\nopenai gpt-4o 128K\n")
+	raw := []byte("provider  model  context\nNot logged in\nopenai  gpt-4o  128K\n")
 	got := parsePiModels(raw)
 	if !reflect.DeepEqual(modelIDs(got), []string{"openai/gpt-4o"}) {
+		t.Fatalf("ids = %#v", modelIDs(got))
+	}
+}
+
+func TestParsePiModelsPreservesOpaqueIdentifiers(t *testing.T) {
+	raw := []byte("provider  model  context\nAcme:Cloud  Model:Preview  128K\n")
+	got := parsePiModels(raw)
+	if !reflect.DeepEqual(modelIDs(got), []string{"Acme:Cloud/Model:Preview"}) {
 		t.Fatalf("ids = %#v", modelIDs(got))
 	}
 }

--- a/internal/agent/modelcatalog/catalog_test.go
+++ b/internal/agent/modelcatalog/catalog_test.go
@@ -41,6 +41,8 @@ func TestLoadStaticCatalog(t *testing.T) {
 		config.AgentVendorOpenCode,
 		config.AgentVendorCursorCLI,
 		config.AgentVendorGrokBuild,
+		config.AgentVendorPi,
+		config.AgentVendorOmp,
 	} {
 		if len(catalog[vendor]) == 0 {
 			t.Fatalf("static catalog empty for %s", vendor)
@@ -154,6 +156,47 @@ func TestParseCursorAndGrokFixtures(t *testing.T) {
 	grok := parseGrokModels(readTestdata(t, "grok_models.txt"))
 	if got := modelIDs(grok); !reflect.DeepEqual(got, []string{"grok-4", "grok-3", "grok-code-fast-1"}) {
 		t.Fatalf("grok ids = %#v", got)
+	}
+}
+
+func TestParsePiModelsFixture(t *testing.T) {
+	got := parsePiModels(readTestdata(t, "pi_models.txt"))
+	want := []string{"openai/gpt-4o", "anthropic/claude-sonnet-4-5", "google/gemini-2.5-pro"}
+	if !reflect.DeepEqual(modelIDs(got), want) {
+		t.Fatalf("pi ids = %#v, want %#v", modelIDs(got), want)
+	}
+	for _, m := range got {
+		if m.Source != SourceProbe {
+			t.Fatalf("source = %q, want probe", m.Source)
+		}
+	}
+}
+
+func TestParsePiModelsSkipsHeaderAndNoise(t *testing.T) {
+	raw := []byte("provider model context\nNot logged in\nopenai gpt-4o 128K\n")
+	got := parsePiModels(raw)
+	if !reflect.DeepEqual(modelIDs(got), []string{"openai/gpt-4o"}) {
+		t.Fatalf("ids = %#v", modelIDs(got))
+	}
+}
+
+func TestParseOmpModelsFixture(t *testing.T) {
+	got, err := parseOmpModels(readTestdata(t, "omp_models.json"))
+	if err != nil {
+		t.Fatalf("parseOmpModels() error = %v", err)
+	}
+	want := []string{"anthropic/claude-sonnet-4-5", "openai/gpt-5.4", "google/gemini-2.5-pro", "sonnet"}
+	if !reflect.DeepEqual(modelIDs(got), want) {
+		t.Fatalf("omp ids = %#v, want %#v", modelIDs(got), want)
+	}
+	if got[0].Label != "Claude Sonnet 4.5" {
+		t.Fatalf("label = %q, want Claude Sonnet 4.5", got[0].Label)
+	}
+	if got[2].ID != "google/gemini-2.5-pro" || got[2].Label != "Gemini 2.5 Pro" {
+		t.Fatalf("provider/id fallback entry = %#v", got[2])
+	}
+	if got[3].ID != "sonnet" || got[3].Label != "Sonnet alias" {
+		t.Fatalf("bare id entry = %#v", got[3])
 	}
 }
 

--- a/internal/agent/modelcatalog/parse.go
+++ b/internal/agent/modelcatalog/parse.go
@@ -29,25 +29,24 @@ func parsePiModels(stdout []byte) []Model {
 	lines := strings.Split(string(stdout), "\n")
 	out := make([]Model, 0, len(lines))
 	seen := make(map[string]struct{})
+	inTable := false
+	columnCount := 0
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" || shouldSkipDecorLine(line) {
 			continue
 		}
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
+		columns := splitPiTableColumns(line)
+		if len(columns) >= 2 && strings.EqualFold(columns[0], "provider") && strings.EqualFold(columns[1], "model") {
+			inTable = true
+			columnCount = len(columns)
 			continue
 		}
-		// Skip header row (provider model context ...).
-		if strings.EqualFold(fields[0], "provider") && strings.EqualFold(fields[1], "model") {
+		if !inTable || len(columns) != columnCount {
 			continue
 		}
-		provider := fields[0]
-		model := fields[1]
-		// Pi table tokens are lowercase ids; reject diagnostic sentences like "Not logged in".
-		if !looksLikePiTableToken(provider) || !looksLikePiTableToken(model) {
-			continue
-		}
+		provider := columns[0]
+		model := columns[1]
 		id := provider + "/" + model
 		if _, ok := seen[id]; ok {
 			continue
@@ -58,24 +57,32 @@ func parsePiModels(stdout []byte) []Model {
 	return out
 }
 
-// looksLikePiTableToken accepts provider/model column values from pi --list-models
-// (lowercase alphanumerics plus - _ . /). Uppercase English words are rejected.
-func looksLikePiTableToken(s string) bool {
-	if s == "" {
-		return false
-	}
-	for i := 0; i < len(s); i++ {
-		r := s[i]
-		switch {
-		case r >= 'a' && r <= 'z':
-		case r >= '0' && r <= '9':
-		case r == '-' || r == '_' || r == '.' || r == '/':
-		default:
-			return false
+// splitPiTableColumns splits the aligned columns emitted by pi --list-models.
+// Two or more spaces (or a tab) delimit columns; single spaces stay in values.
+func splitPiTableColumns(line string) []string {
+	var columns []string
+	start := 0
+	for i := 0; i < len(line); {
+		if line[i] != '\t' && line[i] != ' ' {
+			i++
+			continue
 		}
+		end := i + 1
+		for end < len(line) && (line[end] == ' ' || line[end] == '\t') {
+			end++
+		}
+		if line[i] == '\t' || end-i >= 2 {
+			if column := strings.TrimSpace(line[start:i]); column != "" {
+				columns = append(columns, column)
+			}
+			start = end
+		}
+		i = end
 	}
-	r0 := s[0]
-	return (r0 >= 'a' && r0 <= 'z') || (r0 >= '0' && r0 <= '9')
+	if column := strings.TrimSpace(line[start:]); column != "" {
+		columns = append(columns, column)
+	}
+	return columns
 }
 
 type ompModelsPayload struct {

--- a/internal/agent/modelcatalog/parse.go
+++ b/internal/agent/modelcatalog/parse.go
@@ -19,6 +19,117 @@ func parseGrokModels(stdout []byte) []Model {
 	return parseTableOrIDLines(stdout)
 }
 
+// parsePiModels parses `pi --list-models` multi-column table output:
+//
+//	provider               model                                               context  ...
+//	openai                 gpt-4o                                              128K     ...
+//
+// Model IDs are provider/model when both columns are present (pi accepts that form).
+func parsePiModels(stdout []byte) []Model {
+	lines := strings.Split(string(stdout), "\n")
+	out := make([]Model, 0, len(lines))
+	seen := make(map[string]struct{})
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || shouldSkipDecorLine(line) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		// Skip header row (provider model context ...).
+		if strings.EqualFold(fields[0], "provider") && strings.EqualFold(fields[1], "model") {
+			continue
+		}
+		provider := fields[0]
+		model := fields[1]
+		// Pi table tokens are lowercase ids; reject diagnostic sentences like "Not logged in".
+		if !looksLikePiTableToken(provider) || !looksLikePiTableToken(model) {
+			continue
+		}
+		id := provider + "/" + model
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, Model{ID: id, Source: SourceProbe})
+	}
+	return out
+}
+
+// looksLikePiTableToken accepts provider/model column values from pi --list-models
+// (lowercase alphanumerics plus - _ . /). Uppercase English words are rejected.
+func looksLikePiTableToken(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		r := s[i]
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.' || r == '/':
+		default:
+			return false
+		}
+	}
+	r0 := s[0]
+	return (r0 >= 'a' && r0 <= 'z') || (r0 >= '0' && r0 <= '9')
+}
+
+type ompModelsPayload struct {
+	Models []ompModelEntry `json:"models"`
+}
+
+type ompModelEntry struct {
+	Provider string `json:"provider"`
+	ID       string `json:"id"`
+	Selector string `json:"selector"`
+	Name     string `json:"name"`
+}
+
+// parseOmpModels parses `omp models --json` output. Prefer selector as Model.ID;
+// fallback provider/id or bare id. Use name as Label when present.
+func parseOmpModels(stdout []byte) ([]Model, error) {
+	trimmed := bytesTrimSpace(stdout)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	var payload ompModelsPayload
+	if err := json.Unmarshal(trimmed, &payload); err != nil {
+		var arr []ompModelEntry
+		if err2 := json.Unmarshal(trimmed, &arr); err2 != nil {
+			return nil, err
+		}
+		payload.Models = arr
+	}
+	out := make([]Model, 0, len(payload.Models))
+	seen := make(map[string]struct{})
+	for _, e := range payload.Models {
+		id := strings.TrimSpace(e.Selector)
+		if id == "" {
+			provider := strings.TrimSpace(e.Provider)
+			rawID := strings.TrimSpace(e.ID)
+			switch {
+			case provider != "" && rawID != "":
+				id = provider + "/" + rawID
+			case rawID != "":
+				id = rawID
+			default:
+				continue
+			}
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		label := strings.TrimSpace(e.Name)
+		out = append(out, Model{ID: id, Label: label, Source: SourceProbe})
+	}
+	return out, nil
+}
+
 // parseLineModels is the shared text parser used by cursor/grok-style output.
 // Kept as an alias for tests and call sites that want the table-tolerant path.
 func parseLineModels(stdout []byte) []Model {

--- a/internal/agent/modelcatalog/probe.go
+++ b/internal/agent/modelcatalog/probe.go
@@ -303,6 +303,18 @@ func (s *Service) probe(ctx context.Context, vendor config.AgentVendor, binary s
 			return nil, err
 		}
 		return parseGrokModels(out), nil
+	case config.AgentVendorPi:
+		out, err := s.runner.Run(runCtx, env, binary, "--list-models")
+		if err != nil {
+			return nil, err
+		}
+		return parsePiModels(out), nil
+	case config.AgentVendorOmp:
+		out, err := s.runner.Run(runCtx, env, binary, "models", "--json")
+		if err != nil {
+			return nil, err
+		}
+		return parseOmpModels(out)
 	default:
 		return nil, errors.New("probe unsupported")
 	}

--- a/internal/agent/modelcatalog/static_catalog.json
+++ b/internal/agent/modelcatalog/static_catalog.json
@@ -30,5 +30,17 @@
     { "id": "grok-4", "label": "Grok 4" },
     { "id": "grok-3", "label": "Grok 3" },
     { "id": "grok-code-fast-1", "label": "Grok Code Fast 1" }
+  ],
+  "pi": [
+    { "id": "sonnet", "label": "Sonnet" },
+    { "id": "opus", "label": "Opus" },
+    { "id": "haiku", "label": "Haiku" },
+    { "id": "openai/gpt-5.4", "label": "OpenAI GPT-5.4" }
+  ],
+  "omp": [
+    { "id": "sonnet", "label": "Sonnet" },
+    { "id": "opus", "label": "Opus" },
+    { "id": "haiku", "label": "Haiku" },
+    { "id": "openai/gpt-5.4", "label": "OpenAI GPT-5.4" }
   ]
 }

--- a/internal/agent/modelcatalog/testdata/omp_models.json
+++ b/internal/agent/modelcatalog/testdata/omp_models.json
@@ -1,0 +1,25 @@
+{
+  "models": [
+    {
+      "provider": "anthropic",
+      "id": "claude-sonnet-4-5",
+      "selector": "anthropic/claude-sonnet-4-5",
+      "name": "Claude Sonnet 4.5"
+    },
+    {
+      "provider": "openai",
+      "id": "gpt-5.4",
+      "selector": "openai/gpt-5.4",
+      "name": "OpenAI GPT-5.4"
+    },
+    {
+      "provider": "google",
+      "id": "gemini-2.5-pro",
+      "name": "Gemini 2.5 Pro"
+    },
+    {
+      "id": "sonnet",
+      "name": "Sonnet alias"
+    }
+  ]
+}

--- a/internal/agent/modelcatalog/testdata/pi_models.txt
+++ b/internal/agent/modelcatalog/testdata/pi_models.txt
@@ -1,0 +1,4 @@
+provider               model                                               context  max-out  thinking  images
+openai                 gpt-4o                                              128K     16K      no        yes
+anthropic              claude-sonnet-4-5                                   200K     64K      yes       yes
+google                 gemini-2.5-pro                                      1M       64K      yes       yes

--- a/internal/agent/omp_test.go
+++ b/internal/agent/omp_test.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func ompOwner() *config.AgentVendor {
+	v := config.AgentVendorOmp
+	return &v
+}
+
+func TestResolveOmpArgs(t *testing.T) {
+	model := "sonnet"
+	base := ExecutorConfig{Vendor: config.AgentVendorOmp, Model: &model}
+	workdir := "/tmp/looper-worktree"
+	prompt := "generated prompt"
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{"default", nil, []string{"--model", model, "-p", prompt, "--cwd", workdir, "--auto-approve"}},
+		{"configured model", []string{"--model", "custom"}, []string{"--model", "custom", "-p", prompt, "--cwd", workdir, "--auto-approve"}},
+		{"equals model", []string{"--model=custom"}, []string{"--model=custom", "-p", prompt, "--cwd", workdir, "--auto-approve"}},
+		{"short print owns prompt", []string{"-p", "custom"}, []string{"--model", model, "-p", "custom", "--cwd", workdir, "--auto-approve"}},
+		{"long print owns prompt", []string{"--print", "custom"}, []string{"--model", model, "--print", "custom", "--cwd", workdir, "--auto-approve"}},
+		{"print equals owns prompt", []string{"--print=custom"}, []string{"--model", model, "--print=custom", "--cwd", workdir, "--auto-approve"}},
+		{"cwd", []string{"--cwd", "/operator"}, []string{"--model", model, "--cwd", "/operator", "-p", prompt, "--auto-approve"}},
+		{"cwd equals", []string{"--cwd=/operator"}, []string{"--model", model, "--cwd=/operator", "-p", prompt, "--auto-approve"}},
+		{"auto approve", []string{"--auto-approve"}, []string{"--model", model, "--auto-approve", "-p", prompt, "--cwd", workdir}},
+		{"approval mode", []string{"--approval-mode", "ask"}, []string{"--model", model, "--approval-mode", "ask", "-p", prompt, "--cwd", workdir}},
+		{"approval mode equals", []string{"--approval-mode=ask"}, []string{"--model", model, "--approval-mode=ask", "-p", prompt, "--cwd", workdir}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := append([]string(nil), tt.args...)
+			cfg := base
+			cfg.Params = map[string]any{"args": tt.args}
+			command, got := ResolveSpawn(cfg, workdir, prompt)
+			if command != "omp" || !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ResolveSpawn() = (%q, %#v), want (omp, %#v)", command, got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.args, original) {
+				t.Fatalf("configured args mutated: got %#v, want %#v", tt.args, original)
+			}
+		})
+	}
+}
+
+func TestOmpExecutionContractAndUnsupportedResume(t *testing.T) {
+	workdir := t.TempDir()
+	scriptPath := filepath.Join(t.TempDir(), "omp")
+	observedPath := filepath.Join(t.TempDir(), "observed")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$OBSERVED_PATH\"\nprintf 'env:%s\\n' \"$PWD\" >> \"$OBSERVED_PATH\"\nprintf 'dir:%s\\n' \"$(pwd)\" >> \"$OBSERVED_PATH\"\nprintf 'stderr line\\n' >&2\nprintf '__LOOPER_RESULT__={\"summary\":\"done\"}\\n'\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	repos := storage.NewRepositories(openAgentCoordinator(t).DB())
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendorOmp, NativeResumeEnabled: true, Params: map[string]any{"command": scriptPath}}, Repos: repos,
+		ParamsOwnerVendor: ompOwner(),
+	})
+	execution, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_omp", WorkingDirectory: workdir, Prompt: "fresh prompt", NativeResumePrompt: "resume prompt", NativeSessionID: "session-1", Timeout: 10 * time.Second, Env: map[string]string{"OBSERVED_PATH": observedPath}})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	result, err := execution.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "completed" || result.Summary != "done" || !strings.Contains(result.Stdout, "__LOOPER_RESULT__") || !strings.Contains(result.Stderr, "stderr line") {
+		t.Fatalf("result = %#v, want completed output capture and parsed marker", result)
+	}
+	observed, err := os.ReadFile(observedPath)
+	if err != nil {
+		t.Fatalf("read observed args: %v", err)
+	}
+	got := strings.Split(strings.TrimSpace(string(observed)), "\n")
+	want := []string{"-p", "fresh prompt", "--cwd", workdir, "--auto-approve", "env:" + workdir, "dir:" + workdir}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("observed = %#v, want %#v", got, want)
+	}
+	if nativeResumeSupported(config.AgentVendorOmp) || InteractiveTakeoverSupported(config.AgentVendorOmp) {
+		t.Fatal("Oh My Pi resume support must remain disabled")
+	}
+	record, err := repos.AgentExecutions.GetByID(context.Background(), "agent_omp")
+	if err != nil || record == nil || record.NativeResumeMode == nil || *record.NativeResumeMode != "checkpoint_restart" || record.NativeResumeStatus == nil || *record.NativeResumeStatus != "unsupported" {
+		t.Fatalf("native resume record = %#v, err = %v, want checkpoint_restart/unsupported", record, err)
+	}
+}

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -1,0 +1,99 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func piOwner() *config.AgentVendor {
+	v := config.AgentVendorPi
+	return &v
+}
+
+func TestResolvePiArgs(t *testing.T) {
+	model := "sonnet"
+	base := ExecutorConfig{Vendor: config.AgentVendorPi, Model: &model}
+	workdir := "/tmp/looper-worktree"
+	prompt := "generated prompt"
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{"default", nil, []string{"--model", model, "-p", prompt, "--approve"}},
+		{"configured model", []string{"--model", "custom"}, []string{"--model", "custom", "-p", prompt, "--approve"}},
+		{"equals model", []string{"--model=custom"}, []string{"--model=custom", "-p", prompt, "--approve"}},
+		{"short print owns prompt", []string{"-p", "custom"}, []string{"--model", model, "-p", "custom", "--approve"}},
+		{"long print owns prompt", []string{"--print", "custom"}, []string{"--model", model, "--print", "custom", "--approve"}},
+		{"print equals owns prompt", []string{"--print=custom"}, []string{"--model", model, "--print=custom", "--approve"}},
+		{"short approve", []string{"-a"}, []string{"--model", model, "-a", "-p", prompt}},
+		{"long approve", []string{"--approve"}, []string{"--model", model, "--approve", "-p", prompt}},
+		{"no approve", []string{"-na"}, []string{"--model", model, "-na", "-p", prompt}},
+		{"long no approve", []string{"--no-approve"}, []string{"--model", model, "--no-approve", "-p", prompt}},
+		// workdir is process Dir only; pi has no --cwd default.
+		{"workdir ignored for argv", nil, []string{"--model", model, "-p", prompt, "--approve"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := append([]string(nil), tt.args...)
+			cfg := base
+			cfg.Params = map[string]any{"args": tt.args}
+			command, got := ResolveSpawn(cfg, workdir, prompt)
+			if command != "pi" || !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ResolveSpawn() = (%q, %#v), want (pi, %#v)", command, got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.args, original) {
+				t.Fatalf("configured args mutated: got %#v, want %#v", tt.args, original)
+			}
+		})
+	}
+}
+
+func TestPiExecutionContractAndUnsupportedResume(t *testing.T) {
+	workdir := t.TempDir()
+	scriptPath := filepath.Join(t.TempDir(), "pi")
+	observedPath := filepath.Join(t.TempDir(), "observed")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$OBSERVED_PATH\"\nprintf 'env:%s\\n' \"$PWD\" >> \"$OBSERVED_PATH\"\nprintf 'dir:%s\\n' \"$(pwd)\" >> \"$OBSERVED_PATH\"\nprintf 'stderr line\\n' >&2\nprintf '__LOOPER_RESULT__={\"summary\":\"done\"}\\n'\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	repos := storage.NewRepositories(openAgentCoordinator(t).DB())
+	executor := New(ExecutorOptions{Config: ExecutorConfig{Vendor: config.AgentVendorPi, NativeResumeEnabled: true, Params: map[string]any{"command": scriptPath}}, Repos: repos,
+		ParamsOwnerVendor: piOwner(),
+	})
+	execution, err := executor.Start(context.Background(), RunInput{ExecutionID: "agent_pi", WorkingDirectory: workdir, Prompt: "fresh prompt", NativeResumePrompt: "resume prompt", NativeSessionID: "session-1", Timeout: 10 * time.Second, Env: map[string]string{"OBSERVED_PATH": observedPath}})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	result, err := execution.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result.Status != "completed" || result.Summary != "done" || !strings.Contains(result.Stdout, "__LOOPER_RESULT__") || !strings.Contains(result.Stderr, "stderr line") {
+		t.Fatalf("result = %#v, want completed output capture and parsed marker", result)
+	}
+	observed, err := os.ReadFile(observedPath)
+	if err != nil {
+		t.Fatalf("read observed args: %v", err)
+	}
+	got := strings.Split(strings.TrimSpace(string(observed)), "\n")
+	want := []string{"-p", "fresh prompt", "--approve", "env:" + workdir, "dir:" + workdir}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("observed = %#v, want %#v", got, want)
+	}
+	if nativeResumeSupported(config.AgentVendorPi) || InteractiveTakeoverSupported(config.AgentVendorPi) {
+		t.Fatal("Pi resume support must remain disabled")
+	}
+	record, err := repos.AgentExecutions.GetByID(context.Background(), "agent_pi")
+	if err != nil || record == nil || record.NativeResumeMode == nil || *record.NativeResumeMode != "checkpoint_restart" || record.NativeResumeStatus == nil || *record.NativeResumeStatus != "unsupported" {
+		t.Fatalf("native resume record = %#v, err = %v, want checkpoint_restart/unsupported", record, err)
+	}
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1161,12 +1161,12 @@ func (h *Handler) handleAgentModelsRoute(w http.ResponseWriter, r *http.Request,
 	vendor := config.AgentVendor(vendorRaw)
 	switch vendor {
 	case config.AgentVendorClaudeCode, config.AgentVendorCodex, config.AgentVendorOpenCode,
-		config.AgentVendorCursorCLI, config.AgentVendorGrokBuild:
+		config.AgentVendorCursorCLI, config.AgentVendorGrokBuild, config.AgentVendorPi, config.AgentVendorOmp:
 	default:
 		h.writeError(w, requestID, apiError{
 			code:    pkgapi.ErrorCodeValidationFailed,
 			status:  http.StatusBadRequest,
-			message: "vendor must be one of: claude-code, codex, opencode, cursor-cli, grok-build",
+			message: "vendor must be one of: claude-code, codex, opencode, cursor-cli, grok-build, pi, omp",
 		})
 		return
 	}
@@ -1209,7 +1209,7 @@ func (h *Handler) handleAgentModelsRoute(w http.ResponseWriter, r *http.Request,
 			h.writeError(w, requestID, apiError{
 				code:    pkgapi.ErrorCodeValidationFailed,
 				status:  http.StatusBadRequest,
-				message: "vendor must be one of: claude-code, codex, opencode, cursor-cli, grok-build",
+				message: "vendor must be one of: claude-code, codex, opencode, cursor-cli, grok-build, pi, omp",
 			})
 			return
 		}

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -492,7 +492,7 @@ func (a *App) newRootCommand(argv []string) *cobra.Command {
 				runE:            runtime.takeover,
 				helpSubcommands: []helpSubcommand{{name: "list", description: "List active takeovers"}, {name: "stop", description: "Stop a takeover's reviewer and fixer loops"}},
 				localFlags: []flagSpec{
-					stringFlag("agent-vendor", "vendor", "Agent vendor to run loops (claude-code, codex, opencode, cursor-cli, grok-build)"),
+					stringFlag("agent-vendor", "vendor", "Agent vendor to run loops (claude-code, codex, opencode, cursor-cli, grok-build, pi, omp)"),
 					boolFlag("merge", "Let the reviewer enable auto-merge once the PR is approved and green"),
 					boolFlag("no-fix", "Only run the reviewer loop; skip the fixer loop"),
 					boolFlag("yes", "Run non-interactively; fail instead of prompting for the agent vendor"),

--- a/internal/cliapp/bootstrap.go
+++ b/internal/cliapp/bootstrap.go
@@ -1403,7 +1403,7 @@ func writeHumanBootstrapResult(w io.Writer, result bootstrapResult) error {
 }
 
 func promptBootstrapVendor(reader *bufio.Reader, w io.Writer) (*config.AgentVendor, error) {
-	answer, err := promptBootstrapString(reader, w, "Agent vendor [claude-code/codex/opencode/cursor-cli/grok-build]", "")
+	answer, err := promptBootstrapString(reader, w, "Agent vendor [claude-code/codex/opencode/cursor-cli/grok-build/pi/omp]", "")
 	if err != nil {
 		return nil, err
 	}
@@ -1462,7 +1462,7 @@ func promptBootstrapString(reader *bufio.Reader, w io.Writer, label string, defa
 
 func isSupportedBootstrapVendor(vendor config.AgentVendor) bool {
 	switch vendor {
-	case config.AgentVendorClaudeCode, config.AgentVendorCodex, config.AgentVendorOpenCode, config.AgentVendorCursorCLI, config.AgentVendorGrokBuild:
+	case config.AgentVendorClaudeCode, config.AgentVendorCodex, config.AgentVendorOpenCode, config.AgentVendorCursorCLI, config.AgentVendorGrokBuild, config.AgentVendorPi, config.AgentVendorOmp:
 		return true
 	default:
 		return false

--- a/internal/cliapp/pi_omp_test.go
+++ b/internal/cliapp/pi_omp_test.go
@@ -1,0 +1,85 @@
+package cliapp
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestPiOmpBootstrapSelection(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		vendor config.AgentVendor
+	}{
+		{"pi", config.AgentVendorPi},
+		{"omp", config.AgentVendorOmp},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newCommandRuntime(New(Deps{}), nil)
+			plan, _, err := r.planBootstrapConfig(newTakeoverCmd(t, "", false), t.TempDir(), bootstrapOptions{AgentVendor: string(tc.vendor), Yes: true})
+			if err != nil || plan.AgentVendor == nil || *plan.AgentVendor != tc.vendor {
+				t.Fatalf("planBootstrapConfig() = (%+v, %v), want %s", plan, err, tc.vendor)
+			}
+
+			var output bytes.Buffer
+			vendor, err := promptBootstrapVendor(bufio.NewReader(strings.NewReader(string(tc.vendor)+"\n")), &output)
+			if err != nil || vendor == nil || *vendor != tc.vendor {
+				t.Fatalf("promptBootstrapVendor() = (%v, %v), want %s", vendor, err, tc.vendor)
+			}
+		})
+	}
+}
+
+func TestPiOmpTakeoverSelectionAndDetection(t *testing.T) {
+	configPath := t.TempDir() + "/config.toml"
+	r := newTakeoverRuntime(t, configPath, Deps{LookPath: lookPathFor()})
+
+	for _, tc := range []struct {
+		vendor config.AgentVendor
+		binary string
+	}{
+		{config.AgentVendorPi, "pi"},
+		{config.AgentVendorOmp, "omp"},
+	} {
+		t.Run(string(tc.vendor)+"_explicit", func(t *testing.T) {
+			vendor, _, err := r.resolveTakeoverVendor(newTakeoverCmd(t, string(tc.vendor), false), takeoverOptions{AgentVendor: string(tc.vendor)})
+			if err != nil || vendor != tc.vendor {
+				t.Fatalf("explicit selection = (%q, %v), want %s", vendor, err, tc.vendor)
+			}
+		})
+		t.Run(string(tc.vendor)+"_detect", func(t *testing.T) {
+			got := detectInstalledVendors(lookPathFor(tc.binary))
+			if len(got) != 1 || got[0] != tc.vendor {
+				t.Fatalf("%s-only detection = %v, want [%s]", tc.binary, got, tc.vendor)
+			}
+		})
+	}
+
+	r = newTakeoverRuntime(t, configPath, Deps{LookPath: lookPathFor("pi", "omp")})
+	_, _, err := r.resolveTakeoverVendor(newTakeoverCmd(t, "", true), takeoverOptions{Yes: true})
+	if err == nil || !strings.Contains(err.Error(), "pi") || !strings.Contains(err.Error(), "omp") {
+		t.Fatalf("pi/omp ambiguity error = %v, want both vendors", err)
+	}
+}
+
+func TestPiOmpVendorHelpAndErrors(t *testing.T) {
+	app := New(Deps{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
+	root := app.newRootCommand(nil)
+	takeover, _, err := root.Find([]string{"takeover"})
+	if err != nil {
+		t.Fatalf("find takeover command: %v", err)
+	}
+	flag := takeover.Flags().Lookup("agent-vendor")
+	if flag == nil || !strings.Contains(flag.Usage, "pi") || !strings.Contains(flag.Usage, "omp") {
+		t.Fatalf("takeover agent-vendor help = %v, want pi and omp", flag)
+	}
+
+	r := newTakeoverRuntime(t, t.TempDir()+"/config.toml", Deps{LookPath: lookPathFor()})
+	_, _, err = r.resolveTakeoverVendor(newTakeoverCmd(t, "", true), takeoverOptions{Yes: true})
+	if err == nil || !strings.Contains(err.Error(), "pi") || !strings.Contains(err.Error(), "omp") {
+		t.Fatalf("no-agent error = %v, want pi/omp install guidance", err)
+	}
+}

--- a/internal/cliapp/takeover.go
+++ b/internal/cliapp/takeover.go
@@ -33,6 +33,8 @@ var takeoverVendorBinaries = []struct {
 	{config.AgentVendorCodex, "codex"},
 	{config.AgentVendorOpenCode, "opencode"},
 	{config.AgentVendorGrokBuild, "grok"},
+	{config.AgentVendorPi, "pi"},
+	{config.AgentVendorOmp, "omp"},
 }
 
 type takeoverOptions struct {
@@ -298,7 +300,7 @@ func (r *commandRuntime) resolveTakeoverVendor(cmd *cobra.Command, opts takeover
 	if opts.AgentVendor != "" {
 		vendor := config.AgentVendor(opts.AgentVendor)
 		if !isSupportedBootstrapVendor(vendor) {
-			return "", "", fmt.Errorf("unsupported --agent-vendor %q (supported: claude-code, codex, opencode, cursor-cli, grok-build)", opts.AgentVendor)
+			return "", "", fmt.Errorf("unsupported --agent-vendor %q (supported: claude-code, codex, opencode, cursor-cli, grok-build, pi, omp)", opts.AgentVendor)
 		}
 		return vendor, "", nil
 	}
@@ -314,7 +316,7 @@ func (r *commandRuntime) resolveTakeoverVendor(cmd *cobra.Command, opts takeover
 
 	if opts.Yes {
 		if len(detected) == 0 {
-			return "", "", fmt.Errorf("no supported agent CLI detected on PATH; install one (claude, codex, opencode, or grok) or pass --agent-vendor")
+			return "", "", fmt.Errorf("no supported agent CLI detected on PATH; install one (claude, codex, opencode, grok, pi, or omp) or pass --agent-vendor")
 		}
 		return "", "", fmt.Errorf("multiple agent CLIs detected (%s); pass --agent-vendor to choose one", joinVendors(detected))
 	}
@@ -346,9 +348,9 @@ func (r *commandRuntime) promptTakeoverVendor(cmd *cobra.Command, detected []con
 	if len(detected) > 0 {
 		defaultValue = string(detected[0])
 	}
-	label := "Agent vendor [claude-code/codex/opencode/cursor-cli/grok-build]"
+	label := "Agent vendor [claude-code/codex/opencode/cursor-cli/grok-build/pi/omp]"
 	if len(detected) > 0 {
-		label = fmt.Sprintf("Agent vendor (detected: %s) [claude-code/codex/opencode/cursor-cli/grok-build]", joinVendors(detected))
+		label = fmt.Sprintf("Agent vendor (detected: %s) [claude-code/codex/opencode/cursor-cli/grok-build/pi/omp]", joinVendors(detected))
 	}
 	answer, err := promptBootstrapString(reader, cmd.OutOrStdout(), label, defaultValue)
 	if err != nil {
@@ -360,7 +362,7 @@ func (r *commandRuntime) promptTakeoverVendor(cmd *cobra.Command, detected []con
 	}
 	vendor := config.AgentVendor(answer)
 	if !isSupportedBootstrapVendor(vendor) {
-		return "", fmt.Errorf("unsupported agent vendor %q (supported: claude-code, codex, opencode, cursor-cli, grok-build)", answer)
+		return "", fmt.Errorf("unsupported agent vendor %q (supported: claude-code, codex, opencode, cursor-cli, grok-build, pi, omp)", answer)
 	}
 	return vendor, nil
 }

--- a/internal/config/pi_omp_test.go
+++ b/internal/config/pi_omp_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPiAndOmpVendorValidation(t *testing.T) {
+	for _, vendor := range []AgentVendor{AgentVendorPi, AgentVendorOmp} {
+		t.Run(string(vendor), func(t *testing.T) {
+			cfg, err := DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig() error = %v", err)
+			}
+			cfg.Daemon.LogDir = t.TempDir()
+			cfg.Daemon.WorkingDirectory = t.TempDir()
+			v := vendor
+			cfg.Agent.Vendor = &v
+			if err := ValidateWithOptions(cfg, ValidateOptions{DefaultWorktreeRoot: t.TempDir()}); err != nil {
+				t.Fatalf("ValidateWithOptions() error = %v", err)
+			}
+		})
+	}
+
+	cfg, err := DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Daemon.LogDir = t.TempDir()
+	cfg.Daemon.WorkingDirectory = t.TempDir()
+	invalid := AgentVendor("invalid")
+	cfg.Agent.Vendor = &invalid
+	err = ValidateWithOptions(cfg, ValidateOptions{DefaultWorktreeRoot: t.TempDir()})
+	if err == nil || !strings.Contains(err.Error(), "pi") || !strings.Contains(err.Error(), "omp") {
+		t.Fatalf("invalid vendor error = %v, want pi and omp in supported-vendor copy", err)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -8,6 +8,8 @@ const (
 	AgentVendorOpenCode   AgentVendor = "opencode"
 	AgentVendorCursorCLI  AgentVendor = "cursor-cli"
 	AgentVendorGrokBuild  AgentVendor = "grok-build"
+	AgentVendorPi         AgentVendor = "pi"
+	AgentVendorOmp        AgentVendor = "omp"
 )
 
 type LogLevel string

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -905,7 +905,7 @@ func isNilOrEmptyString(value *string) bool {
 
 func isValidAgentVendor(vendor AgentVendor) bool {
 	switch vendor {
-	case AgentVendorClaudeCode, AgentVendorCodex, AgentVendorOpenCode, AgentVendorCursorCLI, AgentVendorGrokBuild:
+	case AgentVendorClaudeCode, AgentVendorCodex, AgentVendorOpenCode, AgentVendorCursorCLI, AgentVendorGrokBuild, AgentVendorPi, AgentVendorOmp:
 		return true
 	default:
 		return false
@@ -913,7 +913,7 @@ func isValidAgentVendor(vendor AgentVendor) bool {
 }
 
 func agentVendorValidationMessage() string {
-	return fmt.Sprintf("must be one of: %s, %s, %s, %s, %s", AgentVendorClaudeCode, AgentVendorCodex, AgentVendorOpenCode, AgentVendorCursorCLI, AgentVendorGrokBuild)
+	return fmt.Sprintf("must be one of: %s, %s, %s, %s, %s, %s, %s", AgentVendorClaudeCode, AgentVendorCodex, AgentVendorOpenCode, AgentVendorCursorCLI, AgentVendorGrokBuild, AgentVendorPi, AgentVendorOmp)
 }
 
 func validateAgentProfiles(profiles map[string]AgentBindingConfig, issues *[]ValidationIssue) {

--- a/internal/reviewer/pi_omp_test.go
+++ b/internal/reviewer/pi_omp_test.go
@@ -1,0 +1,15 @@
+package reviewer
+
+import (
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestPiOmpReviewerNativeResumeRemainsUnsupported(t *testing.T) {
+	for _, vendor := range []config.AgentVendor{config.AgentVendorPi, config.AgentVendorOmp} {
+		if nativeResumeSupportedForReviewer(vendor) {
+			t.Fatalf("%s reviewer native resume must remain unsupported", vendor)
+		}
+	}
+}

--- a/internal/runtime/pi_omp_test.go
+++ b/internal/runtime/pi_omp_test.go
@@ -1,0 +1,15 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestPiOmpNativeResumeRemainsUnsupported(t *testing.T) {
+	for _, vendor := range []config.AgentVendor{config.AgentVendorPi, config.AgentVendorOmp} {
+		if runtimeNativeResumeSupported(string(vendor)) {
+			t.Fatalf("%s runtime native resume must remain unsupported", vendor)
+		}
+	}
+}

--- a/skills/looper/SKILL.md
+++ b/skills/looper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: looper
-description: Use when installing, bootstrapping, configuring, starting, verifying, operating, or troubleshooting Looper, looperd, the looper CLI, ~/.looper config, or runtime paths; when setting up Looper with opencode, claude-code, codex, cursor-cli, or Grok Build; when registering repos or configuring planner/reviewer/fixer/worker loops; or when diagnosing status, logs, osascript, git, gh, LOOPER_TOKEN, writable path, or daemon startup issues.
+description: Use when installing, bootstrapping, configuring, starting, verifying, operating, or troubleshooting Looper, looperd, the looper CLI, ~/.looper config, or runtime paths; when setting up Looper with opencode, claude-code, codex, cursor-cli, Grok Build, Pi, or Oh My Pi (omp); when registering repos or configuring planner/reviewer/fixer/worker loops; or when diagnosing status, logs, osascript, git, gh, LOOPER_TOKEN, writable path, or daemon startup issues.
 ---
 
 # Looper
@@ -92,6 +92,8 @@ Auto-detect installed agent CLIs in parallel before asking:
 | `opencode` | `command -v opencode` |
 | `cursor-cli` | `command -v agent` |
 | `grok-build` | `command -v grok` |
+| `pi` | `command -v pi` |
+| `omp` | `command -v omp` |
 
 Use the `question` tool to let the user pick one. List detected vendors first, marked `(installed)`, with undetected ones appended as `(not installed — needs setup)`. If multiple are installed, do not impose an opinionated default — present them in detection order and let the user choose.
 
@@ -99,9 +101,11 @@ If none are installed, ask the user which one they want to install before contin
 
 After the user picks a vendor, verify it is authenticated (run the vendor's own status command, e.g. `claude --version` followed by a quick auth check, or `agent status`). If the vendor CLI exits with an auth error, surface it and ask the user to log in via the vendor's own flow before continuing.
 
-Looper inherits the vendor's own authentication (e.g. `claude login`, `agent login`, or env vars in the user's shell). For xAI Grok Build (`agent.vendor = "grok-build"`, executable `grok`), use `grok login --device-auth` or provide `XAI_API_KEY` in the daemon environment. Prefer those vendor/daemon authentication mechanisms over storing credentials in Looper configuration. If the user explicitly manages a value through `agent.env`, treat it as a local secret: the dashboard/API returns only its key, never its value, and it must not be committed or copied into examples.
+Looper inherits the vendor's own authentication (e.g. `claude login`, `agent login`, or env vars in the user's shell). For xAI Grok Build (`agent.vendor = "grok-build"`, executable `grok`), use `grok login --device-auth` or provide `XAI_API_KEY` in the daemon environment. For Pi (`agent.vendor = "pi"`, executable `pi`) and Oh My Pi (`agent.vendor = "omp"`, executable `omp`), use each vendor's own login/config. Prefer those vendor/daemon authentication mechanisms over storing credentials in Looper configuration. If the user explicitly manages a value through `agent.env`, treat it as a local secret: the dashboard/API returns only its key, never its value, and it must not be committed or copied into examples.
 
 Grok Build fresh runs default to `--always-approve` and `--sandbox off` so the agent can update Git metadata outside a linked worktree. Configured arguments override defaults: operators can select a stricter sandbox when the repository layout permits it; `--permission-mode` may prompt or fail unattended runs; non-`plain` output can prevent direct completion-marker parsing; and `-p`/`--single` replaces Looper's generated task prompt. Daemon native resume and interactive `looper resume` takeover are unsupported for Grok Build; retries use a fresh checkpoint prompt, and Looper never uses ambient `--continue`.
+
+Pi fresh runs default to `-p <prompt> --approve` (project-local `.pi` trusted for the run). Oh My Pi (`omp`) fresh runs default to `-p <prompt> --cwd <worktree> --auto-approve`. Configured print/approve/cwd/approval-mode flags override those defaults. Daemon native resume and interactive `looper resume` takeover are unsupported for `pi` and `omp`; retries use a fresh checkpoint prompt.
 
 ### Step 2 — Pick the first project to watch
 

--- a/web/dashboard/src/lib/configForm.test.ts
+++ b/web/dashboard/src/lib/configForm.test.ts
@@ -172,14 +172,24 @@ describe("config form contract", () => {
       roleAgentPath("fixer", "profile"),
     );
     expect(configFieldPaths(data, roles)).not.toContain("roles.worker.agent");
-    expect(configSelectOptions("agent.vendor")).toEqual([
-      ...AGENT_VENDOR_OPTIONS,
-    ]);
+    // Independent expected list so omissions in AGENT_VENDOR_OPTIONS fail this
+    // test instead of comparing the constant to itself.
+    const supportedVendors = [
+      "claude-code",
+      "codex",
+      "opencode",
+      "cursor-cli",
+      "grok-build",
+      "pi",
+      "omp",
+    ] as const;
+    expect([...AGENT_VENDOR_OPTIONS]).toEqual([...supportedVendors]);
+    expect(configSelectOptions("agent.vendor")).toEqual([...supportedVendors]);
     expect(configSelectOptions(roleAgentPath("worker", "vendor"))).toEqual([
-      ...AGENT_VENDOR_OPTIONS,
+      ...supportedVendors,
     ]);
     expect(configSelectOptions("agent.profiles.fast.vendor")).toEqual([
-      ...AGENT_VENDOR_OPTIONS,
+      ...supportedVendors,
     ]);
   });
 

--- a/web/dashboard/src/lib/configForm.ts
+++ b/web/dashboard/src/lib/configForm.ts
@@ -38,6 +38,8 @@ export const AGENT_VENDOR_OPTIONS = [
   "opencode",
   "cursor-cli",
   "grok-build",
+  "pi",
+  "omp",
 ] as const;
 
 const agentProfileLeafPath = /^agent\.profiles\.[A-Za-z0-9_-]+\.(vendor|model)$/;


### PR DESCRIPTION
# Summary

- Add `pi` and `omp` (Oh My Pi) as supported agent vendors, following the grok-build vendor pattern from #529.
- Fresh unattended runs:
  - **pi** (`agent.vendor = "pi"`, binary `pi`): `-p <prompt> --approve`; workspace via process cwd
  - **omp** (`agent.vendor = "omp"`, binary `omp`): `-p <prompt> --cwd <worktree> --auto-approve`
- Configured `agent.params.args` override defaults (print ownership, model, cwd, approve/auto-approve/approval-mode).
- Bootstrap/takeover PATH detection, dashboard vendor selectors, model catalog probe (`pi --list-models`, `omp models --json`), API allowlist, and docs.
- Daemon native resume and interactive `looper resume` remain unsupported (checkpoint restart), same as grok-build.

# Testing

- [x] `go test ./...`
- [x] Additional targeted checks: `gofmt -l .`, `go vet ./...`, `go build ./...`, `git diff --check`
- [x] `npm test -- --run src/lib/configForm.test.ts` (dashboard vendor options)

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [x] Daemon boot / config / runtime path risk
- [x] Worktree / repo isolation / lifecycle risk
- [ ] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

Covered with focused config, executor, CLI, runtime, reviewer, model-catalog, and dashboard contract tests. No authenticated pi/omp invocation was run (can incur API cost and mutate a workspace).

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [x] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- PR / issue links for regression coverage:
  - Pattern reference: #529 (Grok Build agent vendor)
  - Coverage in `pi_test.go` / `omp_test.go` / `pi_omp_test.go` across agent, CLI, config, reviewer, runtime, and modelcatalog packages; dashboard `configForm` vendor list assertion.

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied
