### PR TITLE
feat: cap review-fix ping-pong with per-role HITL budget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -656,6 +656,8 @@ enabledByDefault = true
 # Continuous follow-up debounce after a published review. Inherits defaults.loop when unset.
 quietPeriodSeconds = 60
 minPublishIntervalSeconds = 300
+# Successful reviewer publishes per PR. 0 disables. Exhaustion parks reviewer + sibling fixer via HITL.
+maxPublishesPerPR = 8
 
 [roles.reviewer.behavior.reviewEvents]
 clean = "APPROVE"
@@ -667,6 +669,19 @@ reReviewPromptOnHeadChange = false
 ```
 
 The reviewer defaults above are intentionally aggressive: clean reviews publish `APPROVE`, blocking reviews publish `REQUEST_CHANGES`, and `enableSelfReview` still defaults to `false`.
+
+### Review-fix budget
+
+Unlimited reviewer ⇄ fixer ping-pong is a cost and quality problem: each side can keep inventing new work. The old `maxIterationsPerPR` / `maxIterationsPerHead` knobs are still accepted but **ignored**. The live caps are separate per role:
+
+| Path | Counts | Default |
+| --- | --- | --- |
+| `roles.reviewer.behavior.loop.maxPublishesPerPR` | Successful published reviews on one PR | `8` |
+| `roles.fixer.behavior.loop.maxPushesPerPR` | Successful fixer pushes on one PR | `8` |
+
+`0` disables that role's cap. Authority is live config plus a durable counter (`iterationCount` for reviewer, `reviewFixBudget.pushCount` for fixer). Exhaustion parks the exhausted loop as `awaiting_human` with a Continue/Stop HITL ask and pauses the sibling loop on the same PR. Continue resets the exhausted counter and unpauses the sibling; Stop terminates both. Product terminals (ready label, identical output, closed PR) still win and do not open a budget ask.
+
+**Failure prevented:** expanding-scope review/fix that never converges. **Cost:** a new persisted counter and a HITL park that must not fight discovery or the deprecated budget-strip path. **Why not reuse the old knobs:** those were reviewer-only infra counters that stranded long PRs and were explicitly demoted in #209.
 
 ### Quiet-period debounce (shared + per-role)
 
@@ -947,6 +962,7 @@ publishMode = "single_review"
 enabledByDefault = true
 quietPeriodSeconds = 60
 minPublishIntervalSeconds = 300
+maxPublishesPerPR = 8
 
 [roles.reviewer.behavior.reviewEvents]
 clean = "APPROVE"
@@ -966,6 +982,8 @@ scope = "looper-only"
 [roles.fixer.behavior.loop]
 # Opt-in quiet period (default 0 = immediate enqueue). Recommended starter: 60–120.
 quietPeriodSeconds = 0
+# Successful fixer pushes per PR. 0 disables. Exhaustion parks fixer + sibling reviewer via HITL.
+maxPushesPerPR = 8
 
 [roles.fixer.discovery]
 autoDiscovery = true

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -1431,20 +1431,37 @@ func TestExecutorStartFailsAndReapsProcessWhenInitialPersistenceFails(t *testing
 	if handle != nil {
 		t.Fatalf("Start() handle = %#v, want nil", handle)
 	}
-	if data, readErr := os.ReadFile(pidPath); readErr == nil {
-		pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
-		if parseErr != nil {
-			t.Fatalf("parse pid: %v", parseErr)
+	deadline := time.Now().Add(2 * time.Second)
+	var pid int
+	for {
+		data, readErr := os.ReadFile(pidPath)
+		if readErr != nil {
+			// Process died before creating the pid file.
+			return
 		}
-		deadline := time.Now().Add(2 * time.Second)
-		for time.Now().Before(deadline) {
-			if killErr := syscall.Kill(pid, 0); killErr == syscall.ESRCH {
+		pidStr := strings.TrimSpace(string(data))
+		if pidStr == "" {
+			// Redirection created the file; Start reaped the child before echo flushed.
+			if time.Now().After(deadline) {
 				return
 			}
 			time.Sleep(10 * time.Millisecond)
+			continue
 		}
-		t.Fatalf("spawned process %d survived failed Start", pid)
+		parsed, parseErr := strconv.Atoi(pidStr)
+		if parseErr != nil {
+			t.Fatalf("parse pid: %v", parseErr)
+		}
+		pid = parsed
+		break
 	}
+	for time.Now().Before(deadline) {
+		if killErr := syscall.Kill(pid, 0); killErr == syscall.ESRCH {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("spawned process %d survived failed Start", pid)
 }
 
 func TestExecutorWaitSurfacesTerminalPersistenceFailure(t *testing.T) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5956,7 +5956,10 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 		if loops.IsReviewFixBudgetAsk(ask) {
 			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO)
 			if applyErr != nil {
-				return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: applyErr.Error()}
+				if errors.Is(applyErr, loops.ErrReviewFixBudgetInvalidAnswer) {
+					return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: applyErr.Error()}
+				}
+				return storage.LoopRecord{}, applyErr
 			}
 			if result.Applied {
 				return result.Loop, nil
@@ -5986,6 +5989,9 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 	}
 
 	if updated.Status != string(domain.LoopStatusAwaitingHuman) {
+		if h.context.TriggerSchedulerTick != nil {
+			h.context.TriggerSchedulerTick()
+		}
 		return h.serializeLoopWithDiagnostics(ctx, updated)
 	}
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5940,7 +5940,7 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 
 	services := h.context.Runtime.Services()
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
-	_, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
+	updated, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
 		repos := storage.NewRepositories(tx)
 		loop, err := repos.Loops.GetByID(ctx, loopID)
 		if err != nil {
@@ -5953,6 +5953,15 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Loop %s is not awaiting a human (status: %s)", loopID, loop.Status)}
 		}
 		ask, _ := loops.ReadHITLAsk(loop.MetadataJSON)
+		if loops.IsReviewFixBudgetAsk(ask) {
+			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO)
+			if applyErr != nil {
+				return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: applyErr.Error()}
+			}
+			if result.Applied {
+				return result.Loop, nil
+			}
+		}
 		ask.Answer = answer
 		ask.Status = "answered"
 		ask.AnsweredAt = nowISO
@@ -5974,6 +5983,10 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 			return loopResponse{}, typed
 		}
 		return loopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+
+	if updated.Status != string(domain.LoopStatusAwaitingHuman) {
+		return h.serializeLoopWithDiagnostics(ctx, updated)
 	}
 
 	// Transition awaiting_human -> running (requeues + triggers a scheduler tick)

--- a/internal/api/handler_hitl_test.go
+++ b/internal/api/handler_hitl_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -412,5 +413,130 @@ func TestHandlerRespondRequiresAnswer(t *testing.T) {
 	h.ServeHTTP(recorder, req)
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 for empty answer; body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestHandlerRespondReviewFixBudgetContinueTriggersScheduler(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	triggered := 0
+	h := NewHandler(Context{Config: cfg, Runtime: rt, TriggerSchedulerTick: func() { triggered++ }})
+	seedReviewFixBudgetAwaitingLoop(t, rt, "project_budget_continue", "loop_budget_continue", 641)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/641/respond", strings.NewReader(`{"answer":"Continue"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if triggered != 1 {
+		t.Fatalf("TriggerSchedulerTick called %d times, want 1 after budget Continue", triggered)
+	}
+
+	loop, err := rt.Services().Repositories.Loops.GetByID(context.Background(), "loop_budget_continue")
+	if err != nil || loop == nil || loop.Status != "queued" {
+		t.Fatalf("loop after budget Continue = %#v, %v, want queued", loop, err)
+	}
+	active, err := rt.Services().Repositories.Queue.FindActiveByLoopID(context.Background(), "loop_budget_continue")
+	if err != nil || active == nil || active.Status != "queued" {
+		t.Fatalf("queue after budget Continue = %#v, %v, want queued", active, err)
+	}
+}
+
+func TestHandlerRespondReviewFixBudgetInvalidAnswerIsValidationError(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	triggered := 0
+	h := NewHandler(Context{Config: cfg, Runtime: rt, TriggerSchedulerTick: func() { triggered++ }})
+	seedReviewFixBudgetAwaitingLoop(t, rt, "project_budget_invalid", "loop_budget_invalid", 642)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/642/respond", strings.NewReader(`{"answer":"maybe later"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	errMap := body["error"].(map[string]any)
+	if errMap["code"] != "VALIDATION_FAILED" {
+		t.Fatalf("error.code = %#v, want VALIDATION_FAILED", errMap["code"])
+	}
+	if !strings.Contains(fmt.Sprint(errMap["message"]), "Continue") {
+		t.Fatalf("error.message = %#v, want invalid-option text", errMap["message"])
+	}
+	if triggered != 0 {
+		t.Fatalf("TriggerSchedulerTick called %d times, want 0 for invalid budget answer", triggered)
+	}
+	loop, err := rt.Services().Repositories.Loops.GetByID(context.Background(), "loop_budget_invalid")
+	if err != nil || loop == nil || loop.Status != "awaiting_human" {
+		t.Fatalf("loop after invalid budget answer = %#v, %v, want awaiting_human", loop, err)
+	}
+}
+
+func TestHandlerRespondReviewFixBudgetStorageFailureIsInternalError(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	triggered := 0
+	h := NewHandler(Context{Config: cfg, Runtime: rt, TriggerSchedulerTick: func() { triggered++ }})
+	seedReviewFixBudgetAwaitingLoop(t, rt, "project_budget_storage", "loop_budget_storage", 643)
+
+	if _, err := rt.Services().Coordinator.DB().ExecContext(context.Background(), `
+		CREATE TRIGGER fail_budget_loop_update
+		BEFORE UPDATE ON loops
+		BEGIN
+			SELECT RAISE(ABORT, 'database is locked');
+		END
+	`); err != nil {
+		t.Fatalf("create storage-failure trigger: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/643/respond", strings.NewReader(`{"answer":"Continue"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := parseJSONMap(t, recorder.Body.Bytes())
+	errMap := body["error"].(map[string]any)
+	if errMap["code"] != "INTERNAL_ERROR" {
+		t.Fatalf("error.code = %#v, want INTERNAL_ERROR", errMap["code"])
+	}
+	if triggered != 0 {
+		t.Fatalf("TriggerSchedulerTick called %d times, want 0 after storage failure", triggered)
+	}
+	loop, err := rt.Services().Repositories.Loops.GetByID(context.Background(), "loop_budget_storage")
+	if err != nil || loop == nil || loop.Status != "awaiting_human" {
+		t.Fatalf("loop after storage failure = %#v, %v, want awaiting_human", loop, err)
+	}
+}
+
+func seedReviewFixBudgetAwaitingLoop(t *testing.T, rt *looperdruntime.Runtime, projectID, loopID string, seq int64) {
+	t.Helper()
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	ask := loops.NewReviewFixBudgetAsk("fixer", repo, prNumber, 8, 8, nowISO)
+	metadata, err := loops.WriteHITLAsk(nil, ask)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk() error = %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), storage.LoopRecord{
+		ID: loopID, Seq: seq, ProjectID: projectID, Type: "fixer", TargetType: "pull_request",
+		TargetID: &targetID, Repo: &repo, PRNumber: &prNumber, Status: "awaiting_human",
+		MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	cancelReason := loops.ReviewFixBudgetPauseReason
+	if err := services.Repositories.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: "queue_" + loopID, ProjectID: &projectID, LoopID: &loopID, Type: "fixer",
+		TargetType: "pull_request", TargetID: targetID, Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: "fixer:budget:" + loopID, Priority: storage.QueuePriorityFixer, Status: "cancelled",
+		AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, LastError: &cancelReason,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
 	}
 }

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -420,6 +420,7 @@
                   "minPublishIntervalSeconds": 300,
                   "maxIterationsPerPR": 20,
                   "maxIterationsPerHead": 1,
+                  "maxPublishesPerPR": 8,
                   "maxWallClockSeconds": 0,
                   "maxConsecutiveFailures": 3,
                   "maxAgentExecutionsPerPR": 25,
@@ -480,7 +481,8 @@
               },
               "behavior": {
                 "loop": {
-                  "quietPeriodSeconds": 0
+                  "quietPeriodSeconds": 0,
+                  "maxPushesPerPR": 8
                 }
               }
             },

--- a/internal/cliapp/app.go
+++ b/internal/cliapp/app.go
@@ -807,6 +807,8 @@ func globalFlags() []flagSpec {
 		stringFlag("defaults-loop-quiet-period-seconds", "seconds", "Shared default loop quiet period"),
 		stringFlag("roles-fixer-behavior-loop-quiet-period-seconds", "seconds", "Fixer loop quiet period"),
 		stringFlag("roles-reviewer-behavior-loop-min-publish-interval-seconds", "seconds", "Reviewer loop minimum publish interval"),
+		stringFlag("roles-reviewer-behavior-loop-max-publishes-per-pr", "count", "Max successful reviewer publishes per PR (0 disables)"),
+		stringFlag("roles-fixer-behavior-loop-max-pushes-per-pr", "count", "Max successful fixer pushes per PR (0 disables)"),
 		hiddenStringFlag("reviewer-min-publish-interval-seconds", "seconds", "Reviewer loop minimum publish interval"),
 		stringFlag("roles-reviewer-behavior-loop-max-iterations-per-pr", "count", "Deprecated; ignored by reviewer loop filtering"),
 		hiddenStringFlag("reviewer-max-iterations-per-pr", "count", "Deprecated; ignored by reviewer loop filtering"),

--- a/internal/cliapp/config_commands.go
+++ b/internal/cliapp/config_commands.go
@@ -47,6 +47,16 @@ var configFieldRegistry = map[string]configField{
 	}, func(p *config.PartialConfig) **int {
 		return &ensurePartialFixerLoop(p).QuietPeriodSeconds
 	}),
+	"roles.reviewer.behavior.loop.maxPublishesPerPR": nonNegativeIntField("roles.reviewer.behavior.loop.maxPublishesPerPR", "LOOPER_ROLES_REVIEWER_BEHAVIOR_LOOP_MAX_PUBLISHES_PER_PR", "roles-reviewer-behavior-loop-max-publishes-per-pr", func(c config.Config) any {
+		return c.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR
+	}, func(p *config.PartialConfig) **int {
+		return &ensurePartialReviewerLoop(p).MaxPublishesPerPR
+	}),
+	"roles.fixer.behavior.loop.maxPushesPerPR": nonNegativeIntField("roles.fixer.behavior.loop.maxPushesPerPR", "LOOPER_ROLES_FIXER_BEHAVIOR_LOOP_MAX_PUSHES_PER_PR", "roles-fixer-behavior-loop-max-pushes-per-pr", func(c config.Config) any {
+		return c.Roles.Fixer.Behavior.Loop.MaxPushesPerPR
+	}, func(p *config.PartialConfig) **int {
+		return &ensurePartialFixerLoop(p).MaxPushesPerPR
+	}),
 	"instructions.enabled":       boolFieldWithAlias("instructions.enabled", "", "", "instructions-enabled", "no-custom-instructions", func(c config.Config) any { return c.Instructions.Enabled }, func(p *config.PartialConfig) **bool { return &ensurePartialInstructions(p).Enabled }),
 	"package.autoUpgradeEnabled": boolFieldWithAlias("package.autoUpgradeEnabled", "LOOPER_AUTO_UPGRADE_ENABLED", "", "package-auto-upgrade-enabled", "no-auto-upgrade", func(c config.Config) any { return c.Package.AutoUpgradeEnabled }, func(p *config.PartialConfig) **bool { return &ensurePartialPackage(p).AutoUpgradeEnabled }),
 	"instructions.maxBytes":      positiveIntField("instructions.maxBytes", "", "", func(c config.Config) any { return c.Instructions.MaxBytes }, func(p *config.PartialConfig) **int { return &ensurePartialInstructions(p).MaxBytes }),
@@ -1516,6 +1526,22 @@ func ensurePartialReviewerRole(partial *config.PartialConfig) *config.PartialRev
 		roles.Reviewer = &config.PartialReviewerRoleConfig{}
 	}
 	return roles.Reviewer
+}
+
+func ensurePartialReviewerBehavior(partial *config.PartialConfig) *config.PartialReviewerConfig {
+	reviewer := ensurePartialReviewerRole(partial)
+	if reviewer.Behavior == nil {
+		reviewer.Behavior = &config.PartialReviewerConfig{}
+	}
+	return reviewer.Behavior
+}
+
+func ensurePartialReviewerLoop(partial *config.PartialConfig) *config.PartialReviewerLoopConfig {
+	behavior := ensurePartialReviewerBehavior(partial)
+	if behavior.Loop == nil {
+		behavior.Loop = &config.PartialReviewerLoopConfig{}
+	}
+	return behavior.Loop
 }
 
 func ensurePartialReviewerRoleDiscovery(partial *config.PartialConfig) *config.PartialReviewerRoleDiscoveryConfig {

--- a/internal/cliapp/testdata/golden/daemon-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/daemon-help.stdout.golden
@@ -35,11 +35,13 @@ Global Flags:
   --planner-agent-timeout-seconds <seconds> Planner agent execution timeout
   --port <port>               Server port
   --reviewer-agent-timeout-seconds <seconds> Reviewer agent execution timeout
+  --roles-fixer-behavior-loop-max-pushes-per-pr <count> Max successful fixer pushes per PR (0 disables)
   --roles-fixer-behavior-loop-quiet-period-seconds <seconds> Fixer loop quiet period
   --roles-fixer-triggers-author-filter <filter> Fixer author filter: current-user or any
   --roles-reviewer-behavior-loop-enabled-by-default <bool> Enable reviewer follow-up loops by default
   --roles-reviewer-behavior-loop-max-iterations-per-head <count> Deprecated; ignored by reviewer loop filtering
   --roles-reviewer-behavior-loop-max-iterations-per-pr <count> Deprecated; ignored by reviewer loop filtering
+  --roles-reviewer-behavior-loop-max-publishes-per-pr <count> Max successful reviewer publishes per PR (0 disables)
   --roles-reviewer-behavior-loop-min-publish-interval-seconds <seconds> Reviewer loop minimum publish interval
   --roles-reviewer-behavior-loop-quiet-period-seconds <seconds> Reviewer loop quiet period
   --roles-reviewer-behavior-review-events-blocking <event> Reviewer event for blocking findings: COMMENT or REQUEST_CHANGES

--- a/internal/cliapp/testdata/golden/root-help.stdout.golden
+++ b/internal/cliapp/testdata/golden/root-help.stdout.golden
@@ -61,11 +61,13 @@ Flags:
   --planner-agent-timeout-seconds <seconds> Planner agent execution timeout
   --port <port>               Server port
   --reviewer-agent-timeout-seconds <seconds> Reviewer agent execution timeout
+  --roles-fixer-behavior-loop-max-pushes-per-pr <count> Max successful fixer pushes per PR (0 disables)
   --roles-fixer-behavior-loop-quiet-period-seconds <seconds> Fixer loop quiet period
   --roles-fixer-triggers-author-filter <filter> Fixer author filter: current-user or any
   --roles-reviewer-behavior-loop-enabled-by-default <bool> Enable reviewer follow-up loops by default
   --roles-reviewer-behavior-loop-max-iterations-per-head <count> Deprecated; ignored by reviewer loop filtering
   --roles-reviewer-behavior-loop-max-iterations-per-pr <count> Deprecated; ignored by reviewer loop filtering
+  --roles-reviewer-behavior-loop-max-publishes-per-pr <count> Max successful reviewer publishes per PR (0 disables)
   --roles-reviewer-behavior-loop-min-publish-interval-seconds <seconds> Reviewer loop minimum publish interval
   --roles-reviewer-behavior-loop-quiet-period-seconds <seconds> Reviewer loop quiet period
   --roles-reviewer-behavior-review-events-blocking <event> Reviewer event for blocking findings: COMMENT or REQUEST_CHANGES

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -312,6 +312,32 @@ func TestRoleDefaultsMirrorCurrentDiscoveryPolicy(t *testing.T) {
 	if got := cfg.Roles.Reviewer.Behavior.Loop.MaxWallClockSeconds; got != 0 {
 		t.Fatalf("reviewer loop max wall clock default = %d, want 0", got)
 	}
+	if got := cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR; got != DefaultReviewFixBudgetCap {
+		t.Fatalf("reviewer maxPublishesPerPR default = %d, want %d", got, DefaultReviewFixBudgetCap)
+	}
+	if got := cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR; got != DefaultReviewFixBudgetCap {
+		t.Fatalf("fixer maxPushesPerPR default = %d, want %d", got, DefaultReviewFixBudgetCap)
+	}
+}
+
+func TestValidateReviewFixBudgetCaps(t *testing.T) {
+	t.Parallel()
+	cfg, err := DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = -1
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = -2
+	err = Validate(cfg)
+	if err == nil {
+		t.Fatal("Validate() = nil, want budget cap errors")
+	}
+	var validationErr *ConfigValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("Validate() error = %T, want *ConfigValidationError", err)
+	}
+	assertValidationIssue(t, validationErr, "roles.reviewer.behavior.loop.maxPublishesPerPR", "must be an integer >= 0")
+	assertValidationIssue(t, validationErr, "roles.fixer.behavior.loop.maxPushesPerPR", "must be an integer >= 0")
 }
 
 func TestMinimalForgejoProviderConfigAppliesSafeProjectProfile(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -318,6 +318,9 @@ func TestRoleDefaultsMirrorCurrentDiscoveryPolicy(t *testing.T) {
 	if got := cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR; got != DefaultReviewFixBudgetCap {
 		t.Fatalf("fixer maxPushesPerPR default = %d, want %d", got, DefaultReviewFixBudgetCap)
 	}
+	if cfg.HITL.Enabled {
+		t.Fatal("HITL default must be false so default caps stay inert until HITL is enabled")
+	}
 }
 
 func TestValidateReviewFixBudgetCaps(t *testing.T) {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -11,6 +11,7 @@ const DefaultServerPort = 17310
 const (
 	DefaultReviewerAutoRecoveryMaxAttempts = 3
 	DefaultReviewerRetryMaxDelayMS         = 300000
+	DefaultReviewFixBudgetCap              = 8
 )
 
 func DefaultLooperHome() (string, error) {
@@ -244,6 +245,7 @@ func DefaultConfig(cwd string) (Config, error) {
 						StopOnApproved:            false,
 						StopOnReadyLabel:          true,
 						StopOnIdenticalOutput:     true,
+						MaxPublishesPerPR:         DefaultReviewFixBudgetCap,
 					},
 					Retry:                   DefaultReviewerRetryConfig(),
 					Scope:                   ReviewerScopeChangedRanges,
@@ -282,6 +284,7 @@ func DefaultConfig(cwd string) (Config, error) {
 					Loop: FixerLoopConfig{
 						// Opt-in: keep historical immediate-start behavior until operators enable quiet period.
 						QuietPeriodSeconds: 0,
+						MaxPushesPerPR:     DefaultReviewFixBudgetCap,
 					},
 				},
 			},

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -245,7 +245,8 @@ func DefaultConfig(cwd string) (Config, error) {
 						StopOnApproved:            false,
 						StopOnReadyLabel:          true,
 						StopOnIdenticalOutput:     true,
-						MaxPublishesPerPR:         DefaultReviewFixBudgetCap,
+						// Enforced only when HITL is enabled; park needs Continue/Stop.
+						MaxPublishesPerPR: DefaultReviewFixBudgetCap,
 					},
 					Retry:                   DefaultReviewerRetryConfig(),
 					Scope:                   ReviewerScopeChangedRanges,
@@ -284,7 +285,8 @@ func DefaultConfig(cwd string) (Config, error) {
 					Loop: FixerLoopConfig{
 						// Opt-in: keep historical immediate-start behavior until operators enable quiet period.
 						QuietPeriodSeconds: 0,
-						MaxPushesPerPR:     DefaultReviewFixBudgetCap,
+						// Enforced only when HITL is enabled; park needs Continue/Stop.
+						MaxPushesPerPR: DefaultReviewFixBudgetCap,
 					},
 				},
 			},

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -927,6 +927,28 @@ func parseCLIArgs(args []string) (parsedCLIArgs, error) {
 			}
 			ensureReviewerLoopConfig(&parsed.overrides).MinPublishIntervalSeconds = parsedValue
 			index = nextIndex
+		case matchesFlag(arg, "--roles-reviewer-behavior-loop-max-publishes-per-pr"):
+			value, nextIndex, err := takeValue(index, "--roles-reviewer-behavior-loop-max-publishes-per-pr")
+			if err != nil {
+				return parsedCLIArgs{}, err
+			}
+			parsedValue, err := parseInteger(value)
+			if err != nil {
+				return parsedCLIArgs{}, fmt.Errorf("invalid value for --roles-reviewer-behavior-loop-max-publishes-per-pr: %q is not an integer", value)
+			}
+			ensureReviewerLoopConfig(&parsed.overrides).MaxPublishesPerPR = parsedValue
+			index = nextIndex
+		case matchesFlag(arg, "--roles-fixer-behavior-loop-max-pushes-per-pr"):
+			value, nextIndex, err := takeValue(index, "--roles-fixer-behavior-loop-max-pushes-per-pr")
+			if err != nil {
+				return parsedCLIArgs{}, err
+			}
+			parsedValue, err := parseInteger(value)
+			if err != nil {
+				return parsedCLIArgs{}, fmt.Errorf("invalid value for --roles-fixer-behavior-loop-max-pushes-per-pr: %q is not an integer", value)
+			}
+			ensureFixerLoopConfig(&parsed.overrides).MaxPushesPerPR = parsedValue
+			index = nextIndex
 		case matchesAnyFlag(arg, "--roles-reviewer-behavior-loop-max-iterations-per-pr", "--reviewer-max-iterations-per-pr"):
 			value, nextIndex, err := takeValue(index, "--roles-reviewer-behavior-loop-max-iterations-per-pr")
 			if err != nil {
@@ -1228,6 +1250,20 @@ func buildEnvOverrides(lookupEnv EnvLookupFunc) (PartialConfig, error) {
 			return PartialConfig{}, fmt.Errorf("invalid value for LOOPER_ROLES_REVIEWER_BEHAVIOR_LOOP_MIN_PUBLISH_INTERVAL_SECONDS: %q is not an integer", value)
 		}
 		ensureReviewerLoopConfig(&overrides).MinPublishIntervalSeconds = parsed
+	}
+	if value, ok := lookupEnv("LOOPER_ROLES_REVIEWER_BEHAVIOR_LOOP_MAX_PUBLISHES_PER_PR"); ok {
+		parsed, err := parseInteger(value)
+		if err != nil {
+			return PartialConfig{}, fmt.Errorf("invalid value for LOOPER_ROLES_REVIEWER_BEHAVIOR_LOOP_MAX_PUBLISHES_PER_PR: %q is not an integer", value)
+		}
+		ensureReviewerLoopConfig(&overrides).MaxPublishesPerPR = parsed
+	}
+	if value, ok := lookupEnv("LOOPER_ROLES_FIXER_BEHAVIOR_LOOP_MAX_PUSHES_PER_PR"); ok {
+		parsed, err := parseInteger(value)
+		if err != nil {
+			return PartialConfig{}, fmt.Errorf("invalid value for LOOPER_ROLES_FIXER_BEHAVIOR_LOOP_MAX_PUSHES_PER_PR: %q is not an integer", value)
+		}
+		ensureFixerLoopConfig(&overrides).MaxPushesPerPR = parsed
 	}
 	if value, ok := envValue("LOOPER_ROLES_REVIEWER_BEHAVIOR_LOOP_MAX_ITERATIONS_PER_PR", "LOOPER_REVIEWER_MAX_ITERATIONS_PER_PR"); ok {
 		parsed, err := parseInteger(value)

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -1284,6 +1284,9 @@ func mergeReviewerLoopConfig(config *ReviewerLoopConfig, partial PartialReviewer
 	if partial.StopOnIdenticalOutput != nil {
 		config.StopOnIdenticalOutput = *partial.StopOnIdenticalOutput
 	}
+	if partial.MaxPublishesPerPR != nil {
+		config.MaxPublishesPerPR = *partial.MaxPublishesPerPR
+	}
 }
 
 func mergeInstructionsConfig(config *InstructionsConfig, partial PartialInstructionsConfig) {
@@ -1527,6 +1530,9 @@ func mergeFixerBehaviorConfig(config *FixerBehaviorConfig, partial PartialFixerB
 func mergeFixerLoopConfig(config *FixerLoopConfig, partial PartialFixerLoopConfig) {
 	if partial.QuietPeriodSeconds != nil {
 		config.QuietPeriodSeconds = *partial.QuietPeriodSeconds
+	}
+	if partial.MaxPushesPerPR != nil {
+		config.MaxPushesPerPR = *partial.MaxPushesPerPR
 	}
 }
 

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -279,6 +279,7 @@
               "minPublishIntervalSeconds": 300,
               "maxIterationsPerPR": 20,
               "maxIterationsPerHead": 1,
+              "maxPublishesPerPR": 8,
               "maxWallClockSeconds": 0,
               "maxConsecutiveFailures": 3,
               "maxAgentExecutionsPerPR": 25,
@@ -339,7 +340,8 @@
           },
           "behavior": {
             "loop": {
-              "quietPeriodSeconds": 0
+              "quietPeriodSeconds": 0,
+              "maxPushesPerPR": 8
             }
           }
         },

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -219,6 +219,7 @@
               "minPublishIntervalSeconds": 300,
               "maxIterationsPerPR": 20,
               "maxIterationsPerHead": 1,
+              "maxPublishesPerPR": 8,
               "maxWallClockSeconds": 0,
               "maxConsecutiveFailures": 3,
               "maxAgentExecutionsPerPR": 25,
@@ -279,7 +280,8 @@
           },
           "behavior": {
             "loop": {
-              "quietPeriodSeconds": 0
+              "quietPeriodSeconds": 0,
+              "maxPushesPerPR": 8
             }
           }
         },

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -300,6 +300,7 @@
               "minPublishIntervalSeconds": 300,
               "maxIterationsPerPR": 20,
               "maxIterationsPerHead": 1,
+              "maxPublishesPerPR": 8,
               "maxWallClockSeconds": 0,
               "maxConsecutiveFailures": 3,
               "maxAgentExecutionsPerPR": 25,
@@ -360,7 +361,8 @@
           },
           "behavior": {
             "loop": {
-              "quietPeriodSeconds": 0
+              "quietPeriodSeconds": 0,
+              "maxPushesPerPR": 8
             }
           }
         },

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -429,6 +429,8 @@ type ReviewerLoopConfig struct {
 	StopOnApproved            bool `json:"stopOnApproved"`
 	StopOnReadyLabel          bool `json:"stopOnReadyLabel"`
 	StopOnIdenticalOutput     bool `json:"stopOnIdenticalOutput"`
+	// MaxPublishesPerPR caps successful reviewer publishes on one PR. 0 disables.
+	MaxPublishesPerPR int `json:"maxPublishesPerPR"`
 }
 
 type ReviewerConfig struct {
@@ -549,6 +551,8 @@ type FixerLoopConfig struct {
 	// QuietPeriodSeconds delays fixer work after a new/changed fixable set.
 	// 0 disables quiet-period debounce (immediate enqueue). Default is 0.
 	QuietPeriodSeconds int `json:"quietPeriodSeconds"`
+	// MaxPushesPerPR caps successful fixer pushes on one PR. 0 disables.
+	MaxPushesPerPR int `json:"maxPushesPerPR"`
 }
 
 type FixerBehaviorConfig struct {
@@ -919,6 +923,7 @@ type PartialReviewerLoopConfig struct {
 	StopOnApproved            *bool `json:"stopOnApproved,omitempty"`
 	StopOnReadyLabel          *bool `json:"stopOnReadyLabel,omitempty"`
 	StopOnIdenticalOutput     *bool `json:"stopOnIdenticalOutput,omitempty"`
+	MaxPublishesPerPR         *int  `json:"maxPublishesPerPR,omitempty"`
 }
 
 type PartialReviewerConfig struct {
@@ -1060,6 +1065,7 @@ type PartialReviewerRoleConfig struct {
 
 type PartialFixerLoopConfig struct {
 	QuietPeriodSeconds *int `json:"quietPeriodSeconds,omitempty"`
+	MaxPushesPerPR     *int `json:"maxPushesPerPR,omitempty"`
 }
 
 type PartialFixerBehaviorConfig struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -224,6 +224,8 @@ func ValidateWithOptions(config Config, options ValidateOptions) error {
 	if config.Roles.Reviewer.Behavior.Loop.MinPublishIntervalSeconds < 0 {
 		issues = append(issues, ValidationIssue{Path: "roles.reviewer.behavior.loop.minPublishIntervalSeconds", Message: "must be an integer >= 0"})
 	}
+	validateReviewFixBudgetCap(config.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR, "roles.reviewer.behavior.loop.maxPublishesPerPR", &issues)
+	validateReviewFixBudgetCap(config.Roles.Fixer.Behavior.Loop.MaxPushesPerPR, "roles.fixer.behavior.loop.maxPushesPerPR", &issues)
 	if config.Roles.Reviewer.Behavior.Retry.AutoRecoveryMaxAttempts < 1 {
 		issues = append(issues, ValidationIssue{Path: "roles.reviewer.behavior.retry.autoRecoveryMaxAttempts", Message: "must be a positive integer"})
 	}
@@ -646,6 +648,12 @@ func validateAgentTimeoutSeconds(seconds int, path string, issues *[]ValidationI
 	}
 }
 
+func validateReviewFixBudgetCap(value int, path string, issues *[]ValidationIssue) {
+	if value < 0 {
+		*issues = append(*issues, ValidationIssue{Path: path, Message: "must be an integer >= 0"})
+	}
+}
+
 // validateQuietPeriodSeconds rejects negatives and values that overflow time.Duration
 // when converted from seconds (now.Add(time.Duration(seconds) * time.Second)).
 func validateQuietPeriodSeconds(seconds int, path string, issues *[]ValidationIssue) {
@@ -698,8 +706,13 @@ func validateProjectRoleOverrides(roles *PartialRoleConfigs, prefix string, maxI
 				*issues = append(*issues, ValidationIssue{Path: prefix + ".reviewer.specReview.reviewingLabel", Message: "must not contain leading or trailing whitespace"})
 			}
 		}
-		if roles.Reviewer.Behavior != nil && roles.Reviewer.Behavior.Loop != nil && roles.Reviewer.Behavior.Loop.QuietPeriodSeconds != nil {
-			validateQuietPeriodSeconds(*roles.Reviewer.Behavior.Loop.QuietPeriodSeconds, prefix+".reviewer.behavior.loop.quietPeriodSeconds", issues)
+		if roles.Reviewer.Behavior != nil && roles.Reviewer.Behavior.Loop != nil {
+			if roles.Reviewer.Behavior.Loop.QuietPeriodSeconds != nil {
+				validateQuietPeriodSeconds(*roles.Reviewer.Behavior.Loop.QuietPeriodSeconds, prefix+".reviewer.behavior.loop.quietPeriodSeconds", issues)
+			}
+			if roles.Reviewer.Behavior.Loop.MaxPublishesPerPR != nil {
+				validateReviewFixBudgetCap(*roles.Reviewer.Behavior.Loop.MaxPublishesPerPR, prefix+".reviewer.behavior.loop.maxPublishesPerPR", issues)
+			}
 		}
 		if roles.Reviewer.AutoMerge != nil {
 			validatePartialReviewerAutoMerge(*roles.Reviewer.AutoMerge, prefix+".reviewer.autoMerge", issues)
@@ -710,8 +723,13 @@ func validateProjectRoleOverrides(roles *PartialRoleConfigs, prefix string, maxI
 		if roles.Fixer.Triggers != nil {
 			validateFixerRoleTriggers(partialFixerRoleTriggers(*roles.Fixer.Triggers), prefix+".fixer.triggers", issues)
 		}
-		if roles.Fixer.Behavior != nil && roles.Fixer.Behavior.Loop != nil && roles.Fixer.Behavior.Loop.QuietPeriodSeconds != nil {
-			validateQuietPeriodSeconds(*roles.Fixer.Behavior.Loop.QuietPeriodSeconds, prefix+".fixer.behavior.loop.quietPeriodSeconds", issues)
+		if roles.Fixer.Behavior != nil && roles.Fixer.Behavior.Loop != nil {
+			if roles.Fixer.Behavior.Loop.QuietPeriodSeconds != nil {
+				validateQuietPeriodSeconds(*roles.Fixer.Behavior.Loop.QuietPeriodSeconds, prefix+".fixer.behavior.loop.quietPeriodSeconds", issues)
+			}
+			if roles.Fixer.Behavior.Loop.MaxPushesPerPR != nil {
+				validateReviewFixBudgetCap(*roles.Fixer.Behavior.Loop.MaxPushesPerPR, prefix+".fixer.behavior.loop.maxPushesPerPR", issues)
+			}
 		}
 	}
 	if roles.Coordinator != nil {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1652,17 +1652,28 @@ func (r *Runner) parkFixerBudgetIfExhausted(ctx context.Context, loop storage.Lo
 			loop = *fresh
 		}
 	}
-	if loop.Status == "awaiting_human" || loop.Status == "terminated" || loop.Status == "stopped" {
-		return loop.Status == "awaiting_human", nil
-	}
-	if isManualFixerLoop(loop) {
+	if loop.Status == "terminated" || loop.Status == "stopped" {
 		return false, nil
+	}
+	if loop.Status == "awaiting_human" {
+		if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
+			return true, nil
+		}
+	} else {
+		if !r.hitlEnabled {
+			return false, nil
+		}
+		if isManualFixerLoop(loop) {
+			return false, nil
+		}
+		cap := r.maxPushesPerPR(loop.ProjectID)
+		count := loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount
+		if !loops.BudgetExhausted(count, cap) {
+			return false, nil
+		}
 	}
 	cap := r.maxPushesPerPR(loop.ProjectID)
 	count := loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount
-	if !loops.BudgetExhausted(count, cap) {
-		return false, nil
-	}
 	_, err := loops.ParkReviewFixBudget(ctx, r.repos, loops.ParkReviewFixBudgetInput{
 		Exhausted: loop,
 		Role:      "fixer",

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1675,9 +1675,40 @@ func (r *Runner) parkFixerBudgetAfterSuccessfulRun(ctx context.Context, project 
 		}
 	}
 	if r.shouldCreateFixerBudgetPark(current) && r.livePullRequestClosed(ctx, project, derefString(current.Repo), derefInt64(current.PRNumber)) {
+		if err := r.terminateLoop(ctx, current, "pr_closed_or_merged"); err != nil {
+			return false, err
+		}
 		return false, nil
 	}
 	return r.parkFixerBudgetIfExhausted(ctx, current)
+}
+
+func (r *Runner) terminateLoop(ctx context.Context, loop storage.LoopRecord, reason string) error {
+	_, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
+		updated.Status = "terminated"
+		updated.NextRunAt = nil
+		meta := parseJSONObject(updated.MetadataJSON)
+		loopMeta, _ := meta["loop"].(map[string]any)
+		if loopMeta == nil {
+			loopMeta = map[string]any{}
+		}
+		loopMeta["status"] = "terminated"
+		loopMeta["terminationReason"] = reason
+		loopMeta["lastStatus"] = "terminated"
+		meta["loop"] = loopMeta
+		if encoded, marshalErr := json.Marshal(meta); marshalErr == nil {
+			text := string(encoded)
+			updated.MetadataJSON = &text
+		}
+	})
+	if err != nil {
+		return err
+	}
+	if r.repos == nil || r.repos.Queue == nil {
+		return nil
+	}
+	_, err = r.repos.Queue.CancelByLoop(ctx, loop.ID, r.nowISO(), &reason)
+	return err
 }
 
 func (r *Runner) parkFixerBudgetIfExhausted(ctx context.Context, loop storage.LoopRecord) (bool, error) {
@@ -2371,6 +2402,12 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: statusForSkip(checkpoint.SkipReason), Summary: summary}, nil
 	}
+	if current, err := r.repos.Loops.GetByID(ctx, loop.ID); err != nil {
+		return ProcessResult{}, err
+	} else if current != nil && (current.Status == "terminated" || current.Status == "stopped") {
+		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
+		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: statusForSkip(checkpoint.SkipReason), Summary: summary}, nil
+	}
 	if scheduled, err := r.schedulePendingRediscoveryAfterRun(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber); err != nil {
 		return ProcessResult{}, err
 	} else if scheduled {
@@ -2419,7 +2456,7 @@ func (r *Runner) schedulePendingRediscoveryAfterRun(ctx context.Context, loop st
 	if !ok {
 		return false, nil
 	}
-	if current.Status == "paused" || current.Status == "awaiting_human" || current.Status == "human_takeover" {
+	if current.Status == "paused" || current.Status == "awaiting_human" || current.Status == "human_takeover" || current.Status == "terminated" || current.Status == "stopped" {
 		return false, nil
 	}
 	if r.hitlEnabled && !isManualFixerLoop(*current) {
@@ -2472,6 +2509,9 @@ func (r *Runner) scheduleFollowupRetryAfterSuccess(ctx context.Context, loop sto
 		return false, err
 	}
 	if current == nil {
+		return false, nil
+	}
+	if current.Status == "terminated" || current.Status == "stopped" {
 		return false, nil
 	}
 	if !fixerFollowUpdatesEnabled(*current) {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2087,17 +2087,23 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if loop == nil {
 		return ProcessResult{}, fmt.Errorf("loop not found: %s", *queueItem.LoopID)
 	}
-	if parked, err := r.parkFixerBudgetIfExhausted(ctx, *loop); err != nil {
-		return ProcessResult{}, err
-	} else if parked {
-		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: "review-fix budget exhausted"}, nil
-	}
 	project, err := r.repos.Projects.GetByID(ctx, loop.ProjectID)
 	if err != nil {
 		return ProcessResult{}, err
 	}
 	if project == nil {
 		return ProcessResult{}, fmt.Errorf("project not found: %s", loop.ProjectID)
+	}
+	if r.shouldCreateFixerBudgetPark(*loop) && r.livePullRequestClosed(ctx, *project, derefString(loop.Repo), derefInt64(loop.PRNumber)) {
+		if err := r.terminateLoop(ctx, *loop, "pr_closed_or_merged"); err != nil {
+			return ProcessResult{}, err
+		}
+		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: "pr_closed_or_merged"}, nil
+	}
+	if parked, err := r.parkFixerBudgetIfExhausted(ctx, *loop); err != nil {
+		return ProcessResult{}, err
+	} else if parked {
+		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: "review-fix budget exhausted"}, nil
 	}
 	resumedRun, err := r.createRunContext(ctx, *loop)
 	if err != nil {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1605,6 +1605,73 @@ func (r *Runner) quietPeriodSeconds(projectID string) int {
 	return 0
 }
 
+func (r *Runner) maxPushesPerPR(projectID string) int {
+	if r.projectRoleConfig != nil {
+		return config.ProjectRoleConfigs(*r.projectRoleConfig, projectID).Fixer.Behavior.Loop.MaxPushesPerPR
+	}
+	return 0
+}
+
+func (r *Runner) incrementFixerPushCount(ctx context.Context, loop storage.LoopRecord) (storage.LoopRecord, error) {
+	current := loop
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		fresh, err := r.repos.Loops.GetByID(ctx, loop.ID)
+		if err != nil {
+			return loop, err
+		}
+		if fresh != nil {
+			current = *fresh
+		}
+	}
+	encoded, _, err := loops.IncrementFixerPushCount(current.MetadataJSON)
+	if err != nil {
+		return current, err
+	}
+	if r.repos == nil || r.repos.Loops == nil {
+		current.MetadataJSON = &encoded
+		return current, nil
+	}
+	current.MetadataJSON = &encoded
+	current.UpdatedAt = r.nowISO()
+	if err := r.repos.Loops.Upsert(ctx, current); err != nil {
+		return current, err
+	}
+	return current, nil
+}
+
+func (r *Runner) parkFixerBudgetIfExhausted(ctx context.Context, loop storage.LoopRecord) (bool, error) {
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		fresh, err := r.repos.Loops.GetByID(ctx, loop.ID)
+		if err != nil {
+			return false, err
+		}
+		if fresh != nil {
+			loop = *fresh
+		}
+	}
+	if loop.Status == "awaiting_human" || loop.Status == "terminated" || loop.Status == "stopped" {
+		return loop.Status == "awaiting_human", nil
+	}
+	if isManualFixerLoop(loop) {
+		return false, nil
+	}
+	cap := r.maxPushesPerPR(loop.ProjectID)
+	count := loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount
+	if !loops.BudgetExhausted(count, cap) {
+		return false, nil
+	}
+	_, err := loops.ParkReviewFixBudget(ctx, r.repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: loop,
+		Role:      "fixer",
+		Repo:      derefString(loop.Repo),
+		PRNumber:  derefInt64(loop.PRNumber),
+		Count:     count,
+		Cap:       cap,
+		NowISO:    r.nowISO(),
+	})
+	return err == nil, err
+}
+
 func (r *Runner) isForgejoProject(projectID string) bool {
 	return r.projectRoleConfig != nil && config.ProjectProviderKind(*r.projectRoleConfig, projectID) == config.ProviderKindForgejo
 }
@@ -1736,7 +1803,7 @@ func (r *Runner) discoverPullRequestFromDetail(ctx context.Context, project stor
 	if err != nil {
 		return err
 	}
-	if loopResult.record.Status == "paused" || loopResult.record.Status == "failed" || loopResult.skipped {
+	if loopResult.record.Status == "paused" || loopResult.record.Status == "failed" || loopResult.record.Status == "awaiting_human" || loopResult.record.Status == "human_takeover" || loopResult.skipped {
 		result.Skipped++
 		return nil
 	}
@@ -2247,6 +2314,12 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
 		status := statusForSkip(checkpoint.SkipReason)
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
+	}
+	if parked, err := r.parkFixerBudgetIfExhausted(ctx, *loop); err != nil {
+		return ProcessResult{}, err
+	} else if parked {
+		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
+		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: statusForSkip(checkpoint.SkipReason), Summary: summary}, nil
 	}
 	if scheduled, err := r.scheduleFollowupRetryAfterSuccess(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber, checkpoint.SkipReason == ""); err != nil {
 		return ProcessResult{}, err
@@ -3260,6 +3333,9 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	// After pushing a fix, re-request the reviewers who weighed in so the PR gets
 	// re-reviewed promptly instead of waiting for the coordinator lane.
 	r.reRequestReviewersAfterFix(ctx, input)
+	if _, err := r.incrementFixerPushCount(ctx, input.Loop); err != nil {
+		return checkpoint, err
+	}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
 }
@@ -3352,6 +3428,9 @@ func (r *Runner) adoptLifecyclePushEvidence(ctx context.Context, input stepInput
 	checkpoint.Lifecycle.PRAdopted = true
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	r.appendEvent(ctx, eventInput{eventType: "fixer.push.adopted", projectID: input.Project.ID, loopID: input.Loop.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"branch": branch, "headSha": adoptedHead}})
+	if _, err := r.incrementFixerPushCount(ctx, input.Loop); err != nil {
+		return false, checkpoint, err
+	}
 	return true, checkpoint, nil
 }
 
@@ -5014,6 +5093,21 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 	}
 	if existing != nil {
 		updatedLoop := *existing
+		if updatedLoop.Status == "awaiting_human" || updatedLoop.Status == "human_takeover" || updatedLoop.Status == "terminated" || updatedLoop.Status == "stopped" {
+			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
+		}
+		if parked, err := r.parkFixerBudgetIfExhausted(ctx, updatedLoop); err != nil {
+			return loopUpsertResult{}, err
+		} else if parked {
+			updated, getErr := r.repos.Loops.GetByID(ctx, updatedLoop.ID)
+			if getErr != nil {
+				return loopUpsertResult{}, getErr
+			}
+			if updated != nil {
+				updatedLoop = *updated
+			}
+			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
+		}
 		if updatedLoop.Status == "paused" {
 			if resumed, updated, err := r.resumePausedZeroProgressLoop(ctx, updatedLoop, headSHA, fixItemsStateHash); err != nil {
 				return loopUpsertResult{}, err

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1642,6 +1642,44 @@ func (r *Runner) incrementFixerPushCount(ctx context.Context, loop storage.LoopR
 	return current, nil
 }
 
+func (r *Runner) livePullRequestClosed(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64) bool {
+	if r.github == nil || strings.TrimSpace(repo) == "" || prNumber == 0 {
+		return false
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: project.RepoPath})
+	if err != nil {
+		return false
+	}
+	return normalizePRState(detail.State) != "open"
+}
+
+func (r *Runner) shouldCreateFixerBudgetPark(loop storage.LoopRecord) bool {
+	if loop.Status == "terminated" || loop.Status == "stopped" || loop.Status == "awaiting_human" {
+		return false
+	}
+	if !r.hitlEnabled || isManualFixerLoop(loop) {
+		return false
+	}
+	return loops.BudgetExhausted(loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount, r.maxPushesPerPR(loop.ProjectID))
+}
+
+func (r *Runner) parkFixerBudgetAfterSuccessfulRun(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord) (bool, error) {
+	current := loop
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		fresh, err := r.repos.Loops.GetByID(ctx, loop.ID)
+		if err != nil {
+			return false, err
+		}
+		if fresh != nil {
+			current = *fresh
+		}
+	}
+	if r.shouldCreateFixerBudgetPark(current) && r.livePullRequestClosed(ctx, project, derefString(current.Repo), derefInt64(current.PRNumber)) {
+		return false, nil
+	}
+	return r.parkFixerBudgetIfExhausted(ctx, current)
+}
+
 func (r *Runner) parkFixerBudgetIfExhausted(ctx context.Context, loop storage.LoopRecord) (bool, error) {
 	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
 		fresh, err := r.repos.Loops.GetByID(ctx, loop.ID)
@@ -2327,7 +2365,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: statusForSkip(checkpoint.SkipReason), Summary: summary}, nil
 		}
 	}
-	if parked, err := r.parkFixerBudgetIfExhausted(ctx, *loop); err != nil {
+	if parked, err := r.parkFixerBudgetAfterSuccessfulRun(ctx, *project, *loop); err != nil {
 		return ProcessResult{}, err
 	} else if parked {
 		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -2018,6 +2018,11 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if loop == nil {
 		return ProcessResult{}, fmt.Errorf("loop not found: %s", *queueItem.LoopID)
 	}
+	if parked, err := r.parkFixerBudgetIfExhausted(ctx, *loop); err != nil {
+		return ProcessResult{}, err
+	} else if parked {
+		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: "review-fix budget exhausted"}, nil
+	}
 	project, err := r.repos.Projects.GetByID(ctx, loop.ProjectID)
 	if err != nil {
 		return ProcessResult{}, err
@@ -2322,18 +2327,18 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: statusForSkip(checkpoint.SkipReason), Summary: summary}, nil
 		}
 	}
+	if parked, err := r.parkFixerBudgetIfExhausted(ctx, *loop); err != nil {
+		return ProcessResult{}, err
+	} else if parked {
+		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
+		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: statusForSkip(checkpoint.SkipReason), Summary: summary}, nil
+	}
 	if scheduled, err := r.schedulePendingRediscoveryAfterRun(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber); err != nil {
 		return ProcessResult{}, err
 	} else if scheduled {
 		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
 		status := statusForSkip(checkpoint.SkipReason)
 		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
-	}
-	if parked, err := r.parkFixerBudgetIfExhausted(ctx, *loop); err != nil {
-		return ProcessResult{}, err
-	} else if parked {
-		r.cleanupFixerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
-		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: statusForSkip(checkpoint.SkipReason), Summary: summary}, nil
 	}
 	if scheduled, err := r.scheduleFollowupRetryAfterSuccess(ctx, *loop, *queueItem.Repo, *queueItem.PRNumber, checkpoint.SkipReason == ""); err != nil {
 		return ProcessResult{}, err
@@ -2376,8 +2381,15 @@ func (r *Runner) schedulePendingRediscoveryAfterRun(ctx context.Context, loop st
 	if !ok {
 		return false, nil
 	}
-	if current.Status == "paused" {
+	if current.Status == "paused" || current.Status == "awaiting_human" || current.Status == "human_takeover" {
 		return false, nil
+	}
+	if r.hitlEnabled && !isManualFixerLoop(*current) {
+		cap := r.maxPushesPerPR(current.ProjectID)
+		count := loops.ReadReviewFixBudgetState(current.MetadataJSON).PushCount
+		if loops.BudgetExhausted(count, cap) {
+			return false, nil
+		}
 	}
 	// Pending rediscovery after a run is a new scheduling decision for the
 	// still-actionable set: apply quiet period before the next start.

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -850,6 +850,9 @@ type checkpointPush struct {
 	PushedAt      string       `json:"pushedAt,omitempty"`
 	SkippedReason string       `json:"skippedReason,omitempty"`
 	Evidence      *fixEvidence `json:"evidence,omitempty"`
+	// BudgetCounted is persisted with the durable push fact so a retry that
+	// short-circuits on Push.Pushed still records that successful push once.
+	BudgetCounted bool `json:"budgetCounted,omitempty"`
 }
 
 type fixEvidence struct {
@@ -3226,7 +3229,7 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 		return checkpoint, nil
 	}
 	if checkpoint.Push != nil && checkpoint.Push.Pushed {
-		return checkpoint, nil
+		return r.ensureFixerPushBudgetCounted(ctx, input, checkpoint)
 	}
 	worktree, err := requireWorktree(checkpoint)
 	if err != nil {
@@ -3291,6 +3294,10 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	if err := r.persistCheckpoint(ctx, input.Run.ID, stepPush, checkpoint); err != nil {
 		return checkpoint, err
 	}
+	checkpoint, err = r.ensureFixerPushBudgetCounted(ctx, input, checkpoint)
+	if err != nil {
+		return checkpoint, err
+	}
 	store, err := r.mergedFixEvidenceStoreV2(ctx, input.Loop, buildFixEvidenceStoreV2(checkpoint, evidence, input.Run.ID))
 	if err != nil {
 		return checkpoint, err
@@ -3333,9 +3340,6 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	// After pushing a fix, re-request the reviewers who weighed in so the PR gets
 	// re-reviewed promptly instead of waiting for the coordinator lane.
 	r.reRequestReviewersAfterFix(ctx, input)
-	if _, err := r.incrementFixerPushCount(ctx, input.Loop); err != nil {
-		return checkpoint, err
-	}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
 }
@@ -3413,6 +3417,10 @@ func (r *Runner) adoptLifecyclePushEvidence(ctx context.Context, input stepInput
 	if err := r.persistCheckpoint(ctx, input.Run.ID, stepPush, checkpoint); err != nil {
 		return false, checkpoint, err
 	}
+	checkpoint, err = r.ensureFixerPushBudgetCounted(ctx, input, checkpoint)
+	if err != nil {
+		return false, checkpoint, err
+	}
 	store, err := r.mergedFixEvidenceStoreV2(ctx, input.Loop, buildFixEvidenceStoreV2(checkpoint, evidence, input.Run.ID))
 	if err != nil {
 		return false, checkpoint, err
@@ -3428,10 +3436,21 @@ func (r *Runner) adoptLifecyclePushEvidence(ctx context.Context, input stepInput
 	checkpoint.Lifecycle.PRAdopted = true
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	r.appendEvent(ctx, eventInput{eventType: "fixer.push.adopted", projectID: input.Project.ID, loopID: input.Loop.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"branch": branch, "headSha": adoptedHead}})
-	if _, err := r.incrementFixerPushCount(ctx, input.Loop); err != nil {
-		return false, checkpoint, err
-	}
 	return true, checkpoint, nil
+}
+
+func (r *Runner) ensureFixerPushBudgetCounted(ctx context.Context, input stepInput, checkpoint fixerCheckpoint) (fixerCheckpoint, error) {
+	if checkpoint.Push == nil || !checkpoint.Push.Pushed || checkpoint.Push.BudgetCounted {
+		return checkpoint, nil
+	}
+	if _, err := r.incrementFixerPushCount(ctx, input.Loop); err != nil {
+		return checkpoint, err
+	}
+	checkpoint.Push.BudgetCounted = true
+	if err := r.persistCheckpoint(ctx, input.Run.ID, stepPush, checkpoint); err != nil {
+		return checkpoint, err
+	}
+	return checkpoint, nil
 }
 
 func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (fixerCheckpoint, error) {

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -99,7 +99,8 @@ func TestIncrementAndParkFixerBudgetParksSibling(t *testing.T) {
 		t.Fatalf("DefaultConfig() error = %v", err)
 	}
 	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	cfg.HITL.Enabled = true
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: true})
 	if _, err := runner.incrementFixerPushCount(context.Background(), fixer); err != nil {
 		t.Fatalf("incrementFixerPushCount() error = %v", err)
 	}
@@ -114,6 +115,47 @@ func TestIncrementAndParkFixerBudgetParksSibling(t *testing.T) {
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
 	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		t.Fatalf("reviewer sibling = (%#v, %v), want paused sibling hold", sibling, err)
+	}
+}
+
+func TestParkFixerBudgetIfExhaustedSkipsWhenHITLDisabled(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	fixer := storage.LoopRecord{ID: "loop_fixer_budget_no_hitl", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_no_hitl", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	if cfg.HITL.Enabled {
+		t.Fatal("DefaultConfig HITL.Enabled = true, want false")
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	if _, err := runner.incrementFixerPushCount(context.Background(), fixer); err != nil {
+		t.Fatalf("incrementFixerPushCount() error = %v", err)
+	}
+	parked, err := runner.parkFixerBudgetIfExhausted(context.Background(), fixer)
+	if err != nil || parked {
+		t.Fatalf("parkFixerBudgetIfExhausted() = (%v, %v), want skipped under default HITL-off config", parked, err)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || updated == nil || updated.Status != "running" {
+		t.Fatalf("fixer = (%#v, %v), want still running", updated, err)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || sibling == nil || sibling.Status != "waiting" {
+		t.Fatalf("reviewer sibling = (%#v, %v), want still waiting", sibling, err)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1719,6 +1719,15 @@ func TestProcessClaimedItemDoesNotParkBudgetWhenPushClosesPR(t *testing.T) {
 	if err != nil || claim == nil {
 		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
 	}
+	claimedLoop, err := fixture.repos.Loops.GetByID(context.Background(), *claim.LoopID)
+	if err != nil || claimedLoop == nil {
+		t.Fatalf("Loops.GetByID(claimed) = (%#v, %v), want discovered fixer loop", claimedLoop, err)
+	}
+	pendingMeta := mustMarshalJSON(map[string]any{"pendingFixerRediscovery": map[string]any{"headSha": "head-followup", "fixItemsStateHash": "state-followup", "unresolvedThreadIds": []string{"t2"}, "recordedAt": nowISO}})
+	claimedLoop.MetadataJSON = &pendingMeta
+	if err := fixture.repos.Loops.Upsert(context.Background(), *claimedLoop); err != nil {
+		t.Fatalf("Loops.Upsert(pending rediscovery) error = %v", err)
+	}
 	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
@@ -1727,11 +1736,18 @@ func TestProcessClaimedItemDoesNotParkBudgetWhenPushClosesPR(t *testing.T) {
 		t.Fatalf("result = %#v, want success after pushed fix", result)
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
-	if err != nil || loop == nil || loop.Status == "awaiting_human" {
-		t.Fatalf("fixer = (%#v, %v), want no budget park after closed PR", loop, err)
+	if err != nil || loop == nil || loop.Status != "terminated" {
+		t.Fatalf("fixer = (%#v, %v), want terminated product terminal after closed PR", loop, err)
+	}
+	reason := ""
+	if loopMeta, ok := parseJSONObject(loop.MetadataJSON)["loop"].(map[string]any); ok {
+		reason, _ = stringFromAny(loopMeta["terminationReason"])
+	}
+	if reason != "pr_closed_or_merged" {
+		t.Fatalf("terminationReason = %q, want pr_closed_or_merged", reason)
 	}
 	if loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount < 1 {
-		t.Fatalf("push count = %d, want cap-reaching push before closed-PR skip", loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount)
+		t.Fatalf("push count = %d, want cap-reaching push before closed-PR terminal", loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount)
 	}
 	if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
 		t.Fatalf("HITL ask = %#v, want no budget ask on a closed PR", ask)
@@ -1739,6 +1755,24 @@ func TestProcessClaimedItemDoesNotParkBudgetWhenPushClosesPR(t *testing.T) {
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
 	if err != nil || sibling == nil || sibling.Status != "waiting" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		t.Fatalf("reviewer sibling = (%#v, %v), want still waiting without budget pause", sibling, err)
+	}
+	active, err := fixture.repos.Queue.FindActiveByLoopID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Queue.FindActiveByLoopID() error = %v", err)
+	}
+	if active != nil {
+		t.Fatalf("activeQueue = %#v, want no follow-up after closed-PR terminal", active)
+	}
+	parked, err := runner.parkFixerBudgetIfExhausted(context.Background(), *loop)
+	if err != nil || parked {
+		t.Fatalf("parkFixerBudgetIfExhausted() = (%v, %v), want skipped on terminated closed PR", parked, err)
+	}
+	scheduled, err := runner.schedulePendingRediscoveryAfterRun(context.Background(), *loop, repo, prNumber)
+	if err != nil {
+		t.Fatalf("schedulePendingRediscoveryAfterRun() error = %v", err)
+	}
+	if scheduled {
+		t.Fatal("schedulePendingRediscoveryAfterRun() = true, want no enqueue after closed-PR terminal")
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -118,6 +118,107 @@ func TestIncrementAndParkFixerBudgetParksSibling(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemParksExhaustedBudgetBeforeRun(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	projectID := "project_1"
+	loopID := "loop_fixer_budget_entry"
+	fixer := storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_entry", Seq: 2, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_budget_entry", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:budget-entry", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: nowISO, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	cfg.HITL.Enabled = true
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: true})
+	if _, err := runner.incrementFixerPushCount(context.Background(), fixer); err != nil {
+		t.Fatalf("incrementFixerPushCount() error = %v", err)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_budget_entry", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, Status: "running"})
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped at claim start", result)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || updated == nil || updated.Status != "awaiting_human" {
+		t.Fatalf("fixer = (%#v, %v), want awaiting_human", updated, err)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("reviewer sibling = (%#v, %v), want paused sibling hold", sibling, err)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_fixer_budget_entry")
+	if err != nil || queue == nil || queue.Status != "cancelled" {
+		t.Fatalf("queue = (%#v, %v), want cancelled claimed item", queue, err)
+	}
+}
+
+func TestParkFixerBudgetBeforePendingRediscoveryDoesNotEnqueue(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(85)
+	nowISO := fixture.nowISO()
+	target := buildPullRequestTargetID(repo, prNumber)
+	projectID := "project_1"
+	loopID := "loop_fixer_budget_rediscovery"
+	metadata := mustMarshalJSON(map[string]any{"pendingFixerRediscovery": map[string]any{"headSha": "head-85", "fixItemsStateHash": "state-85", "unresolvedThreadIds": []string{"t1"}, "recordedAt": nowISO}})
+	fixer := storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	cfg.HITL.Enabled = true
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: true})
+	if _, err := runner.incrementFixerPushCount(context.Background(), fixer); err != nil {
+		t.Fatalf("incrementFixerPushCount() error = %v", err)
+	}
+
+	parked, err := runner.parkFixerBudgetIfExhausted(context.Background(), fixer)
+	if err != nil || !parked {
+		t.Fatalf("parkFixerBudgetIfExhausted() = (%v, %v), want parked before rediscovery", parked, err)
+	}
+	scheduled, err := runner.schedulePendingRediscoveryAfterRun(context.Background(), fixer, repo, prNumber)
+	if err != nil {
+		t.Fatalf("schedulePendingRediscoveryAfterRun() error = %v", err)
+	}
+	if scheduled {
+		t.Fatal("schedulePendingRediscoveryAfterRun() = true, want no enqueue after budget park")
+	}
+	active, err := fixture.repos.Queue.FindActiveByLoopID(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Queue.FindActiveByLoopID() error = %v", err)
+	}
+	if active != nil {
+		t.Fatalf("activeQueue = %#v, want no rediscovery item after cap park", active)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || updated == nil || updated.Status != "awaiting_human" {
+		t.Fatalf("fixer = (%#v, %v), want still awaiting_human", updated, err)
+	}
+}
+
 func TestParkFixerBudgetIfExhaustedSkipsWhenHITLDisabled(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -1671,6 +1671,77 @@ func TestProcessClaimedItemCompletesSuccessfulFlow(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemDoesNotParkBudgetWhenPushClosesPR(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := buildPullRequestTargetID(repo, prNumber)
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_closed_pr", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	github := &fakeGitHubGateway{
+		closeAfterResolve: true,
+		listOpen:          []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
+		viewResponses: []PullRequestDetail{
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
+			{Number: 42, State: "OPEN", HeadSHA: "new-head", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
+		},
+	}
+	git := &fakeGitGateway{
+		createResult:  CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt-42"), Branch: "feature/fix-42", HeadSHA: "base-head"},
+		prepareResult: PrepareWorktreeResult{HeadSHA: "base-head", Clean: true},
+		inspectResults: []InspectHeadResult{
+			{HeadSHA: "base-head"},
+			{HeadSHA: "new-head", NewCommitSHAs: []string{"new-head"}},
+			{HeadSHA: "new-head"},
+		},
+	}
+	stdout := fmt.Sprintf(`__LOOPER_RESULT__={"summary":"applied fixes","review_thread_replies":[{"fixItemId":"c1","threadId":"t1","explanation":"Adjusted the off-by-one handling and verified the fix.","threadCommentsObserved":"%s"}]}`+"\n", hashReviewThreadComments(ReviewThread{Comments: []ReviewThreadComment{{ID: "c1"}}}))
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "applied fixes", ParseStatus: "parsed", Stdout: stdout}}}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	cfg.HITL.Enabled = true
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: true})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success after pushed fix", result)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil || loop == nil || loop.Status == "awaiting_human" {
+		t.Fatalf("fixer = (%#v, %v), want no budget park after closed PR", loop, err)
+	}
+	if loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount < 1 {
+		t.Fatalf("push count = %d, want cap-reaching push before closed-PR skip", loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount)
+	}
+	if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("HITL ask = %#v, want no budget ask on a closed PR", ask)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || sibling == nil || sibling.Status != "waiting" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("reviewer sibling = (%#v, %v), want still waiting without budget pause", sibling, err)
+	}
+}
+
 func TestProcessClaimedItemDoesNotResolveCommentsWhenRepairProducesNoCommits(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -6539,6 +6610,7 @@ type fakeGitHubGateway struct {
 	viewThreadCalls       []ViewReviewThreadInput
 	viewIndex             int
 	resolveCalls          []ResolveReviewThreadInput
+	closeAfterResolve     bool
 	addLabelCalls         []PullRequestLabelsInput
 	removeLabelCalls      []PullRequestLabelsInput
 	reviewerRequests      []PullRequestReviewersInput
@@ -6618,6 +6690,9 @@ func (f *fakeGitHubGateway) ViewPullRequest(_ context.Context, input ViewPullReq
 	}
 	result := f.viewResponses[idx]
 	f.viewIndex++
+	if f.closeAfterResolve && len(f.resolveCalls) > 0 {
+		result.State = "CLOSED"
+	}
 	if result.Number == 0 {
 		result.Number = input.PRNumber
 	}

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -117,6 +117,49 @@ func TestIncrementAndParkFixerBudgetParksSibling(t *testing.T) {
 	}
 }
 
+func TestRunPushStepCountsAlreadyPushedCheckpointOnResume(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	loopMetadata := `{}`
+	loopTarget := buildPullRequestTargetID("acme/looper", 42)
+	prNumber := int64(42)
+	loop := storage.LoopRecord{
+		ID: "loop_push_budget_resume", ProjectID: "project_1", Type: "fixer", TargetType: "pull_request",
+		TargetID: &loopTarget, Repo: stringPtr("acme/looper"), PRNumber: &prNumber, Status: "running",
+		MetadataJSON: &loopMetadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	run := storage.RunRecord{ID: "run_push_budget_resume", LoopID: loop.ID, Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Now: fixture.now, Logger: fixture.logger})
+	checkpoint := fixerCheckpoint{Push: &checkpointPush{Pushed: true, Branch: "feature/fix-42", HeadSHA: "fix-head"}}
+
+	updated, err := runner.runPushStep(context.Background(), stepInput{Loop: loop, Run: run, Checkpoint: checkpoint})
+	if err != nil {
+		t.Fatalf("runPushStep() error = %v", err)
+	}
+	if updated.Push == nil || !updated.Push.BudgetCounted {
+		t.Fatalf("updated.Push = %#v, want budgetCounted after resume", updated.Push)
+	}
+	fresh, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || fresh == nil || loops.ReadReviewFixBudgetState(fresh.MetadataJSON).PushCount != 1 {
+		t.Fatalf("pushCount after resume = (%#v, %v), want 1", fresh, err)
+	}
+
+	updated, err = runner.runPushStep(context.Background(), stepInput{Loop: *fresh, Run: run, Checkpoint: updated})
+	if err != nil {
+		t.Fatalf("runPushStep() second resume error = %v", err)
+	}
+	fresh, err = fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || fresh == nil || loops.ReadReviewFixBudgetState(fresh.MetadataJSON).PushCount != 1 {
+		t.Fatalf("pushCount after second resume = (%#v, %v), want still 1", fresh, err)
+	}
+}
+
 func TestNewPreservesInfiniteRetryMaxAttempts(t *testing.T) {
 	t.Parallel()
 
@@ -7537,6 +7580,12 @@ func TestRunPushStepRecordsPushEvidenceBeforePostPushHold(t *testing.T) {
 	}
 	if loop == nil || loop.MetadataJSON == nil || !strings.Contains(*loop.MetadataJSON, `"lastFixHeadSha":"fix-head"`) {
 		t.Fatalf("loop metadata = %#v, want pushed head persisted before hold skip", loop)
+	}
+	if updated.Push == nil || !updated.Push.BudgetCounted {
+		t.Fatalf("updated.Push = %#v, want budget counted before hold skip", updated.Push)
+	}
+	if loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount != 1 {
+		t.Fatalf("pushCount = %d, want 1 before hold skip", loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -79,6 +79,44 @@ func TestBackoffDelayCapsInfiniteRetryOverflow(t *testing.T) {
 	}
 }
 
+func TestIncrementAndParkFixerBudgetParksSibling(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	fixer := storage.LoopRecord{ID: "loop_fixer_budget", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg})
+	if _, err := runner.incrementFixerPushCount(context.Background(), fixer); err != nil {
+		t.Fatalf("incrementFixerPushCount() error = %v", err)
+	}
+	parked, err := runner.parkFixerBudgetIfExhausted(context.Background(), fixer)
+	if err != nil || !parked {
+		t.Fatalf("parkFixerBudgetIfExhausted() = (%v, %v), want parked", parked, err)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || updated == nil || updated.Status != "awaiting_human" {
+		t.Fatalf("fixer = (%#v, %v), want awaiting_human", updated, err)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("reviewer sibling = (%#v, %v), want paused sibling hold", sibling, err)
+	}
+}
+
 func TestNewPreservesInfiniteRetryMaxAttempts(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -170,6 +170,76 @@ func TestProcessClaimedItemParksExhaustedBudgetBeforeRun(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemDoesNotParkBudgetWhenClaimedAfterPRClosed(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	projectID := "project_1"
+	loopID := "loop_fixer_budget_claim_closed"
+	fixer := storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_claim_closed", Seq: 2, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_budget_claim_closed", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, DedupeKey: "fixer:budget-claim-closed", Priority: storage.QueuePriorityFixer, Status: "running", AvailableAt: nowISO, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	cfg.HITL.Enabled = true
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: prNumber, State: "MERGED"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: true})
+	if _, err := runner.incrementFixerPushCount(context.Background(), fixer); err != nil {
+		t.Fatalf("incrementFixerPushCount() error = %v", err)
+	}
+
+	result, err := runner.ProcessClaimedItem(context.Background(), storage.QueueItemRecord{ID: "queue_fixer_budget_claim_closed", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, Status: "running"})
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped after closed-PR claim", result)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || updated == nil || updated.Status != "terminated" {
+		t.Fatalf("fixer = (%#v, %v), want terminated product terminal", updated, err)
+	}
+	reason := ""
+	if loopMeta, ok := parseJSONObject(updated.MetadataJSON)["loop"].(map[string]any); ok {
+		reason, _ = stringFromAny(loopMeta["terminationReason"])
+	}
+	if reason != "pr_closed_or_merged" {
+		t.Fatalf("terminationReason = %q, want pr_closed_or_merged", reason)
+	}
+	if ask, ok := loops.ReadHITLAsk(updated.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("HITL ask = %#v, want no budget ask on a closed PR", ask)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || sibling == nil || sibling.Status != "waiting" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("reviewer sibling = (%#v, %v), want still waiting without budget pause", sibling, err)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_fixer_budget_claim_closed")
+	if err != nil || queue == nil || queue.Status != "cancelled" {
+		t.Fatalf("queue = (%#v, %v), want cancelled claimed item", queue, err)
+	}
+	runs, err := fixture.repos.Runs.ListByLoop(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Runs.ListByLoop() error = %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("runs = %#v, want no run after closed-PR claim", runs)
+	}
+}
+
 func TestParkFixerBudgetBeforePendingRediscoveryDoesNotEnqueue(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/loops/hitl.go
+++ b/internal/loops/hitl.go
@@ -14,6 +14,9 @@ const hitlMetadataKey = "hitl"
 // the answer is filled in by POST /loops/{seq}/respond. On resume the runner
 // reads Answer + SessionID to continue the same agent session.
 type HITLAsk struct {
+	// Kind distinguishes mid-run agent asks (empty) from control-plane asks
+	// such as review-fix budget exhaustion.
+	Kind        string   `json:"kind,omitempty"`
 	Question    string   `json:"question,omitempty"`
 	Options     []string `json:"options,omitempty"`
 	SessionID   string   `json:"sessionId,omitempty"`

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -1,0 +1,478 @@
+package loops
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+const (
+	// HITLKindReviewFixBudget marks an ask that is a cycle-cap decision, not a
+	// mid-run agent question. Resume must not replay an agent session.
+	HITLKindReviewFixBudget = "review_fix_budget"
+
+	ReviewFixBudgetAnswerContinue = "Continue"
+	ReviewFixBudgetAnswerStop     = "Stop"
+
+	ReviewFixBudgetPauseReason       = "sibling_review_fix_budget"
+	ReviewFixBudgetTerminationReason = "review_fix_budget_exhausted"
+
+	reviewFixBudgetMetadataKey = "reviewFixBudget"
+	reviewerLoopMetadataKey    = "loop"
+	reviewerIterationCountKey  = "iterationCount"
+	fixerPushCountKey          = "pushCount"
+)
+
+// ReviewFixBudgetState is the durable PR-scoped ledger for the new caps.
+// Authority for the cap is live config; this record only stores counts and
+// which role exhausted.
+type ReviewFixBudgetState struct {
+	PushCount   int    `json:"pushCount,omitempty"`
+	ExhaustedBy string `json:"exhaustedBy,omitempty"`
+	SiblingOf   string `json:"siblingOf,omitempty"`
+	PauseReason string `json:"pauseReason,omitempty"`
+}
+
+func BudgetExhausted(count, cap int) bool {
+	return cap > 0 && count >= cap
+}
+
+func NewReviewFixBudgetAsk(role, repo string, prNumber int64, count, cap int, nowISO string) HITLAsk {
+	target := strings.TrimSpace(repo)
+	if prNumber > 0 {
+		target = fmt.Sprintf("%s#%d", target, prNumber)
+	}
+	return HITLAsk{
+		Kind:     HITLKindReviewFixBudget,
+		Question: fmt.Sprintf("%s hit its review-fix budget on %s (%d/%d). Continue another %d, or stop review-fix on this PR?", strings.TrimSpace(role), target, count, cap, cap),
+		Options:  []string{ReviewFixBudgetAnswerContinue, ReviewFixBudgetAnswerStop},
+		Status:   "awaiting",
+		AskedAt:  nowISO,
+	}
+}
+
+func IsReviewFixBudgetAsk(ask HITLAsk) bool {
+	return strings.TrimSpace(ask.Kind) == HITLKindReviewFixBudget
+}
+
+func IsReviewFixBudgetContinue(answer string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(answer))
+	return normalized == strings.ToLower(ReviewFixBudgetAnswerContinue) || normalized == "continue another" || strings.HasPrefix(normalized, "continue")
+}
+
+func IsReviewFixBudgetStop(answer string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(answer))
+	return normalized == strings.ToLower(ReviewFixBudgetAnswerStop) || normalized == "stop"
+}
+
+func ReadReviewFixBudgetState(metadataJSON *string) ReviewFixBudgetState {
+	meta := parseMetadataObject(metadataJSON)
+	raw, ok := meta[reviewFixBudgetMetadataKey]
+	if !ok {
+		return ReviewFixBudgetState{}
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return ReviewFixBudgetState{}
+	}
+	var state ReviewFixBudgetState
+	if err := json.Unmarshal(encoded, &state); err != nil {
+		return ReviewFixBudgetState{}
+	}
+	return state
+}
+
+func WriteReviewFixBudgetState(metadataJSON *string, state ReviewFixBudgetState) (string, error) {
+	meta := parseMetadataObject(metadataJSON)
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(encoded, &asMap); err != nil {
+		return "", err
+	}
+	if len(asMap) == 0 {
+		delete(meta, reviewFixBudgetMetadataKey)
+	} else {
+		meta[reviewFixBudgetMetadataKey] = asMap
+	}
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func ReviewerPublishCount(metadataJSON *string) int {
+	meta := parseMetadataObject(metadataJSON)
+	loopMeta, _ := meta[reviewerLoopMetadataKey].(map[string]any)
+	if loopMeta == nil {
+		return 0
+	}
+	return intFromMetadata(loopMeta[reviewerIterationCountKey])
+}
+
+func ResetReviewerPublishCount(metadataJSON *string) (string, error) {
+	meta := parseMetadataObject(metadataJSON)
+	loopMeta, _ := meta[reviewerLoopMetadataKey].(map[string]any)
+	if loopMeta == nil {
+		loopMeta = map[string]any{}
+	}
+	loopMeta[reviewerIterationCountKey] = 0
+	meta[reviewerLoopMetadataKey] = loopMeta
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func IncrementFixerPushCount(metadataJSON *string) (string, int, error) {
+	state := ReadReviewFixBudgetState(metadataJSON)
+	state.PushCount++
+	encoded, err := WriteReviewFixBudgetState(metadataJSON, state)
+	if err != nil {
+		return "", 0, err
+	}
+	return encoded, state.PushCount, nil
+}
+
+func ResetFixerPushCount(metadataJSON *string) (string, error) {
+	state := ReadReviewFixBudgetState(metadataJSON)
+	state.PushCount = 0
+	state.ExhaustedBy = ""
+	return WriteReviewFixBudgetState(metadataJSON, state)
+}
+
+func IsSiblingReviewFixBudgetPause(metadataJSON *string) bool {
+	if reason, _ := stringFromAny(parseMetadataObject(metadataJSON)["pauseReason"]); reason == ReviewFixBudgetPauseReason {
+		return true
+	}
+	return ReadReviewFixBudgetState(metadataJSON).PauseReason == ReviewFixBudgetPauseReason
+}
+
+func FindSiblingReviewFixLoop(all []storage.LoopRecord, loop storage.LoopRecord) *storage.LoopRecord {
+	wantType := ""
+	switch strings.TrimSpace(loop.Type) {
+	case "reviewer":
+		wantType = "fixer"
+	case "fixer":
+		wantType = "reviewer"
+	default:
+		return nil
+	}
+	repo := derefLoopString(loop.Repo)
+	pr := derefLoopInt64(loop.PRNumber)
+	if repo == "" || pr == 0 {
+		return nil
+	}
+	for i := range all {
+		candidate := all[i]
+		if candidate.ID == loop.ID || candidate.Type != wantType || candidate.ProjectID != loop.ProjectID {
+			continue
+		}
+		if derefLoopString(candidate.Repo) != repo || derefLoopInt64(candidate.PRNumber) != pr {
+			continue
+		}
+		return &all[i]
+	}
+	return nil
+}
+
+type ParkReviewFixBudgetInput struct {
+	Exhausted storage.LoopRecord
+	Role      string
+	Repo      string
+	PRNumber  int64
+	Count     int
+	Cap       int
+	NowISO    string
+}
+
+// ParkReviewFixBudget parks the exhausted loop as awaiting_human with a budget
+// HITL ask and pauses the sibling loop on the same PR. Queue items on both
+// sides are cancelled so discovery cannot immediately restart the ping-pong.
+func ParkReviewFixBudget(ctx context.Context, repos *storage.Repositories, input ParkReviewFixBudgetInput) (storage.LoopRecord, error) {
+	if repos == nil || repos.Loops == nil {
+		return input.Exhausted, fmt.Errorf("review-fix budget park requires loop storage")
+	}
+	ask := NewReviewFixBudgetAsk(input.Role, input.Repo, input.PRNumber, input.Count, input.Cap, input.NowISO)
+	metadata, err := WriteHITLAsk(input.Exhausted.MetadataJSON, ask)
+	if err != nil {
+		return input.Exhausted, err
+	}
+	state := ReadReviewFixBudgetState(&metadata)
+	state.ExhaustedBy = strings.TrimSpace(input.Role)
+	metadata, err = WriteReviewFixBudgetState(&metadata, state)
+	if err != nil {
+		return input.Exhausted, err
+	}
+	exhausted := input.Exhausted
+	exhausted.MetadataJSON = &metadata
+	exhausted.Status = "awaiting_human"
+	exhausted.NextRunAt = nil
+	exhausted.UpdatedAt = input.NowISO
+	if err := repos.Loops.Upsert(ctx, exhausted); err != nil {
+		return input.Exhausted, err
+	}
+	reason := ReviewFixBudgetTerminationReason
+	if repos.Queue != nil {
+		if _, err := repos.Queue.CancelByLoop(ctx, exhausted.ID, input.NowISO, &reason); err != nil {
+			return exhausted, err
+		}
+	}
+	if err := parkSiblingReviewFixLoop(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
+		return exhausted, err
+	}
+	return exhausted, nil
+}
+
+func parkSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, exhaustedBy, nowISO string) error {
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	sibling := FindSiblingReviewFixLoop(all, exhausted)
+	if sibling == nil {
+		return nil
+	}
+	switch sibling.Status {
+	case "terminated", "stopped", "completed", "awaiting_human", "human_takeover":
+		return nil
+	}
+	state := ReadReviewFixBudgetState(sibling.MetadataJSON)
+	state.SiblingOf = strings.TrimSpace(exhaustedBy)
+	state.PauseReason = ReviewFixBudgetPauseReason
+	metadata, err := WriteReviewFixBudgetState(sibling.MetadataJSON, state)
+	if err != nil {
+		return err
+	}
+	meta := parseMetadataObject(&metadata)
+	meta["pauseReason"] = ReviewFixBudgetPauseReason
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	text := string(encoded)
+	updated := *sibling
+	updated.MetadataJSON = &text
+	updated.Status = "paused"
+	updated.NextRunAt = nil
+	updated.UpdatedAt = nowISO
+	if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		return err
+	}
+	if repos.Queue != nil {
+		reason := ReviewFixBudgetPauseReason
+		if _, err := repos.Queue.CancelByLoop(ctx, updated.ID, nowISO, &reason); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type ReviewFixBudgetAnswerResult struct {
+	Applied bool
+	Action  string
+	Loop    storage.LoopRecord
+}
+
+// ApplyReviewFixBudgetAnswer handles Continue (reset counter, queue, unpause
+// sibling) or Stop (terminate both). Returns Applied=false for mid-run HITL asks.
+func ApplyReviewFixBudgetAnswer(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string) (ReviewFixBudgetAnswerResult, error) {
+	ask, ok := ReadHITLAsk(loop.MetadataJSON)
+	if !ok || !IsReviewFixBudgetAsk(ask) {
+		return ReviewFixBudgetAnswerResult{}, nil
+	}
+	if repos == nil || repos.Loops == nil {
+		return ReviewFixBudgetAnswerResult{}, fmt.Errorf("review-fix budget answer requires loop storage")
+	}
+	if IsReviewFixBudgetStop(answer) {
+		updated, err := terminateReviewFixPair(ctx, repos, loop, nowISO)
+		if err != nil {
+			return ReviewFixBudgetAnswerResult{}, err
+		}
+		return ReviewFixBudgetAnswerResult{Applied: true, Action: "stop", Loop: updated}, nil
+	}
+	if !IsReviewFixBudgetContinue(answer) {
+		return ReviewFixBudgetAnswerResult{}, fmt.Errorf("review-fix budget answer must be %q or %q", ReviewFixBudgetAnswerContinue, ReviewFixBudgetAnswerStop)
+	}
+	updated, err := continueReviewFixBudget(ctx, repos, loop, nowISO)
+	if err != nil {
+		return ReviewFixBudgetAnswerResult{}, err
+	}
+	return ReviewFixBudgetAnswerResult{Applied: true, Action: "continue", Loop: updated}, nil
+}
+
+func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
+	metadata := loop.MetadataJSON
+	var err error
+	switch loop.Type {
+	case "reviewer":
+		encoded, resetErr := ResetReviewerPublishCount(metadata)
+		if resetErr != nil {
+			return loop, resetErr
+		}
+		metadata = &encoded
+	case "fixer":
+		encoded, resetErr := ResetFixerPushCount(metadata)
+		if resetErr != nil {
+			return loop, resetErr
+		}
+		metadata = &encoded
+	}
+	cleared, err := ClearHITLAsk(metadata)
+	if err != nil {
+		return loop, err
+	}
+	state := ReadReviewFixBudgetState(&cleared)
+	state.ExhaustedBy = ""
+	cleared, err = WriteReviewFixBudgetState(&cleared, state)
+	if err != nil {
+		return loop, err
+	}
+	updated := loop
+	updated.MetadataJSON = &cleared
+	updated.Status = "queued"
+	updated.NextRunAt = &nowISO
+	updated.UpdatedAt = nowISO
+	if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		return loop, err
+	}
+	if err := unpauseSiblingReviewFixLoop(ctx, repos, updated, nowISO); err != nil {
+		return updated, err
+	}
+	return updated, nil
+}
+
+func unpauseSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, nowISO string) error {
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	sibling := FindSiblingReviewFixLoop(all, exhausted)
+	if sibling == nil || sibling.Status != "paused" || !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		return nil
+	}
+	state := ReadReviewFixBudgetState(sibling.MetadataJSON)
+	state.SiblingOf = ""
+	state.PauseReason = ""
+	metadata, err := WriteReviewFixBudgetState(sibling.MetadataJSON, state)
+	if err != nil {
+		return err
+	}
+	meta := parseMetadataObject(&metadata)
+	delete(meta, "pauseReason")
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	text := string(encoded)
+	updated := *sibling
+	updated.MetadataJSON = &text
+	updated.Status = "queued"
+	updated.NextRunAt = &nowISO
+	updated.UpdatedAt = nowISO
+	return repos.Loops.Upsert(ctx, updated)
+}
+
+func terminateReviewFixPair(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
+	updated, err := terminateReviewFixLoop(ctx, repos, loop, nowISO)
+	if err != nil {
+		return loop, err
+	}
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return updated, err
+	}
+	if sibling := FindSiblingReviewFixLoop(all, updated); sibling != nil {
+		if _, err := terminateReviewFixLoop(ctx, repos, *sibling, nowISO); err != nil {
+			return updated, err
+		}
+	}
+	return updated, nil
+}
+
+func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
+	switch loop.Status {
+	case "terminated", "stopped":
+		return loop, nil
+	}
+	meta := parseMetadataObject(loop.MetadataJSON)
+	if loop.Type == "reviewer" {
+		loopMeta, _ := meta[reviewerLoopMetadataKey].(map[string]any)
+		if loopMeta == nil {
+			loopMeta = map[string]any{}
+		}
+		loopMeta["status"] = "terminated"
+		loopMeta["terminationReason"] = ReviewFixBudgetTerminationReason
+		meta[reviewerLoopMetadataKey] = loopMeta
+	}
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		return loop, err
+	}
+	encodedText := string(encoded)
+	cleared, err := ClearHITLAsk(&encodedText)
+	if err != nil {
+		return loop, err
+	}
+	updated := loop
+	updated.MetadataJSON = &cleared
+	updated.Status = "terminated"
+	updated.NextRunAt = nil
+	updated.UpdatedAt = nowISO
+	if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		return loop, err
+	}
+	if repos.Queue != nil {
+		reason := ReviewFixBudgetTerminationReason
+		if _, err := repos.Queue.CancelByLoop(ctx, updated.ID, nowISO, &reason); err != nil {
+			return updated, err
+		}
+	}
+	return updated, nil
+}
+
+func intFromMetadata(value any) int {
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case json.Number:
+		parsed, _ := typed.Int64()
+		return int(parsed)
+	default:
+		return 0
+	}
+}
+
+func stringFromAny(value any) (string, bool) {
+	text, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	text = strings.TrimSpace(text)
+	return text, text != ""
+}
+
+func derefLoopString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func derefLoopInt64(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -62,7 +62,7 @@ func IsReviewFixBudgetAsk(ask HITLAsk) bool {
 
 func IsReviewFixBudgetContinue(answer string) bool {
 	normalized := strings.ToLower(strings.TrimSpace(answer))
-	return normalized == strings.ToLower(ReviewFixBudgetAnswerContinue) || normalized == "continue another" || strings.HasPrefix(normalized, "continue")
+	return normalized == strings.ToLower(ReviewFixBudgetAnswerContinue) || normalized == "continue another"
 }
 
 func IsReviewFixBudgetStop(answer string) bool {

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -27,6 +27,10 @@ const (
 	fixerPushCountKey          = "pushCount"
 )
 
+// ErrReviewFixBudgetInvalidAnswer is the only ApplyReviewFixBudgetAnswer
+// failure that API clients should treat as a 400 validation error.
+var ErrReviewFixBudgetInvalidAnswer = fmt.Errorf("review-fix budget answer must be %q or %q", ReviewFixBudgetAnswerContinue, ReviewFixBudgetAnswerStop)
+
 // ReviewFixBudgetState is the durable PR-scoped ledger for the new caps.
 // Authority for the cap is live config; this record only stores counts and
 // which role exhausted.
@@ -360,7 +364,7 @@ func ApplyReviewFixBudgetAnswer(ctx context.Context, repos *storage.Repositories
 		return ReviewFixBudgetAnswerResult{Applied: true, Action: "stop", Loop: updated}, nil
 	}
 	if !IsReviewFixBudgetContinue(answer) {
-		return ReviewFixBudgetAnswerResult{}, fmt.Errorf("review-fix budget answer must be %q or %q", ReviewFixBudgetAnswerContinue, ReviewFixBudgetAnswerStop)
+		return ReviewFixBudgetAnswerResult{}, ErrReviewFixBudgetInvalidAnswer
 	}
 	updated, err := continueReviewFixBudget(ctx, repos, loop, nowISO)
 	if err != nil {

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -232,12 +232,21 @@ type ParkReviewFixBudgetInput struct {
 // ParkReviewFixBudget parks the exhausted loop as awaiting_human with a budget
 // HITL ask and pauses the sibling loop on the same PR. Queue items on both
 // sides are cancelled so discovery cannot immediately restart the ping-pong.
+// Re-entry on an already-awaiting budget loop finishes cancel/sibling park
+// without rewriting a delivered ask.
 func ParkReviewFixBudget(ctx context.Context, repos *storage.Repositories, input ParkReviewFixBudgetInput) (storage.LoopRecord, error) {
 	if repos == nil || repos.Loops == nil {
 		return input.Exhausted, fmt.Errorf("review-fix budget park requires loop storage")
 	}
+	exhausted := input.Exhausted
+	if ask, ok := ReadHITLAsk(exhausted.MetadataJSON); ok && IsReviewFixBudgetAsk(ask) && exhausted.Status == "awaiting_human" {
+		if err := finishReviewFixBudgetPark(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
+			return exhausted, err
+		}
+		return exhausted, nil
+	}
 	ask := NewReviewFixBudgetAsk(input.Role, input.Repo, input.PRNumber, input.Count, input.Cap, input.NowISO)
-	metadata, err := WriteHITLAsk(input.Exhausted.MetadataJSON, ask)
+	metadata, err := WriteHITLAsk(exhausted.MetadataJSON, ask)
 	if err != nil {
 		return input.Exhausted, err
 	}
@@ -247,7 +256,6 @@ func ParkReviewFixBudget(ctx context.Context, repos *storage.Repositories, input
 	if err != nil {
 		return input.Exhausted, err
 	}
-	exhausted := input.Exhausted
 	exhausted.MetadataJSON = &metadata
 	exhausted.Status = "awaiting_human"
 	exhausted.NextRunAt = nil
@@ -255,16 +263,20 @@ func ParkReviewFixBudget(ctx context.Context, repos *storage.Repositories, input
 	if err := repos.Loops.Upsert(ctx, exhausted); err != nil {
 		return input.Exhausted, err
 	}
-	reason := ReviewFixBudgetTerminationReason
-	if repos.Queue != nil {
-		if _, err := repos.Queue.CancelByLoop(ctx, exhausted.ID, input.NowISO, &reason); err != nil {
-			return exhausted, err
-		}
-	}
-	if err := parkSiblingReviewFixLoop(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
+	if err := finishReviewFixBudgetPark(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
 		return exhausted, err
 	}
 	return exhausted, nil
+}
+
+func finishReviewFixBudgetPark(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, exhaustedBy, nowISO string) error {
+	if repos.Queue != nil {
+		reason := ReviewFixBudgetTerminationReason
+		if _, err := repos.Queue.CancelByLoop(ctx, exhausted.ID, nowISO, &reason); err != nil {
+			return err
+		}
+	}
+	return parkSiblingReviewFixLoop(ctx, repos, exhausted, exhaustedBy, nowISO)
 }
 
 func parkSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, exhaustedBy, nowISO string) error {
@@ -349,8 +361,15 @@ func ApplyReviewFixBudgetAnswer(ctx context.Context, repos *storage.Repositories
 }
 
 func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
+	// Keep awaiting_human + the budget ask until sibling unpause and requeue
+	// succeed so a later GitHub/Feishu poll can retry the same answer.
+	if err := unpauseSiblingReviewFixLoop(ctx, repos, loop, nowISO); err != nil {
+		return loop, err
+	}
+	if err := requeueReviewFixBudgetLoop(ctx, repos, loop.ID, nowISO); err != nil {
+		return loop, err
+	}
 	metadata := loop.MetadataJSON
-	var err error
 	switch loop.Type {
 	case "reviewer":
 		encoded, resetErr := ResetReviewerPublishCount(metadata)
@@ -382,12 +401,6 @@ func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, l
 	updated.UpdatedAt = nowISO
 	if err := repos.Loops.Upsert(ctx, updated); err != nil {
 		return loop, err
-	}
-	if err := requeueReviewFixBudgetLoop(ctx, repos, updated.ID, nowISO); err != nil {
-		return updated, err
-	}
-	if err := unpauseSiblingReviewFixLoop(ctx, repos, updated, nowISO); err != nil {
-		return updated, err
 	}
 	return updated, nil
 }

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -51,6 +51,7 @@ func NewReviewFixBudgetAsk(role, repo string, prNumber int64, count, cap int, no
 		Options:  []string{ReviewFixBudgetAnswerContinue, ReviewFixBudgetAnswerStop},
 		Status:   "awaiting",
 		AskedAt:  nowISO,
+		PRNumber: prNumber,
 	}
 }
 
@@ -155,7 +156,23 @@ func IsSiblingReviewFixBudgetPause(metadataJSON *string) bool {
 	return ReadReviewFixBudgetState(metadataJSON).PauseReason == ReviewFixBudgetPauseReason
 }
 
-func FindSiblingReviewFixLoop(all []storage.LoopRecord, loop storage.LoopRecord) *storage.LoopRecord {
+func isManualReviewFixLoop(loop storage.LoopRecord) bool {
+	manual, _ := parseMetadataObject(loop.MetadataJSON)["manual"].(bool)
+	return manual
+}
+
+func isTerminalReviewFixSiblingStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "terminated", "stopped", "completed", "awaiting_human", "human_takeover":
+		return true
+	default:
+		return false
+	}
+}
+
+// FindSiblingReviewFixLoops returns automatic opposite-role loops on the same
+// project/repo/PR. Manual loops are not part of the review-fix budget pair.
+func FindSiblingReviewFixLoops(all []storage.LoopRecord, loop storage.LoopRecord) []storage.LoopRecord {
 	wantType := ""
 	switch strings.TrimSpace(loop.Type) {
 	case "reviewer":
@@ -170,15 +187,33 @@ func FindSiblingReviewFixLoop(all []storage.LoopRecord, loop storage.LoopRecord)
 	if repo == "" || pr == 0 {
 		return nil
 	}
-	for i := range all {
-		candidate := all[i]
+	siblings := make([]storage.LoopRecord, 0)
+	for _, candidate := range all {
 		if candidate.ID == loop.ID || candidate.Type != wantType || candidate.ProjectID != loop.ProjectID {
 			continue
 		}
 		if derefLoopString(candidate.Repo) != repo || derefLoopInt64(candidate.PRNumber) != pr {
 			continue
 		}
-		return &all[i]
+		if isManualReviewFixLoop(candidate) {
+			continue
+		}
+		siblings = append(siblings, candidate)
+	}
+	return siblings
+}
+
+// FindSiblingReviewFixLoop returns the preferred automatic sibling: a
+// non-terminal match when one exists, otherwise the first automatic match.
+func FindSiblingReviewFixLoop(all []storage.LoopRecord, loop storage.LoopRecord) *storage.LoopRecord {
+	siblings := FindSiblingReviewFixLoops(all, loop)
+	for i := range siblings {
+		if !isTerminalReviewFixSiblingStatus(siblings[i].Status) {
+			return &siblings[i]
+		}
+	}
+	if len(siblings) > 0 {
+		return &siblings[0]
 	}
 	return nil
 }
@@ -236,12 +271,16 @@ func parkSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, 
 	if err != nil {
 		return err
 	}
-	sibling := FindSiblingReviewFixLoop(all, exhausted)
-	if sibling == nil {
-		return nil
+	for _, sibling := range FindSiblingReviewFixLoops(all, exhausted) {
+		if err := parkOneSiblingReviewFixLoop(ctx, repos, sibling, exhaustedBy, nowISO); err != nil {
+			return err
+		}
 	}
-	switch sibling.Status {
-	case "terminated", "stopped", "completed", "awaiting_human", "human_takeover":
+	return nil
+}
+
+func parkOneSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, sibling storage.LoopRecord, exhaustedBy, nowISO string) error {
+	if isTerminalReviewFixSiblingStatus(sibling.Status) {
 		return nil
 	}
 	state := ReadReviewFixBudgetState(sibling.MetadataJSON)
@@ -258,7 +297,7 @@ func parkSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, 
 		return err
 	}
 	text := string(encoded)
-	updated := *sibling
+	updated := sibling
 	updated.MetadataJSON = &text
 	updated.Status = "paused"
 	updated.NextRunAt = nil
@@ -343,10 +382,21 @@ func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, l
 	if err := repos.Loops.Upsert(ctx, updated); err != nil {
 		return loop, err
 	}
+	if err := requeueReviewFixBudgetLoop(ctx, repos, updated.ID, nowISO); err != nil {
+		return updated, err
+	}
 	if err := unpauseSiblingReviewFixLoop(ctx, repos, updated, nowISO); err != nil {
 		return updated, err
 	}
 	return updated, nil
+}
+
+func requeueReviewFixBudgetLoop(ctx context.Context, repos *storage.Repositories, loopID, nowISO string) error {
+	if repos == nil || repos.Queue == nil || strings.TrimSpace(loopID) == "" {
+		return nil
+	}
+	_, err := repos.Queue.RequeueLatestCancelledByLoop(ctx, loopID, nowISO)
+	return err
 }
 
 func unpauseSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, nowISO string) error {
@@ -354,10 +404,18 @@ func unpauseSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositorie
 	if err != nil {
 		return err
 	}
-	sibling := FindSiblingReviewFixLoop(all, exhausted)
-	if sibling == nil || sibling.Status != "paused" || !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
-		return nil
+	for _, sibling := range FindSiblingReviewFixLoops(all, exhausted) {
+		if sibling.Status != "paused" || !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+			continue
+		}
+		if err := unpauseOneSiblingReviewFixLoop(ctx, repos, sibling, nowISO); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+func unpauseOneSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, sibling storage.LoopRecord, nowISO string) error {
 	state := ReadReviewFixBudgetState(sibling.MetadataJSON)
 	state.SiblingOf = ""
 	state.PauseReason = ""
@@ -372,12 +430,15 @@ func unpauseSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositorie
 		return err
 	}
 	text := string(encoded)
-	updated := *sibling
+	updated := sibling
 	updated.MetadataJSON = &text
 	updated.Status = "queued"
 	updated.NextRunAt = &nowISO
 	updated.UpdatedAt = nowISO
-	return repos.Loops.Upsert(ctx, updated)
+	if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		return err
+	}
+	return requeueReviewFixBudgetLoop(ctx, repos, updated.ID, nowISO)
 }
 
 func terminateReviewFixPair(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
@@ -389,8 +450,8 @@ func terminateReviewFixPair(ctx context.Context, repos *storage.Repositories, lo
 	if err != nil {
 		return updated, err
 	}
-	if sibling := FindSiblingReviewFixLoop(all, updated); sibling != nil {
-		if _, err := terminateReviewFixLoop(ctx, repos, *sibling, nowISO); err != nil {
+	for _, sibling := range FindSiblingReviewFixLoops(all, updated) {
+		if _, err := terminateReviewFixLoop(ctx, repos, sibling, nowISO); err != nil {
 			return updated, err
 		}
 	}

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nexu-io/looper/internal/eventlog"
 	"github.com/nexu-io/looper/internal/storage"
 )
 
@@ -395,7 +396,44 @@ func requeueReviewFixBudgetLoop(ctx context.Context, repos *storage.Repositories
 	if repos == nil || repos.Queue == nil || strings.TrimSpace(loopID) == "" {
 		return nil
 	}
-	_, err := repos.Queue.RequeueLatestCancelledByLoop(ctx, loopID, nowISO)
+	requeued, err := repos.Queue.RequeueLatestCancelledByLoop(ctx, loopID, nowISO)
+	if err != nil {
+		return err
+	}
+	if requeued > 0 {
+		return nil
+	}
+	active, err := repos.Queue.FindActiveByLoopID(ctx, loopID)
+	if err != nil || active != nil {
+		return err
+	}
+	latest, err := repos.Queue.GetLatestByLoopID(ctx, loopID)
+	if err != nil || latest == nil {
+		return err
+	}
+	if latest.DedupeKey != "" {
+		activeDedupe, dedupeErr := repos.Queue.FindActiveByDedupe(ctx, latest.DedupeKey)
+		if dedupeErr != nil {
+			return dedupeErr
+		}
+		if activeDedupe != nil {
+			return nil
+		}
+	}
+	replacement := *latest
+	replacement.ID = eventlog.NewEventID("queue")
+	replacement.Status = "queued"
+	replacement.AvailableAt = nowISO
+	replacement.Attempts = 0
+	replacement.ClaimedBy = nil
+	replacement.ClaimedAt = nil
+	replacement.StartedAt = nil
+	replacement.FinishedAt = nil
+	replacement.LastError = nil
+	replacement.LastErrorKind = nil
+	replacement.CreatedAt = nowISO
+	replacement.UpdatedAt = nowISO
+	_, _, err = repos.Queue.UpsertActiveByDedupeOrGetExisting(ctx, replacement)
 	return err
 }
 

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -122,6 +122,22 @@ func ReviewerPublishCount(metadataJSON *string) int {
 	return intFromMetadata(loopMeta[reviewerIterationCountKey])
 }
 
+func IncrementReviewerPublishCount(metadataJSON *string) (string, int, error) {
+	meta := parseMetadataObject(metadataJSON)
+	loopMeta, _ := meta[reviewerLoopMetadataKey].(map[string]any)
+	if loopMeta == nil {
+		loopMeta = map[string]any{}
+	}
+	count := intFromMetadata(loopMeta[reviewerIterationCountKey]) + 1
+	loopMeta[reviewerIterationCountKey] = count
+	meta[reviewerLoopMetadataKey] = loopMeta
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return "", 0, err
+	}
+	return string(out), count, nil
+}
+
 func ResetReviewerPublishCount(metadataJSON *string) (string, error) {
 	meta := parseMetadataObject(metadataJSON)
 	loopMeta, _ := meta[reviewerLoopMetadataKey].(map[string]any)
@@ -307,6 +323,9 @@ func parkSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, 
 
 func parkOneSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, sibling storage.LoopRecord, exhaustedBy, nowISO string) error {
 	if !isReviewFixBudgetPauseApplicable(sibling.Status) {
+		return nil
+	}
+	if sibling.Status == "paused" && !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		return nil
 	}
 	state := ReadReviewFixBudgetState(sibling.MetadataJSON)

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -171,6 +171,15 @@ func isTerminalReviewFixSiblingStatus(status string) bool {
 	}
 }
 
+func isReviewFixBudgetPauseApplicable(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "failed", "interrupted":
+		return false
+	default:
+		return !isTerminalReviewFixSiblingStatus(status)
+	}
+}
+
 // FindSiblingReviewFixLoops returns automatic opposite-role loops on the same
 // project/repo/PR. Manual loops are not part of the review-fix budget pair.
 func FindSiblingReviewFixLoops(all []storage.LoopRecord, loop storage.LoopRecord) []storage.LoopRecord {
@@ -293,7 +302,7 @@ func parkSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, 
 }
 
 func parkOneSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, sibling storage.LoopRecord, exhaustedBy, nowISO string) error {
-	if isTerminalReviewFixSiblingStatus(sibling.Status) {
+	if !isReviewFixBudgetPauseApplicable(sibling.Status) {
 		return nil
 	}
 	state := ReadReviewFixBudgetState(sibling.MetadataJSON)
@@ -493,20 +502,18 @@ func unpauseOneSiblingReviewFixLoop(ctx context.Context, repos *storage.Reposito
 }
 
 func terminateReviewFixPair(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
-	updated, err := terminateReviewFixLoop(ctx, repos, loop, nowISO)
+	// Keep awaiting_human + the budget ask until every automatic sibling is
+	// terminated so a later GitHub/Feishu poll can retry the same Stop.
+	all, err := repos.Loops.List(ctx)
 	if err != nil {
 		return loop, err
 	}
-	all, err := repos.Loops.List(ctx)
-	if err != nil {
-		return updated, err
-	}
-	for _, sibling := range FindSiblingReviewFixLoops(all, updated) {
+	for _, sibling := range FindSiblingReviewFixLoops(all, loop) {
 		if _, err := terminateReviewFixLoop(ctx, repos, sibling, nowISO); err != nil {
-			return updated, err
+			return loop, err
 		}
 	}
-	return updated, nil
+	return terminateReviewFixLoop(ctx, repos, loop, nowISO)
 }
 
 func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -1,0 +1,141 @@
+package loops
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestBudgetExhausted(t *testing.T) {
+	t.Parallel()
+	if BudgetExhausted(8, 0) {
+		t.Fatal("cap 0 must be unlimited")
+	}
+	if BudgetExhausted(7, 8) {
+		t.Fatal("7/8 must not be exhausted")
+	}
+	if !BudgetExhausted(8, 8) {
+		t.Fatal("8/8 must be exhausted")
+	}
+}
+
+func TestParkAndContinueReviewFixBudget(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer", "fixer", "queued")
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: "queue_fixer", ProjectID: stringPtr("project_1"), LoopID: &fixer.ID, Type: "fixer",
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Status: "queued",
+		Priority: storage.QueuePriorityFixer, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO, DedupeKey: "fixer:budget",
+	}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	if parked.Status != "awaiting_human" {
+		t.Fatalf("exhausted status = %q, want awaiting_human", parked.Status)
+	}
+	ask, ok := ReadHITLAsk(parked.MetadataJSON)
+	if !ok || !IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("HITL ask = %#v, want review-fix budget ask", ask)
+	}
+
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling = (%#v, %v), want paused sibling budget hold", sibling, err)
+	}
+	queue, err := repos.Queue.GetByID(context.Background(), "queue_fixer")
+	if err != nil || queue == nil || queue.Status != "cancelled" {
+		t.Fatalf("sibling queue = (%#v, %v), want cancelled", queue, err)
+	}
+
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
+	}
+	if result.Loop.Status != "queued" || ReviewerPublishCount(result.Loop.MetadataJSON) != 0 {
+		t.Fatalf("continued loop = %#v, want queued with reset publish count", result.Loop)
+	}
+	sibling, err = repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "queued" || IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling after continue = (%#v, %v), want queued and unpaused", sibling, err)
+	}
+}
+
+func TestApplyReviewFixBudgetAnswerStopTerminatesPair(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_stop", "reviewer", "awaiting_human")
+	_ = seedBudgetLoop(t, repos, nowISO, "loop_fixer_stop", "fixer", "paused")
+	metadata, err := WriteHITLAsk(reviewer.MetadataJSON, NewReviewFixBudgetAsk("reviewer", "acme/looper", 42, 8, 8, nowISO))
+	if err != nil {
+		t.Fatalf("WriteHITLAsk() error = %v", err)
+	}
+	reviewer.MetadataJSON = &metadata
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, reviewer, "Stop", nowISO)
+	if err != nil || !result.Applied || result.Action != "stop" {
+		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
+	}
+	if result.Loop.Status != "terminated" {
+		t.Fatalf("exhausted after stop = %q, want terminated", result.Loop.Status)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), "loop_fixer_stop")
+	if err != nil || sibling == nil || sibling.Status != "terminated" {
+		t.Fatalf("sibling after stop = (%#v, %v), want terminated", sibling, err)
+	}
+}
+
+func TestApplyReviewFixBudgetAnswerIgnoresAgentAsk(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	loop := seedBudgetLoop(t, repos, nowISO, "loop_agent_ask", "fixer", "awaiting_human")
+	metadata, err := WriteHITLAsk(loop.MetadataJSON, HITLAsk{Question: "follow the reviewer?", Status: "awaiting", AskedAt: nowISO})
+	if err != nil {
+		t.Fatalf("WriteHITLAsk() error = %v", err)
+	}
+	loop.MetadataJSON = &metadata
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, loop, "Continue", nowISO)
+	if err != nil || result.Applied {
+		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v), want not applied", result, err)
+	}
+}
+
+func newBudgetFixture(t *testing.T) (*storage.Repositories, string) {
+	t.Helper()
+	coordinator := openCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	seedProject(t, repos, now)
+	return repos, now.UTC().Format("2006-01-02T15:04:05.000Z")
+}
+
+func seedBudgetLoop(t *testing.T, repos *storage.Repositories, nowISO, id, loopType, status string) storage.LoopRecord {
+	t.Helper()
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":8}}`
+	loop := storage.LoopRecord{
+		ID: id, Seq: int64(len(id)), ProjectID: "project_1", Type: loopType, TargetType: "pull_request",
+		TargetID: &target, Repo: &repo, PRNumber: &pr, Status: status, CreatedAt: nowISO, UpdatedAt: nowISO,
+		MetadataJSON: &metadata,
+	}
+	if err := repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert(%s) error = %v", id, err)
+	}
+	return loop
+}
+
+func stringPtr(value string) *string { return &value }

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -21,6 +21,26 @@ func TestBudgetExhausted(t *testing.T) {
 	}
 }
 
+func TestIsReviewFixBudgetContinueRequiresExplicitOption(t *testing.T) {
+	t.Parallel()
+	for _, answer := range []string{"Continue", "continue", " Continue ", "continue another"} {
+		if !IsReviewFixBudgetContinue(answer) {
+			t.Fatalf("IsReviewFixBudgetContinue(%q) = false, want true", answer)
+		}
+	}
+	for _, answer := range []string{
+		"Continue investigating; do not resume yet",
+		"continue the investigation",
+		"continued",
+		"Stop",
+		"",
+	} {
+		if IsReviewFixBudgetContinue(answer) {
+			t.Fatalf("IsReviewFixBudgetContinue(%q) = true, want false", answer)
+		}
+	}
+}
+
 func TestParkAndContinueReviewFixBudget(t *testing.T) {
 	t.Parallel()
 	repos, nowISO := newBudgetFixture(t)

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -76,6 +76,50 @@ func TestParkAndContinueReviewFixBudget(t *testing.T) {
 	}
 }
 
+func TestContinueReviewFixBudgetEnqueuesFreshWorkAfterCompletedClaim(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_completed", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_completed", "fixer", "queued")
+	seedBudgetQueue(t, repos, nowISO, "queue_reviewer_completed", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer_completed", fixer.ID, "fixer", storage.QueuePriorityFixer)
+	if err := repos.Queue.Complete(context.Background(), "queue_reviewer_completed", nowISO); err != nil {
+		t.Fatalf("Queue.Complete() error = %v", err)
+	}
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	completed, err := repos.Queue.GetByID(context.Background(), "queue_reviewer_completed")
+	if err != nil || completed == nil || completed.Status != "completed" {
+		t.Fatalf("exhausted claim after park = (%#v, %v), want completed", completed, err)
+	}
+	siblingQueue, err := repos.Queue.GetByID(context.Background(), "queue_fixer_completed")
+	if err != nil || siblingQueue == nil || siblingQueue.Status != "cancelled" {
+		t.Fatalf("sibling queue after park = (%#v, %v), want cancelled", siblingQueue, err)
+	}
+
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
+	}
+	active, err := repos.Queue.FindActiveByLoopID(context.Background(), reviewer.ID)
+	if err != nil || active == nil || active.Status != "queued" || active.ID == "queue_reviewer_completed" {
+		t.Fatalf("exhausted active queue = (%#v, %v), want a fresh queued item", active, err)
+	}
+	completed, err = repos.Queue.GetByID(context.Background(), "queue_reviewer_completed")
+	if err != nil || completed == nil || completed.Status != "completed" {
+		t.Fatalf("original claim after continue = (%#v, %v), want still completed", completed, err)
+	}
+	siblingQueue, err = repos.Queue.GetByID(context.Background(), "queue_fixer_completed")
+	if err != nil || siblingQueue == nil || siblingQueue.Status != "queued" {
+		t.Fatalf("sibling queue after continue = (%#v, %v), want requeued", siblingQueue, err)
+	}
+}
+
 func TestApplyReviewFixBudgetAnswerStopTerminatesPair(t *testing.T) {
 	t.Parallel()
 	repos, nowISO := newBudgetFixture(t)

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -210,6 +210,90 @@ func TestParkAndStopReviewFixBudgetSkipsManualSibling(t *testing.T) {
 	}
 }
 
+func TestParkReviewFixBudgetCompletesSiblingAfterPartialPark(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_partial", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_partial", "fixer", "queued")
+	seedBudgetQueue(t, repos, nowISO, "queue_reviewer_partial", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer_partial", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	ask := NewReviewFixBudgetAsk("reviewer", "acme/looper", 42, 8, 8, nowISO)
+	ask.Transport = "github"
+	ask.AskCommentID = 99
+	metadata, err := WriteHITLAsk(reviewer.MetadataJSON, ask)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk() error = %v", err)
+	}
+	state := ReadReviewFixBudgetState(&metadata)
+	state.ExhaustedBy = "reviewer"
+	metadata, err = WriteReviewFixBudgetState(&metadata, state)
+	if err != nil {
+		t.Fatalf("WriteReviewFixBudgetState() error = %v", err)
+	}
+	reviewer.MetadataJSON = &metadata
+	reviewer.Status = "awaiting_human"
+	reviewer.NextRunAt = nil
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(partial reviewer) error = %v", err)
+	}
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	kept, ok := ReadHITLAsk(parked.MetadataJSON)
+	if !ok || kept.Transport != "github" || kept.AskCommentID != 99 {
+		t.Fatalf("HITL ask after retry = %#v, want preserved github delivery stamps", kept)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling after retry = (%#v, %v), want paused", sibling, err)
+	}
+	for _, queueID := range []string{"queue_reviewer_partial", "queue_fixer_partial"} {
+		queue, err := repos.Queue.GetByID(context.Background(), queueID)
+		if err != nil || queue == nil || queue.Status != "cancelled" {
+			t.Fatalf("%s after retry = (%#v, %v), want cancelled", queueID, queue, err)
+		}
+	}
+}
+
+func TestContinueReviewFixBudgetRetriesAfterSiblingAlreadyUnpaused(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_retry", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_retry", "fixer", "queued")
+	seedBudgetQueue(t, repos, nowISO, "queue_reviewer_retry", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer_retry", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	if err := unpauseSiblingReviewFixLoop(context.Background(), repos, parked, nowISO); err != nil {
+		t.Fatalf("unpauseSiblingReviewFixLoop() error = %v", err)
+	}
+
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
+	}
+	if result.Loop.Status != "queued" {
+		t.Fatalf("continued loop status = %q, want queued", result.Loop.Status)
+	}
+	if _, ok := ReadHITLAsk(result.Loop.MetadataJSON); ok {
+		t.Fatal("continued loop still has a HITL ask")
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "queued" || IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling after retry continue = (%#v, %v), want queued and unpaused", sibling, err)
+	}
+}
+
 func TestApplyReviewFixBudgetAnswerIgnoresAgentAsk(t *testing.T) {
 	t.Parallel()
 	repos, nowISO := newBudgetFixture(t)

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -294,6 +294,83 @@ func TestContinueReviewFixBudgetRetriesAfterSiblingAlreadyUnpaused(t *testing.T)
 	}
 }
 
+func TestParkAndContinueReviewFixBudgetSkipsFailedSibling(t *testing.T) {
+	t.Parallel()
+	for _, status := range []string{"failed", "interrupted"} {
+		status := status
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			repos, nowISO := newBudgetFixture(t)
+			reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_"+status, "reviewer", "running")
+			fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_"+status, "fixer", status)
+			seedBudgetQueue(t, repos, nowISO, "queue_reviewer_"+status, reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+			seedBudgetQueue(t, repos, nowISO, "queue_fixer_"+status, fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+			parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+				Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+			})
+			if err != nil {
+				t.Fatalf("ParkReviewFixBudget() error = %v", err)
+			}
+			sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+			if err != nil || sibling == nil || sibling.Status != status || IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+				t.Fatalf("sibling after park = (%#v, %v), want still %s", sibling, err, status)
+			}
+			siblingQueue, err := repos.Queue.GetByID(context.Background(), "queue_fixer_"+status)
+			if err != nil || siblingQueue == nil || siblingQueue.Status != "queued" {
+				t.Fatalf("sibling queue after park = (%#v, %v), want still queued", siblingQueue, err)
+			}
+
+			result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+			if err != nil || !result.Applied || result.Action != "continue" {
+				t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
+			}
+			sibling, err = repos.Loops.GetByID(context.Background(), fixer.ID)
+			if err != nil || sibling == nil || sibling.Status != status || IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+				t.Fatalf("sibling after continue = (%#v, %v), want still %s", sibling, err, status)
+			}
+			siblingQueue, err = repos.Queue.GetByID(context.Background(), "queue_fixer_"+status)
+			if err != nil || siblingQueue == nil || siblingQueue.Status != "queued" {
+				t.Fatalf("sibling queue after continue = (%#v, %v), want not requeued as fresh work", siblingQueue, err)
+			}
+		})
+	}
+}
+
+func TestStopReviewFixBudgetRetriesAfterSiblingAlreadyTerminated(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_stop_retry", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_stop_retry", "fixer", "queued")
+	seedBudgetQueue(t, repos, nowISO, "queue_reviewer_stop_retry", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer_stop_retry", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	if _, err := terminateReviewFixLoop(context.Background(), repos, fixer, nowISO); err != nil {
+		t.Fatalf("terminateReviewFixLoop(sibling) error = %v", err)
+	}
+
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO)
+	if err != nil || !result.Applied || result.Action != "stop" {
+		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
+	}
+	if result.Loop.Status != "terminated" {
+		t.Fatalf("exhausted after retry stop = %q, want terminated", result.Loop.Status)
+	}
+	if _, ok := ReadHITLAsk(result.Loop.MetadataJSON); ok {
+		t.Fatal("exhausted loop still has a HITL ask after retry stop")
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "terminated" {
+		t.Fatalf("sibling after retry stop = (%#v, %v), want terminated", sibling, err)
+	}
+}
+
 func TestApplyReviewFixBudgetAnswerIgnoresAgentAsk(t *testing.T) {
 	t.Parallel()
 	repos, nowISO := newBudgetFixture(t)

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -314,6 +314,54 @@ func TestContinueReviewFixBudgetRetriesAfterSiblingAlreadyUnpaused(t *testing.T)
 	}
 }
 
+func TestParkAndContinueReviewFixBudgetSkipsPreexistingPausedSibling(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_pre_paused", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_pre_paused", "fixer", "paused")
+	pauseMeta := `{"pauseReason":"fixer_zero_progress"}`
+	fixer.MetadataJSON = &pauseMeta
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(pre-paused fixer) error = %v", err)
+	}
+	seedBudgetQueue(t, repos, nowISO, "queue_reviewer_pre_paused", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer_pre_paused", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling after park = (%#v, %v), want still independently paused", sibling, err)
+	}
+	if reason, _ := stringFromAny(parseMetadataObject(sibling.MetadataJSON)["pauseReason"]); reason != "fixer_zero_progress" {
+		t.Fatalf("sibling pauseReason = %q, want fixer_zero_progress", reason)
+	}
+	siblingQueue, err := repos.Queue.GetByID(context.Background(), "queue_fixer_pre_paused")
+	if err != nil || siblingQueue == nil || siblingQueue.Status != "queued" {
+		t.Fatalf("sibling queue after park = (%#v, %v), want still queued", siblingQueue, err)
+	}
+
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
+	}
+	sibling, err = repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling after continue = (%#v, %v), want still independently paused", sibling, err)
+	}
+	if reason, _ := stringFromAny(parseMetadataObject(sibling.MetadataJSON)["pauseReason"]); reason != "fixer_zero_progress" {
+		t.Fatalf("sibling pauseReason after continue = %q, want fixer_zero_progress", reason)
+	}
+	siblingQueue, err = repos.Queue.GetByID(context.Background(), "queue_fixer_pre_paused")
+	if err != nil || siblingQueue == nil || siblingQueue.Status != "queued" {
+		t.Fatalf("sibling queue after continue = (%#v, %v), want not requeued as budget work", siblingQueue, err)
+	}
+}
+
 func TestParkAndContinueReviewFixBudgetSkipsFailedSibling(t *testing.T) {
 	t.Parallel()
 	for _, status := range []string{"failed", "interrupted"} {

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -26,13 +26,8 @@ func TestParkAndContinueReviewFixBudget(t *testing.T) {
 	repos, nowISO := newBudgetFixture(t)
 	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer", "reviewer", "running")
 	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer", "fixer", "queued")
-	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
-		ID: "queue_fixer", ProjectID: stringPtr("project_1"), LoopID: &fixer.ID, Type: "fixer",
-		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Status: "queued",
-		Priority: storage.QueuePriorityFixer, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO, DedupeKey: "fixer:budget",
-	}); err != nil {
-		t.Fatalf("Queue.Upsert() error = %v", err)
-	}
+	seedBudgetQueue(t, repos, nowISO, "queue_reviewer", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
 		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
@@ -44,17 +39,22 @@ func TestParkAndContinueReviewFixBudget(t *testing.T) {
 		t.Fatalf("exhausted status = %q, want awaiting_human", parked.Status)
 	}
 	ask, ok := ReadHITLAsk(parked.MetadataJSON)
-	if !ok || !IsReviewFixBudgetAsk(ask) {
-		t.Fatalf("HITL ask = %#v, want review-fix budget ask", ask)
+	if !ok || !IsReviewFixBudgetAsk(ask) || ask.PRNumber != 42 {
+		t.Fatalf("HITL ask = %#v, want review-fix budget ask with PR 42", ask)
+	}
+	if ask.Transport != "" || ask.AskCommentID != 0 {
+		t.Fatalf("HITL ask transport = %#v, want unset until GitHub delivery", ask)
 	}
 
 	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
 	if err != nil || sibling == nil || sibling.Status != "paused" || !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		t.Fatalf("sibling = (%#v, %v), want paused sibling budget hold", sibling, err)
 	}
-	queue, err := repos.Queue.GetByID(context.Background(), "queue_fixer")
-	if err != nil || queue == nil || queue.Status != "cancelled" {
-		t.Fatalf("sibling queue = (%#v, %v), want cancelled", queue, err)
+	for _, queueID := range []string{"queue_reviewer", "queue_fixer"} {
+		queue, err := repos.Queue.GetByID(context.Background(), queueID)
+		if err != nil || queue == nil || queue.Status != "cancelled" {
+			t.Fatalf("%s = (%#v, %v), want cancelled", queueID, queue, err)
+		}
 	}
 
 	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
@@ -67,6 +67,12 @@ func TestParkAndContinueReviewFixBudget(t *testing.T) {
 	sibling, err = repos.Loops.GetByID(context.Background(), fixer.ID)
 	if err != nil || sibling == nil || sibling.Status != "queued" || IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		t.Fatalf("sibling after continue = (%#v, %v), want queued and unpaused", sibling, err)
+	}
+	for _, queueID := range []string{"queue_reviewer", "queue_fixer"} {
+		queue, err := repos.Queue.GetByID(context.Background(), queueID)
+		if err != nil || queue == nil || queue.Status != "queued" {
+			t.Fatalf("%s after continue = (%#v, %v), want queued", queueID, queue, err)
+		}
 	}
 }
 
@@ -94,6 +100,69 @@ func TestApplyReviewFixBudgetAnswerStopTerminatesPair(t *testing.T) {
 	sibling, err := repos.Loops.GetByID(context.Background(), "loop_fixer_stop")
 	if err != nil || sibling == nil || sibling.Status != "terminated" {
 		t.Fatalf("sibling after stop = (%#v, %v), want terminated", sibling, err)
+	}
+}
+
+func TestFindSiblingReviewFixLoopPrefersActiveAutomatic(t *testing.T) {
+	t.Parallel()
+	repo := "acme/looper"
+	pr := int64(42)
+	reviewer := storage.LoopRecord{ID: "loop_reviewer", ProjectID: "project_1", Type: "reviewer", Repo: &repo, PRNumber: &pr}
+	manual := `{"manual":true}`
+	manualFixer := storage.LoopRecord{ID: "loop_manual_fixer", ProjectID: "project_1", Type: "fixer", Status: "queued", Repo: &repo, PRNumber: &pr, MetadataJSON: &manual}
+	terminalFixer := storage.LoopRecord{ID: "loop_terminal_fixer", ProjectID: "project_1", Type: "fixer", Status: "terminated", Repo: &repo, PRNumber: &pr}
+	automaticFixer := storage.LoopRecord{ID: "loop_auto_fixer", ProjectID: "project_1", Type: "fixer", Status: "queued", Repo: &repo, PRNumber: &pr}
+
+	got := FindSiblingReviewFixLoop([]storage.LoopRecord{manualFixer, terminalFixer, automaticFixer}, reviewer)
+	if got == nil || got.ID != automaticFixer.ID {
+		t.Fatalf("FindSiblingReviewFixLoop() = %#v, want automatic fixer", got)
+	}
+	siblings := FindSiblingReviewFixLoops([]storage.LoopRecord{manualFixer, terminalFixer, automaticFixer}, reviewer)
+	if len(siblings) != 2 || siblings[0].ID != terminalFixer.ID || siblings[1].ID != automaticFixer.ID {
+		t.Fatalf("FindSiblingReviewFixLoops() = %#v, want automatic siblings only", siblings)
+	}
+}
+
+func TestParkAndStopReviewFixBudgetSkipsManualSibling(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_multi", "reviewer", "running")
+	manual := seedBudgetLoop(t, repos, nowISO, "loop_fixer_manual", "fixer", "queued")
+	manualMeta := `{"manual":true}`
+	manual.MetadataJSON = &manualMeta
+	if err := repos.Loops.Upsert(context.Background(), manual); err != nil {
+		t.Fatalf("Loops.Upsert(manual) error = %v", err)
+	}
+	automatic := seedBudgetLoop(t, repos, nowISO, "loop_fixer_auto", "fixer", "queued")
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer_manual", manual.ID, "fixer", storage.QueuePriorityFixer)
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer_auto", automatic.ID, "fixer", storage.QueuePriorityFixer)
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	manualAfter, err := repos.Loops.GetByID(context.Background(), manual.ID)
+	if err != nil || manualAfter == nil || manualAfter.Status != "queued" {
+		t.Fatalf("manual sibling = (%#v, %v), want still queued", manualAfter, err)
+	}
+	automaticAfter, err := repos.Loops.GetByID(context.Background(), automatic.ID)
+	if err != nil || automaticAfter == nil || automaticAfter.Status != "paused" || !IsSiblingReviewFixBudgetPause(automaticAfter.MetadataJSON) {
+		t.Fatalf("automatic sibling = (%#v, %v), want paused", automaticAfter, err)
+	}
+
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO)
+	if err != nil || !result.Applied || result.Action != "stop" {
+		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
+	}
+	manualAfter, err = repos.Loops.GetByID(context.Background(), manual.ID)
+	if err != nil || manualAfter == nil || manualAfter.Status != "queued" {
+		t.Fatalf("manual sibling after stop = (%#v, %v), want still queued", manualAfter, err)
+	}
+	automaticAfter, err = repos.Loops.GetByID(context.Background(), automatic.ID)
+	if err != nil || automaticAfter == nil || automaticAfter.Status != "terminated" {
+		t.Fatalf("automatic sibling after stop = (%#v, %v), want terminated", automaticAfter, err)
 	}
 }
 
@@ -136,6 +205,17 @@ func seedBudgetLoop(t *testing.T, repos *storage.Repositories, nowISO, id, loopT
 		t.Fatalf("Loops.Upsert(%s) error = %v", id, err)
 	}
 	return loop
+}
+
+func seedBudgetQueue(t *testing.T, repos *storage.Repositories, nowISO, id, loopID, queueType string, priority int64) {
+	t.Helper()
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: id, ProjectID: stringPtr("project_1"), LoopID: &loopID, Type: queueType,
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Status: "queued",
+		Priority: priority, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO, DedupeKey: queueType + ":" + id,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert(%s) error = %v", id, err)
+	}
 }
 
 func stringPtr(value string) *string { return &value }

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -718,7 +718,7 @@ func New(options Options) *Runner {
 	}
 	loopConfig := options.LoopConfig
 	if loopConfig == (config.ReviewerLoopConfig{}) {
-		loopConfig = config.ReviewerLoopConfig{EnabledByDefault: false, QuietPeriodSeconds: 60, MinPublishIntervalSeconds: 300, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 0, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25, StopOnApproved: false, StopOnReadyLabel: true, StopOnIdenticalOutput: true}
+		loopConfig = config.ReviewerLoopConfig{EnabledByDefault: false, QuietPeriodSeconds: 60, MinPublishIntervalSeconds: 300, MaxIterationsPerPR: 20, MaxIterationsPerHead: 1, MaxWallClockSeconds: 0, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25, StopOnApproved: false, StopOnReadyLabel: true, StopOnIdenticalOutput: true, MaxPublishesPerPR: config.DefaultReviewFixBudgetCap}
 	}
 	scope := options.Scope
 	if scope == "" {
@@ -1065,6 +1065,16 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		return nil
 	}
 	if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && last == pr.HeadSHA && pr.HeadSHA != "" {
+		result.Skipped++
+		return nil
+	}
+	if loopResult.record.Status == "awaiting_human" || loopResult.record.Status == "human_takeover" {
+		result.Skipped++
+		return nil
+	}
+	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
+		return err
+	} else if parked {
 		result.Skipped++
 		return nil
 	}
@@ -1817,12 +1827,23 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		if metaErr == nil {
 			updated.MetadataJSON = &metadataJSON
 		}
+		if r.shouldParkReviewerBudget(*updated, checkpoint) {
+			updated.LastRunAt = stringPtr(r.nowISO())
+			updated.NextRunAt = nil
+			return
+		}
 		updated.Status = r.loopSuccessStatus(updated.Status, updated.MetadataJSON, checkpoint.SkipReason)
 		updated.LastRunAt = stringPtr(r.nowISO())
 		updated.NextRunAt = nil
 	})
 	if err != nil {
 		return ProcessResult{}, err
+	}
+	if parked, parkErr := r.parkReviewerBudgetIfExhausted(ctx, updatedLoop); parkErr != nil {
+		return ProcessResult{}, parkErr
+	} else if parked {
+		r.cleanupReviewerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
+		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
 	}
 	if reason := terminalReviewerLoopReason(updatedLoop); reason != "" {
 		if _, err := r.repos.Queue.CancelByLoop(ctx, updatedLoop.ID, r.nowISO(), &reason); err != nil {
@@ -6192,11 +6213,54 @@ func (r *Runner) loopSuccessStatus(currentStatus string, metadataJSON *string, s
 
 func isTerminalReviewerLoopStatus(status string) bool {
 	switch status {
-	case "terminated", "failed", "paused", "stopped":
+	case "terminated", "failed", "paused", "stopped", "awaiting_human", "human_takeover":
 		return true
 	default:
 		return false
 	}
+}
+
+func (r *Runner) maxPublishesPerPR(projectID string) int {
+	if r.projectRoleConfig != nil {
+		return config.ProjectRoleConfigs(*r.projectRoleConfig, projectID).Reviewer.Behavior.Loop.MaxPublishesPerPR
+	}
+	return r.loopConfig.MaxPublishesPerPR
+}
+
+func (r *Runner) shouldParkReviewerBudget(loop storage.LoopRecord, checkpoint reviewerCheckpoint) bool {
+	if isManualReviewerLoop(loop) || checkpoint.SkipReason != "" || checkpoint.PendingReview == nil {
+		return false
+	}
+	if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
+		return false
+	}
+	return loops.BudgetExhausted(loops.ReviewerPublishCount(loop.MetadataJSON), r.maxPublishesPerPR(loop.ProjectID))
+}
+
+func (r *Runner) parkReviewerBudgetIfExhausted(ctx context.Context, loop storage.LoopRecord) (bool, error) {
+	if loop.Status == "awaiting_human" || loop.Status == "terminated" || loop.Status == "stopped" {
+		return loop.Status == "awaiting_human", nil
+	}
+	if isManualReviewerLoop(loop) {
+		return false, nil
+	}
+	if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
+		return false, nil
+	}
+	cap := r.maxPublishesPerPR(loop.ProjectID)
+	if !loops.BudgetExhausted(loops.ReviewerPublishCount(loop.MetadataJSON), cap) {
+		return false, nil
+	}
+	_, err := loops.ParkReviewFixBudget(ctx, r.repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: loop,
+		Role:      "reviewer",
+		Repo:      derefString(loop.Repo),
+		PRNumber:  derefInt64(loop.PRNumber),
+		Count:     loops.ReviewerPublishCount(loop.MetadataJSON),
+		Cap:       cap,
+		NowISO:    r.nowISO(),
+	})
+	return err == nil, err
 }
 
 func terminalReviewerLoopReason(loop storage.LoopRecord) string {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1844,7 +1844,7 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if err != nil {
 		return ProcessResult{}, err
 	}
-	if parked, parkErr := r.parkReviewerBudgetIfExhausted(ctx, updatedLoop); parkErr != nil {
+	if parked, parkErr := r.parkReviewerBudgetAfterSuccessfulRun(ctx, *project, updatedLoop); parkErr != nil {
 		return ProcessResult{}, parkErr
 	} else if parked {
 		r.cleanupReviewerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
@@ -6253,6 +6253,40 @@ func (r *Runner) shouldParkReviewerBudget(loop storage.LoopRecord, checkpoint re
 		return false
 	}
 	return loops.BudgetExhausted(loops.ReviewerPublishCount(loop.MetadataJSON), r.maxPublishesPerPR(loop.ProjectID))
+}
+
+func (r *Runner) livePullRequestClosed(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64) bool {
+	if r.github == nil || strings.TrimSpace(repo) == "" || prNumber == 0 {
+		return false
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: project.RepoPath})
+	if err != nil {
+		return false
+	}
+	return normalizePRState(detail.State) != "open"
+}
+
+func (r *Runner) shouldCreateReviewerBudgetPark(loop storage.LoopRecord) bool {
+	if loop.Status == "terminated" || loop.Status == "stopped" || loop.Status == "awaiting_human" {
+		return false
+	}
+	if !r.reviewFixHITLEnabled() || isManualReviewerLoop(loop) {
+		return false
+	}
+	if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
+		return false
+	}
+	return loops.BudgetExhausted(loops.ReviewerPublishCount(loop.MetadataJSON), r.maxPublishesPerPR(loop.ProjectID))
+}
+
+func (r *Runner) parkReviewerBudgetAfterSuccessfulRun(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord) (bool, error) {
+	if r.shouldCreateReviewerBudgetPark(loop) && r.livePullRequestClosed(ctx, project, derefString(loop.Repo), derefInt64(loop.PRNumber)) {
+		if err := r.terminateLoop(ctx, loop, "pr_closed_or_merged"); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	return r.parkReviewerBudgetIfExhausted(ctx, loop)
 }
 
 func (r *Runner) parkReviewerBudgetIfExhausted(ctx context.Context, loop storage.LoopRecord) (bool, error) {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1604,6 +1604,11 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		summary := fmt.Sprintf("Skipped terminal reviewer loop %s: %s", loop.ID, reason)
 		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, nil
 	}
+	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, *loop); err != nil {
+		return ProcessResult{}, err
+	} else if parked {
+		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: "review-fix budget exhausted"}, nil
+	}
 	project, err := r.repos.Projects.GetByID(ctx, loop.ProjectID)
 	if err != nil {
 		return ProcessResult{}, err

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -6227,8 +6227,12 @@ func (r *Runner) maxPublishesPerPR(projectID string) int {
 	return r.loopConfig.MaxPublishesPerPR
 }
 
+func (r *Runner) reviewFixHITLEnabled() bool {
+	return r.projectRoleConfig != nil && r.projectRoleConfig.HITL.Enabled
+}
+
 func (r *Runner) shouldParkReviewerBudget(loop storage.LoopRecord, checkpoint reviewerCheckpoint) bool {
-	if isManualReviewerLoop(loop) || checkpoint.SkipReason != "" || checkpoint.PendingReview == nil {
+	if !r.reviewFixHITLEnabled() || isManualReviewerLoop(loop) || checkpoint.SkipReason != "" || checkpoint.PendingReview == nil {
 		return false
 	}
 	if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
@@ -6238,19 +6242,29 @@ func (r *Runner) shouldParkReviewerBudget(loop storage.LoopRecord, checkpoint re
 }
 
 func (r *Runner) parkReviewerBudgetIfExhausted(ctx context.Context, loop storage.LoopRecord) (bool, error) {
-	if loop.Status == "awaiting_human" || loop.Status == "terminated" || loop.Status == "stopped" {
-		return loop.Status == "awaiting_human", nil
-	}
-	if isManualReviewerLoop(loop) {
+	if loop.Status == "terminated" || loop.Status == "stopped" {
 		return false, nil
 	}
-	if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
-		return false, nil
+	if loop.Status == "awaiting_human" {
+		if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
+			return true, nil
+		}
+	} else {
+		if !r.reviewFixHITLEnabled() {
+			return false, nil
+		}
+		if isManualReviewerLoop(loop) {
+			return false, nil
+		}
+		if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
+			return false, nil
+		}
+		cap := r.maxPublishesPerPR(loop.ProjectID)
+		if !loops.BudgetExhausted(loops.ReviewerPublishCount(loop.MetadataJSON), cap) {
+			return false, nil
+		}
 	}
 	cap := r.maxPublishesPerPR(loop.ProjectID)
-	if !loops.BudgetExhausted(loops.ReviewerPublishCount(loop.MetadataJSON), cap) {
-		return false, nil
-	}
 	_, err := loops.ParkReviewFixBudget(ctx, r.repos, loops.ParkReviewFixBudgetInput{
 		Exhausted: loop,
 		Role:      "reviewer",

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1604,11 +1604,6 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		summary := fmt.Sprintf("Skipped terminal reviewer loop %s: %s", loop.ID, reason)
 		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, nil
 	}
-	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, *loop); err != nil {
-		return ProcessResult{}, err
-	} else if parked {
-		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: "review-fix budget exhausted"}, nil
-	}
 	project, err := r.repos.Projects.GetByID(ctx, loop.ProjectID)
 	if err != nil {
 		return ProcessResult{}, err
@@ -1616,12 +1611,24 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if project == nil {
 		return ProcessResult{}, fmt.Errorf("project not found: %s", loop.ProjectID)
 	}
+	if r.shouldCreateReviewerBudgetPark(*loop) && r.livePullRequestClosed(ctx, *project, derefString(loop.Repo), derefInt64(loop.PRNumber)) {
+		if err := r.terminateLoop(ctx, *loop, "pr_closed_or_merged"); err != nil {
+			return ProcessResult{}, err
+		}
+		summary := fmt.Sprintf("Skipped terminal reviewer loop %s: pr_closed_or_merged", loop.ID)
+		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, nil
+	}
 	if err := r.revalidateRoutedReviewerClaim(ctx, *project, queueItem); err != nil {
 		var holdErr *holdSkipError
 		if errors.As(err, &holdErr) {
 			return r.finishHeldReviewerQueueItem(ctx, *loop, nil, queueItem, reviewerCheckpoint{}, holdErr.summary)
 		}
 		return ProcessResult{}, err
+	}
+	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, *loop); err != nil {
+		return ProcessResult{}, err
+	} else if parked {
+		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: "review-fix budget exhausted"}, nil
 	}
 	resumedRun, err := r.createRunContext(ctx, *loop)
 	if err != nil {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4626,10 +4626,19 @@ func isValidBlockingReviewEvent(value string) bool {
 
 func (r *Runner) recordPublishedReviewProgress(ctx context.Context, input stepInput, pending pendingReviewCheckpoint, reviewEvent ReviewEvent) error {
 	if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) {
+		previous, _ := stringFromAny(parseJSONObject(updated.MetadataJSON)["lastPublishedHeadSha"])
 		metadataJSON, err := mergeLoopMetadataJSON(updated.MetadataJSON, map[string]any{"lastPublishedHeadSha": pending.HeadSHA, "lastReviewEvent": string(reviewEvent), "lastReviewSummary": pending.Summary, "lastPublishedAt": r.nowISO()})
-		if err == nil {
-			updated.MetadataJSON = stringPtr(metadataJSON)
+		if err != nil {
+			return
 		}
+		if strings.TrimSpace(previous) != strings.TrimSpace(pending.HeadSHA) {
+			counted, _, countErr := loops.IncrementReviewerPublishCount(&metadataJSON)
+			if countErr != nil {
+				return
+			}
+			metadataJSON = counted
+		}
+		updated.MetadataJSON = stringPtr(metadataJSON)
 	}); err != nil {
 		return err
 	}
@@ -6330,7 +6339,9 @@ func (r *Runner) recordLoopSuccessMetadata(current *string, checkpoint reviewerC
 	loopMeta["lastStatus"] = "success"
 	loopMeta["consecutiveFailures"] = 0
 	reviewCompleted := checkpoint.SkipReason == "" && checkpoint.PendingReview != nil
-	if reviewCompleted {
+	publishedHead, _ := stringFromAny(meta["lastPublishedHeadSha"])
+	alreadyCounted := publishedHead != "" && (head == "" || publishedHead == head)
+	if reviewCompleted && !alreadyCounted {
 		loopMeta["iterationCount"] = iterations + 1
 	}
 	if reviewCompleted && head != "" {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1934,6 +1934,67 @@ func TestEnsureLoopForPullRequestReactivatesLegacyBudgetTerminatedLoop(t *testin
 	}
 }
 
+func TestProcessClaimedItemParksExhaustedBudgetBeforeRun(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	projectID := "project_1"
+	loopID := "loop_reviewer_budget_entry"
+	metadata := `{"loop":{"iterationCount":1}}`
+	reviewer := storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	fixer := storage.LoopRecord{ID: "loop_fixer_budget_entry", Seq: 2, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_budget_entry", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:budget-entry", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 1
+	cfg.HITL.Enabled = true
+	agent := &fakeAgentExecutor{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg})
+
+	result, err := runner.ProcessClaimedItem(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_budget_entry", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, Status: "running"})
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped at claim start", result)
+	}
+	if len(agent.starts) != 0 {
+		t.Fatalf("agent.starts = %#v, want none after lowered-cap claim", agent.starts)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || updated == nil || updated.Status != "awaiting_human" {
+		t.Fatalf("reviewer = (%#v, %v), want awaiting_human", updated, err)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer sibling = (%#v, %v), want paused sibling hold", sibling, err)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_reviewer_budget_entry")
+	if err != nil || queue == nil || queue.Status != "cancelled" {
+		t.Fatalf("queue = (%#v, %v), want cancelled claimed item", queue, err)
+	}
+	runs, err := fixture.repos.Runs.ListByLoop(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Runs.ListByLoop() error = %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("runs = %#v, want no run after restart/claim park", runs)
+	}
+}
+
 func TestParkReviewerBudgetIfExhaustedParksSibling(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1995,6 +1995,60 @@ func TestProcessClaimedItemParksExhaustedBudgetBeforeRun(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemDoesNotParkBudgetWhenPublishClosesPR(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	fixer := storage.LoopRecord{ID: "loop_fixer_budget_closed_pr", Seq: 2, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 1
+	cfg.HITL.Enabled = true
+	github := &fakeGitHubGateway{closeAfterReviewMarker: true, reviewRequests: []string{"octocat"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success after published review", result)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil || loop == nil || loop.Status != "terminated" {
+		t.Fatalf("reviewer = (%#v, %v), want terminated product terminal", loop, err)
+	}
+	if loops.ReviewerPublishCount(loop.MetadataJSON) < 1 {
+		t.Fatalf("publish count = %d, want cap-reaching publish before closed-PR terminal", loops.ReviewerPublishCount(loop.MetadataJSON))
+	}
+	if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "pr_closed_or_merged" {
+		t.Fatalf("terminationReason = %q, want pr_closed_or_merged", reason)
+	}
+	if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("HITL ask = %#v, want no budget ask on a closed PR", ask)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "waiting" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer sibling = (%#v, %v), want still waiting without budget pause", sibling, err)
+	}
+}
+
 func TestParkReviewerBudgetIfExhaustedParksSibling(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -10126,6 +10180,8 @@ type fakeGitHubGateway struct {
 	viewDiff                        string
 	viewState                       string
 	viewStateAfterFirstView         string
+	closeAfterReviewMarker          bool
+	closeOnNextView                 bool
 	viewErrs                        []error
 	issueDetailErr                  error
 	addReactionErr                  error
@@ -10245,6 +10301,9 @@ func (g *fakeGitHubGateway) ViewPullRequest(context.Context, ViewPullRequestInpu
 	if g.viewStateAfterFirstView != "" && g.viewCalls > 1 {
 		state = g.viewStateAfterFirstView
 	}
+	if g.closeAfterReviewMarker && g.closeOnNextView {
+		state = "CLOSED"
+	}
 	if state == "" {
 		state = "OPEN"
 	}
@@ -10357,6 +10416,9 @@ func (g *fakeGitHubGateway) CapturePullRequestSnapshot(_ context.Context, input 
 func (g *fakeGitHubGateway) FindReviewMarker(_ context.Context, input VerifyReviewMarkerInput) (ReviewMarkerResult, error) {
 	g.reviewMarkerCalls++
 	g.reviewMarkerInputs = append(g.reviewMarkerInputs, input)
+	if g.closeAfterReviewMarker {
+		g.closeOnNextView = true
+	}
 	if g.reviewMarkerErr != nil {
 		return ReviewMarkerResult{}, g.reviewMarkerErr
 	}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1950,7 +1950,12 @@ func TestParkReviewerBudgetIfExhaustedParksSibling(t *testing.T) {
 	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
 		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
 	}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{MaxPublishesPerPR: 8}})
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.HITL.Enabled = true
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{MaxPublishesPerPR: 8}, CustomInstructions: &cfg})
 	parked, err := runner.parkReviewerBudgetIfExhausted(context.Background(), reviewer)
 	if err != nil || !parked {
 		t.Fatalf("parkReviewerBudgetIfExhausted() = (%v, %v), want parked", parked, err)
@@ -1962,6 +1967,76 @@ func TestParkReviewerBudgetIfExhaustedParksSibling(t *testing.T) {
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
 	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		t.Fatalf("fixer sibling = (%#v, %v), want paused sibling hold", sibling, err)
+	}
+}
+
+func TestParkReviewerBudgetIfExhaustedSkipsWhenHITLDisabled(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	reviewerTarget := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":8}}`
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_no_hitl", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	fixer := storage.LoopRecord{ID: "loop_fixer_budget_no_hitl", Seq: 2, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	if cfg.HITL.Enabled {
+		t.Fatal("DefaultConfig HITL.Enabled = true, want false")
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg})
+	parked, err := runner.parkReviewerBudgetIfExhausted(context.Background(), reviewer)
+	if err != nil || parked {
+		t.Fatalf("parkReviewerBudgetIfExhausted() = (%v, %v), want skipped under default HITL-off config", parked, err)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || updated == nil || updated.Status != "running" {
+		t.Fatalf("reviewer = (%#v, %v), want still running", updated, err)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "queued" {
+		t.Fatalf("fixer sibling = (%#v, %v), want still queued", sibling, err)
+	}
+}
+
+func TestParkReviewerBudgetIfExhaustedCompletesSiblingAfterPartialPark(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	reviewerTarget := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_retry", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO}
+	fixer := storage.LoopRecord{ID: "loop_fixer_budget_retry", Seq: 2, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	askMeta, err := loops.WriteHITLAsk(reviewer.MetadataJSON, loops.NewReviewFixBudgetAsk("reviewer", repo, prNumber, 8, 8, nowISO))
+	if err != nil {
+		t.Fatalf("WriteHITLAsk() error = %v", err)
+	}
+	reviewer.MetadataJSON = &askMeta
+	reviewer.Status = "awaiting_human"
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	parked, err := runner.parkReviewerBudgetIfExhausted(context.Background(), reviewer)
+	if err != nil || !parked {
+		t.Fatalf("parkReviewerBudgetIfExhausted() = (%v, %v), want reconciled park", parked, err)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer sibling = (%#v, %v), want paused after reconcile", sibling, err)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -19,6 +19,7 @@ import (
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/shell"
 	"github.com/nexu-io/looper/internal/infra/specpr"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/loops/failureclass"
 	"github.com/nexu-io/looper/internal/networkpolicy"
 	"github.com/nexu-io/looper/internal/reviewer/automerge"
@@ -1930,6 +1931,37 @@ func TestEnsureLoopForPullRequestReactivatesLegacyBudgetTerminatedLoop(t *testin
 	}
 	if loopMeta["status"] != "active" {
 		t.Fatalf("loop metadata status = %#v, want active", loopMeta["status"])
+	}
+}
+
+func TestParkReviewerBudgetIfExhaustedParksSibling(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	reviewerTarget := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":8}}`
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	fixer := storage.LoopRecord{ID: "loop_fixer_budget", Seq: 2, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, LoopConfig: config.ReviewerLoopConfig{MaxPublishesPerPR: 8}})
+	parked, err := runner.parkReviewerBudgetIfExhausted(context.Background(), reviewer)
+	if err != nil || !parked {
+		t.Fatalf("parkReviewerBudgetIfExhausted() = (%v, %v), want parked", parked, err)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || updated == nil || updated.Status != "awaiting_human" {
+		t.Fatalf("reviewer = (%#v, %v), want awaiting_human", updated, err)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer sibling = (%#v, %v), want paused sibling hold", sibling, err)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2101,6 +2101,76 @@ func TestParkReviewerBudgetIfExhaustedCompletesSiblingAfterPartialPark(t *testin
 	}
 }
 
+func TestRecordPublishedReviewProgressCountsBeforeClaimComplete(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	metadata := `{"loop":{"iterationCount":0}}`
+	loop := storage.LoopRecord{ID: "loop_publish_count", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queueID := "queue_publish_count"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: queueID, ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Status: "queued",
+		Priority: 1, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	pending := pendingReviewCheckpoint{HeadSHA: "abc123", Summary: "needs work"}
+	if err := runner.recordPublishedReviewProgress(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "project_1"},
+		Loop:     loop,
+		Run:      storage.RunRecord{ID: "run_publish_count"},
+		Repo:     repo,
+		PRNumber: prNumber,
+	}, pending, ReviewEventComment); err != nil {
+		t.Fatalf("recordPublishedReviewProgress() error = %v", err)
+	}
+	afterPublish, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || afterPublish == nil {
+		t.Fatalf("Loops.GetByID() after publish = (%#v, %v)", afterPublish, err)
+	}
+	if loops.ReviewerPublishCount(afterPublish.MetadataJSON) != 1 {
+		t.Fatalf("iterationCount after publish = %d, want 1 before claim complete", loops.ReviewerPublishCount(afterPublish.MetadataJSON))
+	}
+	if got, _ := stringFromAny(parseJSONObject(afterPublish.MetadataJSON)["lastPublishedHeadSha"]); got != "abc123" {
+		t.Fatalf("lastPublishedHeadSha = %q, want abc123", got)
+	}
+
+	if err := fixture.repos.Queue.Complete(context.Background(), queueID, nowISO); err != nil {
+		t.Fatalf("Queue.Complete() error = %v", err)
+	}
+	if err := runner.recordPublishedReviewProgress(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "project_1"},
+		Loop:     *afterPublish,
+		Run:      storage.RunRecord{ID: "run_publish_count"},
+		Repo:     repo,
+		PRNumber: prNumber,
+	}, pending, ReviewEventComment); err != nil {
+		t.Fatalf("recordPublishedReviewProgress(retry) error = %v", err)
+	}
+	successMeta, err := runner.recordLoopSuccessMetadata(afterPublish.MetadataJSON, reviewerCheckpoint{
+		Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+		PendingReview: &pendingReviewCheckpoint{HeadSHA: "abc123"},
+	}, "Published review")
+	if err != nil {
+		t.Fatalf("recordLoopSuccessMetadata() error = %v", err)
+	}
+	if loops.ReviewerPublishCount(&successMeta) != 1 {
+		t.Fatalf("iterationCount after success metadata = %d, want 1", loops.ReviewerPublishCount(&successMeta))
+	}
+	retried, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || retried == nil || loops.ReviewerPublishCount(retried.MetadataJSON) != 1 {
+		t.Fatalf("iterationCount after same-head retry = (%#v, %v), want 1", retried, err)
+	}
+}
+
 func TestRecordLoopSuccessMetadataRemovesDeprecatedBudgetMetadata(t *testing.T) {
 	t.Parallel()
 	runner := New(Options{LoopConfig: testReviewerLoopConfig()})

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1995,6 +1995,73 @@ func TestProcessClaimedItemParksExhaustedBudgetBeforeRun(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemDoesNotParkBudgetWhenClaimedAfterPRClosed(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	projectID := "project_1"
+	loopID := "loop_reviewer_budget_claim_closed"
+	metadata := `{"loop":{"iterationCount":1}}`
+	reviewer := storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	fixer := storage.LoopRecord{ID: "loop_fixer_budget_claim_closed", Seq: 2, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_budget_claim_closed", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:budget-claim-closed", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 1
+	cfg.HITL.Enabled = true
+	agent := &fakeAgentExecutor{}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{viewState: "MERGED"}, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg})
+
+	result, err := runner.ProcessClaimedItem(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_budget_claim_closed", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, Status: "running"})
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped after closed-PR claim", result)
+	}
+	if len(agent.starts) != 0 {
+		t.Fatalf("agent.starts = %#v, want none after closed-PR claim", agent.starts)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || updated == nil || updated.Status != "terminated" {
+		t.Fatalf("reviewer = (%#v, %v), want terminated product terminal", updated, err)
+	}
+	if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(updated.MetadataJSON))["terminationReason"]); reason != "pr_closed_or_merged" {
+		t.Fatalf("terminationReason = %q, want pr_closed_or_merged", reason)
+	}
+	if ask, ok := loops.ReadHITLAsk(updated.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("HITL ask = %#v, want no budget ask on a closed PR", ask)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "waiting" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer sibling = (%#v, %v), want still waiting without budget pause", sibling, err)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_reviewer_budget_claim_closed")
+	if err != nil || queue == nil || queue.Status != "cancelled" {
+		t.Fatalf("queue = (%#v, %v), want cancelled claimed item", queue, err)
+	}
+	runs, err := fixture.repos.Runs.ListByLoop(context.Background(), loopID)
+	if err != nil {
+		t.Fatalf("Runs.ListByLoop() error = %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("runs = %#v, want no run after closed-PR claim", runs)
+	}
+}
+
 func TestProcessClaimedItemDoesNotParkBudgetWhenPublishClosesPR(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -166,6 +166,28 @@ func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopR
 	return delivered
 }
 
+// enqueueFeishuHITLMessage applies a typed inbox reply and, when that reply is
+// an explicit budget Continue/Stop, invokes onAnswered so the live ask card is
+// marked resolved. Card-action delivery already does this; typed decisions must
+// too, or the cached loop-seq buttons can answer a later budget cycle.
+func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, nowISO, loopID, text string, onAnswered func(context.Context, string, string)) error {
+	shouldResolve := false
+	if repos != nil && repos.Loops != nil && (loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text)) {
+		if loop, err := repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
+			if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+				shouldResolve = true
+			}
+		}
+	}
+	if err := enqueueHumanMessageToLoop(ctx, repos, nowISO, loopID, text); err != nil {
+		return err
+	}
+	if shouldResolve && onAnswered != nil {
+		onAnswered(ctx, loopID, text)
+	}
+	return nil
+}
+
 func sendFeishuBudgetAsk(ctx context.Context, input defaultSchedulerTickInput, loop storage.LoopRecord, ask loops.HITLAsk) error {
 	if input.OnHITLAsk == nil {
 		return fmt.Errorf("feishu HITL notifier is not configured")
@@ -265,7 +287,7 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 			return nil
 		},
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
-			return enqueueHumanMessageToLoop(ctx, input.Repos, nowISO, loopID, text)
+			return enqueueFeishuHITLMessage(ctx, input.Repos, nowISO, loopID, text, input.OnHITLAnswerDelivered)
 		},
 	}
 	if input.Logger != nil {

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -14,7 +14,9 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/worker"
 )
 
 // feishuInboxEvent is one event from the shared Cloudflare inbox (GET /events).
@@ -109,6 +111,85 @@ var feishuInboxCursor struct {
 
 var feishuInboxHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
+type feishuHITLDeliveryDeps struct {
+	sendAsk func(ctx contextType, loop storage.LoopRecord, ask loops.HITLAsk) error
+	nowISO  string
+	logWarn func(msg string, fields map[string]any)
+}
+
+func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopRecord, repos *storage.Repositories, deps feishuHITLDeliveryDeps) int {
+	if repos == nil || repos.Loops == nil || deps.sendAsk == nil {
+		return 0
+	}
+	delivered := 0
+	for _, loop := range records {
+		if loop.Status != "awaiting_human" {
+			continue
+		}
+		ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
+		if !ok || !loops.IsReviewFixBudgetAsk(ask) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(ask.Transport), "feishu") {
+			continue
+		}
+		if strings.TrimSpace(ask.Transport) != "" {
+			continue
+		}
+		if err := deps.sendAsk(ctx, loop, ask); err != nil {
+			if deps.logWarn != nil {
+				deps.logWarn("hitl feishu: budget ask delivery failed", map[string]any{"loopId": loop.ID, "error": err.Error()})
+			}
+			continue
+		}
+		ask.Transport = "feishu"
+		meta, werr := loops.WriteHITLAsk(loop.MetadataJSON, ask)
+		if werr != nil {
+			if deps.logWarn != nil {
+				deps.logWarn("hitl feishu: budget ask metadata write failed", map[string]any{"loopId": loop.ID, "error": werr.Error()})
+			}
+			continue
+		}
+		updated := loop
+		updated.MetadataJSON = &meta
+		if deps.nowISO != "" {
+			updated.UpdatedAt = deps.nowISO
+		}
+		if err := repos.Loops.Upsert(ctx, updated); err != nil {
+			if deps.logWarn != nil {
+				deps.logWarn("hitl feishu: budget ask persist failed", map[string]any{"loopId": loop.ID, "error": err.Error()})
+			}
+			continue
+		}
+		delivered++
+	}
+	return delivered
+}
+
+func sendFeishuBudgetAsk(ctx context.Context, input defaultSchedulerTickInput, loop storage.LoopRecord, ask loops.HITLAsk) error {
+	if input.OnHITLAsk == nil {
+		return fmt.Errorf("feishu HITL notifier is not configured")
+	}
+	prNumber := ask.PRNumber
+	if prNumber == 0 {
+		prNumber = derefLoopPRNumber(loop)
+	}
+	notif := worker.HITLAskNotification{
+		ProjectID: loop.ProjectID,
+		LoopID:    loop.ID,
+		LoopSeq:   loop.Seq,
+		Repo:      derefLoopRepo(loop),
+		Title:     ask.Question,
+		Question:  ask.Question,
+		Options:   ask.Options,
+	}
+	if prNumber > 0 {
+		notif.SourceType = "GitHub PR"
+		notif.SourceRef = "#" + strconv.FormatInt(prNumber, 10)
+	}
+	return input.OnHITLAsk(ctx, notif)
+}
+
 // runFeishuHITLPoll polls the shared Cloudflare inbox once and delivers any
 // answers for this looper's awaiting loops. Gated by the feishu transport +
 // cf-inbox inbound; a no-op otherwise.
@@ -129,6 +210,20 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 		return
 	}
 
+	nowISO := eventlog.FormatJavaScriptISOString(input.Now().UTC())
+	if allLoops, err := input.Repos.Loops.List(ctx); err == nil {
+		deliveryDeps := feishuHITLDeliveryDeps{
+			sendAsk: func(ctx contextType, loop storage.LoopRecord, ask loops.HITLAsk) error {
+				return sendFeishuBudgetAsk(ctx, input, loop, ask)
+			},
+			nowISO: nowISO,
+		}
+		if input.Logger != nil {
+			deliveryDeps.logWarn = func(msg string, fields map[string]any) { input.Logger.Warn(msg, fields) }
+		}
+		_ = deliverUndeliveredFeishuBudgetAsks(ctx, allLoops, input.Repos, deliveryDeps)
+	}
+
 	feishuInboxCursor.mu.Lock()
 	since := feishuInboxCursor.v
 	feishuInboxCursor.mu.Unlock()
@@ -144,7 +239,6 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 		return
 	}
 
-	nowISO := eventlog.FormatJavaScriptISOString(input.Now().UTC())
 	deps := feishuHITLPollDeps{
 		loopByRoot: func(ctx contextType, rootID string) string {
 			if input.Repos.FeishuThreads == nil {

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -2,7 +2,13 @@ package runtime
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
+	"github.com/nexu-io/looper/internal/worker"
 )
 
 func TestPollFeishuHITLInboxOnce(t *testing.T) {
@@ -41,6 +47,124 @@ func TestPollFeishuHITLInboxOnce(t *testing.T) {
 	}
 	if len(answers) != 1 || answers[0] != "loop-seq71=redis" {
 		t.Fatalf("delivered answers = %v, want the button click", answers)
+	}
+}
+
+func TestFeishuHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_budget_feishu"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Budget", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewerMeta := `{"loop":{"iterationCount":8}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_feishu_reviewer", Seq: 71, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &reviewerMeta,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_feishu_fixer", Seq: 72, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	for _, item := range []storage.QueueItemRecord{
+		{ID: "queue_feishu_reviewer", ProjectID: stringPtr(projectID), LoopID: &reviewer.ID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Status: "queued", Priority: storage.QueuePriorityReviewer, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO, DedupeKey: "reviewer:queue_feishu_reviewer"},
+		{ID: "queue_feishu_fixer", ProjectID: stringPtr(projectID), LoopID: &fixer.ID, Type: "fixer", TargetType: "pull_request", TargetID: target, Status: "queued", Priority: storage.QueuePriorityFixer, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO, DedupeKey: "fixer:queue_feishu_fixer"},
+	} {
+		if err := repos.Queue.Upsert(context.Background(), item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+
+	parked, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	ask, ok := loops.ReadHITLAsk(parked.MetadataJSON)
+	if !ok || !loops.IsReviewFixBudgetAsk(ask) || ask.Transport != "" {
+		t.Fatalf("parked ask = %#v, want undelivered budget ask", ask)
+	}
+
+	var sent []worker.HITLAskNotification
+	all, err := repos.Loops.List(context.Background())
+	if err != nil {
+		t.Fatalf("Loops.List() error = %v", err)
+	}
+	delivered := deliverUndeliveredFeishuBudgetAsks(context.Background(), all, repos, feishuHITLDeliveryDeps{
+		sendAsk: func(_ contextType, loop storage.LoopRecord, got loops.HITLAsk) error {
+			sent = append(sent, worker.HITLAskNotification{
+				LoopID: loop.ID, LoopSeq: loop.Seq, Question: got.Question, Options: got.Options,
+			})
+			if loop.ID != reviewer.ID || got.Question != ask.Question {
+				t.Fatalf("sendAsk = loop %s question %q, want reviewer budget ask", loop.ID, got.Question)
+			}
+			return nil
+		},
+		nowISO: nowISO,
+	})
+	if delivered != 1 || len(sent) != 1 {
+		t.Fatalf("deliverUndeliveredFeishuBudgetAsks() = %d sent=%d, want 1", delivered, len(sent))
+	}
+	if len(sent[0].Options) != 2 || sent[0].Options[0] != loops.ReviewFixBudgetAnswerContinue || sent[0].Options[1] != loops.ReviewFixBudgetAnswerStop {
+		t.Fatalf("sent options = %#v, want Continue/Stop", sent[0].Options)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil {
+		t.Fatalf("Loops.GetByID(reviewer) = (%#v, %v)", fresh, err)
+	}
+	ask, ok = loops.ReadHITLAsk(fresh.MetadataJSON)
+	if !ok || ask.Transport != "feishu" {
+		t.Fatalf("delivered ask = %#v, want feishu transport", ask)
+	}
+
+	card := mustCardAction(20, "71", "Continue")
+	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{card}, feishuHITLPollDeps{
+		loopBySeq: func(_ contextType, seq int64) string {
+			if seq == reviewer.Seq {
+				return reviewer.ID
+			}
+			return ""
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+		},
+	})
+	if n != 1 || maxID != 20 {
+		t.Fatalf("poll delivered = %d maxID=%d, want Continue on reviewer", n, maxID)
+	}
+	fresh, err = repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "queued" || loops.ReviewerPublishCount(fresh.MetadataJSON) != 0 {
+		t.Fatalf("reviewer after continue = (%#v, %v), want queued with reset count", fresh, err)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "queued" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer after continue = (%#v, %v), want queued and unpaused", sibling, err)
 	}
 }
 

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -235,6 +235,7 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 		t.Fatalf("deliverUndeliveredFeishuBudgetAsks() = %d, want 1", delivered)
 	}
 
+	var resolved []string
 	deps := feishuHITLPollDeps{
 		loopByRoot: func(_ contextType, rootID string) string {
 			if rootID == "om_budget_root" {
@@ -243,7 +244,9 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 			return ""
 		},
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
-			return enqueueHumanMessageToLoop(ctx, repos, nowISO, loopID, text)
+			return enqueueFeishuHITLMessage(ctx, repos, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
+				resolved = append(resolved, answeredLoopID+"="+answer)
+			})
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
 			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
@@ -266,6 +269,9 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 	if got := loops.ReadHumanInbox(fresh.MetadataJSON); len(got) != 0 {
 		t.Fatalf("human inbox after typed discussion = %#v, want empty", got)
 	}
+	if len(resolved) != 0 {
+		t.Fatalf("card resolution after typed discussion = %#v, want none", resolved)
+	}
 	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
 	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		t.Fatalf("fixer after typed discussion = (%#v, %v), want still paused", sibling, err)
@@ -284,6 +290,9 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 	sibling, err = repos.Loops.GetByID(context.Background(), fixer.ID)
 	if err != nil || sibling == nil || sibling.Status != "queued" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		t.Fatalf("fixer after typed Continue = (%#v, %v), want queued and unpaused", sibling, err)
+	}
+	if len(resolved) != 1 || resolved[0] != reviewer.ID+"=Continue" {
+		t.Fatalf("card resolution after typed Continue = %#v, want reviewer Continue", resolved)
 	}
 }
 

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -168,6 +168,125 @@ func TestFeishuHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 	}
 }
 
+func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_budget_feishu_typed"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Budget", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewerMeta := `{"loop":{"iterationCount":8}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_feishu_typed_reviewer", Seq: 81, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &reviewerMeta,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_feishu_typed_fixer", Seq: 82, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	for _, item := range []storage.QueueItemRecord{
+		{ID: "queue_feishu_typed_reviewer", ProjectID: stringPtr(projectID), LoopID: &reviewer.ID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Status: "queued", Priority: storage.QueuePriorityReviewer, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO, DedupeKey: "reviewer:queue_feishu_typed_reviewer"},
+		{ID: "queue_feishu_typed_fixer", ProjectID: stringPtr(projectID), LoopID: &fixer.ID, Type: "fixer", TargetType: "pull_request", TargetID: target, Status: "queued", Priority: storage.QueuePriorityFixer, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO, DedupeKey: "fixer:queue_feishu_typed_fixer"},
+	} {
+		if err := repos.Queue.Upsert(context.Background(), item); err != nil {
+			t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+		}
+	}
+
+	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+	}); err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+
+	all, err := repos.Loops.List(context.Background())
+	if err != nil {
+		t.Fatalf("Loops.List() error = %v", err)
+	}
+	if delivered := deliverUndeliveredFeishuBudgetAsks(context.Background(), all, repos, feishuHITLDeliveryDeps{
+		sendAsk: func(_ contextType, _ storage.LoopRecord, _ loops.HITLAsk) error { return nil },
+		nowISO:  nowISO,
+	}); delivered != 1 {
+		t.Fatalf("deliverUndeliveredFeishuBudgetAsks() = %d, want 1", delivered)
+	}
+
+	deps := feishuHITLPollDeps{
+		loopByRoot: func(_ contextType, rootID string) string {
+			if rootID == "om_budget_root" {
+				return reviewer.ID
+			}
+			return ""
+		},
+		enqueueMessage: func(ctx contextType, loopID, text string) error {
+			return enqueueHumanMessageToLoop(ctx, repos, nowISO, loopID, text)
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+		},
+	}
+
+	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{{
+		ID: 30, Kind: "message", RootID: "om_budget_root", Text: "looking into this first",
+	}}, deps)
+	if n != 1 || maxID != 30 {
+		t.Fatalf("typed discussion poll = %d maxID=%d, want handled discussion", n, maxID)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "awaiting_human" || loops.ReviewerPublishCount(fresh.MetadataJSON) != 8 {
+		t.Fatalf("reviewer after typed discussion = (%#v, %v), want still parked", fresh, err)
+	}
+	if ask, ok := loops.ReadHITLAsk(fresh.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) || ask.Transport != "feishu" {
+		t.Fatalf("ask after typed discussion = %#v, want delivered budget ask", ask)
+	}
+	if got := loops.ReadHumanInbox(fresh.MetadataJSON); len(got) != 0 {
+		t.Fatalf("human inbox after typed discussion = %#v, want empty", got)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer after typed discussion = (%#v, %v), want still paused", sibling, err)
+	}
+
+	n, maxID = pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{{
+		ID: 31, Kind: "message", RootID: "om_budget_root", Text: "Continue",
+	}}, deps)
+	if n != 1 || maxID != 31 {
+		t.Fatalf("typed Continue poll = %d maxID=%d, want applied Continue", n, maxID)
+	}
+	fresh, err = repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "queued" || loops.ReviewerPublishCount(fresh.MetadataJSON) != 0 {
+		t.Fatalf("reviewer after typed Continue = (%#v, %v), want queued with reset count", fresh, err)
+	}
+	sibling, err = repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "queued" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer after typed Continue = (%#v, %v), want queued and unpaused", sibling, err)
+	}
+}
+
 func mustCardAction(id int64, seq, answer string) feishuInboxEvent {
 	e := feishuInboxEvent{ID: id, Kind: "card_action"}
 	e.Value.LoopSeq = seq

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -80,6 +80,7 @@ func detectGitHubHITLAnswerMatching(comments []githubAnswerComment, askCommentID
 // review-fix budget ask onto its PR so the answer-poll lane can later consume it.
 type githubHITLDeliveryDeps struct {
 	createComment func(ctx contextType, repo string, prNumber int64, body, cwd string) (int64, error)
+	listComments  func(ctx contextType, repo string, prNumber int64, cwd string) ([]githubAnswerComment, error)
 	addLabel      func(ctx contextType, repo string, prNumber int64, label, cwd string)
 	projectCWD    func(projectID string) string
 	stampBody     func(body, runner string) string
@@ -121,15 +122,14 @@ func deliverUndeliveredGitHubBudgetAsks(ctx contextType, projectID string, recor
 		if deps.projectCWD != nil {
 			cwd = deps.projectCWD(loop.ProjectID)
 		}
-		body := buildGitHubBudgetAskComment(loop.Seq, ask.Question, ask.Options, deps.mentionLogins)
-		if deps.stampBody != nil {
-			body = deps.stampBody(body, loop.Type)
-		}
-		commentID, err := deps.createComment(ctx, repo, prNumber, body, cwd)
+		commentID, err := recoverOrCreateGitHubBudgetAskComment(ctx, repo, prNumber, cwd, loop, ask, deps)
 		if err != nil {
 			if deps.logWarn != nil {
 				deps.logWarn("hitl github: budget ask delivery failed", map[string]any{"loopId": loop.ID, "error": err.Error()})
 			}
+			continue
+		}
+		if commentID == 0 {
 			continue
 		}
 		if deps.addLabel != nil {
@@ -161,9 +161,56 @@ func deliverUndeliveredGitHubBudgetAsks(ctx contextType, projectID string, recor
 	return delivered
 }
 
+func githubBudgetAskMarker(loopSeq int64) string {
+	return fmt.Sprintf("<!-- looper:hitl:ask v=1 loop=%d -->", loopSeq)
+}
+
+func recoverOrCreateGitHubBudgetAskComment(ctx contextType, repo string, prNumber int64, cwd string, loop storage.LoopRecord, ask loops.HITLAsk, deps githubHITLDeliveryDeps) (int64, error) {
+	if deps.listComments != nil {
+		comments, err := deps.listComments(ctx, repo, prNumber, cwd)
+		if err != nil {
+			return 0, err
+		}
+		if recovered := recoverGitHubBudgetAskCommentID(comments, loop.Seq); recovered != 0 {
+			return recovered, nil
+		}
+	}
+	if deps.createComment == nil {
+		return 0, nil
+	}
+	body := buildGitHubBudgetAskComment(loop.Seq, ask.Question, ask.Options, deps.mentionLogins)
+	if deps.stampBody != nil {
+		body = deps.stampBody(body, loop.Type)
+	}
+	return deps.createComment(ctx, repo, prNumber, body, cwd)
+}
+
+func recoverGitHubBudgetAskCommentID(comments []githubAnswerComment, loopSeq int64) int64 {
+	marker := githubBudgetAskMarker(loopSeq)
+	bestID := int64(0)
+	for _, comment := range comments {
+		if !strings.Contains(comment.Body, marker) {
+			continue
+		}
+		if githubBudgetAskAlreadyAnswered(comments, comment.ID) {
+			continue
+		}
+		if bestID == 0 || comment.ID < bestID {
+			bestID = comment.ID
+		}
+	}
+	return bestID
+}
+
+func githubBudgetAskAlreadyAnswered(comments []githubAnswerComment, askCommentID int64) bool {
+	return detectGitHubHITLAnswerMatching(comments, askCommentID, nil, func(body string) bool {
+		return loops.IsReviewFixBudgetContinue(body) || loops.IsReviewFixBudgetStop(body)
+	}) != ""
+}
+
 func buildGitHubBudgetAskComment(loopSeq int64, question string, options []string, mentionLogins []string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "<!-- looper:hitl:ask v=1 loop=%d -->\n", loopSeq)
+	fmt.Fprintf(&b, "%s\n", githubBudgetAskMarker(loopSeq))
 	b.WriteString("🤔 **looper needs a decision to continue.**\n\n")
 	b.WriteString(strings.TrimSpace(question))
 	for _, option := range options {
@@ -418,6 +465,17 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 				return 0, err
 			}
 			return res.ID, nil
+		},
+		listComments: func(ctx contextType, repo string, pr int64, cwd string) ([]githubAnswerComment, error) {
+			cs, err := input.GitHubGateway.ListIssueComments(ctx, githubinfra.ViewIssueInput{Repo: repo, IssueNumber: pr, CWD: cwd})
+			if err != nil {
+				return nil, err
+			}
+			out := make([]githubAnswerComment, 0, len(cs))
+			for _, c := range cs {
+				out = append(out, githubAnswerComment{ID: c.ID, Author: c.Author, Body: c.Body})
+			}
+			return out, nil
 		},
 		addLabel: func(ctx contextType, repo string, pr int64, label, cwd string) {
 			_ = input.GitHubGateway.AddPullRequestLabels(ctx, githubinfra.PullRequestLabelsInput{Repo: repo, PRNumber: pr, Labels: []string{label}, CWD: cwd})

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -351,8 +351,10 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 // queued so the scheduler picks it up and the worker drains the message on its
 // next turn; a running loop drains it when the current turn ends. Terminal loops
 // are left alone (a message can't reopen a finished loop yet). Unlike a button
-// answer, a message does NOT resolve a pending ask — the agent reads it and
-// decides whether to proceed, answer, or ask again.
+// answer, a message does NOT resolve a pending mid-run ask — the agent reads it
+// and decides whether to proceed, answer, or ask again. A review-fix budget ask
+// is the exception: only Continue/Stop may unpark, and they apply the budget
+// decision instead of enqueueing conversational text.
 func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, text string) error {
 	// Share process-wide requeue exclusion with API discard+retry so free-text
 	// inbox delivery cannot requeue paused/waiting/manual_intervention loops
@@ -374,6 +376,17 @@ func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories,
 	// per-loop mutex and wipes the shared worktree before the retry TX.
 	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*loop))
 	defer unlockTarget()
+
+	if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+		// Budget holds are Continue/Stop decisions, not conversational inbox
+		// turns. A typed Feishu reply must not flip awaiting_human to queued
+		// without resetting the counter or unpausing the sibling.
+		if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
+			_, err = loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, text, nowISO)
+			return err
+		}
+		return nil
+	}
 
 	meta, werr := loops.AppendHumanMessage(loop.MetadataJSON, loops.HumanMessage{At: nowISO, Text: text})
 	if werr != nil {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -35,6 +35,10 @@ const looperCommentMarker = "<!-- looper:"
 // commenter must be on that allowlist; otherwise any human reply may answer.
 // Empty-bodied comments are ignored so ordinary reactions/edits don't count.
 func detectGitHubHITLAnswer(comments []githubAnswerComment, askCommentID int64, answerAuthors []string) string {
+	return detectGitHubHITLAnswerMatching(comments, askCommentID, answerAuthors, nil)
+}
+
+func detectGitHubHITLAnswerMatching(comments []githubAnswerComment, askCommentID int64, answerAuthors []string, accept func(string) bool) string {
 	allow := make(map[string]bool, len(answerAuthors))
 	for _, a := range answerAuthors {
 		if a = strings.TrimSpace(a); a != "" {
@@ -59,6 +63,9 @@ func detectGitHubHITLAnswer(comments []githubAnswerComment, askCommentID int64, 
 		}
 		body := strings.TrimSpace(c.Body)
 		if body == "" {
+			continue
+		}
+		if accept != nil && !accept(body) {
 			continue
 		}
 		if bestID == 0 || c.ID < bestID {
@@ -225,15 +232,16 @@ type githubHITLAwaitingLoop struct {
 	AskStatus    string
 	PRNumber     int64
 	AskCommentID int64
+	BudgetAsk    bool
 }
 
 // pollGitHubHITLAnswersOnce runs one pass of the answer-poll lane: for each loop
 // waiting on a GitHub HITL answer, it looks for a human's reply after the ask and
 // delivers it. It is idempotent — a loop that leaves awaiting_human on delivery
 // simply won't be passed in again.
-func pollGitHubHITLAnswersOnce(ctx contextType, loops []githubHITLAwaitingLoop, deps githubHITLPollDeps) int {
+func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoop, deps githubHITLPollDeps) int {
 	delivered := 0
-	for _, loop := range loops {
+	for _, loop := range awaiting {
 		if !strings.EqualFold(strings.TrimSpace(loop.Transport), "github") || loop.PRNumber == 0 {
 			continue
 		}
@@ -255,7 +263,13 @@ func pollGitHubHITLAnswersOnce(ctx contextType, loops []githubHITLAwaitingLoop, 
 			}
 			continue
 		}
-		answer := detectGitHubHITLAnswer(comments, loop.AskCommentID, deps.answerAuthors)
+		var accept func(string) bool
+		if loop.BudgetAsk {
+			accept = func(body string) bool {
+				return loops.IsReviewFixBudgetContinue(body) || loops.IsReviewFixBudgetStop(body)
+			}
+		}
+		answer := detectGitHubHITLAnswerMatching(comments, loop.AskCommentID, deps.answerAuthors, accept)
 		if answer == "" {
 			continue
 		}
@@ -441,6 +455,7 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 		awaiting = append(awaiting, githubHITLAwaitingLoop{
 			ID: l.ID, ProjectID: l.ProjectID, Repo: repo,
 			Transport: ask.Transport, AskStatus: ask.Status, PRNumber: ask.PRNumber, AskCommentID: ask.AskCommentID,
+			BudgetAsk: loops.IsReviewFixBudgetAsk(ask),
 		})
 	}
 	if len(awaiting) == 0 {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -2,8 +2,10 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/eventlog"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/loops"
@@ -65,6 +67,136 @@ func detectGitHubHITLAnswer(comments []githubAnswerComment, askCommentID int64, 
 		}
 	}
 	return answer
+}
+
+// githubHITLDeliveryDeps are the injected dependencies for posting an undelivered
+// review-fix budget ask onto its PR so the answer-poll lane can later consume it.
+type githubHITLDeliveryDeps struct {
+	createComment func(ctx contextType, repo string, prNumber int64, body, cwd string) (int64, error)
+	addLabel      func(ctx contextType, repo string, prNumber int64, label, cwd string)
+	projectCWD    func(projectID string) string
+	stampBody     func(body, runner string) string
+	mentionLogins []string
+	awaitingLabel string
+	nowISO        string
+	logWarn       func(msg string, fields map[string]any)
+}
+
+func deliverUndeliveredGitHubBudgetAsks(ctx contextType, projectID string, records []storage.LoopRecord, repos *storage.Repositories, deps githubHITLDeliveryDeps) int {
+	if repos == nil || repos.Loops == nil || deps.createComment == nil {
+		return 0
+	}
+	delivered := 0
+	awaitingLabel := strings.TrimSpace(deps.awaitingLabel)
+	if awaitingLabel == "" {
+		awaitingLabel = "looper:awaiting-human"
+	}
+	for _, loop := range records {
+		if loop.ProjectID != projectID || loop.Status != "awaiting_human" {
+			continue
+		}
+		ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
+		if !ok || !loops.IsReviewFixBudgetAsk(ask) {
+			continue
+		}
+		if ask.AskCommentID != 0 && strings.EqualFold(strings.TrimSpace(ask.Transport), "github") {
+			continue
+		}
+		prNumber := ask.PRNumber
+		if prNumber == 0 {
+			prNumber = derefLoopPRNumber(loop)
+		}
+		repo := derefLoopRepo(loop)
+		if prNumber == 0 || repo == "" {
+			continue
+		}
+		cwd := ""
+		if deps.projectCWD != nil {
+			cwd = deps.projectCWD(loop.ProjectID)
+		}
+		body := buildGitHubBudgetAskComment(loop.Seq, ask.Question, ask.Options, deps.mentionLogins)
+		if deps.stampBody != nil {
+			body = deps.stampBody(body, loop.Type)
+		}
+		commentID, err := deps.createComment(ctx, repo, prNumber, body, cwd)
+		if err != nil {
+			if deps.logWarn != nil {
+				deps.logWarn("hitl github: budget ask delivery failed", map[string]any{"loopId": loop.ID, "error": err.Error()})
+			}
+			continue
+		}
+		if deps.addLabel != nil {
+			deps.addLabel(ctx, repo, prNumber, awaitingLabel, cwd)
+		}
+		ask.Transport = "github"
+		ask.PRNumber = prNumber
+		ask.AskCommentID = commentID
+		meta, werr := loops.WriteHITLAsk(loop.MetadataJSON, ask)
+		if werr != nil {
+			if deps.logWarn != nil {
+				deps.logWarn("hitl github: budget ask metadata write failed", map[string]any{"loopId": loop.ID, "error": werr.Error()})
+			}
+			continue
+		}
+		updated := loop
+		updated.MetadataJSON = &meta
+		if deps.nowISO != "" {
+			updated.UpdatedAt = deps.nowISO
+		}
+		if err := repos.Loops.Upsert(ctx, updated); err != nil {
+			if deps.logWarn != nil {
+				deps.logWarn("hitl github: budget ask persist failed", map[string]any{"loopId": loop.ID, "error": err.Error()})
+			}
+			continue
+		}
+		delivered++
+	}
+	return delivered
+}
+
+func buildGitHubBudgetAskComment(loopSeq int64, question string, options []string, mentionLogins []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "<!-- looper:hitl:ask v=1 loop=%d -->\n", loopSeq)
+	b.WriteString("🤔 **looper needs a decision to continue.**\n\n")
+	b.WriteString(strings.TrimSpace(question))
+	for _, option := range options {
+		if option = strings.TrimSpace(option); option != "" {
+			fmt.Fprintf(&b, "\n- %s", option)
+		}
+	}
+	b.WriteString("\n\nReply to this comment with Continue or Stop.")
+	if mentions := githubBudgetMentionLine(mentionLogins); mentions != "" {
+		b.WriteString("\n\n" + mentions)
+	}
+	return b.String()
+}
+
+func githubBudgetMentionLine(logins []string) string {
+	parts := make([]string, 0, len(logins))
+	for _, login := range logins {
+		login = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(login), "@"))
+		if login != "" {
+			parts = append(parts, "@"+login)
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "/cc " + strings.Join(parts, " ")
+}
+
+func derefLoopRepo(loop storage.LoopRecord) string {
+	if loop.Repo == nil {
+		return ""
+	}
+	return strings.TrimSpace(*loop.Repo)
+}
+
+func derefLoopPRNumber(loop storage.LoopRecord) int64 {
+	if loop.PRNumber == nil {
+		return 0
+	}
+	return *loop.PRNumber
 }
 
 // githubHITLPollDeps are the injected dependencies of the answer-poll lane, kept
@@ -254,6 +386,45 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 	if err != nil {
 		return
 	}
+	awaitingLabel := "looper:awaiting-human"
+	var mentionLogins []string
+	var answerAuthors []string
+	if gh := input.Config.HITL.GitHub; gh != nil {
+		if strings.TrimSpace(gh.AwaitingLabel) != "" {
+			awaitingLabel = strings.TrimSpace(gh.AwaitingLabel)
+		}
+		mentionLogins = gh.MentionLogins
+		answerAuthors = gh.AnswerAuthors
+	}
+	nowISO := eventlog.FormatJavaScriptISOString(input.Now().UTC())
+	deliveryDeps := githubHITLDeliveryDeps{
+		createComment: func(ctx contextType, repo string, pr int64, body, cwd string) (int64, error) {
+			res, err := input.GitHubGateway.CreateIssueComment(ctx, githubinfra.IssueCommentInput{Repo: repo, IssueNumber: pr, Body: body, CWD: cwd})
+			if err != nil {
+				return 0, err
+			}
+			return res.ID, nil
+		},
+		addLabel: func(ctx contextType, repo string, pr int64, label, cwd string) {
+			_ = input.GitHubGateway.AddPullRequestLabels(ctx, githubinfra.PullRequestLabelsInput{Repo: repo, PRNumber: pr, Labels: []string{label}, CWD: cwd})
+		},
+		projectCWD: func(string) string { return project.RepoPath },
+		stampBody: func(body, runner string) string {
+			return disclosure.FromConfig(*input.Config).Markdown(body, runner, disclosure.ChannelIssueComment)
+		},
+		mentionLogins: mentionLogins,
+		awaitingLabel: awaitingLabel,
+		nowISO:        nowISO,
+	}
+	if input.Logger != nil {
+		deliveryDeps.logWarn = func(msg string, fields map[string]any) { input.Logger.Warn(msg, fields) }
+	}
+	if deliverUndeliveredGitHubBudgetAsks(ctx, project.ID, allLoops, input.Repos, deliveryDeps) > 0 {
+		allLoops, err = input.Repos.Loops.List(ctx)
+		if err != nil {
+			return
+		}
+	}
 	awaiting := make([]githubHITLAwaitingLoop, 0)
 	for _, l := range allLoops {
 		if l.ProjectID != project.ID || l.Status != "awaiting_human" {
@@ -276,16 +447,7 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 		return
 	}
 
-	awaitingLabel := "looper:awaiting-human"
-	var answerAuthors []string
-	if gh := input.Config.HITL.GitHub; gh != nil {
-		if strings.TrimSpace(gh.AwaitingLabel) != "" {
-			awaitingLabel = strings.TrimSpace(gh.AwaitingLabel)
-		}
-		answerAuthors = gh.AnswerAuthors
-	}
 	gw := input.GitHubGateway
-	nowISO := eventlog.FormatJavaScriptISOString(input.Now().UTC())
 
 	deps := githubHITLPollDeps{
 		listComments: func(ctx contextType, repo string, pr int64, cwd string) ([]githubAnswerComment, error) {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -161,8 +161,12 @@ func deliverUndeliveredGitHubBudgetAsks(ctx contextType, projectID string, recor
 	return delivered
 }
 
-func githubBudgetAskMarker(loopSeq int64) string {
-	return fmt.Sprintf("<!-- looper:hitl:ask v=1 loop=%d -->", loopSeq)
+func githubBudgetAskMarker(loopSeq int64, askedAt string) string {
+	askedAt = strings.TrimSpace(askedAt)
+	if askedAt == "" {
+		return fmt.Sprintf("<!-- looper:hitl:ask v=1 loop=%d -->", loopSeq)
+	}
+	return fmt.Sprintf("<!-- looper:hitl:ask v=1 loop=%d askedAt=%s -->", loopSeq, askedAt)
 }
 
 func recoverOrCreateGitHubBudgetAskComment(ctx contextType, repo string, prNumber int64, cwd string, loop storage.LoopRecord, ask loops.HITLAsk, deps githubHITLDeliveryDeps) (int64, error) {
@@ -171,22 +175,26 @@ func recoverOrCreateGitHubBudgetAskComment(ctx contextType, repo string, prNumbe
 		if err != nil {
 			return 0, err
 		}
-		if recovered := recoverGitHubBudgetAskCommentID(comments, loop.Seq); recovered != 0 {
+		if recovered := recoverGitHubBudgetAskCommentID(comments, loop.Seq, ask.AskedAt); recovered != 0 {
 			return recovered, nil
 		}
 	}
 	if deps.createComment == nil {
 		return 0, nil
 	}
-	body := buildGitHubBudgetAskComment(loop.Seq, ask.Question, ask.Options, deps.mentionLogins)
+	body := buildGitHubBudgetAskComment(loop.Seq, ask.AskedAt, ask.Question, ask.Options, deps.mentionLogins)
 	if deps.stampBody != nil {
 		body = deps.stampBody(body, loop.Type)
 	}
 	return deps.createComment(ctx, repo, prNumber, body, cwd)
 }
 
-func recoverGitHubBudgetAskCommentID(comments []githubAnswerComment, loopSeq int64) int64 {
-	marker := githubBudgetAskMarker(loopSeq)
+func recoverGitHubBudgetAskCommentID(comments []githubAnswerComment, loopSeq int64, askedAt string) int64 {
+	askedAt = strings.TrimSpace(askedAt)
+	if askedAt == "" {
+		return 0
+	}
+	marker := githubBudgetAskMarker(loopSeq, askedAt)
 	bestID := int64(0)
 	for _, comment := range comments {
 		if !strings.Contains(comment.Body, marker) {
@@ -208,9 +216,9 @@ func githubBudgetAskAlreadyAnswered(comments []githubAnswerComment, askCommentID
 	}) != ""
 }
 
-func buildGitHubBudgetAskComment(loopSeq int64, question string, options []string, mentionLogins []string) string {
+func buildGitHubBudgetAskComment(loopSeq int64, askedAt, question string, options []string, mentionLogins []string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s\n", githubBudgetAskMarker(loopSeq))
+	fmt.Fprintf(&b, "%s\n", githubBudgetAskMarker(loopSeq, askedAt))
 	b.WriteString("🤔 **looper needs a decision to continue.**\n\n")
 	b.WriteString(strings.TrimSpace(question))
 	for _, option := range options {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -215,6 +215,10 @@ func deliverHITLAnswerToLoop(ctx context.Context, repos *storage.Repositories, n
 	if !ok {
 		return nil
 	}
+	if loops.IsReviewFixBudgetAsk(ask) {
+		_, err = loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO)
+		return err
+	}
 	ask.Answer = answer
 	ask.Status = "answered"
 	ask.AnsweredAt = nowISO

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -2,7 +2,13 @@ package runtime
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
 )
 
 func TestDetectGitHubHITLAnswer(t *testing.T) {
@@ -64,5 +70,155 @@ func TestPollGitHubHITLAnswersOnce(t *testing.T) {
 	}
 	if len(cleared) != 1 || cleared[0] != 42 {
 		t.Fatalf("cleared = %v, want [42]", cleared)
+	}
+}
+
+func TestGitHubHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_budget_github"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Budget", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewerMeta := `{"loop":{"iterationCount":8}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_reviewer", Seq: 11, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &reviewerMeta,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_fixer", Seq: 12, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	seedPollBudgetQueue(t, repos, nowISO, "queue_budget_reviewer", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedPollBudgetQueue(t, repos, nowISO, "queue_budget_fixer", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	parked, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	ask, ok := loops.ReadHITLAsk(parked.MetadataJSON)
+	if !ok || !loops.IsReviewFixBudgetAsk(ask) || ask.PRNumber != pr || ask.Transport != "" || ask.AskCommentID != 0 {
+		t.Fatalf("parked ask = %#v, want budget ask with PR and no GitHub transport yet", ask)
+	}
+
+	var posted []string
+	var labeled []string
+	all, err := repos.Loops.List(context.Background())
+	if err != nil {
+		t.Fatalf("Loops.List() error = %v", err)
+	}
+	delivered := deliverUndeliveredGitHubBudgetAsks(context.Background(), projectID, all, repos, githubHITLDeliveryDeps{
+		createComment: func(_ contextType, gotRepo string, gotPR int64, body, _ string) (int64, error) {
+			posted = append(posted, body)
+			if gotRepo != repo || gotPR != pr {
+				t.Fatalf("createComment target = %s#%d, want %s#%d", gotRepo, gotPR, repo, pr)
+			}
+			if !strings.Contains(body, "<!-- looper:hitl:ask v=1") || !strings.Contains(body, ask.Question) || !strings.Contains(body, "Continue") {
+				t.Fatalf("createComment body missing ask marker/question/options: %s", body)
+			}
+			return 9001, nil
+		},
+		addLabel: func(_ contextType, _ string, gotPR int64, label, _ string) {
+			labeled = append(labeled, label)
+			if gotPR != pr {
+				t.Fatalf("addLabel pr = %d, want %d", gotPR, pr)
+			}
+		},
+		projectCWD:    func(string) string { return root },
+		mentionLogins: []string{"operator"},
+		awaitingLabel: "looper:awaiting-human",
+		nowISO:        nowISO,
+	})
+	if delivered != 1 {
+		t.Fatalf("deliverUndeliveredGitHubBudgetAsks() = %d, want 1", delivered)
+	}
+	if len(posted) != 1 || !strings.Contains(posted[0], "@operator") {
+		t.Fatalf("posted = %#v, want one mention of @operator", posted)
+	}
+	if len(labeled) != 1 || labeled[0] != "looper:awaiting-human" {
+		t.Fatalf("labeled = %#v, want awaiting-human", labeled)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil {
+		t.Fatalf("Loops.GetByID(reviewer) = (%#v, %v)", fresh, err)
+	}
+	ask, ok = loops.ReadHITLAsk(fresh.MetadataJSON)
+	if !ok || ask.Transport != "github" || ask.PRNumber != pr || ask.AskCommentID != 9001 {
+		t.Fatalf("delivered ask = %#v, want github transport + comment 9001", ask)
+	}
+
+	var answers []string
+	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{{
+		ID: reviewer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
+		AskStatus: "awaiting", PRNumber: pr, AskCommentID: 9001,
+	}}, githubHITLPollDeps{
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return []githubAnswerComment{
+				{ID: 9001, Author: "looper", Body: posted[0]},
+				{ID: 9002, Author: "operator", Body: "Continue"},
+			}, nil
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			answers = append(answers, loopID+"="+answer)
+			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+		},
+		clearAwaiting: func(_ contextType, _ string, _ int64, _ string) {},
+		projectCWD:    func(string) string { return root },
+	})
+	if n != 1 || len(answers) != 1 || answers[0] != reviewer.ID+"=Continue" {
+		t.Fatalf("poll delivered = %d answers=%v, want Continue on reviewer", n, answers)
+	}
+	fresh, err = repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "queued" || loops.ReviewerPublishCount(fresh.MetadataJSON) != 0 {
+		t.Fatalf("reviewer after continue = (%#v, %v), want queued with reset count", fresh, err)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "queued" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer after continue = (%#v, %v), want queued and unpaused", sibling, err)
+	}
+	for _, queueID := range []string{"queue_budget_reviewer", "queue_budget_fixer"} {
+		queue, err := repos.Queue.GetByID(context.Background(), queueID)
+		if err != nil || queue == nil || queue.Status != "queued" {
+			t.Fatalf("%s after continue = (%#v, %v), want queued", queueID, queue, err)
+		}
+	}
+}
+
+func seedPollBudgetQueue(t *testing.T, repos *storage.Repositories, nowISO, id, loopID, queueType string, priority int64) {
+	t.Helper()
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: id, ProjectID: stringPtr("project_budget_github"), LoopID: &loopID, Type: queueType,
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Status: "queued",
+		Priority: priority, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO,
+		DedupeKey: queueType + ":" + id,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert(%s) error = %v", id, err)
 	}
 }

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -231,21 +231,28 @@ func TestGitHubHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 }
 
 func TestRecoverGitHubBudgetAskCommentID(t *testing.T) {
-	marker := githubBudgetAskMarker(11)
+	const askedAt = "2026-04-17T12:34:56.000Z"
+	marker := githubBudgetAskMarker(11, askedAt)
 	comments := []githubAnswerComment{
 		{ID: 7001, Author: "looper", Body: marker + "\nfirst ask"},
 		{ID: 7002, Author: "operator", Body: "Continue"},
 		{ID: 8001, Author: "looper", Body: marker + "\nretry ask"},
-		{ID: 9001, Author: "looper", Body: githubBudgetAskMarker(99) + "\nother loop"},
+		{ID: 9001, Author: "looper", Body: githubBudgetAskMarker(99, askedAt) + "\nother loop"},
 	}
-	if got := recoverGitHubBudgetAskCommentID(comments[:1], 11); got != 7001 {
+	if got := recoverGitHubBudgetAskCommentID(comments[:1], 11, askedAt); got != 7001 {
 		t.Fatalf("unanswered ask = %d, want 7001", got)
 	}
-	if got := recoverGitHubBudgetAskCommentID(comments, 11); got != 8001 {
+	if got := recoverGitHubBudgetAskCommentID(comments, 11, askedAt); got != 8001 {
 		t.Fatalf("after prior Continue = %d, want unanswered retry ask 8001", got)
 	}
-	if got := recoverGitHubBudgetAskCommentID(comments, 12); got != 0 {
+	if got := recoverGitHubBudgetAskCommentID(comments, 12, askedAt); got != 0 {
 		t.Fatalf("missing loop marker = %d, want 0", got)
+	}
+	if got := recoverGitHubBudgetAskCommentID(comments[:1], 11, "2026-04-18T00:00:00.000Z"); got != 0 {
+		t.Fatalf("prior-cycle unanswered ask = %d, want 0 so a new prompt is posted", got)
+	}
+	if got := recoverGitHubBudgetAskCommentID(comments[:1], 11, ""); got != 0 {
+		t.Fatalf("missing askedAt = %d, want 0", got)
 	}
 }
 
@@ -303,7 +310,7 @@ func TestGitHubHITLPollRecoversBudgetAskAfterPersistFailure(t *testing.T) {
 	if !ok {
 		t.Fatal("parked loop missing budget ask")
 	}
-	existingBody := buildGitHubBudgetAskComment(reviewer.Seq, parkedAsk.Question, parkedAsk.Options, nil)
+	existingBody := buildGitHubBudgetAskComment(reviewer.Seq, parkedAsk.AskedAt, parkedAsk.Question, parkedAsk.Options, nil)
 	var created int
 	all, err := repos.Loops.List(context.Background())
 	if err != nil {
@@ -353,6 +360,134 @@ func TestGitHubHITLPollRecoversBudgetAskAfterPersistFailure(t *testing.T) {
 	fresh, err = repos.Loops.GetByID(context.Background(), reviewer.ID)
 	if err != nil || fresh == nil || fresh.Status != "queued" {
 		t.Fatalf("reviewer after recovered continue = (%#v, %v), want queued", fresh, err)
+	}
+}
+
+func TestGitHubHITLPollPostsNewAskAfterAPIAnsweredPriorCycle(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	firstISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	secondISO := now.Add(time.Hour).UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_budget_github_generation"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Budget", RepoPath: root, CreatedAt: firstISO, UpdatedAt: firstISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewerMeta := `{"loop":{"iterationCount":8}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_reviewer_generation", Seq: 11, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: firstISO, UpdatedAt: firstISO, MetadataJSON: &reviewerMeta,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_fixer_generation", Seq: 12, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: firstISO, UpdatedAt: firstISO,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	seedPollBudgetQueue(t, repos, firstISO, projectID, "queue_budget_reviewer_generation", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedPollBudgetQueue(t, repos, firstISO, projectID, "queue_budget_fixer_generation", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: firstISO,
+	}); err != nil {
+		t.Fatalf("ParkReviewFixBudget(first) error = %v", err)
+	}
+	all, err := repos.Loops.List(context.Background())
+	if err != nil {
+		t.Fatalf("Loops.List() error = %v", err)
+	}
+	var firstBody string
+	if delivered := deliverUndeliveredGitHubBudgetAsks(context.Background(), projectID, all, repos, githubHITLDeliveryDeps{
+		createComment: func(_ contextType, _ string, _ int64, body, _ string) (int64, error) {
+			firstBody = body
+			if !strings.Contains(body, githubBudgetAskMarker(reviewer.Seq, firstISO)) {
+				t.Fatalf("first ask missing generation marker: %s", body)
+			}
+			return 7001, nil
+		},
+		nowISO: firstISO,
+	}); delivered != 1 || firstBody == "" {
+		t.Fatalf("first deliver = %d body empty=%t, want posted ask", delivered, firstBody == "")
+	}
+
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil {
+		t.Fatalf("Loops.GetByID(reviewer) = (%#v, %v)", fresh, err)
+	}
+	if _, err := loops.ApplyReviewFixBudgetAnswer(context.Background(), repos, *fresh, loops.ReviewFixBudgetAnswerContinue, firstISO); err != nil {
+		t.Fatalf("ApplyReviewFixBudgetAnswer(API Continue) error = %v", err)
+	}
+
+	fresh, err = repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil {
+		t.Fatalf("Loops.GetByID(after continue) = (%#v, %v)", fresh, err)
+	}
+	reexhaustMeta := `{"loop":{"iterationCount":8}}`
+	fresh.MetadataJSON = &reexhaustMeta
+	fresh.Status = "running"
+	fresh.UpdatedAt = secondISO
+	if err := repos.Loops.Upsert(context.Background(), *fresh); err != nil {
+		t.Fatalf("Loops.Upsert(re-exhaust) error = %v", err)
+	}
+	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: *fresh, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: secondISO,
+	}); err != nil {
+		t.Fatalf("ParkReviewFixBudget(second) error = %v", err)
+	}
+
+	all, err = repos.Loops.List(context.Background())
+	if err != nil {
+		t.Fatalf("Loops.List(second) error = %v", err)
+	}
+	var created int
+	var secondBody string
+	if delivered := deliverUndeliveredGitHubBudgetAsks(context.Background(), projectID, all, repos, githubHITLDeliveryDeps{
+		createComment: func(_ contextType, _ string, _ int64, body, _ string) (int64, error) {
+			created++
+			secondBody = body
+			return 8001, nil
+		},
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return []githubAnswerComment{{ID: 7001, Author: "looper", Body: firstBody}}, nil
+		},
+		nowISO: secondISO,
+	}); delivered != 1 || created != 1 {
+		t.Fatalf("second deliver = delivered %d created %d, want a new prompt after API-answered prior cycle", delivered, created)
+	}
+	if !strings.Contains(secondBody, githubBudgetAskMarker(reviewer.Seq, secondISO)) {
+		t.Fatalf("second ask missing current generation marker: %s", secondBody)
+	}
+	if strings.Contains(secondBody, githubBudgetAskMarker(reviewer.Seq, firstISO)) {
+		t.Fatalf("second ask reused prior-cycle marker: %s", secondBody)
+	}
+	fresh, err = repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil {
+		t.Fatalf("Loops.GetByID(second deliver) = (%#v, %v)", fresh, err)
+	}
+	ask, ok := loops.ReadHITLAsk(fresh.MetadataJSON)
+	if !ok || ask.AskCommentID != 8001 || ask.AskedAt != secondISO {
+		t.Fatalf("second delivered ask = %#v, want comment 8001 at %s", ask, secondISO)
 	}
 }
 

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -42,13 +42,14 @@ func TestDetectGitHubHITLAnswerSkipsUnrelatedBudgetComments(t *testing.T) {
 	comments := []githubAnswerComment{
 		{ID: 9001, Author: "looper", Body: "<!-- looper:hitl:ask --> Continue or Stop?"},
 		{ID: 9002, Author: "operator", Body: "looking into this first"},
-		{ID: 9003, Author: "operator", Body: "Continue"},
+		{ID: 9003, Author: "operator", Body: "Continue investigating; do not resume yet"},
+		{ID: 9004, Author: "operator", Body: "Continue"},
 	}
 	accept := func(body string) bool {
 		return loops.IsReviewFixBudgetContinue(body) || loops.IsReviewFixBudgetStop(body)
 	}
 	if got := detectGitHubHITLAnswerMatching(comments, 9001, nil, accept); got != "Continue" {
-		t.Fatalf("budget answer = %q, want Continue after skipping unrelated comment", got)
+		t.Fatalf("budget answer = %q, want exact Continue after skipping prefix-only discussion", got)
 	}
 	if got := detectGitHubHITLAnswer(comments, 9001, nil); got != "looking into this first" {
 		t.Fatalf("generic answer = %q, want earliest human comment", got)

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -38,6 +38,23 @@ func TestDetectGitHubHITLAnswer(t *testing.T) {
 	}
 }
 
+func TestDetectGitHubHITLAnswerSkipsUnrelatedBudgetComments(t *testing.T) {
+	comments := []githubAnswerComment{
+		{ID: 9001, Author: "looper", Body: "<!-- looper:hitl:ask --> Continue or Stop?"},
+		{ID: 9002, Author: "operator", Body: "looking into this first"},
+		{ID: 9003, Author: "operator", Body: "Continue"},
+	}
+	accept := func(body string) bool {
+		return loops.IsReviewFixBudgetContinue(body) || loops.IsReviewFixBudgetStop(body)
+	}
+	if got := detectGitHubHITLAnswerMatching(comments, 9001, nil, accept); got != "Continue" {
+		t.Fatalf("budget answer = %q, want Continue after skipping unrelated comment", got)
+	}
+	if got := detectGitHubHITLAnswer(comments, 9001, nil); got != "looking into this first" {
+		t.Fatalf("generic answer = %q, want earliest human comment", got)
+	}
+}
+
 func TestPollGitHubHITLAnswersOnce(t *testing.T) {
 	commentsByPR := map[int64][]githubAnswerComment{
 		42: {{ID: 500, Author: "lefarcen", Body: "<!-- looper:hitl:ask --> ask"}, {ID: 501, Author: "lefarcen", Body: "go with A"}},
@@ -177,12 +194,13 @@ func TestGitHubHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 	var answers []string
 	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{{
 		ID: reviewer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
-		AskStatus: "awaiting", PRNumber: pr, AskCommentID: 9001,
+		AskStatus: "awaiting", PRNumber: pr, AskCommentID: 9001, BudgetAsk: true,
 	}}, githubHITLPollDeps{
 		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
 			return []githubAnswerComment{
 				{ID: 9001, Author: "looper", Body: posted[0]},
-				{ID: 9002, Author: "operator", Body: "Continue"},
+				{ID: 9002, Author: "operator", Body: "unrelated discussion"},
+				{ID: 9003, Author: "operator", Body: "Continue"},
 			}, nil
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -131,8 +131,8 @@ func TestGitHubHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
 		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
 	}
-	seedPollBudgetQueue(t, repos, nowISO, "queue_budget_reviewer", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
-	seedPollBudgetQueue(t, repos, nowISO, "queue_budget_fixer", fixer.ID, "fixer", storage.QueuePriorityFixer)
+	seedPollBudgetQueue(t, repos, nowISO, "project_budget_github", "queue_budget_reviewer", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedPollBudgetQueue(t, repos, nowISO, "project_budget_github", "queue_budget_fixer", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
 		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
@@ -229,10 +229,235 @@ func TestGitHubHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 	}
 }
 
-func seedPollBudgetQueue(t *testing.T, repos *storage.Repositories, nowISO, id, loopID, queueType string, priority int64) {
+func TestRecoverGitHubBudgetAskCommentID(t *testing.T) {
+	marker := githubBudgetAskMarker(11)
+	comments := []githubAnswerComment{
+		{ID: 7001, Author: "looper", Body: marker + "\nfirst ask"},
+		{ID: 7002, Author: "operator", Body: "Continue"},
+		{ID: 8001, Author: "looper", Body: marker + "\nretry ask"},
+		{ID: 9001, Author: "looper", Body: githubBudgetAskMarker(99) + "\nother loop"},
+	}
+	if got := recoverGitHubBudgetAskCommentID(comments[:1], 11); got != 7001 {
+		t.Fatalf("unanswered ask = %d, want 7001", got)
+	}
+	if got := recoverGitHubBudgetAskCommentID(comments, 11); got != 8001 {
+		t.Fatalf("after prior Continue = %d, want unanswered retry ask 8001", got)
+	}
+	if got := recoverGitHubBudgetAskCommentID(comments, 12); got != 0 {
+		t.Fatalf("missing loop marker = %d, want 0", got)
+	}
+}
+
+func TestGitHubHITLPollRecoversBudgetAskAfterPersistFailure(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_budget_github_recover"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Budget", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewerMeta := `{"loop":{"iterationCount":8}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_reviewer_recover", Seq: 11, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &reviewerMeta,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_fixer_recover", Seq: 12, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	seedPollBudgetQueue(t, repos, nowISO, projectID, "queue_budget_reviewer_recover", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedPollBudgetQueue(t, repos, nowISO, projectID, "queue_budget_fixer_recover", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	parked, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	parkedAsk, ok := loops.ReadHITLAsk(parked.MetadataJSON)
+	if !ok {
+		t.Fatal("parked loop missing budget ask")
+	}
+	existingBody := buildGitHubBudgetAskComment(reviewer.Seq, parkedAsk.Question, parkedAsk.Options, nil)
+	var created int
+	all, err := repos.Loops.List(context.Background())
+	if err != nil {
+		t.Fatalf("Loops.List() error = %v", err)
+	}
+	delivered := deliverUndeliveredGitHubBudgetAsks(context.Background(), projectID, all, repos, githubHITLDeliveryDeps{
+		createComment: func(_ contextType, _ string, _ int64, _ string, _ string) (int64, error) {
+			created++
+			return 9002, nil
+		},
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return []githubAnswerComment{{ID: 7001, Author: "looper", Body: existingBody}}, nil
+		},
+		nowISO: nowISO,
+	})
+	if delivered != 1 || created != 0 {
+		t.Fatalf("deliver after persist-failure = delivered %d created %d, want recover without repost", delivered, created)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil {
+		t.Fatalf("Loops.GetByID(reviewer) = (%#v, %v)", fresh, err)
+	}
+	ask, ok := loops.ReadHITLAsk(fresh.MetadataJSON)
+	if !ok || ask.Transport != "github" || ask.AskCommentID != 7001 {
+		t.Fatalf("recovered ask = %#v, want github comment 7001", ask)
+	}
+
+	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{{
+		ID: reviewer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
+		AskStatus: "awaiting", PRNumber: pr, AskCommentID: 7001, BudgetAsk: true,
+	}}, githubHITLPollDeps{
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return []githubAnswerComment{
+				{ID: 7001, Author: "looper", Body: existingBody},
+				{ID: 7002, Author: "operator", Body: "Continue"},
+				{ID: 9002, Author: "looper", Body: "duplicate ask that must not become the recorded id"},
+			}, nil
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+		},
+		clearAwaiting: func(_ contextType, _ string, _ int64, _ string) {},
+	})
+	if n != 1 {
+		t.Fatalf("poll delivered = %d, want Continue against recovered ask", n)
+	}
+	fresh, err = repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "queued" {
+		t.Fatalf("reviewer after recovered continue = (%#v, %v), want queued", fresh, err)
+	}
+}
+
+func TestGitHubHITLPollDeliversAndStopsReviewFixBudget(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_budget_github_stop"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Budget", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewerMeta := `{"loop":{"iterationCount":8}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_reviewer_stop", Seq: 21, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &reviewerMeta,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_fixer_stop", Seq: 22, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	seedPollBudgetQueue(t, repos, nowISO, projectID, "queue_budget_reviewer_stop", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedPollBudgetQueue(t, repos, nowISO, projectID, "queue_budget_fixer_stop", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+	}); err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	all, err := repos.Loops.List(context.Background())
+	if err != nil {
+		t.Fatalf("Loops.List() error = %v", err)
+	}
+	if delivered := deliverUndeliveredGitHubBudgetAsks(context.Background(), projectID, all, repos, githubHITLDeliveryDeps{
+		createComment: func(_ contextType, _ string, _ int64, _ string, _ string) (int64, error) {
+			return 9101, nil
+		},
+		nowISO: nowISO,
+	}); delivered != 1 {
+		t.Fatalf("deliverUndeliveredGitHubBudgetAsks() = %d, want 1", delivered)
+	}
+	terminatedSibling := fixer
+	terminatedSibling.Status = "terminated"
+	terminatedSibling.UpdatedAt = nowISO
+	if err := repos.Loops.Upsert(context.Background(), terminatedSibling); err != nil {
+		t.Fatalf("Loops.Upsert(partial sibling terminate) error = %v", err)
+	}
+
+	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{{
+		ID: reviewer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
+		AskStatus: "awaiting", PRNumber: pr, AskCommentID: 9101, BudgetAsk: true,
+	}}, githubHITLPollDeps{
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return []githubAnswerComment{
+				{ID: 9101, Author: "looper", Body: "<!-- looper:hitl:ask v=1 loop=21 -->"},
+				{ID: 9102, Author: "operator", Body: "Stop"},
+			}, nil
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+		},
+		clearAwaiting: func(_ contextType, _ string, _ int64, _ string) {},
+	})
+	if n != 1 {
+		t.Fatalf("poll delivered = %d, want Stop on reviewer", n)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "terminated" {
+		t.Fatalf("reviewer after stop = (%#v, %v), want terminated", fresh, err)
+	}
+	if _, stillAsked := loops.ReadHITLAsk(fresh.MetadataJSON); stillAsked {
+		t.Fatal("reviewer still has a HITL ask after stop")
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "terminated" {
+		t.Fatalf("fixer after stop = (%#v, %v), want terminated", sibling, err)
+	}
+}
+
+func seedPollBudgetQueue(t *testing.T, repos *storage.Repositories, nowISO, projectID, id, loopID, queueType string, priority int64) {
 	t.Helper()
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
-		ID: id, ProjectID: stringPtr("project_budget_github"), LoopID: &loopID, Type: queueType,
+		ID: id, ProjectID: stringPtr(projectID), LoopID: &loopID, Type: queueType,
 		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Status: "queued",
 		Priority: priority, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO,
 		DedupeKey: queueType + ":" + id,

--- a/internal/runtime/safety_floor_admission_test.go
+++ b/internal/runtime/safety_floor_admission_test.go
@@ -81,7 +81,6 @@ func TestSafetyFloorMutationsAndClaimsGatedUntilReady(t *testing.T) {
 	if claimCalls.Load() <= beforeReadyClaims {
 		t.Fatalf("claim pump calls after ready = %d, want > %d", claimCalls.Load(), beforeReadyClaims)
 	}
-	claimsWhenReady := claimCalls.Load()
 
 	// Dual-flag invariant: forcing ownershipAcquired alone must not admit work
 	// when admission is degraded.
@@ -95,9 +94,12 @@ func TestSafetyFloorMutationsAndClaimsGatedUntilReady(t *testing.T) {
 	if err := rt.AllowClaim(); !errors.Is(err, ErrAdmissionDegraded) {
 		t.Fatalf("AllowClaim() while degraded with ownershipAcquired = %v, want degraded", err)
 	}
+	// Snapshot after degrade so a background claim-pump tick that raced while
+	// still ready cannot fail the assertion.
+	claimsAtDegrade := claimCalls.Load()
 	rt.executeSchedulerClaimPass(context.Background())
-	if claimCalls.Load() != claimsWhenReady {
-		t.Fatalf("claim pump advanced while degraded, calls=%d want %d", claimCalls.Load(), claimsWhenReady)
+	if claimCalls.Load() != claimsAtDegrade {
+		t.Fatalf("claim pump advanced while degraded, calls=%d want %d", claimCalls.Load(), claimsAtDegrade)
 	}
 }
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -4610,7 +4610,7 @@ func schedulerLoopParked(ctx context.Context, item storage.QueueItemRecord, inpu
 		return false
 	}
 	switch loop.Status {
-	case "human_takeover", "paused":
+	case "human_takeover", "paused", "awaiting_human":
 		return true
 	default:
 		return false

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -638,6 +638,57 @@ func TestRunScheduledQueueItemsDoesNotReopenStopGate(t *testing.T) {
 	}
 }
 
+func TestRunScheduledQueueItemsReleasesAwaitingHumanClaim(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	backupDir := t.TempDir()
+	coordinator := openMigratedCoordinator(t, filepath.Join(workingDir, "awaiting-human.sqlite"), backupDir)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 21, 8, 0, 0, 0, time.UTC)
+	nowISO := formatJavaScriptISOString(now)
+	projectID := "project_awaiting_human"
+	loopID := "loop_awaiting_human"
+	queueID := "queue_awaiting_human"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Awaiting", RepoPath: filepath.Join(workingDir, "repo"), CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{
+		ID: queueID, ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: "pr:acme/looper:42",
+		DedupeKey: "fixer:awaiting_human", Priority: storage.QueuePriorityFixer, Status: "running",
+		AvailableAt: nowISO, Attempts: 0, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	item := storage.QueueItemRecord{ID: queueID, ProjectID: &projectID, LoopID: &loopID, Type: "fixer", Status: "running"}
+	input := defaultSchedulerTickInput{Repos: repos, Now: func() time.Time { return now }}
+	if !schedulerLoopParked(context.Background(), item, input) {
+		t.Fatal("schedulerLoopParked() = false, want true for awaiting_human")
+	}
+
+	fixerRunner := &stubFixerScheduler{}
+	if err := runScheduledQueueItems(context.Background(), []storage.QueueItemRecord{item}, defaultSchedulerTickInput{
+		Repos: repos, Now: func() time.Time { return now }, Fixer: fixerRunner,
+	}); err != nil {
+		t.Fatalf("runScheduledQueueItems() error = %v", err)
+	}
+	if fixerRunner.processItemCount() != 0 {
+		t.Fatalf("fixer processed = %d, want 0 for awaiting_human claim", fixerRunner.processItemCount())
+	}
+	queue, err := repos.Queue.GetByID(context.Background(), queueID)
+	if err != nil || queue == nil || queue.Status != "completed" {
+		t.Fatalf("queue = (%#v, %v), want completed parked claim", queue, err)
+	}
+	loop, err := repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || loop == nil || loop.Status != "awaiting_human" {
+		t.Fatalf("loop = (%#v, %v), want still awaiting_human", loop, err)
+	}
+}
+
 func TestRunScheduledQueueItemsProcessesItemsConcurrently(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/repositories.go
+++ b/internal/storage/repositories.go
@@ -2640,7 +2640,7 @@ const scheduledQueueBaseQuery = `
 	WHERE qi.status = 'queued'
 		AND qi.available_at <= ?
 		AND (qi.project_id IS NULL OR p.archived = 0)
-		AND COALESCE(l.status, 'queued') NOT IN ('paused', 'completed', 'failed', 'interrupted', 'terminated', 'stopped')
+		AND COALESCE(l.status, 'queued') NOT IN ('paused', 'completed', 'failed', 'interrupted', 'terminated', 'stopped', 'awaiting_human')
 		AND (
 			qi.lock_key IS NULL
 			OR NOT EXISTS (

--- a/internal/storage/repositories_test.go
+++ b/internal/storage/repositories_test.go
@@ -2018,6 +2018,32 @@ func TestQueueClaimNextOfTypeSkipsTerminatedAndStoppedLoops(t *testing.T) {
 	}
 }
 
+func TestQueueClaimNextOfTypeSkipsAwaitingHumanLoops(t *testing.T) {
+	ctx := context.Background()
+	coordinator := openMigratedCoordinatorForRepositories(t)
+	repos := NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	projectID := "project_queue_awaiting_human"
+	if err := repos.Projects.Upsert(ctx, ProjectRecord{ID: projectID, Name: "Queue Awaiting Human", RepoPath: "/tmp/repo", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	loopID := "loop_awaiting_human"
+	if err := repos.Loops.Upsert(ctx, LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", Status: "awaiting_human", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	if err := repos.Queue.Upsert(ctx, QueueItemRecord{ID: "queue_awaiting_human", ProjectID: &projectID, LoopID: &loopID, Type: "fixer", TargetType: "pull_request", TargetID: "pr:awaiting", DedupeKey: "d_awaiting_human", Priority: 1, Status: "queued", AvailableAt: now, Attempts: 0, MaxAttempts: 3, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+
+	claimed, err := repos.Queue.ClaimNextOfType(ctx, now, "worker", "fixer")
+	if err != nil {
+		t.Fatalf("Queue.ClaimNextOfType() error = %v", err)
+	}
+	if claimed != nil {
+		t.Fatalf("Queue.ClaimNextOfType() = %#v, want nil for awaiting_human loop", claimed)
+	}
+}
+
 func TestQueueClaimNextSkipsArchivedProjects(t *testing.T) {
 	t.Parallel()
 

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -370,12 +370,16 @@ reviewingLabel = "looper:spec-reviewing"
 scope = "changed_ranges"
 publishMode = "single_review"
 
+[roles.reviewer.behavior.loop]
+maxPublishesPerPR = 8
+
 [roles.reviewer.behavior.reviewEvents]
 clean = "APPROVE"
 blocking = "REQUEST_CHANGES"
 
 [roles.fixer.behavior.loop]
 quietPeriodSeconds = 0
+maxPushesPerPR = 8
 
 [roles.fixer.discovery]
 autoDiscovery = true


### PR DESCRIPTION
# Summary

Unlimited reviewer ⇄ fixer ping-pong is a cost and quality problem: each side can keep inventing new work after the other has already done a full pass. The old `maxIterationsPerPR` / `maxIterationsPerHead` knobs were reviewer-only, counted the wrong events, and were correctly deprecated in #209. This PR adds live, independent caps on the events that actually cost money:

- `roles.reviewer.behavior.loop.maxPublishesPerPR` — successful published reviews (default `8`, `0` disables)
- `roles.fixer.behavior.loop.maxPushesPerPR` — successful fixer pushes (default `8`, `0` disables)

When either role hits its cap, both loops park: the exhausted role goes `awaiting_human` with a Continue/Stop ask (`HITLAsk.Kind = review_fix_budget`); the sibling goes `paused` with `pauseReason = sibling_review_fix_budget`. Continue resets the exhausted counter and unpauses the sibling. Stop terminates both. Product terminals (ready, identical output, closed PR) still win.

Old `maxIterations*` fields stay accepted but ignored.

## New concept trade-off

**Failure this prevents:** a reviewer/fixer pair that never converges, burning agent turns and GitHub review events until a human notices.

**Cost:** a small persisted counter per role (`loop.iterationCount` for reviewer, `reviewFixBudget.pushCount` for fixer), a new HITL kind, a sibling pause reason, and two new config fields that are restart-bound like quiet period. New edge cases: Continue must not replay an agent session; sibling pause must not be auto-resumed by label-mismatch / noop-resolve / zero-progress resume; `waiting → awaiting_human` is invalid so park happens from `running`.

**Why a simpler alternative is insufficient:**
- Deleting the loop entirely is not an option; review-fix is the product.
- Trusting the agent to stop itself is the failure mode we are seeing.
- A single shared counter would stop the wrong role and hide which side exhausted.
- Reviving `maxIterations*` would count reviewer filter iterations, not publishes/pushes, and would reintroduce a knob we already told operators to ignore.
- Failing loud / terminating without HITL would strand the sibling and give operators no way to grant another slice.

**Authority:** live config is the cap. Successful publish/push events are the counted facts. The agent's structured output is not the authority, because the problem is the loop continuing after those facts, not a claim the agent makes.

# Testing

- [x] Targeted: `go test ./internal/loops ./internal/config ./internal/reviewer ./internal/fixer ./internal/cliapp ./internal/api ./internal/runtime`
- [ ] `go test ./...` (CI)
- [x] Additional targeted checks: `gofmt -l` clean on touched packages; `go vet` on the same set

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [x] Daemon boot / config / runtime path risk
- [ ] Worktree / repo isolation / lifecycle risk
- [ ] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

Config load/normalize/validate/parity fixtures and daemon HTTP contract snapshots change. HITL resume is covered by unit/integration tests on `ApplyReviewFixBudgetAnswer` (API + GitHub poll lanes). No new GitHub mutation contract.

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [ ] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- PR / issue links for regression coverage:
  - Supersedes the live effect of deprecated `maxIterations*` (#209 / `70d6b1c3`) without reviving those knobs
  - Park/continue/stop: `internal/loops/review_fix_budget_test.go`
  - Reviewer publish count + sibling park: `internal/reviewer/runner_test.go`
  - Fixer push count + park: `internal/fixer/runner_test.go`
  - Config default/validation: `internal/config/config_test.go`

# Reviewer Checklist

- [ ] Tests validate user-visible invariants, not only implementation details
- [ ] P0/P1 regression policy requirements above are satisfied
