### PR TITLE
feat: add same-head disposition path and review-fix handoff

### DIFF
--- a/docs/GUIDE-hitl-setup.md
+++ b/docs/GUIDE-hitl-setup.md
@@ -9,6 +9,11 @@ milestones), and one-command local takeover. For the design rationale see
 **Everything here is off by default** — a looper with none of these flags behaves
 exactly as before. Turn them on one at a time.
 
+Review-fix budget and scope holds still fire when HITL is off. They pause the
+pair with no ask; resume with `looper unpause <seq>` or stop with
+`looper stop <seq>`. Enabling HITL only changes presentation (Continue/Stop
+card), not whether the pair halts. See [configuration.md](configuration.md#review-fix-budget).
+
 ---
 
 ## What each capability needs (at a glance)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -656,8 +656,9 @@ enabledByDefault = true
 # Continuous follow-up debounce after a published review. Inherits defaults.loop when unset.
 quietPeriodSeconds = 60
 minPublishIntervalSeconds = 300
-# Successful reviewer publishes per PR. 0 disables. Exhaustion parks reviewer + sibling fixer via HITL.
-maxPublishesPerPR = 8
+# Successful reviewer publishes per PR. 0 disables. Exhaustion always
+# holds the pair; HITL only chooses ask vs no-ask presentation.
+maxPublishesPerPR = 3
 
 [roles.reviewer.behavior.reviewEvents]
 clean = "APPROVE"
@@ -676,12 +677,35 @@ Unlimited reviewer ⇄ fixer ping-pong is a cost and quality problem: each side 
 
 | Path | Counts | Default |
 | --- | --- | --- |
-| `roles.reviewer.behavior.loop.maxPublishesPerPR` | Successful published reviews on one PR | `8` |
-| `roles.fixer.behavior.loop.maxPushesPerPR` | Successful fixer pushes on one PR | `8` |
+| `roles.reviewer.behavior.loop.maxPublishesPerPR` | Successful published reviews on one PR | `3` |
+| `roles.fixer.behavior.loop.maxPushesPerPR` | Successful fixer pushes on one PR | `3` |
 
-`0` disables that role's cap. Authority is live config plus a durable counter (`iterationCount` for reviewer, `reviewFixBudget.pushCount` for fixer). Exhaustion parks the exhausted loop as `awaiting_human` with a Continue/Stop HITL ask and pauses the sibling loop on the same PR. Continue resets the exhausted counter and unpauses the sibling; Stop terminates both. Product terminals (ready label, identical output, closed PR) still win and do not open a budget ask.
+`0` disables that role's cap. Authority is live config plus a durable counter (`iterationCount` for reviewer, `reviewFixBudget.pushCount` for fixer). Caps enforce whether or not HITL is enabled. Automatic and takeover (`manual` + `followUpdates`) loops participate; one-shot manual loops do not. Either exhausted role holds the same-lane pair:
 
-**Failure prevented:** expanding-scope review/fix that never converges. **Cost:** a new persisted counter and a HITL park that must not fight discovery or the deprecated budget-strip path. **Why not reuse the old knobs:** those were reviewer-only infra counters that stranded long PRs and were explicitly demoted in #209.
+| `hitl.enabled` | Exhausted role | Sibling | Resume |
+| --- | --- | --- | --- |
+| `true` | `awaiting_human` with Continue/Stop | budget-paused | answer the ask |
+| `false` (default) | `paused`, reason `review_fix_budget_exhausted`, no ask | paired budget-paused | `looper unpause <seq>` or `looper stop <seq>` |
+
+Continue / no-HITL `unpause` refills only meters currently at/over their live cap and releases the pair. Stop / no-HITL `looper stop` terminates both roles. Product terminals (ready label, identical output, closed PR) still win and do not open a budget ask. Budget exhaustion never approves, resolves, or merges.
+
+CLI `looper describe <seq>` / `looper loop inspect <seq>` and the dashboard loop page show the handoff brief: meters, last reviewed signal, and the exact next command. Events: `loop.review_fix_budget.exhausted` (level `action_required`) and `loop.review_scope_human.required`.
+
+**Failure prevented:** expanding-scope review/fix that never converges, including on default HITL-off installs. **Cost:** paired pause/unpause/stop plus an action-required event. **Why not reuse the old knobs:** those were reviewer-only infra counters that stranded long PRs and were explicitly demoted in #209.
+
+### Same-head disposition (always on for GitHub)
+
+Continuous GitHub Reviewer loops react to trusted `wontfix` / Fixer decline changes even when the PR head is unchanged. This path does **not** enable `roles.reviewer.behavior.threadResolution`; that setting still gates objective stale-thread reconciliation only and remains `enabled=false` by default.
+
+- Canonical command inside a Looper-authored thread: `/looper wontfix <reason>`. Compatibility aliases: a trusted human comment whose entire non-quoted body is `wontfix`, `won't fix`, or `won’t fix`.
+- `/looper reconsider <reason>` cancels the latest accepted disposition on an unresolved/reopened thread.
+- Authority is the PR author or `OWNER` / `MEMBER` / `COLLABORATOR`. Arbitrary users and bots are not disposition authorities. A Fixer `declined` reply is a dispute signal; Reviewer adjudicates it and Fixer does not resolve its own decline.
+- Reviewer decisions: `accept_wontfix` (reply + resolve), `reject_wontfix` (reply, leave open), `needs_human` (pair hold, no remote adjudication reply).
+- Discovery identity is `lastReviewedSignalFingerprint` (head + canonical Looper-thread feedback), not `lastPublishedHeadSha` alone. Queue dedupe stays `reviewer:{project}:{loop}:{repo}:{pr}`.
+- GitHub webhooks accelerate the same path: `pull_request_review_comment` create/edit/delete and `pull_request_review_thread` `resolved` route both Reviewer and Fixer. Polling remains the correctness fallback. Forgejo is exempt from same-head disposition; its role budgets still apply.
+- A budget-held pair may run disposition-only reconciliation. That cannot publish a review, push code, refill a meter, or release the hold.
+
+Disposition outcomes emit `reviewer.thread_resolution` with `disposition=true`.
 
 ### Quiet-period debounce (shared + per-role)
 
@@ -962,7 +986,7 @@ publishMode = "single_review"
 enabledByDefault = true
 quietPeriodSeconds = 60
 minPublishIntervalSeconds = 300
-maxPublishesPerPR = 8
+maxPublishesPerPR = 3
 
 [roles.reviewer.behavior.reviewEvents]
 clean = "APPROVE"
@@ -982,8 +1006,9 @@ scope = "looper-only"
 [roles.fixer.behavior.loop]
 # Opt-in quiet period (default 0 = immediate enqueue). Recommended starter: 60–120.
 quietPeriodSeconds = 0
-# Successful fixer pushes per PR. 0 disables. Exhaustion parks fixer + sibling reviewer via HITL.
-maxPushesPerPR = 8
+# Successful fixer pushes per PR. 0 disables. Exhaustion always holds
+# the pair; HITL only chooses ask vs no-ask presentation.
+maxPushesPerPR = 3
 
 [roles.fixer.discovery]
 autoDiscovery = true

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -106,7 +106,7 @@ If no project matches the current directory, or multiple projects match, pass `-
 | `coordinator` | Proactively triages fresh issues and commits a Disposition with durable labels | runs automatically inside `looperd` |
 | `planner` | Generates a spec from an issue and opens a spec PR | `looper plan --project <id> --issue <num>` |
 | `reviewer` | Reviews a PR or spec PR and publishes GitHub reviews | `looper review <repo>#<pr> [--loop]` or `looper review <pr> [--loop]` from inside the repo |
-| `fixer` | Fixes PR issues based on review comments and tries to resolve threads | `looper fix <repo>#<pr>` |
+| `fixer` | Fixes PR issues based on review comments; declines leave threads open for Reviewer | `looper fix <repo>#<pr>` |
 | `worker` | Implements the actual work from a spec or issue, and can reuse an existing PR | `looper work --issue <num>` or `looper work --project <id> --issue <num>` |
 
 Forgejo MVP role support:
@@ -344,6 +344,26 @@ Fixer will:
 - run validation
 - push back to the same PR branch
 - after validation and push succeed, try to resolve only the review threads that were both verified by Looper and explicitly confirmed by the fixer agent
+- if a finding is out of documented PR scope, reply with a structured decline and **leave the thread unresolved** so Reviewer can accept, reject, or escalate
+
+### Review-fix budget and same-head `wontfix`
+
+Reviewer and Fixer have independent default caps of **3 published reviews** and **3 Fixer pushes** per PR. Caps apply with HITL off (the default). When either cap trips, Looper holds the pair:
+
+- HITL on: Continue/Stop ask
+- HITL off: paused with no ask. Resume with `looper unpause <seq>` (Continue: refill exhausted meters only) or `looper stop <seq>` (terminate both). Dashboard Unpause is the same Continue path.
+
+Budget exhaustion is not approval. It never publishes a clean review, resolves a blocker, or enables auto-merge.
+
+On GitHub, a trusted human can dispose a Looper-authored thread without a new commit:
+
+```text
+/looper wontfix optional cleanup, out of this PR's stated scope
+```
+
+Standalone `wontfix` / `won't fix` comments work as aliases. Reviewer then accepts (resolves), rejects (keeps the thread open for Fixer), or parks the pair as `needs_human`. Forgejo keeps budgets but does not offer this same-head disposition path.
+
+Inspect a hold with `looper describe <seq>` or the dashboard loop page. The brief names the next command and does not imply the code is approved.
 
 For Forgejo projects, automatic Fixer runs are summary-only because Forgejo's public REST API does not currently expose a native review-comment resolve mutation:
 
@@ -504,11 +524,11 @@ looper run reconcile-stale
 Typical usage:
 
 - `looper ps`: see which loops are currently running (includes a truncated failure reason when present)
-- `looper describe <id>`: show why a loop is blocked (manual intervention reason, diagnosis); same as `looper loop inspect`
+- `looper describe <id>`: show why a loop is blocked (manual intervention, review-fix budget/scope handoff, diagnosis); same as `looper loop inspect`
 - `looper logs <id> --follow`: stream logs live
 - `looper jump <id>`: print the shell command for the loop's worktree; use `eval "$(looper jump 12)"` to actually change directories, or pass `--print-path` to print just the path
 - `looper worktree cleanup`: inspect Looper-managed worktree cleanup candidates without deleting anything; add `--confirm` for one immediate cleanup pass or `--json` for structured output
-- `looper stop <id>`: stop an active loop
+- `looper stop <id>`: stop an active loop, or terminate a budget/scope-held pair
 - `looper run reconcile-stale`: interrupt stale running runs, repair blocked queue state, and requeue eligible loops after sleep/wake or other local process loss; `looper daemon restart` is still a reasonable fallback if you want a full daemon restart
 
 ## 15. Minimal end-to-end example

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5948,9 +5948,11 @@ func (h *Handler) reviewFixBudgetLiveCaps(projectID string) loops.ReviewFixBudge
 }
 
 // applyReviewFixBudgetContinueIfHeld delegates looper unpause /start on a
-// budget-held role to paired Continue. Returns nil response when not a hold.
+// budget-held or scope-held role to paired Continue. Scope-only holds release
+// without resetting meters; budget holds keep existing refill semantics.
+// Returns nil response when not a pair hold.
 func (h *Handler) applyReviewFixBudgetContinueIfHeld(ctx context.Context, loop storage.LoopRecord) (*loopResponse, error) {
-	if !loops.IsReviewFixBudgetHold(loop) {
+	if !loops.IsReviewFixPairHold(loop) {
 		return nil, nil
 	}
 	services := h.context.Runtime.Services()
@@ -5968,17 +5970,28 @@ func (h *Handler) applyReviewFixBudgetContinueIfHeld(ctx context.Context, loop s
 		if fresh == nil {
 			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loop.ID)}
 		}
-		if !loops.IsReviewFixBudgetHold(*fresh) {
-			return storage.LoopRecord{}, nil
+		// Budget hold (including combined with scope) uses meter-aware Continue.
+		if loops.IsReviewFixBudgetHold(*fresh) {
+			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerContinue, nowISO, caps)
+			if applyErr != nil {
+				return storage.LoopRecord{}, applyErr
+			}
+			if !result.Applied {
+				return storage.LoopRecord{}, nil
+			}
+			return result.Loop, nil
 		}
-		result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerContinue, nowISO, caps)
-		if applyErr != nil {
-			return storage.LoopRecord{}, applyErr
+		if loops.IsReviewScopeHumanHold(*fresh) {
+			result, applyErr := loops.ApplyReviewScopeHumanAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerContinue, nowISO)
+			if applyErr != nil {
+				return storage.LoopRecord{}, applyErr
+			}
+			if !result.Applied {
+				return storage.LoopRecord{}, nil
+			}
+			return result.Loop, nil
 		}
-		if !result.Applied {
-			return storage.LoopRecord{}, nil
-		}
-		return result.Loop, nil
+		return storage.LoopRecord{}, nil
 	})
 	if err != nil {
 		var typed apiError
@@ -6000,10 +6013,10 @@ func (h *Handler) applyReviewFixBudgetContinueIfHeld(ctx context.Context, loop s
 	return &resp, nil
 }
 
-// applyReviewFixBudgetStopIfHeld delegates looper stop on a budget-held role to
-// paired Stop (terminate both). Returns nil when not a hold.
+// applyReviewFixBudgetStopIfHeld delegates looper stop on a budget-held or
+// scope-held role to paired Stop (terminate both). Returns nil when not a hold.
 func (h *Handler) applyReviewFixBudgetStopIfHeld(ctx context.Context, loop storage.LoopRecord) (any, error) {
-	if !loops.IsReviewFixBudgetHold(loop) {
+	if !loops.IsReviewFixPairHold(loop) {
 		return nil, nil
 	}
 	services := h.context.Runtime.Services()
@@ -6021,17 +6034,27 @@ func (h *Handler) applyReviewFixBudgetStopIfHeld(ctx context.Context, loop stora
 		if fresh == nil {
 			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loop.ID)}
 		}
-		if !loops.IsReviewFixBudgetHold(*fresh) {
-			return storage.LoopRecord{}, nil
+		if loops.IsReviewFixBudgetHold(*fresh) {
+			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerStop, nowISO, caps)
+			if applyErr != nil {
+				return storage.LoopRecord{}, applyErr
+			}
+			if !result.Applied {
+				return storage.LoopRecord{}, nil
+			}
+			return result.Loop, nil
 		}
-		result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerStop, nowISO, caps)
-		if applyErr != nil {
-			return storage.LoopRecord{}, applyErr
+		if loops.IsReviewScopeHumanHold(*fresh) {
+			result, applyErr := loops.ApplyReviewScopeHumanAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerStop, nowISO)
+			if applyErr != nil {
+				return storage.LoopRecord{}, applyErr
+			}
+			if !result.Applied {
+				return storage.LoopRecord{}, nil
+			}
+			return result.Loop, nil
 		}
-		if !result.Applied {
-			return storage.LoopRecord{}, nil
-		}
-		return result.Loop, nil
+		return storage.LoopRecord{}, nil
 	})
 	if err != nil {
 		var typed apiError
@@ -6043,11 +6066,15 @@ func (h *Handler) applyReviewFixBudgetStopIfHeld(ctx context.Context, loop stora
 	if updated.ID == "" {
 		return nil, nil
 	}
+	outcome := "review_fix_budget_stop"
+	if loops.IsReviewScopeHumanHold(loop) && !loops.IsReviewFixBudgetHold(loop) {
+		outcome = "review_scope_human_stop"
+	}
 	return map[string]any{
 		"stopped": true,
 		"loopId":  updated.ID,
 		"status":  updated.Status,
-		"outcome": "review_fix_budget_stop",
+		"outcome": outcome,
 	}, nil
 }
 
@@ -6080,6 +6107,18 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO, h.reviewFixBudgetLiveCaps(loop.ProjectID))
 			if applyErr != nil {
 				if errors.Is(applyErr, loops.ErrReviewFixBudgetInvalidAnswer) {
+					return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: applyErr.Error()}
+				}
+				return storage.LoopRecord{}, applyErr
+			}
+			if result.Applied {
+				return result.Loop, nil
+			}
+		}
+		if loops.IsReviewScopeHumanAsk(ask) {
+			result, applyErr := loops.ApplyReviewScopeHumanAnswer(ctx, repos, *loop, answer, nowISO)
+			if applyErr != nil {
+				if errors.Is(applyErr, loops.ErrReviewScopeHumanInvalidAnswer) {
 					return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: applyErr.Error()}
 				}
 				return storage.LoopRecord{}, applyErr
@@ -7150,12 +7189,16 @@ func (h *Handler) assertLoopRetryPreconditions(ctx context.Context, repos *stora
 			return err
 		}
 	}
-	// Budget holds require paired Continue (looper unpause) or Stop — not single-role retry.
-	if loops.IsReviewFixBudgetHold(loop) {
+	// Budget/scope pair holds require paired Continue (looper unpause) or Stop — not single-role retry.
+	if loops.IsReviewFixPairHold(loop) {
+		kind := "budget"
+		if loops.IsReviewScopeHumanHold(loop) && !loops.IsReviewFixBudgetHold(loop) {
+			kind = "scope"
+		}
 		return apiError{
 			code:    pkgapi.ErrorCodeValidationFailed,
 			status:  http.StatusBadRequest,
-			message: fmt.Sprintf("Cannot retry review-fix budget hold on loop %s; use looper unpause (Continue) or looper stop", loop.ID),
+			message: fmt.Sprintf("Cannot retry review-fix %s hold on loop %s; use looper unpause (Continue) or looper stop", kind, loop.ID),
 		}
 	}
 	if loop.Status == string(domain.LoopStatusStopped) || loop.Status == string(domain.LoopStatusTerminated) || loop.Status == string(domain.LoopStatusCompleted) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3115,6 +3115,11 @@ func (h *Handler) buildActiveRunRouteResponse(r *http.Request, path string) (any
 		if err != nil {
 			return nil, err
 		}
+		if stopped, stopErr := h.applyReviewFixBudgetStopIfHeld(r.Context(), loop); stopErr != nil {
+			return nil, stopErr
+		} else if stopped != nil {
+			return stopped, nil
+		}
 		return h.context.StopLoop(r.Context(), loop.ID, fmt.Sprintf("Stopped by user via selector %s", selector))
 	case "close":
 		if r.Method != http.MethodPost {
@@ -5583,6 +5588,12 @@ func (h *Handler) mutateLoopStatus(ctx context.Context, loopID string, status do
 			return loopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
 		if preflightLoop != nil {
+			// No-HITL budget hold: looper unpause must paired-Continue, not resume one role.
+			if continued, contErr := h.applyReviewFixBudgetContinueIfHeld(ctx, *preflightLoop); contErr != nil {
+				return loopResponse{}, contErr
+			} else if continued != nil {
+				return *continued, nil
+			}
 			target, targetErr := loopTargetFromRecordCompat(*preflightLoop)
 			if targetErr != nil {
 				return loopResponse{}, targetErr
@@ -5928,6 +5939,118 @@ func (h *Handler) respondToLoop(ctx context.Context, r *http.Request, loopID str
 	return h.deliverHumanAnswer(ctx, loopID, body.Answer)
 }
 
+func (h *Handler) reviewFixBudgetLiveCaps(projectID string) loops.ReviewFixBudgetLiveCaps {
+	roles := config.ProjectRoleConfigs(h.effectiveConfig(), projectID)
+	return loops.ReviewFixBudgetLiveCaps{
+		ReviewerMaxPublishes: roles.Reviewer.Behavior.Loop.MaxPublishesPerPR,
+		FixerMaxPushes:       roles.Fixer.Behavior.Loop.MaxPushesPerPR,
+	}
+}
+
+// applyReviewFixBudgetContinueIfHeld delegates looper unpause /start on a
+// budget-held role to paired Continue. Returns nil response when not a hold.
+func (h *Handler) applyReviewFixBudgetContinueIfHeld(ctx context.Context, loop storage.LoopRecord) (*loopResponse, error) {
+	if !loops.IsReviewFixBudgetHold(loop) {
+		return nil, nil
+	}
+	services := h.context.Runtime.Services()
+	if services.Repositories == nil || services.Coordinator == nil {
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Storage is not configured"}
+	}
+	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
+	caps := h.reviewFixBudgetLiveCaps(loop.ProjectID)
+	updated, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
+		repos := storage.NewRepositories(tx)
+		fresh, getErr := repos.Loops.GetByID(ctx, loop.ID)
+		if getErr != nil {
+			return storage.LoopRecord{}, getErr
+		}
+		if fresh == nil {
+			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loop.ID)}
+		}
+		if !loops.IsReviewFixBudgetHold(*fresh) {
+			return storage.LoopRecord{}, nil
+		}
+		result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerContinue, nowISO, caps)
+		if applyErr != nil {
+			return storage.LoopRecord{}, applyErr
+		}
+		if !result.Applied {
+			return storage.LoopRecord{}, nil
+		}
+		return result.Loop, nil
+	})
+	if err != nil {
+		var typed apiError
+		if asAPIError(err, &typed) {
+			return nil, typed
+		}
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	if updated.ID == "" {
+		return nil, nil
+	}
+	if h.context.TriggerSchedulerTick != nil {
+		h.context.TriggerSchedulerTick()
+	}
+	resp, serErr := h.serializeLoopWithDiagnostics(ctx, updated)
+	if serErr != nil {
+		return nil, serErr
+	}
+	return &resp, nil
+}
+
+// applyReviewFixBudgetStopIfHeld delegates looper stop on a budget-held role to
+// paired Stop (terminate both). Returns nil when not a hold.
+func (h *Handler) applyReviewFixBudgetStopIfHeld(ctx context.Context, loop storage.LoopRecord) (any, error) {
+	if !loops.IsReviewFixBudgetHold(loop) {
+		return nil, nil
+	}
+	services := h.context.Runtime.Services()
+	if services.Repositories == nil || services.Coordinator == nil {
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Storage is not configured"}
+	}
+	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
+	caps := h.reviewFixBudgetLiveCaps(loop.ProjectID)
+	updated, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
+		repos := storage.NewRepositories(tx)
+		fresh, getErr := repos.Loops.GetByID(ctx, loop.ID)
+		if getErr != nil {
+			return storage.LoopRecord{}, getErr
+		}
+		if fresh == nil {
+			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loop.ID)}
+		}
+		if !loops.IsReviewFixBudgetHold(*fresh) {
+			return storage.LoopRecord{}, nil
+		}
+		result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerStop, nowISO, caps)
+		if applyErr != nil {
+			return storage.LoopRecord{}, applyErr
+		}
+		if !result.Applied {
+			return storage.LoopRecord{}, nil
+		}
+		return result.Loop, nil
+	})
+	if err != nil {
+		var typed apiError
+		if asAPIError(err, &typed) {
+			return nil, typed
+		}
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	if updated.ID == "" {
+		return nil, nil
+	}
+	return map[string]any{
+		"stopped": true,
+		"loopId":  updated.ID,
+		"status":  updated.Status,
+		"outcome": "review_fix_budget_stop",
+	}, nil
+}
+
 // deliverHumanAnswer is the shared core of the HITL respond path: it validates
 // the loop is awaiting_human, stores the answer on the loop's HITL metadata, and
 // transitions the loop back to running (requeue + scheduler tick). Both the
@@ -5954,7 +6077,7 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 		}
 		ask, _ := loops.ReadHITLAsk(loop.MetadataJSON)
 		if loops.IsReviewFixBudgetAsk(ask) {
-			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO)
+			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO, h.reviewFixBudgetLiveCaps(loop.ProjectID))
 			if applyErr != nil {
 				if errors.Is(applyErr, loops.ErrReviewFixBudgetInvalidAnswer) {
 					return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: applyErr.Error()}
@@ -7025,6 +7148,14 @@ func (h *Handler) assertLoopRetryPreconditions(ctx context.Context, repos *stora
 	if strings.TrimSpace(loop.ProjectID) != "" {
 		if _, err := requireActiveProjectRecord(ctx, repos.Projects, loop.ProjectID); err != nil {
 			return err
+		}
+	}
+	// Budget holds require paired Continue (looper unpause) or Stop — not single-role retry.
+	if loops.IsReviewFixBudgetHold(loop) {
+		return apiError{
+			code:    pkgapi.ErrorCodeValidationFailed,
+			status:  http.StatusBadRequest,
+			message: fmt.Sprintf("Cannot retry review-fix budget hold on loop %s; use looper unpause (Continue) or looper stop", loop.ID),
 		}
 	}
 	if loop.Status == string(domain.LoopStatusStopped) || loop.Status == string(domain.LoopStatusTerminated) || loop.Status == string(domain.LoopStatusCompleted) {

--- a/internal/api/review_fix_budget_test.go
+++ b/internal/api/review_fix_budget_test.go
@@ -1,0 +1,201 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestHandlerLoopStartDelegatesNoHITLBudgetHoldToPairedContinue(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = false
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 3
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_budget_unpause"
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_unpause_rev", Seq: 4201, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixerMeta := `{"reviewFixBudget":{"pushCount":1}}`
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_unpause_fix", Seq: 4202, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", MetadataJSON: &fixerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	parked, err := loops.ParkReviewFixBudget(context.Background(), services.Repositories, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+	if parked.Status != "paused" {
+		t.Fatalf("parked status = %q, want paused", parked.Status)
+	}
+
+	// Unpause from sibling side.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/"+fixer.ID+"/start", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("start status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+
+	reviewerAfter, err := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || reviewerAfter == nil || reviewerAfter.Status != "queued" || loops.ReviewerPublishCount(reviewerAfter.MetadataJSON) != 0 {
+		t.Fatalf("reviewer after unpause = (%#v, %v), want queued with reset meter", reviewerAfter, err)
+	}
+	fixerAfter, err := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || fixerAfter == nil || fixerAfter.Status != "queued" || loops.FixerPushCount(fixerAfter.MetadataJSON) != 1 {
+		t.Fatalf("fixer after unpause = (%#v, %v), want queued with preserved unused budget", fixerAfter, err)
+	}
+	if loops.IsReviewFixBudgetHold(*reviewerAfter) || loops.IsReviewFixBudgetHold(*fixerAfter) {
+		t.Fatal("pair still budget-held after unpause")
+	}
+}
+
+func TestHandlerActiveStopDelegatesBudgetHoldToPairedStop(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = false
+	h := NewHandler(Context{
+		Config:  cfg,
+		Runtime: rt,
+		StopLoop: func(context.Context, string, string) (any, error) {
+			t.Fatal("generic StopLoop must not run for budget-held pair")
+			return nil, nil
+		},
+	})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_budget_stop"
+	repo := "acme/looper"
+	pr := int64(43)
+	target := "pr:acme/looper:43"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_stop_rev", Seq: 4301, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_stop_fix", Seq: 4302, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if _, err := loops.ParkReviewFixBudget(context.Background(), services.Repositories, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	}); err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/active/"+fixer.ID+"/stop", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("stop status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var envelope struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode: %v body=%s", err, recorder.Body.String())
+	}
+	if envelope.Data["outcome"] != "review_fix_budget_stop" {
+		t.Fatalf("outcome = %#v, want review_fix_budget_stop", envelope.Data)
+	}
+	reviewerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	fixerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if reviewerAfter == nil || reviewerAfter.Status != "terminated" || fixerAfter == nil || fixerAfter.Status != "terminated" {
+		t.Fatalf("pair after stop = reviewer %#v fixer %#v, want both terminated", reviewerAfter, fixerAfter)
+	}
+}
+
+func TestHandlerRetryRejectsReviewFixBudgetHold(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = false
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_budget_retry"
+	repo := "acme/looper"
+	pr := int64(44)
+	target := "pr:acme/looper:44"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_retry_rev", Seq: 4401, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_retry_fix", Seq: 4402, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if _, err := loops.ParkReviewFixBudget(context.Background(), services.Repositories, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	}); err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/4401/retry", strings.NewReader(`{"mode":"auto","resetAttempts":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("retry status = %d body=%s, want 400", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "looper unpause") && !strings.Contains(recorder.Body.String(), "budget") {
+		t.Fatalf("retry body = %s, want budget hold guidance", recorder.Body.String())
+	}
+	// Counters and hold must be unchanged.
+	after, _ := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	if after == nil || !loops.IsReviewFixBudgetHold(*after) || loops.ReviewerPublishCount(after.MetadataJSON) != 3 {
+		t.Fatalf("after rejected retry = %#v, want still held with count 3", after)
+	}
+}

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -420,7 +420,7 @@
                   "minPublishIntervalSeconds": 300,
                   "maxIterationsPerPR": 20,
                   "maxIterationsPerHead": 1,
-                  "maxPublishesPerPR": 8,
+                  "maxPublishesPerPR": 3,
                   "maxWallClockSeconds": 0,
                   "maxConsecutiveFailures": 3,
                   "maxAgentExecutionsPerPR": 25,
@@ -482,7 +482,7 @@
               "behavior": {
                 "loop": {
                   "quietPeriodSeconds": 0,
-                  "maxPushesPerPR": 8
+                  "maxPushesPerPR": 3
                 }
               }
             },

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/spf13/cobra"
 )
@@ -17,15 +18,16 @@ import (
 const defaultDiagnosticsLimit int64 = 100
 
 type loopInspectOutput struct {
-	NowISO          string                  `json:"nowIso"`
-	Selector        string                  `json:"selector"`
-	SelectorKind    string                  `json:"selectorKind"`
-	Loop            loopDiagnosticLoop      `json:"loop"`
-	Metadata        loopDiagnosticMetadata  `json:"metadata"`
-	Run             *loopDiagnosticRun      `json:"run,omitempty"`
-	LatestQueueItem *queueItemCommandOutput `json:"latestQueueItem,omitempty"`
-	Agent           *loopDiagnosticAgent    `json:"agent,omitempty"`
-	Diagnosis       loopDiagnosis           `json:"diagnosis"`
+	NowISO          string                       `json:"nowIso"`
+	Selector        string                       `json:"selector"`
+	SelectorKind    string                       `json:"selectorKind"`
+	Loop            loopDiagnosticLoop           `json:"loop"`
+	Metadata        loopDiagnosticMetadata       `json:"metadata"`
+	Handoff         *loops.ReviewFixHandoffBrief `json:"handoff,omitempty"`
+	Run             *loopDiagnosticRun           `json:"run,omitempty"`
+	LatestQueueItem *queueItemCommandOutput      `json:"latestQueueItem,omitempty"`
+	Agent           *loopDiagnosticAgent         `json:"agent,omitempty"`
+	Diagnosis       loopDiagnosis                `json:"diagnosis"`
 }
 
 type loopFailuresOutput struct {
@@ -73,14 +75,19 @@ type loopDiagnosticTarget struct {
 }
 
 type loopDiagnosticMetadata struct {
-	DecodeError          *string                     `json:"decodeError,omitempty"`
-	FollowUpdates        *bool                       `json:"followUpdates,omitempty"`
-	LastPublishedAt      *string                     `json:"lastPublishedAt,omitempty"`
-	LastPublishedHeadSHA *string                     `json:"lastPublishedHeadSha,omitempty"`
-	LastReviewEvent      *string                     `json:"lastReviewEvent,omitempty"`
-	LastReviewSummary    *string                     `json:"lastReviewSummary,omitempty"`
-	LastFilterSkip       map[string]any              `json:"lastFilterSkip,omitempty"`
-	Loop                 *loopDiagnosticLoopMetadata `json:"loop,omitempty"`
+	DecodeError                   *string                     `json:"decodeError,omitempty"`
+	FollowUpdates                 *bool                       `json:"followUpdates,omitempty"`
+	LastPublishedAt               *string                     `json:"lastPublishedAt,omitempty"`
+	LastPublishedHeadSHA          *string                     `json:"lastPublishedHeadSha,omitempty"`
+	LastFixHeadSHA                *string                     `json:"lastFixHeadSha,omitempty"`
+	LastReviewedSignalFingerprint *string                     `json:"lastReviewedSignalFingerprint,omitempty"`
+	LastReviewEvent               *string                     `json:"lastReviewEvent,omitempty"`
+	LastReviewSummary             *string                     `json:"lastReviewSummary,omitempty"`
+	PauseReason                   *string                     `json:"pauseReason,omitempty"`
+	LastFilterSkip                map[string]any              `json:"lastFilterSkip,omitempty"`
+	ReviewFixBudget               map[string]any              `json:"reviewFixBudget,omitempty"`
+	ReviewScopeHuman              map[string]any              `json:"reviewScopeHuman,omitempty"`
+	Loop                          *loopDiagnosticLoopMetadata `json:"loop,omitempty"`
 }
 
 type loopDiagnosticLoopMetadata struct {
@@ -380,6 +387,9 @@ func buildLoopInspectOutput(ctx context.Context, repos *storage.Repositories, se
 		LatestQueueItem: queueOutput,
 		Diagnosis:       diagnoseLoop(resolved.Loop, resolved.Run, queueItem, metadata, associateQueueWithDiagnosis),
 	}
+	if brief, ok := loops.BuildReviewFixHandoffBrief(resolved.Loop); ok {
+		output.Handoff = &brief
+	}
 	if resolved.Run != nil {
 		run := diagnosticRunOutput(*resolved.Run, now)
 		output.Run = &run
@@ -428,14 +438,23 @@ func parseLoopDiagnosticMetadata(raw *string) loopDiagnosticMetadata {
 		return loopDiagnosticMetadata{DecodeError: &msg}
 	}
 	output := loopDiagnosticMetadata{
-		FollowUpdates:        boolPtrFromMap(doc, "followUpdates"),
-		LastPublishedAt:      stringPtrFromMap(doc, "lastPublishedAt"),
-		LastPublishedHeadSHA: stringPtrFromMap(doc, "lastPublishedHeadSha"),
-		LastReviewEvent:      stringPtrFromMap(doc, "lastReviewEvent"),
-		LastReviewSummary:    stringPtrFromMap(doc, "lastReviewSummary"),
+		FollowUpdates:                 boolPtrFromMap(doc, "followUpdates"),
+		LastPublishedAt:               stringPtrFromMap(doc, "lastPublishedAt"),
+		LastPublishedHeadSHA:          stringPtrFromMap(doc, "lastPublishedHeadSha"),
+		LastFixHeadSHA:                stringPtrFromMap(doc, "lastFixHeadSha"),
+		LastReviewedSignalFingerprint: stringPtrFromMap(doc, "lastReviewedSignalFingerprint"),
+		LastReviewEvent:               stringPtrFromMap(doc, "lastReviewEvent"),
+		LastReviewSummary:             stringPtrFromMap(doc, "lastReviewSummary"),
+		PauseReason:                   stringPtrFromMap(doc, "pauseReason"),
 	}
 	if skip, ok := doc["lastFilterSkip"].(map[string]any); ok {
 		output.LastFilterSkip = skip
+	}
+	if budget, ok := doc["reviewFixBudget"].(map[string]any); ok {
+		output.ReviewFixBudget = budget
+	}
+	if scope, ok := doc["reviewScopeHuman"].(map[string]any); ok {
+		output.ReviewScopeHuman = scope
 	}
 	if loopDoc, ok := doc["loop"].(map[string]any); ok {
 		output.Loop = &loopDiagnosticLoopMetadata{
@@ -583,6 +602,9 @@ func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storag
 	}
 	if diagnosis.RecommendedAction == "" {
 		diagnosis.RecommendedAction = recommendedActionForState(state)
+	}
+	if brief, ok := loops.BuildReviewFixHandoffBrief(loop); ok && strings.TrimSpace(brief.NextAction) != "" {
+		diagnosis.RecommendedAction = brief.NextAction
 	}
 	// Expand <seq> before emitting JSON/human output so operators and scripts
 	// never see the literal placeholder outside writeHumanLoopInspect.
@@ -914,12 +936,30 @@ func writeHumanLoopInspect(w io.Writer, output loopInspectOutput) error {
 			}
 		}
 	}
+	if output.Handoff != nil {
+		if _, err := fmt.Fprintf(w, "Handoff: kind=%s hitl=%t\n", output.Handoff.Kind, output.Handoff.HITLEnabled); err != nil {
+			return err
+		}
+		if output.Handoff.Question != "" {
+			if _, err := fmt.Fprintf(w, "Question: %s\n", output.Handoff.Question); err != nil {
+				return err
+			}
+		}
+		if output.Handoff.Evidence != "" {
+			if _, err := fmt.Fprintf(w, "Evidence: %s\n", output.Handoff.Evidence); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "Resume: %s\n", output.Handoff.Resume); err != nil {
+			return err
+		}
+	}
 	if output.Diagnosis.RecommendedAction != "" {
 		if _, err := fmt.Fprintf(w, "Action: %s\n", formatActionWithSeq(output.Diagnosis.RecommendedAction, output.Loop.Seq)); err != nil {
 			return err
 		}
 	}
-	if requiresOperatorHold(output) {
+	if requiresOperatorHold(output) && output.Handoff == nil {
 		if _, err := fmt.Fprintf(w, "Next: after resolving the blocker, looper retry %d (see also looper logs %d)\n", output.Loop.Seq, output.Loop.Seq); err != nil {
 			return err
 		}

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 	pkgapi "github.com/nexu-io/looper/pkg/api"
 )
@@ -536,4 +537,41 @@ func writeLoopDiagnosticsFixture(t *testing.T, serverURL string) string {
 		t.Fatalf("WriteFile(config) error = %v", err)
 	}
 	return configPath
+}
+
+func TestDiagnoseLoopBudgetHoldRecommendsUnpauseStop(t *testing.T) {
+	t.Parallel()
+	meta := `{"pauseReason":"review_fix_budget_exhausted","lastReviewedSignalFingerprint":"sig-abc","lastPublishedHeadSha":"abc123","loop":{"iterationCount":3},"reviewFixBudget":{"exhaustedBy":"reviewer","pauseReason":"review_fix_budget_exhausted"}}`
+	loop := storage.LoopRecord{ID: "loop_budget", Seq: 12, Type: "reviewer", Status: "paused", MetadataJSON: &meta}
+	diagnosis := diagnoseLoop(loop, nil, nil, parseLoopDiagnosticMetadata(loop.MetadataJSON), true)
+	if !strings.Contains(diagnosis.RecommendedAction, "looper unpause 12") || !strings.Contains(diagnosis.RecommendedAction, "looper stop 12") {
+		t.Fatalf("RecommendedAction = %q, want unpause/stop", diagnosis.RecommendedAction)
+	}
+	if strings.Contains(diagnosis.RecommendedAction, "retry") {
+		t.Fatalf("RecommendedAction = %q, must not recommend retry for budget hold", diagnosis.RecommendedAction)
+	}
+	parsed := parseLoopDiagnosticMetadata(loop.MetadataJSON)
+	if parsed.LastReviewedSignalFingerprint == nil || *parsed.LastReviewedSignalFingerprint != "sig-abc" {
+		t.Fatalf("parsed signal = %#v, want sig-abc", parsed.LastReviewedSignalFingerprint)
+	}
+	brief, ok := loops.BuildReviewFixHandoffBrief(loop)
+	if !ok {
+		t.Fatal("BuildReviewFixHandoffBrief() = false")
+	}
+	var buf strings.Builder
+	if err := writeHumanLoopInspect(&buf, loopInspectOutput{
+		Loop:      diagnosticLoopOutput(loop),
+		Metadata:  parsed,
+		Handoff:   &brief,
+		Diagnosis: diagnosis,
+	}); err != nil {
+		t.Fatalf("writeHumanLoopInspect: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "Handoff: kind=review_fix_budget hitl=false") || !strings.Contains(got, "Resume: looper unpause 12 / looper stop 12") {
+		t.Fatalf("human inspect = %q, want no-HITL budget handoff", got)
+	}
+	if strings.Contains(got, "looper retry 12") {
+		t.Fatalf("human inspect = %q, must not suggest retry", got)
+	}
 }

--- a/internal/cliapp/netadmin_commands.go
+++ b/internal/cliapp/netadmin_commands.go
@@ -191,7 +191,7 @@ func (r *commandRuntime) createWebhookHook(ctx context.Context, ghPath, repo, de
 	body := map[string]any{
 		"name":   "web",
 		"active": true,
-		"events": []string{"check_run", "issue_comment", "pull_request", "pull_request_review", "pull_request_review_comment", "push"},
+		"events": append([]string{}, webhookHookEvents...),
 		"config": map[string]string{"url": deliveryURL, "content_type": "json", "insecure_ssl": "0", "secret": secret},
 	}
 	raw, _ := json.Marshal(body)

--- a/internal/cliapp/review_submit.go
+++ b/internal/cliapp/review_submit.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nexu-io/looper/internal/forge"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/shell"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/outboundguard"
 	"github.com/nexu-io/looper/internal/projects"
 	"github.com/nexu-io/looper/internal/storage"
@@ -495,7 +496,7 @@ func (r *commandRuntime) reviewSubmit(cmd *cobra.Command, args []string) error {
 			if err := validateForgejoReviewSubmitRequest(cmd.Context(), gateway, prNumber, freshLabels, requestBypass); err != nil {
 				return err
 			}
-			return submitReviewWithoutAnchorValidation(cmd, gateway, repo, prNumber, submissionEvent, payload, commitID, cwd, loaded.Config.Disclosure)
+			return submitReviewWithoutAnchorValidation(cmd, r, loaded.Config, gateway, repo, prNumber, submissionEvent, payload, commitID, cwd, loaded.Config.Disclosure)
 		}
 		// Never reach SubmitReview's content guard on this path: redact paths and
 		// never return path-bearing git/remote errors (path may be secret-shaped).
@@ -518,6 +519,12 @@ func (r *commandRuntime) reviewSubmit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if err := validateForgejoReviewSubmitRequest(cmd.Context(), gateway, prNumber, freshLabels, requestBypass); err != nil {
+		return err
+	}
+	// Budget admission before mutation: agent-native reviews must not publish when
+	// a participating reviewer loop is already at/over live maxPublishesPerPR or
+	// on a review-fix budget hold. Daemon owns park; CLI only refuses.
+	if err := r.refuseReviewSubmitIfBudgetExhausted(cmd, loaded.Config, repo, prNumber); err != nil {
 		return err
 	}
 	if err := gateway.SubmitReview(cmd.Context(), githubinfra.SubmitReviewInput{Repo: repo, PRNumber: prNumber, Event: submissionEvent, Body: payload.Body, CommitID: commitID, Comments: comments, Anchors: anchors, Disclosure: loaded.Config.Disclosure, CWD: cwd}); err != nil {
@@ -1082,11 +1089,115 @@ func canSubmitWithoutAnchorValidation(err error, comments []reviewSubmitComment)
 	return errors.Is(err, githubinfra.ErrDiffTooLarge) || errors.Is(err, githubinfra.ErrLocalCaptureTruncated)
 }
 
-func submitReviewWithoutAnchorValidation(cmd *cobra.Command, gh reviewSubmitGateway, repo string, prNumber int64, event string, payload reviewSubmitPayload, commitID string, cwd string, disclosureCfg config.DisclosureConfig) error {
+func submitReviewWithoutAnchorValidation(cmd *cobra.Command, r *commandRuntime, cfg config.Config, gh reviewSubmitGateway, repo string, prNumber int64, event string, payload reviewSubmitPayload, commitID string, cwd string, disclosureCfg config.DisclosureConfig) error {
+	if err := r.refuseReviewSubmitIfBudgetExhausted(cmd, cfg, repo, prNumber); err != nil {
+		return err
+	}
 	if err := gh.SubmitReview(cmd.Context(), githubinfra.SubmitReviewInput{Repo: repo, PRNumber: prNumber, Event: event, Body: payload.Body, CommitID: commitID, Disclosure: disclosureCfg, CWD: cwd}); err != nil {
 		return wrapReviewSubmitError(cmd, repo, prNumber, event, commitID, payload, "submit PR review without anchor validation", err)
 	}
 	return writeJSON(cmd.OutOrStdout(), map[string]any{"submitted": true})
+}
+
+// refuseReviewSubmitIfBudgetExhausted refuses agent-native review publish when the
+// authoritative submitting reviewer loop is already at/over the live
+// maxPublishesPerPR cap or is on a review-fix budget hold. One-shot manual is
+// exempt via ParticipatesInReviewFixBudget. Does not park — daemon owns park.
+//
+// Authority is the submitting loop only (--reviewer-run-id / current running
+// reviewer run). Other lanes and terminal/historical loops are ignored. When no
+// submitting loop can be resolved, skip (same optional-authority posture as a
+// missing DB).
+//
+// Storage probe matches trustedReviewRequestSubmitBypass: only open an already-
+// materialized DB; if DB is absent, skip (optional authority lookup).
+func (r *commandRuntime) refuseReviewSubmitIfBudgetExhausted(cmd *cobra.Command, cfg config.Config, repo string, prNumber int64) error {
+	dbPath := strings.TrimSpace(cfg.Storage.DBPath)
+	if dbPath == "" {
+		return nil
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("check review-fix publish budget: %w", err)
+	}
+	db, err := storage.OpenSQLiteDB(cmd.Context(), dbPath)
+	if err != nil {
+		return fmt.Errorf("check review-fix publish budget: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	runID := strings.TrimSpace(getStringFlag(cmd, "reviewer-run-id"))
+	return refuseReviewSubmitBudgetAgainstRepos(cmd.Context(), storage.NewRepositories(db), cfg, repo, prNumber, runID)
+}
+
+// refuseReviewSubmitBudgetAgainstRepos is the DB-present budget gate used by
+// refuseReviewSubmitIfBudgetExhausted and unit tests. runID is the optional
+// --reviewer-run-id binding for the submitting loop.
+func refuseReviewSubmitBudgetAgainstRepos(ctx context.Context, repos *storage.Repositories, cfg config.Config, repo string, prNumber int64, runID string) error {
+	if repos == nil || repos.Loops == nil {
+		return nil
+	}
+	loop, err := submittingReviewerLoopForBudgetGate(ctx, repos, repo, prNumber, runID)
+	if err != nil {
+		return err
+	}
+	if loop == nil {
+		// No authoritative submitting loop — optional authority, same as missing DB.
+		return nil
+	}
+	if !loops.ParticipatesInReviewFixBudget(*loop) {
+		// One-shot manual (and any non-participating lane) is exempt.
+		return nil
+	}
+	if loops.IsReviewFixBudgetHold(*loop) {
+		return fmt.Errorf("review submit refused: review-fix budget is held for %s#%d; unpause or stop the loop before publishing", repo, prNumber)
+	}
+	cap := config.ProjectRoleConfigs(cfg, loop.ProjectID).Reviewer.Behavior.Loop.MaxPublishesPerPR
+	count := loops.ReviewerPublishCount(loop.MetadataJSON)
+	if loops.BudgetExhausted(count, cap) {
+		return fmt.Errorf("review submit refused: review-fix publish budget exhausted for %s#%d (%d/%d); unpause or stop the loop before publishing", repo, prNumber, count, cap)
+	}
+	return nil
+}
+
+// submittingReviewerLoopForBudgetGate resolves only the submitting reviewer loop.
+// Prefer --reviewer-run-id via trustedCurrentReviewerLoopForRun; otherwise the
+// current running reviewer run's loop. Does not scan all participating loops.
+func submittingReviewerLoopForBudgetGate(ctx context.Context, repos *storage.Repositories, repo string, prNumber int64, runID string) (*storage.LoopRecord, error) {
+	runID = strings.TrimSpace(runID)
+	if runID != "" {
+		loop, err := trustedCurrentReviewerLoopForRun(ctx, repos, repo, prNumber, runID)
+		if err != nil {
+			return nil, fmt.Errorf("check review-fix publish budget: %w", err)
+		}
+		return loop, nil
+	}
+	if repos.Runs == nil {
+		return nil, nil
+	}
+	currentRun, err := currentRunningReviewerRun(ctx, repos, repo, prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("check review-fix publish budget: %w", err)
+	}
+	if currentRun == nil {
+		return nil, nil
+	}
+	loop, err := repos.Loops.GetByID(ctx, currentRun.LoopID)
+	if err != nil {
+		return nil, fmt.Errorf("check review-fix publish budget: %w", err)
+	}
+	if loop == nil || loop.Type != string(domain.LoopTypeReviewer) {
+		return nil, nil
+	}
+	loopRepo := ""
+	if loop.Repo != nil {
+		loopRepo = *loop.Repo
+	}
+	if !strings.EqualFold(strings.TrimSpace(loopRepo), strings.TrimSpace(repo)) || loop.PRNumber == nil || *loop.PRNumber != prNumber {
+		return nil, nil
+	}
+	return loop, nil
 }
 
 func writeReviewSubmitDiagnostic(w io.Writer, event string, fields reviewSubmitDiagnosticFields) {

--- a/internal/cliapp/review_submit.go
+++ b/internal/cliapp/review_submit.go
@@ -47,7 +47,19 @@ type reviewSubmitComment struct {
 	Side      string `json:"side"`
 	StartLine int64  `json:"start_line"`
 	StartSide string `json:"start_side"`
+	// Looper-only finding contract fields. Validated on actionable comments and
+	// stripped before provider SubmitReview (GitHub/Forgejo receive body/path/line/side only).
+	Disposition   string `json:"disposition,omitempty"`
+	Severity      string `json:"severity,omitempty"`
+	ScopeBasis    string `json:"scopeBasis,omitempty"`
+	ScopeEvidence string `json:"scopeEvidence,omitempty"`
 }
+
+const (
+	reviewFindingDispositionMustFix    = "must_fix"
+	reviewFindingDispositionFollowUp   = "follow_up"
+	reviewFindingDispositionNeedsHuman = "needs_human"
+)
 
 type reviewSubmitDiagnosticFields struct {
 	Repo        string
@@ -476,6 +488,12 @@ func (r *commandRuntime) reviewSubmit(cmd *cobra.Command, args []string) error {
 		})
 		return err
 	}
+	if err := validateReviewSubmitCommentDispositions(payload.Comments); err != nil {
+		writeReviewSubmitDiagnostic(cmd.ErrOrStderr(), "github_review_submit_validation_failed", reviewSubmitDiagnosticFields{
+			Repo: repo, PRNumber: prNumber, Event: event, CommitID: commitID, Payload: payload, Error: err.Error(), RedactPaths: true,
+		})
+		return err
+	}
 	submissionEvent, err := r.effectiveReviewSubmitEvent(cmd, gateway, repo, prNumber, event, detail.Author, cwd)
 	if err != nil {
 		return err
@@ -511,6 +529,7 @@ func (r *commandRuntime) reviewSubmit(cmd *cobra.Command, args []string) error {
 
 	comments := make([]githubinfra.ReviewComment, 0, len(payload.Comments))
 	for _, comment := range payload.Comments {
+		// Strip Looper-only disposition/scope fields before the provider Adapter.
 		comments = append(comments, githubinfra.ReviewComment{Body: comment.Body, Path: comment.Path, Line: comment.Line, Side: comment.Side, StartLine: comment.StartLine, StartSide: comment.StartSide})
 	}
 	// Fail closed on base/head drift between anchor resolution and mutation.
@@ -754,12 +773,49 @@ func validateReviewSubmitBody(body string, comments []reviewSubmitComment, commi
 		if outcome != "blocking" {
 			return fmt.Errorf("review marker outcome=%s does not match REQUEST_CHANGES event", outcome)
 		}
+		// Body-only must not be the sole carrier of a blocking finding.
+		if len(comments) == 0 {
+			return fmt.Errorf("REQUEST_CHANGES requires at least one inline comment; body-only reviews may only be clean COMMENT/APPROVE")
+		}
 	case "COMMENT":
 		if outcome == "clean" && policy.Clean == config.ReviewerReviewEventApprove {
 			return fmt.Errorf("review marker outcome=clean requires APPROVE under effective policy")
 		}
 		if outcome == "blocking" && policy.Blocking == config.ReviewerReviewEventRequestChanges {
 			return fmt.Errorf("review marker outcome=blocking requires REQUEST_CHANGES under effective policy")
+		}
+		// Clean COMMENT is body-only (same as APPROVE); inline comments imply must_fix.
+		if outcome == "clean" && len(comments) > 0 {
+			return fmt.Errorf("COMMENT reviews require clean outcome without inline comments")
+		}
+		// Actionable/blocking COMMENT with zero comments smuggles findings in body only.
+		if outcome != "clean" && len(comments) == 0 {
+			return fmt.Errorf("actionable COMMENT reviews require at least one inline comment; body-only reviews may only be clean COMMENT/APPROVE")
+		}
+	}
+	return nil
+}
+
+// validateReviewSubmitCommentDispositions enforces the trusted finding contract on
+// actionable inline comments. Clean body-only APPROVE/COMMENT needs no dispositions.
+func validateReviewSubmitCommentDispositions(comments []reviewSubmitComment) error {
+	if len(comments) == 0 {
+		return nil
+	}
+	for i, comment := range comments {
+		disposition := strings.TrimSpace(comment.Disposition)
+		scopeBasis := strings.TrimSpace(comment.ScopeBasis)
+		scopeEvidence := strings.TrimSpace(comment.ScopeEvidence)
+		if disposition == "" || scopeBasis == "" || scopeEvidence == "" {
+			return fmt.Errorf("actionable review comment %d requires disposition=must_fix, non-empty scopeBasis, and non-empty scopeEvidence", i)
+		}
+		switch disposition {
+		case reviewFindingDispositionMustFix:
+			// ok
+		case reviewFindingDispositionFollowUp, reviewFindingDispositionNeedsHuman:
+			return fmt.Errorf("actionable review comment %d rejects disposition=%s; only must_fix may be submitted as remote feedback", i, disposition)
+		default:
+			return fmt.Errorf("actionable review comment %d has invalid disposition %q (want must_fix)", i, disposition)
 		}
 	}
 	return nil
@@ -1150,7 +1206,10 @@ func refuseReviewSubmitBudgetAgainstRepos(ctx context.Context, repos *storage.Re
 		// One-shot manual (and any non-participating lane) is exempt.
 		return nil
 	}
-	if loops.IsReviewFixBudgetHold(*loop) {
+	if loops.IsReviewFixPairHold(*loop) {
+		if loops.IsReviewScopeHumanHold(*loop) && !loops.IsReviewFixBudgetHold(*loop) {
+			return fmt.Errorf("review submit refused: review scope requires human judgment for %s#%d; unpause or stop the loop before publishing", repo, prNumber)
+		}
 		return fmt.Errorf("review submit refused: review-fix budget is held for %s#%d; unpause or stop the loop before publishing", repo, prNumber)
 	}
 	cap := config.ProjectRoleConfigs(cfg, loop.ProjectID).Reviewer.Behavior.Loop.MaxPublishesPerPR

--- a/internal/cliapp/review_submit_contract_failclosed_test.go
+++ b/internal/cliapp/review_submit_contract_failclosed_test.go
@@ -20,7 +20,7 @@ func TestReviewSubmitOrchestrationFailsClosedOnBaseHeadMismatch(t *testing.T) {
 	payload := map[string]any{
 		"body": "Actionable review\n<!-- looper:review id=review-mismatch head=" + strings.Repeat("a", 40) + " outcome=actionable -->",
 		"comments": []map[string]any{
-			{"body": "late change", "path": "target/late.go", "line": targetLine, "side": "RIGHT"},
+			reviewSubmitMustFixComment("late change", "target/late.go", targetLine, "RIGHT"),
 		},
 	}
 	raw, _ := json.Marshal(payload)
@@ -67,7 +67,7 @@ func TestReviewSubmitOrchestrationFailsClosedWhenRemoteOversizedAndLocalUnavaila
 	payload := map[string]any{
 		"body": "Actionable review\n<!-- looper:review id=review-oversized head=" + headSHA + " outcome=actionable -->",
 		"comments": []map[string]any{
-			{"body": "needs fix", "path": secretPath, "line": 1, "side": "RIGHT"},
+			reviewSubmitMustFixComment("needs fix", secretPath, 1, "RIGHT"),
 		},
 	}
 	raw, _ := json.Marshal(payload)
@@ -123,7 +123,7 @@ func TestReviewSubmitOrchestrationRetryDoesNotDuplicateAfterAuthorityRecovery(t 
 	payload := map[string]any{
 		"body": "Actionable review\n<!-- looper:review id=review-retry head=" + headSHA + " outcome=actionable -->",
 		"comments": []map[string]any{
-			{"body": "late change needs attention", "path": "target/late.go", "line": targetLine, "side": "RIGHT"},
+			reviewSubmitMustFixComment("late change needs attention", "target/late.go", targetLine, "RIGHT"),
 		},
 	}
 	raw, _ := json.Marshal(payload)

--- a/internal/cliapp/review_submit_contract_helpers_test.go
+++ b/internal/cliapp/review_submit_contract_helpers_test.go
@@ -13,6 +13,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// reviewSubmitMustFixComment returns a contract-test comment with required
+// Looper disposition fields. Provider payloads must strip these before GitHub.
+func reviewSubmitMustFixComment(body, path string, line int64, side string) map[string]any {
+	return map[string]any{
+		"body":          body,
+		"path":          path,
+		"line":          line,
+		"side":          side,
+		"disposition":   "must_fix",
+		"severity":      "blocking",
+		"scopeBasis":    "introduced_regression",
+		"scopeEvidence": "contract test finding in PR scope",
+	}
+}
+
 func newReviewSubmitTestCommand(stdout, stderr *bytes.Buffer) *cobra.Command {
 	cmd := &cobra.Command{Use: "submit"}
 	cmd.SetOut(stdout)

--- a/internal/cliapp/review_submit_contract_test.go
+++ b/internal/cliapp/review_submit_contract_test.go
@@ -22,12 +22,7 @@ func TestReviewSubmitOrchestrationPreservesInlineCommentsWhenFullDiffExceedsCapt
 	payload := map[string]any{
 		"body": "Actionable review\n<!-- looper:review id=review-large head=" + headSHA + " outcome=actionable -->",
 		"comments": []map[string]any{
-			{
-				"body": "late change needs attention",
-				"path": "target/late.go",
-				"line": targetLine,
-				"side": "RIGHT",
-			},
+			reviewSubmitMustFixComment("late change needs attention", "target/late.go", targetLine, "RIGHT"),
 		},
 	}
 	raw, err := json.Marshal(payload)
@@ -77,6 +72,11 @@ func TestReviewSubmitOrchestrationPreservesInlineCommentsWhenFullDiffExceedsCapt
 	if comment["path"] != "target/late.go" || int64(comment["line"].(float64)) != targetLine || comment["side"] != "RIGHT" {
 		t.Fatalf("comment = %#v, want resolvable target/late.go RIGHT %d", comment, targetLine)
 	}
+	for _, forbidden := range []string{"disposition", "scopeBasis", "scopeEvidence", "severity"} {
+		if _, ok := comment[forbidden]; ok {
+			t.Fatalf("provider comment retained Looper-only field %q: %#v", forbidden, comment)
+		}
+	}
 	// A non-empty comments[] entry is the GitHub contract for a resolvable review thread.
 	if submitted["commit_id"] != headSHA {
 		t.Fatalf("commit_id = %#v, want %s", submitted["commit_id"], headSHA)
@@ -94,7 +94,7 @@ func TestReviewSubmitOrchestrationPreservesLeftDeletedInlineComment(t *testing.T
 	payload := map[string]any{
 		"body": "Actionable review\n<!-- looper:review id=review-left head=" + headSHA + " outcome=actionable -->",
 		"comments": []map[string]any{
-			{"body": "deleted line issue", "path": "removed.go", "line": deletedLine, "side": "LEFT"},
+			reviewSubmitMustFixComment("deleted line issue", "removed.go", deletedLine, "LEFT"),
 		},
 	}
 	raw, _ := json.Marshal(payload)

--- a/internal/cliapp/review_submit_test.go
+++ b/internal/cliapp/review_submit_test.go
@@ -459,6 +459,234 @@ func TestTrustedFollowUpNewHeadReviewRequestBypass(t *testing.T) {
 	}
 }
 
+func TestRefuseReviewSubmitBudgetAgainstRepos(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations, BackupDir: filepath.Join(root, "backups")})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("MigrationRunner.RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Project", RepoPath: "/tmp/project", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert(project_1) error = %v", err)
+	}
+
+	cfg, err := config.DefaultConfig(root)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+
+	seedSubmittingRun := func(loopID, runID string) {
+		t.Helper()
+		if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+			ID: runID, LoopID: loopID, Status: "running", StartedAt: now, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("Runs.Upsert(%s) error = %v", runID, err)
+		}
+	}
+
+	// Exhausted submitting loop blocks submit.
+	exhaustedMeta := `{"loop":{"iterationCount":3}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_exhausted", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &exhaustedMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(exhausted) error = %v", err)
+	}
+	seedSubmittingRun("loop_exhausted", "run_exhausted")
+	err = refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_exhausted")
+	if err == nil || !strings.Contains(err.Error(), "publish budget exhausted") {
+		t.Fatalf("exhausted count error = %v, want publish budget exhausted", err)
+	}
+	// Same via current running run (no --reviewer-run-id).
+	err = refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "")
+	if err == nil || !strings.Contains(err.Error(), "publish budget exhausted") {
+		t.Fatalf("exhausted via current run error = %v, want publish budget exhausted", err)
+	}
+
+	// Held loop without a resolvable submitting run skips (optional authority).
+	holdMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"fixer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_exhausted", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &holdMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(hold) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_exhausted", LoopID: "loop_exhausted", Status: "completed", StartedAt: now, EndedAt: &now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(complete exhausted) error = %v", err)
+	}
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, ""); err != nil {
+		t.Fatalf("held without submitting run error = %v, want nil (skip)", err)
+	}
+
+	// Under-cap participating submitting loop allows submit (no error).
+	underMeta := `{"loop":{"iterationCount":1}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_under", Seq: 10, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &underMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(under) error = %v", err)
+	}
+	seedSubmittingRun("loop_under", "run_under")
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_under"); err != nil {
+		t.Fatalf("under-cap error = %v, want nil", err)
+	}
+
+	// One-shot manual submitting loop is exempt even when count is at cap.
+	manualMeta := `{"manual":true,"loop":{"iterationCount":9}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_manual_cap", Seq: 11, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &manualMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(manual) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_under", LoopID: "loop_under", Status: "completed", StartedAt: now, EndedAt: &now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(complete under) error = %v", err)
+	}
+	seedSubmittingRun("loop_manual_cap", "run_manual")
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_manual"); err != nil {
+		t.Fatalf("one-shot manual error = %v, want nil", err)
+	}
+
+	// Exhausted automatic must not block a one-shot manual submitting loop.
+	autoExhausted := `{"loop":{"iterationCount":3}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_auto_exhausted", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &autoExhausted, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(auto exhausted) error = %v", err)
+	}
+	oneShotMeta := `{"manual":true,"loop":{"iterationCount":0}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_oneshot_submit", Seq: 3, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &oneShotMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(oneshot) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_manual", LoopID: "loop_manual_cap", Status: "completed", StartedAt: now, EndedAt: &now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(complete manual) error = %v", err)
+	}
+	seedSubmittingRun("loop_oneshot_submit", "run_oneshot")
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_oneshot"); err != nil {
+		t.Fatalf("oneshot with exhausted automatic error = %v, want nil", err)
+	}
+
+	// Held automatic must not block a different-lane continuous_manual under-cap submit.
+	holdAutoMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"fixer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_auto_held", Seq: 4, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &holdAutoMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(auto held) error = %v", err)
+	}
+	cmMeta := `{"manual":true,"followUpdates":true,"loop":{"iterationCount":1}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_cm_submit", Seq: 5, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &cmMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(continuous manual) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_oneshot", LoopID: "loop_oneshot_submit", Status: "completed", StartedAt: now, EndedAt: &now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(complete oneshot) error = %v", err)
+	}
+	seedSubmittingRun("loop_cm_submit", "run_cm")
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_cm"); err != nil {
+		t.Fatalf("continuous_manual under-cap with held automatic error = %v, want nil", err)
+	}
+
+	// Exhausted continuous_manual submitting loop still blocks.
+	cmExhausted := `{"manual":true,"followUpdates":true,"loop":{"iterationCount":3}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_cm_submit", Seq: 5, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &cmExhausted, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(cm exhausted) error = %v", err)
+	}
+	err = refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_cm")
+	if err == nil || !strings.Contains(err.Error(), "publish budget exhausted") {
+		t.Fatalf("exhausted continuous_manual error = %v, want publish budget exhausted", err)
+	}
+}
+
+func TestSubmitReviewWithoutAnchorValidationRefusesBudgetBeforeSubmit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "looper.sqlite")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), dbPath, storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations, BackupDir: filepath.Join(root, "backups")})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("MigrationRunner.RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Project", RepoPath: "/tmp/project", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert error = %v", err)
+	}
+	exhaustedMeta := `{"loop":{"iterationCount":3}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_budget", Seq: 7, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &exhaustedMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_budget", LoopID: "loop_budget", Status: "running", StartedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert error = %v", err)
+	}
+
+	cfg, err := config.DefaultConfig(root)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = dbPath
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+
+	var submitCalls int
+	gateway := &budgetGateSubmitGateway{onSubmit: func() { submitCalls++ }}
+	var stdout, stderr bytes.Buffer
+	cmd := newReviewSubmitTestCommand(&stdout, &stderr)
+	cmd.SetContext(context.Background())
+	if err := cmd.Flags().Set("reviewer-run-id", "run_budget"); err != nil {
+		t.Fatalf("set reviewer-run-id: %v", err)
+	}
+	runtime := &commandRuntime{}
+	payload := reviewSubmitPayload{Body: "ok\n<!-- looper:review id=a head=head outcome=clean -->"}
+	err = submitReviewWithoutAnchorValidation(cmd, runtime, cfg, gateway, repo, prNumber, "COMMENT", payload, "head", root, cfg.Disclosure)
+	if err == nil || !strings.Contains(err.Error(), "publish budget exhausted") {
+		t.Fatalf("submitReviewWithoutAnchorValidation() error = %v, want budget exhausted", err)
+	}
+	if submitCalls != 0 {
+		t.Fatalf("SubmitReview calls = %d, want 0 (refused before mutation)", submitCalls)
+	}
+
+	// Under-cap still reaches mock gateway.
+	underMeta := `{"loop":{"iterationCount":1}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_budget", Seq: 7, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &underMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(under) error = %v", err)
+	}
+	err = submitReviewWithoutAnchorValidation(cmd, runtime, cfg, gateway, repo, prNumber, "COMMENT", payload, "head", root, cfg.Disclosure)
+	if err != nil {
+		t.Fatalf("under-cap submit error = %v", err)
+	}
+	if submitCalls != 1 {
+		t.Fatalf("SubmitReview calls = %d, want 1", submitCalls)
+	}
+}
+
+type budgetGateSubmitGateway struct {
+	onSubmit func()
+}
+
+func (g *budgetGateSubmitGateway) ViewPullRequest(context.Context, githubinfra.ViewPullRequestInput) (githubinfra.PullRequestDetail, error) {
+	return githubinfra.PullRequestDetail{}, nil
+}
+func (g *budgetGateSubmitGateway) GetCurrentUserLogin(context.Context, string) (string, error) {
+	return "reviewer", nil
+}
+func (g *budgetGateSubmitGateway) GetPullRequestDiff(context.Context, githubinfra.GetPullRequestDiffInput) (string, error) {
+	return "", nil
+}
+func (g *budgetGateSubmitGateway) SubmitReview(context.Context, githubinfra.SubmitReviewInput) error {
+	if g.onSubmit != nil {
+		g.onSubmit()
+	}
+	return nil
+}
+
 func TestValidateReviewSubmitEventAcceptsRequestChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/review_submit_test.go
+++ b/internal/cliapp/review_submit_test.go
@@ -704,7 +704,8 @@ func TestValidateReviewSubmitEventAcceptsRequestChanges(t *testing.T) {
 func TestValidateReviewSubmitBodyRequiresSingleMatchingMarker(t *testing.T) {
 	t.Parallel()
 	body := "Review body\n<!-- looper:review id=abc head=def outcome=actionable -->"
-	if err := validateReviewSubmitBody(body, nil, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err != nil {
+	// Actionable COMMENT requires inline comments (no body-only smuggling).
+	if err := validateReviewSubmitBody(body, []reviewSubmitComment{{Body: "fix", Path: "main.go", Line: 1, Side: "RIGHT"}}, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err != nil {
 		t.Fatalf("validateReviewSubmitBody() error = %v", err)
 	}
 	for _, tc := range []struct {
@@ -750,12 +751,51 @@ func TestValidateReviewSubmitBodyAllowsRequestChangesOnlyForBlocking(t *testing.
 	}
 }
 
+func TestValidateReviewSubmitBodyRejectsActionableBodyOnly(t *testing.T) {
+	t.Parallel()
+	blocking := "<!-- looper:review id=abc head=def outcome=blocking -->"
+	if err := validateReviewSubmitBody(blocking, nil, "def", "REQUEST_CHANGES", decisionReviewPolicy, "octocat"); err == nil || !strings.Contains(err.Error(), "at least one inline comment") {
+		t.Fatalf("REQUEST_CHANGES body-only error = %v, want inline comment requirement", err)
+	}
+	actionable := "<!-- looper:review id=abc head=def outcome=non_blocking -->"
+	if err := validateReviewSubmitBody(actionable, nil, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err == nil || !strings.Contains(err.Error(), "at least one inline comment") {
+		t.Fatalf("actionable COMMENT body-only error = %v, want inline comment requirement", err)
+	}
+	// Clean body-only COMMENT remains allowed.
+	clean := "<!-- looper:review id=abc head=def outcome=clean -->"
+	if err := validateReviewSubmitBody(clean, nil, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err != nil {
+		t.Fatalf("clean COMMENT body-only error = %v", err)
+	}
+}
+
 func TestValidateReviewSubmitBodyRejectsCleanApproveWithInlineComments(t *testing.T) {
 	t.Parallel()
 	body := "<!-- looper:review id=abc head=def outcome=clean -->"
 	err := validateReviewSubmitBody(body, []reviewSubmitComment{{Body: "inline", Path: "main.go", Line: 10, Side: "RIGHT"}}, "def", "APPROVE", decisionReviewPolicy, "octocat")
 	if err == nil || !strings.Contains(err.Error(), "without inline comments") {
 		t.Fatalf("validateReviewSubmitBody(APPROVE with comments) error = %v, want inline rejection", err)
+	}
+}
+
+func TestValidateReviewSubmitBodyRejectsCleanCommentWithInlineComments(t *testing.T) {
+	t.Parallel()
+	body := "<!-- looper:review id=abc head=def outcome=clean -->"
+	// Clean COMMENT must reject any inline comments (same as APPROVE).
+	err := validateReviewSubmitBody(body, []reviewSubmitComment{{
+		Body: "must_fix smuggled", Path: "main.go", Line: 10, Side: "RIGHT",
+		Disposition: "must_fix", ScopeBasis: "required_invariant", ScopeEvidence: "rule",
+	}}, "def", "COMMENT", commentOnlyReviewPolicy, "octocat")
+	if err == nil || !strings.Contains(err.Error(), "without inline comments") {
+		t.Fatalf("validateReviewSubmitBody(clean COMMENT with comments) error = %v, want inline rejection", err)
+	}
+	// Clean body-only COMMENT remains allowed.
+	if err := validateReviewSubmitBody(body, nil, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err != nil {
+		t.Fatalf("validateReviewSubmitBody(clean COMMENT body-only) error = %v", err)
+	}
+	// Actionable COMMENT still requires ≥1 inline comment (must_fix enforced separately).
+	actionable := "<!-- looper:review id=abc head=def outcome=non_blocking -->"
+	if err := validateReviewSubmitBody(actionable, nil, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err == nil || !strings.Contains(err.Error(), "at least one inline comment") {
+		t.Fatalf("actionable COMMENT body-only error = %v, want inline comment requirement", err)
 	}
 }
 
@@ -1389,5 +1429,110 @@ func TestReviewSubmitGatewayUsesStorageProjectRoles(t *testing.T) {
 	}
 	if got := strings.Join(forgeGateway.labels, ","); got != "looper:review" {
 		t.Fatalf("labels = %q, want looper:review from storage project roles", got)
+	}
+}
+
+func TestValidateReviewSubmitCommentDispositionsRequiresMustFixEvidence(t *testing.T) {
+	t.Parallel()
+
+	mustFix := []reviewSubmitComment{{
+		Body: "Null check missing", Path: "app.go", Line: 10, Side: "RIGHT",
+		Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "PR adds nil deref on happy path",
+	}}
+	if err := validateReviewSubmitCommentDispositions(mustFix); err != nil {
+		t.Fatalf("must_fix+evidence error = %v", err)
+	}
+	if err := validateReviewSubmitCommentDispositions(nil); err != nil {
+		t.Fatalf("empty comments error = %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		comments []reviewSubmitComment
+		want     string
+	}{
+		{
+			name: "missing fields",
+			comments: []reviewSubmitComment{{
+				Body: "x", Path: "app.go", Line: 1, Side: "RIGHT",
+			}},
+			want: "requires disposition=must_fix",
+		},
+		{
+			name: "follow_up rejected",
+			comments: []reviewSubmitComment{{
+				Body: "x", Path: "app.go", Line: 1, Side: "RIGHT",
+				Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "nice to have",
+			}},
+			want: "follow_up",
+		},
+		{
+			name: "needs_human rejected",
+			comments: []reviewSubmitComment{{
+				Body: "x", Path: "app.go", Line: 1, Side: "RIGHT",
+				Disposition: "needs_human", ScopeBasis: "ambiguous_intent", ScopeEvidence: "unclear",
+			}},
+			want: "needs_human",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateReviewSubmitCommentDispositions(tc.comments)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestReviewSubmitStripsLooperOnlyFieldsAndRejectsBeforeSubmit(t *testing.T) {
+	t.Parallel()
+
+	// Unknown extra JSON keys are ignored by encoding/json into the struct.
+	raw := []byte(`{
+		"body": "Blocking\n\n<!-- looper:review id=abc head=deadbeef outcome=blocking -->",
+		"comments": [{
+			"body": "fix it",
+			"path": "app.go",
+			"line": 10,
+			"side": "RIGHT",
+			"disposition": "must_fix",
+			"severity": "blocking",
+			"scopeBasis": "introduced_regression",
+			"scopeEvidence": "nil deref",
+			"unknownExtra": true
+		}]
+	}`)
+	var payload reviewSubmitPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if err := validateReviewSubmitCommentDispositions(payload.Comments); err != nil {
+		t.Fatalf("validate dispositions: %v", err)
+	}
+	if payload.Comments[0].Disposition != "must_fix" || payload.Comments[0].ScopeBasis == "" {
+		t.Fatalf("payload comments = %#v", payload.Comments[0])
+	}
+	// Provider mapping strips Looper-only fields (same as reviewSubmit path).
+	mapped := githubinfra.ReviewComment{
+		Body: payload.Comments[0].Body, Path: payload.Comments[0].Path,
+		Line: payload.Comments[0].Line, Side: payload.Comments[0].Side,
+	}
+	if mapped.Body != "fix it" || mapped.Path != "app.go" {
+		t.Fatalf("mapped = %#v", mapped)
+	}
+
+	// Reject path: follow_up never reaches SubmitReview.
+	submitCalls := 0
+	gateway := &budgetGateSubmitGateway{onSubmit: func() { submitCalls++ }}
+	_ = gateway
+	bad := []reviewSubmitComment{{
+		Body: "x", Path: "app.go", Line: 1, Side: "RIGHT",
+		Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "later",
+	}}
+	if err := validateReviewSubmitCommentDispositions(bad); err == nil {
+		t.Fatal("expected follow_up rejection")
+	}
+	if submitCalls != 0 {
+		t.Fatalf("SubmitReview calls = %d, want 0", submitCalls)
 	}
 }

--- a/internal/cliapp/webhook_commands.go
+++ b/internal/cliapp/webhook_commands.go
@@ -788,11 +788,23 @@ func (r *commandRuntime) updateWebhookHookSecret(ctx context.Context, ghPath, re
 	return nil
 }
 
+// webhookHookEvents is the managed-hook subscription set. Keep identical to
+// runtime webhookForwardEvents / webhookForwarderEvents (order may differ).
+var webhookHookEvents = []string{
+	"check_run",
+	"issue_comment",
+	"pull_request",
+	"pull_request_review",
+	"pull_request_review_comment",
+	"pull_request_review_thread",
+	"push",
+}
+
 func webhookHookMutationBodyForCLI(managedURL string, secret string) []byte {
 	body := map[string]any{
 		"name":   "web",
 		"active": true,
-		"events": []string{"check_run", "issue_comment", "pull_request", "pull_request_review", "pull_request_review_comment", "push"},
+		"events": append([]string{}, webhookHookEvents...),
 		"config": map[string]string{"url": managedURL, "content_type": "json", "insecure_ssl": "0", "secret": secret},
 	}
 	encoded, _ := json.Marshal(body)

--- a/internal/cliapp/webhook_commands_test.go
+++ b/internal/cliapp/webhook_commands_test.go
@@ -611,3 +611,38 @@ func TestWebhookCleanupConfirmContinuesPastMissingShownHook(t *testing.T) {
 		t.Fatalf("stdout = %q, want delete confirmation after continuing past a missing hook", stdout.String())
 	}
 }
+
+func TestWebhookHookEventsIncludeReviewThread(t *testing.T) {
+	t.Parallel()
+	want := map[string]struct{}{
+		"check_run":                   {},
+		"issue_comment":               {},
+		"pull_request":                {},
+		"pull_request_review":         {},
+		"pull_request_review_comment": {},
+		"pull_request_review_thread":  {},
+		"push":                        {},
+	}
+	if len(webhookHookEvents) != len(want) {
+		t.Fatalf("webhookHookEvents = %v, want %d events", webhookHookEvents, len(want))
+	}
+	for _, event := range webhookHookEvents {
+		if _, ok := want[event]; !ok {
+			t.Fatalf("webhookHookEvents contains unexpected %q: %v", event, webhookHookEvents)
+		}
+	}
+	var body map[string]any
+	if err := json.Unmarshal(webhookHookMutationBodyForCLI("https://example.com/hook", "secret"), &body); err != nil {
+		t.Fatalf("json.Unmarshal(hook body) error = %v", err)
+	}
+	rawEvents, _ := body["events"].([]any)
+	if len(rawEvents) != len(want) {
+		t.Fatalf("hook body events = %#v, want %d events including pull_request_review_thread", rawEvents, len(want))
+	}
+	for _, item := range rawEvents {
+		event, _ := item.(string)
+		if _, ok := want[event]; !ok {
+			t.Fatalf("hook body events contain unexpected %q: %#v", event, rawEvents)
+		}
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -319,7 +319,7 @@ func TestRoleDefaultsMirrorCurrentDiscoveryPolicy(t *testing.T) {
 		t.Fatalf("fixer maxPushesPerPR default = %d, want %d", got, DefaultReviewFixBudgetCap)
 	}
 	if cfg.HITL.Enabled {
-		t.Fatal("HITL default must be false so default caps stay inert until HITL is enabled")
+		t.Fatal("HITL default must remain false; caps enforce with a no-ask paired hold when HITL is off")
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -11,7 +11,7 @@ const DefaultServerPort = 17310
 const (
 	DefaultReviewerAutoRecoveryMaxAttempts = 3
 	DefaultReviewerRetryMaxDelayMS         = 300000
-	DefaultReviewFixBudgetCap              = 8
+	DefaultReviewFixBudgetCap              = 3
 )
 
 func DefaultLooperHome() (string, error) {
@@ -245,7 +245,7 @@ func DefaultConfig(cwd string) (Config, error) {
 						StopOnApproved:            false,
 						StopOnReadyLabel:          true,
 						StopOnIdenticalOutput:     true,
-						// Enforced only when HITL is enabled; park needs Continue/Stop.
+						// Always enforced; HITL only selects ask vs no-ask hold presentation.
 						MaxPublishesPerPR: DefaultReviewFixBudgetCap,
 					},
 					Retry:                   DefaultReviewerRetryConfig(),
@@ -285,7 +285,7 @@ func DefaultConfig(cwd string) (Config, error) {
 					Loop: FixerLoopConfig{
 						// Opt-in: keep historical immediate-start behavior until operators enable quiet period.
 						QuietPeriodSeconds: 0,
-						// Enforced only when HITL is enabled; park needs Continue/Stop.
+						// Always enforced; HITL only selects ask vs no-ask hold presentation.
 						MaxPushesPerPR: DefaultReviewFixBudgetCap,
 					},
 				},

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -279,7 +279,7 @@
               "minPublishIntervalSeconds": 300,
               "maxIterationsPerPR": 20,
               "maxIterationsPerHead": 1,
-              "maxPublishesPerPR": 8,
+              "maxPublishesPerPR": 3,
               "maxWallClockSeconds": 0,
               "maxConsecutiveFailures": 3,
               "maxAgentExecutionsPerPR": 25,
@@ -341,7 +341,7 @@
           "behavior": {
             "loop": {
               "quietPeriodSeconds": 0,
-              "maxPushesPerPR": 8
+              "maxPushesPerPR": 3
             }
           }
         },

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -219,7 +219,7 @@
               "minPublishIntervalSeconds": 300,
               "maxIterationsPerPR": 20,
               "maxIterationsPerHead": 1,
-              "maxPublishesPerPR": 8,
+              "maxPublishesPerPR": 3,
               "maxWallClockSeconds": 0,
               "maxConsecutiveFailures": 3,
               "maxAgentExecutionsPerPR": 25,
@@ -281,7 +281,7 @@
           "behavior": {
             "loop": {
               "quietPeriodSeconds": 0,
-              "maxPushesPerPR": 8
+              "maxPushesPerPR": 3
             }
           }
         },

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -300,7 +300,7 @@
               "minPublishIntervalSeconds": 300,
               "maxIterationsPerPR": 20,
               "maxIterationsPerHead": 1,
-              "maxPublishesPerPR": 8,
+              "maxPublishesPerPR": 3,
               "maxWallClockSeconds": 0,
               "maxConsecutiveFailures": 3,
               "maxAgentExecutionsPerPR": 25,
@@ -362,7 +362,7 @@
           "behavior": {
             "loop": {
               "quietPeriodSeconds": 0,
-              "maxPushesPerPR": 8
+              "maxPushesPerPR": 3
             }
           }
         },

--- a/internal/fixer/disposition_withhold.go
+++ b/internal/fixer/disposition_withhold.go
@@ -1,0 +1,301 @@
+package fixer
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+const (
+	decisionAcceptWontfix    = "accept_wontfix"
+	decisionRejectWontfix    = "reject_wontfix"
+	decisionObjectivelyFixed = "objectively_fixed"
+	decisionNotFixed         = "not_fixed"
+	decisionNeedsHuman       = "needs_human"
+)
+
+var (
+	fixerLooperDirectiveRE = regexp.MustCompile(`(?is)^\s*/looper\s+(wontfix|reconsider)(?:\s+(.+))?\s*$`)
+	fixerWontfixAliasRE    = regexp.MustCompile(`(?is)^\s*(wontfix|won't fix|won` + "\u2019" + `t fix)(?:\s*:\s*(.+))?\s*$`)
+	// Exact looper:thread-resolution decision field (not incidental prose).
+	fixerThreadResolutionDecisionRE = regexp.MustCompile(`(?is)<!--\s*looper:thread-resolution\b[^>]*\bdecision=(accept_wontfix|reject_wontfix|objectively_fixed|not_fixed|needs_human)\b[^>]*-->`)
+	// Exact validated Fixer decline marker (HTML comment form).
+	fixerDeclinedMarkerRE = regexp.MustCompile(`(?is)<!--\s*looper-fixer-reply-declined\b[^>]*-->`)
+)
+
+// ThreadWithheldFromFixer reports whether an unresolved Looper-authored thread
+// must not receive further Fixer edits. Authority is Reviewer audit decisions
+// and trusted human / validated Fixer disposition signals — not "any audit
+// comment exists".
+//
+// Rules:
+//   - Unaudited trusted human wontfix/reconsider → withheld
+//   - Unaudited validated Fixer decline → withheld
+//   - Latest Reviewer decision accept_wontfix (or objectively_fixed) while still
+//     unresolved → withheld until the thread is actually resolved
+//   - Latest Reviewer decision reject_wontfix (or not_fixed) → actionable again
+//     on the existing thread (no new thread)
+func ThreadWithheldFromFixer(thread ReviewThread, prAuthorLogin, looperLogin string) bool {
+	if thread.IsResolved || len(thread.Comments) == 0 {
+		return false
+	}
+	if !isLooperAuthoredFixerThread(thread, looperLogin) {
+		return false
+	}
+	lastDecision, lastDecisionIdx, hasDecision := lastReviewerAuditDecision(thread, looperLogin)
+	if hasUnauditedTrustedDispositionAfter(thread, prAuthorLogin, lastDecisionIdx) {
+		return true
+	}
+	if hasUnauditedValidatedFixerDeclineAfter(thread, looperLogin, lastDecisionIdx) {
+		return true
+	}
+	if !hasDecision {
+		return false
+	}
+	switch lastDecision {
+	case decisionAcceptWontfix, decisionObjectivelyFixed, decisionNeedsHuman:
+		// Accept/resolve path: stay withheld while unresolved (e.g. accept reply
+		// succeeded but resolve failed). needs_human also blocks Fixer edits.
+		return true
+	case decisionRejectWontfix, decisionNotFixed:
+		return false
+	default:
+		return false
+	}
+}
+
+func isLooperAuthoredFixerThread(thread ReviewThread, looperLogin string) bool {
+	if len(thread.Comments) == 0 {
+		return false
+	}
+	root := thread.Comments[0]
+	if !hasLooperReviewRootMarker(root.Body) {
+		return false
+	}
+	return isLooperIdentityAuthor(root.Author, looperLogin)
+}
+
+func hasLooperReviewRootMarker(body string) bool {
+	return strings.Contains(body, "looper:stamp") || strings.Contains(body, "looper:review")
+}
+
+// isLooperIdentityAuthor reports whether author is the configured Looper/Fixer
+// identity (current login). Empty looperLogin never matches — callers must
+// supply the live login; spoofed stamps from other authors do not count.
+func isLooperIdentityAuthor(authorLogin, looperLogin string) bool {
+	return sameGitHubLogin(authorLogin, looperLogin)
+}
+
+func lastReviewerAuditDecision(thread ReviewThread, looperLogin string) (decision string, idx int, ok bool) {
+	idx = -1
+	for i, comment := range thread.Comments {
+		if !isLooperIdentityAuthor(comment.Author, looperLogin) {
+			continue
+		}
+		if d, found := parseThreadResolutionDecision(comment.Body); found {
+			decision = d
+			idx = i
+			ok = true
+		}
+	}
+	return decision, idx, ok
+}
+
+func parseThreadResolutionDecision(body string) (string, bool) {
+	m := fixerThreadResolutionDecisionRE.FindStringSubmatch(body)
+	if len(m) < 2 {
+		return "", false
+	}
+	return strings.ToLower(strings.TrimSpace(m[1])), true
+}
+
+func isValidatedFixerDeclineComment(comment ReviewThreadComment, looperLogin string) bool {
+	if !isLooperIdentityAuthor(comment.Author, looperLogin) {
+		return false
+	}
+	return fixerDeclinedMarkerRE.MatchString(comment.Body)
+}
+
+func hasUnauditedTrustedDispositionAfter(thread ReviewThread, prAuthorLogin string, afterIdx int) bool {
+	for i := len(thread.Comments) - 1; i > afterIdx; i-- {
+		comment := thread.Comments[i]
+		if !parseTrustedWontfixOrReconsider(comment.Body) {
+			continue
+		}
+		if !isTrustedDispositionAuthority(comment.Author, prAuthorLogin, commentAuthorAssociation(comment)) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func hasUnauditedValidatedFixerDeclineAfter(thread ReviewThread, looperLogin string, afterIdx int) bool {
+	for i := len(thread.Comments) - 1; i > afterIdx; i-- {
+		if isValidatedFixerDeclineComment(thread.Comments[i], looperLogin) {
+			return true
+		}
+	}
+	return false
+}
+
+// lastRejectWontfixIndex returns the index of the latest Looper-authored
+// reject_wontfix audit, or -1 when none exists.
+func lastRejectWontfixIndex(thread ReviewThread, looperLogin string) int {
+	idx := -1
+	for i, comment := range thread.Comments {
+		if !isLooperIdentityAuthor(comment.Author, looperLogin) {
+			continue
+		}
+		if d, ok := parseThreadResolutionDecision(comment.Body); ok && d == decisionRejectWontfix {
+			idx = i
+		}
+	}
+	return idx
+}
+
+func commentAuthorAssociation(comment ReviewThreadComment) string {
+	// Association is optional on the fixer gateway type; when absent, only PR
+	// author match grants authority.
+	return strings.TrimSpace(comment.AuthorAssociation)
+}
+
+func isTrustedDispositionAuthority(authorLogin, prAuthorLogin, authorAssociation string) bool {
+	author := strings.ToLower(strings.TrimSpace(authorLogin))
+	if author == "" {
+		return false
+	}
+	if strings.HasSuffix(author, "[bot]") || strings.EqualFold(authorAssociation, "BOT") {
+		return false
+	}
+	if pr := strings.ToLower(strings.TrimSpace(prAuthorLogin)); pr != "" && author == pr {
+		return true
+	}
+	switch strings.ToUpper(strings.TrimSpace(authorAssociation)) {
+	case "OWNER", "MEMBER", "COLLABORATOR":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseTrustedWontfixOrReconsider(body string) bool {
+	content := stripQuotedAndHTML(body)
+	if content == "" {
+		return false
+	}
+	if fixerLooperDirectiveRE.MatchString(content) {
+		return true
+	}
+	return fixerWontfixAliasRE.MatchString(content)
+}
+
+func stripQuotedAndHTML(body string) string {
+	lines := strings.Split(body, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimLeftFunc(line, unicode.IsSpace)
+		if strings.HasPrefix(trimmed, ">") {
+			continue
+		}
+		if strings.Contains(line, "<!--") {
+			cleaned := stripHTMLCommentsFixer(line)
+			if strings.TrimSpace(cleaned) == "" {
+				continue
+			}
+			kept = append(kept, cleaned)
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
+func stripHTMLCommentsFixer(s string) string {
+	var b strings.Builder
+	rest := s
+	for {
+		start := strings.Index(rest, "<!--")
+		if start < 0 {
+			b.WriteString(rest)
+			break
+		}
+		b.WriteString(rest[:start])
+		end := strings.Index(rest[start:], "-->")
+		if end < 0 {
+			break
+		}
+		rest = rest[start+end+3:]
+	}
+	return b.String()
+}
+
+// SuppressWithheldDispositionFixItems drops comment fix items whose threads are
+// withheld pending Reviewer adjudication. Non-comment items pass through.
+func SuppressWithheldDispositionFixItems(fixItems []FixItem, threads []ReviewThread, prAuthorLogin, looperLogin string) []FixItem {
+	if len(fixItems) == 0 || len(threads) == 0 {
+		return fixItems
+	}
+	withheld := map[string]struct{}{}
+	for _, thread := range threads {
+		if ThreadWithheldFromFixer(thread, prAuthorLogin, looperLogin) {
+			withheld[strings.TrimSpace(thread.ID)] = struct{}{}
+		}
+	}
+	if len(withheld) == 0 {
+		return fixItems
+	}
+	out := make([]FixItem, 0, len(fixItems))
+	for _, item := range fixItems {
+		if item.Type == "comment" {
+			if _, ok := withheld[strings.TrimSpace(item.ThreadID)]; ok {
+				continue
+			}
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+// declineMarkerForThread chooses the decline HTML marker. After a Reviewer
+// reject_wontfix that followed a same-fingerprint decline, use a distinct
+// post-reject marker so one new decline is visible without a ledger.
+func declineMarkerForThread(thread ReviewThread, threadID, decisionFingerprint, looperLogin string) string {
+	base := fixerDeclinedReplyMarker(threadID, decisionFingerprint)
+	if base == "" {
+		return ""
+	}
+	lastReject := lastRejectWontfixIndex(thread, looperLogin)
+	if lastReject < 0 {
+		return base
+	}
+	for i := 0; i <= lastReject && i < len(thread.Comments); i++ {
+		comment := thread.Comments[i]
+		if !isValidatedFixerDeclineComment(comment, looperLogin) {
+			continue
+		}
+		if strings.Contains(comment.Body, base) {
+			return fixerDeclinedReplyMarkerPostReject(threadID, decisionFingerprint)
+		}
+	}
+	return base
+}
+
+// hasValidatedDeclineWithMarkerAfter reports a Looper-authored decline carrying
+// marker at an index strictly after afterIdx (-1 = entire thread).
+func hasValidatedDeclineWithMarkerAfter(thread ReviewThread, marker, looperLogin string, afterIdx int) bool {
+	marker = strings.TrimSpace(marker)
+	if marker == "" {
+		return false
+	}
+	for i := afterIdx + 1; i < len(thread.Comments); i++ {
+		comment := thread.Comments[i]
+		if !isValidatedFixerDeclineComment(comment, looperLogin) {
+			continue
+		}
+		if strings.Contains(comment.Body, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/fixer/disposition_withhold_test.go
+++ b/internal/fixer/disposition_withhold_test.go
@@ -1,0 +1,441 @@
+package fixer
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+const testLooperLogin = "looper-bot"
+
+func TestThreadWithheldFromFixerTrustedDisposition(t *testing.T) {
+	t.Parallel()
+	thread := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix out of scope"},
+		},
+	}
+	if !ThreadWithheldFromFixer(thread, "alice", testLooperLogin) {
+		t.Fatal("trusted disposition should withhold")
+	}
+	// reject_wontfix restores the existing thread as actionable.
+	thread.Comments = append(thread.Comments, ReviewThreadComment{
+		ID: "c3", Author: testLooperLogin,
+		Body: "<!-- looper:thread-resolution thread=t1 head=h feedback=f decision=reject_wontfix -->",
+	})
+	if ThreadWithheldFromFixer(thread, "alice", testLooperLogin) {
+		t.Fatal("reject_wontfix should restore actionable Fixer item")
+	}
+}
+
+func TestThreadWithheldFromFixerAcceptWontfixStaysWithheldUntilResolved(t *testing.T) {
+	t.Parallel()
+	thread := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix out of scope"},
+			{ID: "c3", Author: testLooperLogin, Body: "accepted <!-- looper:thread-resolution thread=t1 head=h feedback=f decision=accept_wontfix -->"},
+		},
+	}
+	// accept reply succeeded but resolve failed → still unresolved → withheld.
+	if !ThreadWithheldFromFixer(thread, "alice", testLooperLogin) {
+		t.Fatal("accept_wontfix on unresolved thread must stay withheld")
+	}
+	thread.IsResolved = true
+	if ThreadWithheldFromFixer(thread, "alice", testLooperLogin) {
+		t.Fatal("resolved accept_wontfix thread must not withhold")
+	}
+}
+
+func TestThreadWithheldFromFixerValidatedDecline(t *testing.T) {
+	t.Parallel()
+	thread := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: testLooperLogin, Body: "nope <!-- looper-fixer-reply-declined thread:t1 fingerprint:x -->"},
+		},
+	}
+	if !ThreadWithheldFromFixer(thread, "alice", testLooperLogin) {
+		t.Fatal("validated fixer decline should withhold further edits")
+	}
+}
+
+func TestThreadWithheldFromFixerIgnoresUntrusted(t *testing.T) {
+	t.Parallel()
+	thread := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: "rando", AuthorAssociation: "NONE", Body: "/looper wontfix no"},
+		},
+	}
+	if ThreadWithheldFromFixer(thread, "alice", testLooperLogin) {
+		t.Fatal("untrusted wontfix must not withhold")
+	}
+}
+
+func TestThreadWithheldFromFixerIgnoresSpoofedMarkers(t *testing.T) {
+	t.Parallel()
+	// Spoofed root stamp from untrusted author is not Looper-authored.
+	spoofedRoot := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "evil", Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix"},
+		},
+	}
+	if ThreadWithheldFromFixer(spoofedRoot, "alice", testLooperLogin) {
+		t.Fatal("spoofed stamp root must not withhold")
+	}
+	// Spoofed decline from untrusted author is not a validated decline.
+	spoofedDecline := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: "evil", Body: "nope <!-- looper-fixer-reply-declined thread:t1 fingerprint:x -->"},
+		},
+	}
+	if ThreadWithheldFromFixer(spoofedDecline, "alice", testLooperLogin) {
+		t.Fatal("spoofed decline must not withhold")
+	}
+	// Spoofed accept audit must not keep thread withheld / count as audit.
+	spoofedAudit := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix"},
+			{ID: "c3", Author: "evil", Body: "<!-- looper:thread-resolution thread=t1 head=h feedback=f decision=accept_wontfix -->"},
+		},
+	}
+	if !ThreadWithheldFromFixer(spoofedAudit, "alice", testLooperLogin) {
+		t.Fatal("spoofed audit must not clear trusted disposition withhold")
+	}
+	// Substring needle without exact HTML marker is not a validated decline.
+	needleOnly := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: testLooperLogin, Body: "mentioning looper-fixer-reply-declined without marker"},
+		},
+	}
+	if ThreadWithheldFromFixer(needleOnly, "alice", testLooperLogin) {
+		t.Fatal("substring decline needle must not count as validated decline")
+	}
+}
+
+func TestSuppressWithheldDispositionFixItems(t *testing.T) {
+	t.Parallel()
+	threads := []ReviewThread{{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "MEMBER", Body: "wontfix"},
+		},
+	}}
+	items := []FixItem{
+		{Type: "comment", ID: "c1", ThreadID: "t1"},
+		{Type: "comment", ID: "c3", ThreadID: "t2"},
+		{Type: "check", Name: "ci"},
+	}
+	got := SuppressWithheldDispositionFixItems(items, threads, "alice", testLooperLogin)
+	if len(got) != 2 {
+		t.Fatalf("got %#v, want t2 + check", got)
+	}
+	if got[0].ThreadID != "t2" || got[1].Type != "check" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestAdmitWithheldDispositionSkipsQueuedItemAfterNewDisposition(t *testing.T) {
+	t.Parallel()
+	github := &fakeGitHubGateway{
+		currentUser: testLooperLogin,
+		viewResponses: []PullRequestDetail{{
+			Number: 42, State: "OPEN", HeadSHA: "h1", Author: "alice",
+		}},
+		threads: []ReviewThread{{
+			ID: "t1",
+			Comments: []ReviewThreadComment{
+				{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+				{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix after queue"},
+			},
+		}},
+	}
+	runner := New(Options{GitHub: github})
+	items := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Author: "reviewer", Summary: "fix me"}}
+	// collect-fixes admission path
+	got, err := runner.admitWithheldDispositionFixItems(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "p1", RepoPath: t.TempDir()},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+	}, items)
+	if err != nil {
+		t.Fatalf("admit error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %#v, want all comment items withheld (no agent edits)", got)
+	}
+}
+
+func TestAdmitWithheldDispositionListFailureFailClosed(t *testing.T) {
+	t.Parallel()
+	github := &fakeGitHubGateway{
+		currentUser:    testLooperLogin,
+		listThreadsErr: errors.New("github timeout"),
+		viewResponses:  []PullRequestDetail{{Number: 42, State: "OPEN", Author: "alice"}},
+	}
+	runner := New(Options{GitHub: github})
+	items := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}
+	got, err := runner.admitWithheldDispositionFixItems(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "p1", RepoPath: t.TempDir()},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+	}, items)
+	if err == nil {
+		t.Fatal("want retryable fail-closed error on list failure")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("err = %#v, want retryable_transient loopError", err)
+	}
+	if got != nil {
+		t.Fatalf("got items %#v, want nil on fail-closed", got)
+	}
+}
+
+func TestAdmitWithheldDispositionEmptyLoginFailClosed(t *testing.T) {
+	t.Parallel()
+	// Integration tokens can yield ("", nil) from GetCurrentUserLogin; empty
+	// identity must not fail-open into SuppressWithheldDispositionFixItems.
+	github := &fakeGitHubGateway{
+		currentUserEmpty: true,
+		viewResponses:    []PullRequestDetail{{Number: 42, State: "OPEN", Author: "alice"}},
+		threads: []ReviewThread{{
+			ID: "t1",
+			Comments: []ReviewThreadComment{
+				{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+				{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "wontfix"},
+			},
+		}},
+	}
+	runner := New(Options{GitHub: github})
+	items := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Author: "reviewer", Summary: "fix me"}}
+	got, err := runner.admitWithheldDispositionFixItems(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "p1", RepoPath: t.TempDir()},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+	}, items)
+	if err == nil {
+		t.Fatal("want retryable fail-closed error on empty disposition identity")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("err = %#v, want retryable_transient loopError", err)
+	}
+	if !strings.Contains(loopErr.message, "fixer disposition identity is empty") {
+		t.Fatalf("err message = %q, want empty identity", loopErr.message)
+	}
+	if got != nil {
+		t.Fatalf("got items %#v, want nil (not treated as actionable)", got)
+	}
+	if len(github.listThreadsCalls) != 0 {
+		t.Fatalf("listThreadsCalls = %d, want 0 (reject empty login before withhold scan)", len(github.listThreadsCalls))
+	}
+}
+
+func TestDispositionLooperLoginRejectsEmpty(t *testing.T) {
+	t.Parallel()
+	runner := New(Options{GitHub: &fakeGitHubGateway{currentUserEmpty: true}})
+	login, err := runner.dispositionLooperLogin(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("want error for empty login")
+	}
+	var loopErr *loopError
+	if !errors.As(err, &loopErr) || loopErr.kind != FailureRetryableTransient {
+		t.Fatalf("err = %#v, want retryable_transient loopError", err)
+	}
+	if login != "" {
+		t.Fatalf("login = %q, want empty", login)
+	}
+	if !strings.Contains(loopErr.message, "fixer disposition identity is empty") {
+		t.Fatalf("message = %q", loopErr.message)
+	}
+}
+
+func TestAdmitWithheldDispositionListUsesAllPages(t *testing.T) {
+	t.Parallel()
+	github := &fakeGitHubGateway{
+		currentUser: testLooperLogin,
+		viewResponses: []PullRequestDetail{{
+			Number: 42, State: "OPEN", HeadSHA: "h1", Author: "alice",
+		}},
+		threads: []ReviewThread{{
+			ID: "t1",
+			Comments: []ReviewThreadComment{
+				{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+			},
+		}},
+	}
+	runner := New(Options{GitHub: github})
+	items := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Author: "reviewer", Summary: "fix me"}}
+	if _, err := runner.admitWithheldDispositionFixItems(context.Background(), stepInput{
+		Project:  storage.ProjectRecord{ID: "p1", RepoPath: t.TempDir()},
+		Repo:     "acme/looper",
+		PRNumber: 42,
+	}, items); err != nil {
+		t.Fatalf("admit error = %v", err)
+	}
+	if len(github.listThreadsCalls) != 1 {
+		t.Fatalf("listThreadsCalls = %d, want 1", len(github.listThreadsCalls))
+	}
+	got := github.listThreadsCalls[0]
+	if !got.AllPages {
+		t.Fatalf("ListReviewThreads AllPages = false, want true (authority withhold read must paginate fully)")
+	}
+	if got.Limit != 0 {
+		t.Fatalf("ListReviewThreads Limit = %d, want 0 when AllPages is set", got.Limit)
+	}
+	if got.Repo != "acme/looper" || got.PRNumber != 42 {
+		t.Fatalf("ListReviewThreads input = %#v", got)
+	}
+}
+
+func TestCollectFixesAdmissionWithholdsBeforeWorktree(t *testing.T) {
+	t.Parallel()
+	github := &fakeGitHubGateway{
+		currentUser: testLooperLogin,
+		viewResponses: []PullRequestDetail{{
+			Number: 42, State: "OPEN", HeadSHA: "h1", HeadRefName: "feature/x", BaseRefName: "main", Author: "alice",
+			Comments: []map[string]any{
+				{"id": "c1", "threadId": "t1", "body": "please fix", "author": "reviewer"},
+			},
+		}},
+		threads: []ReviewThread{{
+			ID: "t1",
+			Comments: []ReviewThreadComment{
+				{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+				{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "wontfix"},
+			},
+		}},
+	}
+	runner := New(Options{GitHub: github})
+	checkpoint := fixerCheckpoint{
+		Detail: &checkpointDetail{
+			State: "OPEN", HeadSHA: "h1", HeadRefName: "feature/x", BaseRefName: "main",
+			Comments: []map[string]any{
+				{"id": "c1", "threadId": "t1", "body": "please fix", "author": "reviewer"},
+			},
+		},
+	}
+	updated, err := runner.runCollectFixesStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{ID: "p1", RepoPath: t.TempDir()},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err != nil {
+		t.Fatalf("runCollectFixesStep() error = %v", err)
+	}
+	if updated.SkipReason == "" {
+		t.Fatal("want skip when all remaining comment items are withheld")
+	}
+	if len(updated.FixItems) != 0 {
+		t.Fatalf("FixItems = %#v, want empty (no agent/worktree mutation)", updated.FixItems)
+	}
+}
+
+func TestReplyToDeclinedAfterRejectPostsNewMarker(t *testing.T) {
+	t.Parallel()
+	fp := "deadbeef"
+	baseMarker := fixerDeclinedReplyMarker("t1", fp)
+	postMarker := fixerDeclinedReplyMarkerPostReject("t1", fp)
+	github := &fakeGitHubGateway{
+		currentUser: testLooperLogin,
+		threads: []ReviewThread{{
+			ID: "t1",
+			Comments: []ReviewThreadComment{
+				{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+				{ID: "c2", Author: testLooperLogin, Body: "first decline " + baseMarker},
+				{ID: "c3", Author: testLooperLogin, Body: "<!-- looper:thread-resolution thread=t1 head=h feedback=f decision=reject_wontfix -->"},
+			},
+		}},
+	}
+	runner := New(Options{GitHub: github})
+	item := FixItem{Type: "comment", ID: "c1", ThreadID: "t1", Author: "alice"}
+	state, replyErr := runner.replyToDeclinedComment(context.Background(), stepInput{
+		Project: storage.ProjectRecord{RepoPath: t.TempDir()},
+		Repo:    "acme/looper",
+	}, item, fp, "Still out of scope after reject.", nil)
+	if replyErr != "" || state != "sent" {
+		t.Fatalf("reply state=%q err=%q, want sent", state, replyErr)
+	}
+	if len(github.replyCalls) != 1 {
+		t.Fatalf("reply calls = %d, want 1 new post-reject decline", len(github.replyCalls))
+	}
+	if !strings.Contains(github.replyCalls[0].Body, postMarker) {
+		t.Fatalf("reply body = %q, want post-reject marker %q", github.replyCalls[0].Body, postMarker)
+	}
+	// Second call is idempotent (same post-reject marker already present).
+	state2, replyErr2 := runner.replyToDeclinedComment(context.Background(), stepInput{
+		Project: storage.ProjectRecord{RepoPath: t.TempDir()},
+		Repo:    "acme/looper",
+	}, item, fp, "Still out of scope after reject.", nil)
+	if replyErr2 != "" || state2 != "sent" {
+		t.Fatalf("second reply state=%q err=%q", state2, replyErr2)
+	}
+	if len(github.replyCalls) != 1 {
+		t.Fatalf("reply calls after idempotent retry = %d, want still 1", len(github.replyCalls))
+	}
+}
+
+func TestReplyToDeclinedBeforeRejectIsIdempotent(t *testing.T) {
+	t.Parallel()
+	fp := "cafebabe"
+	baseMarker := fixerDeclinedReplyMarker("t1", fp)
+	github := &fakeGitHubGateway{
+		currentUser: testLooperLogin,
+		threads: []ReviewThread{{
+			ID: "t1",
+			Comments: []ReviewThreadComment{
+				{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+				{ID: "c2", Author: testLooperLogin, Body: "first decline " + baseMarker},
+			},
+		}},
+	}
+	runner := New(Options{GitHub: github})
+	item := FixItem{Type: "comment", ID: "c1", ThreadID: "t1", Author: "alice"}
+	state, replyErr := runner.replyToDeclinedComment(context.Background(), stepInput{
+		Project: storage.ProjectRecord{RepoPath: t.TempDir()},
+		Repo:    "acme/looper",
+	}, item, fp, "Out of scope.", nil)
+	if replyErr != "" || state != "sent" {
+		t.Fatalf("reply state=%q err=%q, want sent (idempotent)", state, replyErr)
+	}
+	if len(github.replyCalls) != 0 {
+		t.Fatalf("reply calls = %d, want 0 (same-fingerprint decline remains idempotent before reject)", len(github.replyCalls))
+	}
+}
+
+func TestRejectWontfixRestoresExistingFixerItem(t *testing.T) {
+	t.Parallel()
+	threads := []ReviewThread{{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: testLooperLogin, Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: testLooperLogin, Body: "declined <!-- looper-fixer-reply-declined thread:t1 fingerprint:x -->"},
+			{ID: "c3", Author: testLooperLogin, Body: "<!-- looper:thread-resolution thread=t1 head=h feedback=f decision=reject_wontfix -->"},
+		},
+	}}
+	items := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}
+	got := SuppressWithheldDispositionFixItems(items, threads, "alice", testLooperLogin)
+	if len(got) != 1 || got[0].ThreadID != "t1" {
+		t.Fatalf("got %#v, want existing t1 item restored after reject_wontfix", got)
+	}
+}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -812,12 +812,13 @@ type checkpointRepair struct {
 }
 
 // replyExplanationEntry holds the agent's per-fix-item explanation for the
-// auto-reply posted before resolving the review thread. Stored on the repair
-// checkpoint so resume/retry reuses the same explanation if it still maps to
-// the current fix items snapshot. Fixed decisions must include
-// ThreadCommentsObserved so resolve-comments can verify the live thread still
-// contains exactly the same target review comment IDs before auto-resolving,
-// excluding only prior Looper fixer replies.
+// auto-reply Looper posts on the review thread. Stored on the repair checkpoint
+// so resume/retry reuses the same explanation if it still maps to the current
+// fix items snapshot. Fixed decisions must include ThreadCommentsObserved so
+// resolve-comments can verify the live thread still contains exactly the same
+// target review comment IDs before auto-resolving, excluding only prior Looper
+// fixer replies. Declined decisions reply and leave the thread unresolved for
+// Reviewer adjudication.
 type replyExplanationEntry struct {
 	FixItemID              string `json:"fixItemId"`
 	ThreadID               string `json:"threadId,omitempty"`
@@ -996,9 +997,13 @@ const (
 	agentMissingThreadDecisionExplanation = "Agent did not provide a decision for this thread"
 	agentInvalidThreadDecisionExplanation = "Agent provided an unrecognized decision for this thread"
 	agentDeclinedThreadWithoutReason      = "Agent declined this thread without a substantive reason"
-	maxDeclinedThreadRecords              = 200
-	zeroProgressPauseReason               = "agent_zero_progress"
-	labelMismatchPauseReason              = "fixer_label_mismatch"
+	// declinePendingAdjudicationStatus marks a Fixer decline reply that left the
+	// review thread unresolved for Reviewer accept/reject/needs_human. It is not
+	// terminal same-head suppression and must not call ResolveReviewThread.
+	declinePendingAdjudicationStatus = "decline_pending_adjudication"
+	maxDeclinedThreadRecords         = 200
+	zeroProgressPauseReason          = "agent_zero_progress"
+	labelMismatchPauseReason         = "fixer_label_mismatch"
 )
 
 // parseReplyExplanations extracts the optional review_thread_replies array from
@@ -3774,7 +3779,6 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	}
 	resolvedCount := 0
 	contractViolationCount := 0
-	declinedUpdates := map[string]declinedThreadRecord{}
 	commentItems := make([]FixItem, 0, len(fixItems))
 	nativeCommentItems := make([]FixItem, 0, len(fixItems))
 	for _, item := range fixItems {
@@ -3876,6 +3880,10 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		}
 		switch normalizeReplyAction(decision.Action) {
 		case string(replyActionDeclined):
+			// Decline is a scope dispute for Reviewer adjudication: reply with
+			// evidence, leave the thread unresolved, and do not write terminal
+			// same-head declinedThreads suppression. Legacy remotely-resolved
+			// declines are handled above via thread.IsResolved.
 			decisionFingerprint := buildDeclinedThreadFingerprint(item, liveDetail.HeadSHA)
 			replyState, replyError := r.replyToDeclinedComment(ctx, input, item, decisionFingerprint, decision.Explanation, checkpoint.ResolvedComments.Items)
 			if replyState == "failed" {
@@ -3886,24 +3894,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 			if err := r.persistCheckpoint(ctx, input.Run.ID, stepResolveComments, checkpoint); err != nil {
 				return checkpoint, err
 			}
-			if err := r.github.ResolveReviewThread(ctx, ResolveReviewThreadInput{Repo: input.Repo, ThreadID: item.ThreadID, CWD: input.Project.RepoPath}); err != nil {
-				message := err.Error()
-				if strings.Contains(strings.ToLower(message), "already") {
-					if replyState == "sent" {
-						declinedUpdates[decisionFingerprint] = declinedThreadRecord{RecordedAt: r.nowISO(), ThreadID: item.ThreadID, Reason: decision.Explanation}
-					}
-					upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionDeclined), Status: "already_resolved", Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
-					continue
-				}
-				mutationFailureCount++
-				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionDeclined), Status: "failed_mutation_retry", Message: message, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
-				continue
-			}
-			resolvedCount++
-			if replyState == "sent" {
-				declinedUpdates[decisionFingerprint] = declinedThreadRecord{RecordedAt: r.nowISO(), ThreadID: item.ThreadID, Reason: decision.Explanation}
-			}
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionDeclined), Status: "agent_declined", Message: decision.Explanation, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
+			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: string(replyActionDeclined), Status: declinePendingAdjudicationStatus, Message: decision.Explanation, UpdatedAt: r.nowISO(), ReplyState: replyState, ReplyError: replyError})
 		default:
 			replyState, replyError := r.replyToFixedComment(ctx, input, item, commitSHA, decision.Explanation, checkpoint.ResolvedComments.Items)
 			if err := r.persistCheckpoint(ctx, input.Run.ID, stepResolveComments, checkpoint); err != nil {
@@ -3983,11 +3974,6 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	}
 	if contractViolationCount > 0 {
 		if _, err := r.incrementContractViolationCount(ctx, input.Loop, contractViolationCount); err != nil {
-			return checkpoint, err
-		}
-	}
-	if len(declinedUpdates) > 0 {
-		if _, err := r.persistDeclinedThreadRecords(ctx, input.Loop, declinedUpdates); err != nil {
 			return checkpoint, err
 		}
 	}
@@ -4880,7 +4866,7 @@ func summaryStatusIcon(status string) string {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "resolved", "already_resolved":
 		return "✅"
-	case "agent_declined":
+	case "agent_declined", declinePendingAdjudicationStatus:
 		return "⏸️"
 	case "failed":
 		return "⚠️"
@@ -6575,7 +6561,9 @@ func hasProgressed(checkpoint fixerCheckpoint) bool {
 		return false
 	}
 	for _, item := range checkpoint.ResolvedComments.Items {
-		if item.Status == "resolved" || item.Status == "already_resolved" || item.Status == "agent_declined" || item.Action == string(replyActionFixed) {
+		// decline_pending_adjudication counts as progress (reply posted) but is
+		// not terminal resolution — the thread stays open for Reviewer.
+		if item.Status == "resolved" || item.Status == "already_resolved" || item.Status == "agent_declined" || item.Status == declinePendingAdjudicationStatus || item.Action == string(replyActionFixed) {
 			return true
 		}
 	}
@@ -7628,7 +7616,7 @@ func buildFixerReplyExplanationInstruction(fixItems []FixItem) string {
 			`  - "fixItemId": the exact "id" of the fix item`,
 			`  - "threadId": the exact "threadId" of the same fix item`,
 			`  - "action": "fixed" or "declined"; a later HUMAN-IN-THE-LOOP instruction may additionally enable "needs_human"`,
-			`  - "explanation": one or two sentences (max ~500 chars). If action is "fixed", say what you changed and where. If action is "declined", respectfully explain why the suggestion was not adopted and cite the relevant scope, intent, repository rule, or concrete technical evidence. Make the explanation self-contained because Looper will post it as the thread reply before resolving the thread. No greetings, no @mentions, no markdown headings, no HTML, no disclosure markers.`,
+			`  - "explanation": one or two sentences (max ~500 chars). If action is "fixed", say what you changed and where. If action is "declined", respectfully explain why the suggestion was not adopted and cite the relevant scope, intent, repository rule, or concrete technical evidence. Make the explanation self-contained because Looper will post it as the thread reply and leave the thread unresolved for Reviewer adjudication. No greetings, no @mentions, no markdown headings, no HTML, no disclosure markers.`,
 			`  - "threadCommentsObserved": sha256 of the JSON array of review-thread comments you observed in thread order, where each element is {"id","updatedAt"}. The "id" MUST be the GraphQL PullRequestReviewComment node ID. If you fetched comments with REST pulls/{number}/comments, map REST "node_id" to "id" and REST "updated_at" to "updatedAt"; do not use the REST numeric "id". Include target reviewer comments even when they contain a Looper stamp. Exclude only prior Looper fixer replies/round comments.`,
 			"Before including an entry, re-read the relevant review thread/comment context.",
 			"Use \"fixed\" only when you can confidently confirm the current branch state actually addresses the thread; in other words, only include items you can confidently confirm are actually addressed by the current branch state. Use \"declined\" if you deliberately are not acting, including cases such as: already implemented on this branch, out of scope for this PR, reviewer request is incorrect, or you cannot safely complete it.",
@@ -7753,9 +7741,39 @@ func shouldBlockResolveWithoutFix(checkpoint fixerCheckpoint, fixItems []FixItem
 	if checkpoint.ReconcileCommits.FinalHeadSHA != "" && checkpoint.ReconcileCommits.BaseHeadSHA != "" && checkpoint.ReconcileCommits.FinalHeadSHA != checkpoint.ReconcileCommits.BaseHeadSHA {
 		return false
 	}
+	// Remaining open comment threads normally mean resolve was a no-op without a
+	// push. Decline-pending-adjudication threads are intentionally left open for
+	// Reviewer and must not trip this generic manual-intervention path. Do not
+	// fold them into terminal declinedThreads suppression.
 	for _, item := range fixItems {
-		if item.Type == "comment" {
+		if item.Type != "comment" {
+			continue
+		}
+		if commentExemptFromNoCommitResolveBlock(checkpoint, item) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// commentExemptFromNoCommitResolveBlock reports whether a still-open remaining
+// comment should not trigger the no-new-commits manual hold. Decline pending
+// Reviewer adjudication is the primary case; already-resolved statuses are
+// included defensively if they still appear in RemainingFixItems.
+func commentExemptFromNoCommitResolveBlock(checkpoint fixerCheckpoint, item FixItem) bool {
+	if checkpoint.ResolvedComments == nil {
+		return false
+	}
+	for _, entry := range checkpoint.ResolvedComments.Items {
+		if entry.FixItemID != item.ID && (entry.ThreadID == "" || entry.ThreadID != item.ThreadID) {
+			continue
+		}
+		switch entry.Status {
+		case declinePendingAdjudicationStatus, "already_resolved", "resolved", "agent_declined":
 			return true
+		default:
+			return false
 		}
 	}
 	return false

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1662,7 +1662,7 @@ func (r *Runner) shouldCreateFixerBudgetPark(loop storage.LoopRecord) bool {
 	if loop.Status == "terminated" || loop.Status == "stopped" || loop.Status == "awaiting_human" {
 		return false
 	}
-	if loop.Status == "paused" && loops.IsReviewFixBudgetHold(loop) {
+	if loop.Status == "paused" && loops.IsReviewFixPairHold(loop) {
 		return false
 	}
 	if !loops.ParticipatesInReviewFixBudget(loop) {
@@ -1732,12 +1732,16 @@ func (r *Runner) parkFixerBudgetIfExhausted(ctx context.Context, loop storage.Lo
 	if loop.Status == "terminated" || loop.Status == "stopped" {
 		return false, nil
 	}
-	// Sibling pause is already a hold; do not treat "not self-exhausted" as proceed.
-	if loop.Status == "paused" && loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) {
+	// Sibling pause / scope hold is already a hold; do not treat "not self-exhausted" as proceed.
+	if loop.Status == "paused" && (loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) || loops.IsSiblingReviewScopeHumanPause(loop.MetadataJSON)) {
+		return true, nil
+	}
+	if loops.IsReviewScopeHumanHold(loop) && !loops.IsReviewFixBudgetHold(loop) {
 		return true, nil
 	}
 	if loop.Status == "awaiting_human" {
 		if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
+			// Agent ask or scope ask: not a budget park target.
 			return true, nil
 		}
 	} else if loop.Status == "paused" && loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
@@ -1800,11 +1804,14 @@ func (r *Runner) refusePushIfBudgetExhausted(ctx context.Context, input stepInpu
 	if !loops.ParticipatesInReviewFixBudget(loop) {
 		return false, nil
 	}
-	if loops.IsReviewFixBudgetHold(loop) {
-		if _, err := r.parkFixerBudgetIfExhausted(ctx, loop); err != nil {
-			return true, err
+	if loops.IsReviewFixPairHold(loop) {
+		if loops.IsReviewFixBudgetHold(loop) {
+			if _, err := r.parkFixerBudgetIfExhausted(ctx, loop); err != nil {
+				return true, err
+			}
+			return true, &holdSkipError{summary: "Fixer stopped because review-fix budget is held"}
 		}
-		return true, &holdSkipError{summary: "Fixer stopped because review-fix budget is held"}
+		return true, &holdSkipError{summary: "Fixer stopped because review scope requires human judgment"}
 	}
 	cap := r.maxPushesPerPR(loop.ProjectID)
 	if !loops.BudgetExhausted(loops.FixerPushCount(loop.MetadataJSON), cap) {
@@ -2739,7 +2746,7 @@ func (r *Runner) finishHeldFixerQueueItem(ctx context.Context, loop storage.Loop
 	// step already persisted — only ordinary label/hold skips re-queue.
 	if _, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
 		updated.LastRunAt = stringPtr(r.nowISO())
-		if loops.IsReviewFixBudgetHold(*updated) || updated.Status == "terminated" || updated.Status == "stopped" || updated.Status == "awaiting_human" || updated.Status == "human_takeover" {
+		if loops.IsReviewFixPairHold(*updated) || updated.Status == "terminated" || updated.Status == "stopped" || updated.Status == "awaiting_human" || updated.Status == "human_takeover" {
 			updated.NextRunAt = nil
 			return
 		}
@@ -5338,13 +5345,15 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 		if updatedLoop.Status == "awaiting_human" || updatedLoop.Status == "human_takeover" || updatedLoop.Status == "terminated" || updatedLoop.Status == "stopped" {
 			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
 		}
-		// Sibling pause / exhausted hold must not be revived by discovery enqueue.
+		// Sibling pause / exhausted / scope hold must not be revived by discovery enqueue.
 		// Notify only from discovery after a successful park (not from shared park).
-		if loops.IsReviewFixBudgetHold(updatedLoop) {
-			if parked, err := r.parkFixerBudgetIfExhausted(ctx, updatedLoop); err != nil {
-				return loopUpsertResult{}, err
-			} else if parked {
-				r.notifyHumanAttentionBestEffort(ctx, updatedLoop.ID)
+		if loops.IsReviewFixPairHold(updatedLoop) {
+			if loops.IsReviewFixBudgetHold(updatedLoop) {
+				if parked, err := r.parkFixerBudgetIfExhausted(ctx, updatedLoop); err != nil {
+					return loopUpsertResult{}, err
+				} else if parked {
+					r.notifyHumanAttentionBestEffort(ctx, updatedLoop.ID)
+				}
 			}
 			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
 		}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -212,6 +212,10 @@ type ListReviewThreadsInput struct {
 	PRNumber int64
 	CWD      string
 	Limit    int
+	// AllPages requests full pagination for authority reads (withhold
+	// admission). When true, Limit is ignored as a stop condition.
+	// Existing Limit<=0 callers keep the historical default page cap.
+	AllPages bool
 }
 
 type ViewReviewThreadInput struct {
@@ -226,11 +230,12 @@ type ReviewThread struct {
 }
 
 type ReviewThreadComment struct {
-	ID        string
-	Body      string
-	Author    string
-	CreatedAt string
-	UpdatedAt string
+	ID                string
+	Body              string
+	Author            string
+	AuthorAssociation string
+	CreatedAt         string
+	UpdatedAt         string
 }
 
 type ResolveReviewThreadInput struct {
@@ -1946,6 +1951,10 @@ func (r *Runner) discoverPullRequestFromDetail(ctx context.Context, project stor
 	}
 	allFixItemsStateHash := hashFixItemsState(allFixItems)
 	fixItems := suppressDeclinedFixItems(loopMetadataForPR(ctx, r, project.ID, repo, detail.Number), detail.HeadSHA, allFixItems)
+	fixItems, err = r.suppressWithheldDispositionFixItems(ctx, project, repo, detail, fixItems)
+	if err != nil {
+		return err
+	}
 	if len(fixItems) == 0 {
 		if err := r.resumePausedZeroProgressLoopIfStateChanged(ctx, project.ID, repo, detail.Number, detail.HeadSHA, allFixItemsStateHash); err != nil {
 			return err
@@ -2842,6 +2851,13 @@ func (r *Runner) runCollectFixesStep(ctx context.Context, input stepInput) (fixe
 	fixItems, err = r.unsatisfiedForgejoSummaryItems(input.Project.ID, checkpoint.Detail, fixItems)
 	if err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureNonRetryable}
+	}
+	// Claim / pre-agent admission: re-evaluate disposition withhold before any
+	// worktree mutation or agent run so already-queued items that gained a
+	// trusted disposition after discovery are not edited or pushed.
+	fixItems, err = r.admitWithheldDispositionFixItems(ctx, input, fixItems)
+	if err != nil {
+		return checkpoint, err
 	}
 	checkpoint.FixItems = fixItems
 	checkpoint.FixItemsHash = hashFixItems(fixItems)
@@ -3835,6 +3851,10 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	// successful "fixed" decision whenever a single new thread appeared,
 	// which on PRs receiving a steady stream of bot comments produced an
 	// unbreakable drift loop.
+	looperLogin, err := r.dispositionLooperLogin(ctx, input.Project.RepoPath)
+	if err != nil {
+		return checkpoint, err
+	}
 	for _, item := range commentItems {
 		if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
 			continue
@@ -3857,11 +3877,23 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		}
 		thread, err := r.github.ViewReviewThread(ctx, ViewReviewThreadInput{ThreadID: item.ThreadID, CWD: input.Project.RepoPath})
 		if err != nil {
-			return checkpoint, err
+			// Fail-closed: do not mutate from stale "actionable" assumptions.
+			return checkpoint, &loopError{message: fmt.Sprintf("fixer disposition thread view failed: %v", err), kind: FailureRetryableTransient}
 		}
 		if thread.IsResolved {
 			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "already_resolved", UpdatedAt: r.nowISO()})
 			continue
+		}
+		// Last-line drift guard: withhold further edits while Reviewer
+		// adjudicates. Admission already suppressed withheld items before
+		// agent/worktree mutation; this catches races after the agent ran.
+		if ThreadWithheldFromFixer(thread, liveDetail.Author, looperLogin) {
+			allowDecline := normalizeReplyAction(decision.Action) == string(replyActionDeclined) &&
+				allowDeclineReplyWhileWithheld(thread, liveDetail.Author, looperLogin)
+			if !allowDecline {
+				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_pending_disposition", Message: "Thread withheld pending Reviewer disposition adjudication", UpdatedAt: r.nowISO()})
+				continue
+			}
 		}
 		if hasNonLooperCommentSince(thread, driftSince) {
 			driftCount++
@@ -4243,24 +4275,42 @@ func (r *Runner) replyToDeclinedComment(ctx context.Context, input stepInput, it
 	if item.ThreadID == "" {
 		return "skipped_no_thread", ""
 	}
-	for _, entry := range existing {
-		if entry.Action != string(replyActionDeclined) {
-			continue
-		}
-		if entry.FixItemID == item.ID || (entry.ThreadID != "" && entry.ThreadID == item.ThreadID) {
-			if entry.ReplyState == "sent" || entry.ReplyState == "skipped_self_author" || entry.ReplyState == "skipped_no_thread" {
-				return entry.ReplyState, entry.ReplyError
-			}
-		}
-	}
-	body := buildFixerDeclinedReplyBody(item, explanation, decisionFingerprint)
-	existingRemoteReply, err := r.hasExistingFixerDeclinedReply(ctx, input, item, decisionFingerprint)
+	thread, err := r.github.ViewReviewThread(ctx, ViewReviewThreadInput{ThreadID: item.ThreadID, CWD: input.Project.RepoPath})
 	if err != nil {
 		return "failed", err.Error()
 	}
-	if existingRemoteReply {
+	looperLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+	if err != nil {
+		return "failed", err.Error()
+	}
+	looperLogin = strings.TrimSpace(looperLogin)
+	marker := declineMarkerForThread(thread, item.ThreadID, decisionFingerprint, looperLogin)
+	lastRejectIdx := lastRejectWontfixIndex(thread, looperLogin)
+	// Checkpoint idempotency only applies when we are not posting a fresh
+	// post-reject decline (new marker after Reviewer reject_wontfix).
+	if lastRejectIdx < 0 || hasValidatedDeclineWithMarkerAfter(thread, marker, looperLogin, lastRejectIdx) {
+		for _, entry := range existing {
+			if entry.Action != string(replyActionDeclined) {
+				continue
+			}
+			if entry.FixItemID == item.ID || (entry.ThreadID != "" && entry.ThreadID == item.ThreadID) {
+				if entry.ReplyState == "sent" || entry.ReplyState == "skipped_self_author" || entry.ReplyState == "skipped_no_thread" {
+					return entry.ReplyState, entry.ReplyError
+				}
+			}
+		}
+	}
+	if hasValidatedDeclineWithMarkerAfter(thread, marker, looperLogin, lastRejectIdx) {
 		return "sent", ""
 	}
+	// Before any reject, also treat the base same-fingerprint marker as sent.
+	if lastRejectIdx < 0 {
+		base := fixerDeclinedReplyMarker(item.ThreadID, decisionFingerprint)
+		if hasValidatedDeclineWithMarkerAfter(thread, base, looperLogin, -1) {
+			return "sent", ""
+		}
+	}
+	body := buildFixerDeclinedReplyBodyWithMarker(item, explanation, marker)
 	disclosureAgent, disclosureModel := r.disclosureIdentity(input.Run)
 	if err := r.github.AddReviewThreadReply(ctx, AddReviewThreadReplyInput{Repo: input.Repo, ThreadID: item.ThreadID, Body: body, CWD: input.Project.RepoPath, DisclosureAgent: disclosureAgent, DisclosureModel: disclosureModel}); err != nil {
 		return "failed", err.Error()
@@ -4286,20 +4336,21 @@ func (r *Runner) hasExistingFixerReply(ctx context.Context, input stepInput, ite
 }
 
 func (r *Runner) hasExistingFixerDeclinedReply(ctx context.Context, input stepInput, item FixItem, decisionFingerprint string) (bool, error) {
-	marker := fixerDeclinedReplyMarker(item.ThreadID, decisionFingerprint)
-	if marker == "" {
-		return false, nil
-	}
 	thread, err := r.github.ViewReviewThread(ctx, ViewReviewThreadInput{ThreadID: item.ThreadID, CWD: input.Project.RepoPath})
 	if err != nil {
 		return false, err
 	}
-	for _, comment := range thread.Comments {
-		if strings.Contains(comment.Body, marker) {
-			return true, nil
-		}
+	looperLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+	if err != nil {
+		return false, err
 	}
-	return false, nil
+	looperLogin = strings.TrimSpace(looperLogin)
+	marker := declineMarkerForThread(thread, item.ThreadID, decisionFingerprint, looperLogin)
+	if marker == "" {
+		return false, nil
+	}
+	lastRejectIdx := lastRejectWontfixIndex(thread, looperLogin)
+	return hasValidatedDeclineWithMarkerAfter(thread, marker, looperLogin, lastRejectIdx), nil
 }
 
 func (r *Runner) refreshResolveCommentState(ctx context.Context, input stepInput, checkpoint fixerCheckpoint, evidence threadFixEvidence, item FixItem) (string, PullRequestDetail, error) {
@@ -4555,6 +4606,10 @@ func buildFixerReplyBody(item FixItem, commitSHA, explanation string) string {
 }
 
 func buildFixerDeclinedReplyBody(item FixItem, explanation, decisionFingerprint string) string {
+	return buildFixerDeclinedReplyBodyWithMarker(item, explanation, fixerDeclinedReplyMarker(item.ThreadID, decisionFingerprint))
+}
+
+func buildFixerDeclinedReplyBodyWithMarker(item FixItem, explanation, marker string) string {
 	var b strings.Builder
 	mention := strings.TrimSpace(item.Author)
 	if mention != "" {
@@ -4567,7 +4622,7 @@ func buildFixerDeclinedReplyBody(item FixItem, explanation, decisionFingerprint 
 		b.WriteString("\n\n")
 		b.WriteString(explanation)
 	}
-	if marker := fixerDeclinedReplyMarker(item.ThreadID, decisionFingerprint); marker != "" {
+	if marker = strings.TrimSpace(marker); marker != "" {
 		b.WriteString("\n\n")
 		b.WriteString(marker)
 	}
@@ -4603,6 +4658,17 @@ func fixerDeclinedReplyMarker(threadID, decisionFingerprint string) string {
 		return ""
 	}
 	return fmt.Sprintf("<!-- looper-fixer-reply-declined thread:%s fingerprint:%s -->", threadID, decisionFingerprint)
+}
+
+// fixerDeclinedReplyMarkerPostReject is a distinct decline marker used once after
+// Reviewer reject_wontfix so the second same-fingerprint decline is visible.
+func fixerDeclinedReplyMarkerPostReject(threadID, decisionFingerprint string) string {
+	threadID = strings.TrimSpace(threadID)
+	decisionFingerprint = strings.TrimSpace(decisionFingerprint)
+	if threadID == "" || decisionFingerprint == "" {
+		return ""
+	}
+	return fmt.Sprintf("<!-- looper-fixer-reply-declined thread:%s fingerprint:%s attempt:post-reject -->", threadID, decisionFingerprint)
 }
 
 func summarizeFixItem(item FixItem) string {
@@ -7373,6 +7439,87 @@ func buildDeclinedThreadFingerprint(item FixItem, headSHA string) string {
 	}, "|")
 	sum := sha1.Sum([]byte(payload))
 	return hex.EncodeToString(sum[:])
+}
+
+// admitWithheldDispositionFixItems re-evaluates withhold at claim/collect-fixes
+// (before prepare-worktree and agent). Failures are retryable fail-closed.
+func (r *Runner) admitWithheldDispositionFixItems(ctx context.Context, input stepInput, fixItems []FixItem) ([]FixItem, error) {
+	if r.github == nil || len(fixItems) == 0 {
+		return fixItems, nil
+	}
+	if r.isForgejoProject(input.Project.ID) {
+		return fixItems, nil
+	}
+	prAuthor, err := r.github.GetPullRequestAuthor(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
+	if err != nil {
+		return nil, &loopError{message: fmt.Sprintf("fixer disposition admission author lookup failed: %v", err), kind: FailureRetryableTransient}
+	}
+	return r.suppressWithheldDispositionFixItems(ctx, input.Project, input.Repo, PullRequestDetail{Number: input.PRNumber, Author: prAuthor}, fixItems)
+}
+
+// suppressWithheldDispositionFixItems drops threads with unaudited trusted
+// dispositions or validated Fixer declines until Reviewer adjudicates.
+// List/identity failures are retryable fail-closed (never treat items as
+// actionable from a stale empty withhold set).
+func (r *Runner) suppressWithheldDispositionFixItems(ctx context.Context, project storage.ProjectRecord, repo string, detail PullRequestDetail, fixItems []FixItem) ([]FixItem, error) {
+	if r.github == nil || len(fixItems) == 0 {
+		return fixItems, nil
+	}
+	// Forgejo and other non-native providers have no same-head disposition path.
+	if r.isForgejoProject(project.ID) {
+		return fixItems, nil
+	}
+	looperLogin, err := r.dispositionLooperLogin(ctx, project.RepoPath)
+	if err != nil {
+		return nil, err
+	}
+	threads, err := r.github.ListReviewThreads(ctx, ListReviewThreadsInput{Repo: repo, PRNumber: detail.Number, CWD: project.RepoPath, AllPages: true})
+	if err != nil {
+		return nil, &loopError{message: fmt.Sprintf("fixer withheld-disposition thread listing failed: %v", err), kind: FailureRetryableTransient}
+	}
+	return SuppressWithheldDispositionFixItems(fixItems, threads, detail.Author, looperLogin), nil
+}
+
+// dispositionLooperLogin returns the live Fixer GitHub login used for withhold
+// and mutation-guard identity checks. Empty login (e.g. integration tokens
+// that cannot resolve viewer login) is retryable fail-closed so withheld
+// dispositions are never treated as unowned/actionable.
+func (r *Runner) dispositionLooperLogin(ctx context.Context, repoPath string) (string, error) {
+	if r.github == nil {
+		return "", &loopError{message: "fixer disposition identity lookup failed: github gateway is nil", kind: FailureRetryableTransient}
+	}
+	looperLogin, err := r.github.GetCurrentUserLogin(ctx, repoPath)
+	if err != nil {
+		return "", &loopError{message: fmt.Sprintf("fixer disposition identity lookup failed: %v", err), kind: FailureRetryableTransient}
+	}
+	looperLogin = strings.TrimSpace(looperLogin)
+	if looperLogin == "" {
+		return "", &loopError{message: "fixer disposition identity is empty", kind: FailureRetryableTransient}
+	}
+	return looperLogin, nil
+}
+
+// allowDeclineReplyWhileWithheld is true only when the withhold is the Fixer's
+// own pending decline (idempotent re-reply) or a reject_wontfix path that still
+// has an open post-reject decline slot. accept_wontfix and trusted human
+// dispositions must not receive Fixer decline mutations.
+func allowDeclineReplyWhileWithheld(thread ReviewThread, prAuthorLogin, looperLogin string) bool {
+	lastDecision, lastIdx, hasDecision := lastReviewerAuditDecision(thread, looperLogin)
+	if hasUnauditedValidatedFixerDeclineAfter(thread, looperLogin, lastIdx) {
+		return true
+	}
+	if hasUnauditedTrustedDispositionAfter(thread, prAuthorLogin, lastIdx) {
+		return false
+	}
+	if !hasDecision {
+		return true
+	}
+	switch lastDecision {
+	case decisionRejectWontfix, decisionNotFixed:
+		return true
+	default:
+		return false
+	}
 }
 
 func suppressDeclinedFixItems(loopMetadataJSON *string, headSHA string, fixItems []FixItem) []FixItem {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -563,6 +563,9 @@ type Options struct {
 	RetryMaxAttempts        int64
 	OnAgentExecutionStarted AgentExecutionStartedFunc
 	OnQueueItemEnqueued     func()
+	// NotifyHumanAttention, when set, observes durable loop state after a new
+	// review-fix budget park (including discovery-time parks before claim).
+	NotifyHumanAttention func(context.Context, string)
 }
 
 type DiscoveryPolicy struct {
@@ -604,6 +607,7 @@ type Runner struct {
 	retryMaxAttempts        int64
 	onAgentExecutionStarted AgentExecutionStartedFunc
 	onQueueItemEnqueued     func()
+	notifyHumanAttention    func(context.Context, string)
 }
 
 type DiscoveryInput struct {
@@ -1336,6 +1340,7 @@ func New(options Options) *Runner {
 		retryMaxAttempts:        retryMax,
 		onAgentExecutionStarted: options.OnAgentExecutionStarted,
 		onQueueItemEnqueued:     options.OnQueueItemEnqueued,
+		notifyHumanAttention:    options.NotifyHumanAttention,
 	}
 }
 
@@ -1657,7 +1662,10 @@ func (r *Runner) shouldCreateFixerBudgetPark(loop storage.LoopRecord) bool {
 	if loop.Status == "terminated" || loop.Status == "stopped" || loop.Status == "awaiting_human" {
 		return false
 	}
-	if !r.hitlEnabled || isManualFixerLoop(loop) {
+	if loop.Status == "paused" && loops.IsReviewFixBudgetHold(loop) {
+		return false
+	}
+	if !loops.ParticipatesInReviewFixBudget(loop) {
 		return false
 	}
 	return loops.BudgetExhausted(loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount, r.maxPushesPerPR(loop.ProjectID))
@@ -1724,15 +1732,18 @@ func (r *Runner) parkFixerBudgetIfExhausted(ctx context.Context, loop storage.Lo
 	if loop.Status == "terminated" || loop.Status == "stopped" {
 		return false, nil
 	}
+	// Sibling pause is already a hold; do not treat "not self-exhausted" as proceed.
+	if loop.Status == "paused" && loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) {
+		return true, nil
+	}
 	if loop.Status == "awaiting_human" {
 		if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
 			return true, nil
 		}
+	} else if loop.Status == "paused" && loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
+		// Re-enter no-ask hold to finish cancel/sibling park / handoff event.
 	} else {
-		if !r.hitlEnabled {
-			return false, nil
-		}
-		if isManualFixerLoop(loop) {
+		if !loops.ParticipatesInReviewFixBudget(loop) {
 			return false, nil
 		}
 		cap := r.maxPushesPerPR(loop.ProjectID)
@@ -1743,16 +1754,72 @@ func (r *Runner) parkFixerBudgetIfExhausted(ctx context.Context, loop storage.Lo
 	}
 	cap := r.maxPushesPerPR(loop.ProjectID)
 	count := loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount
+	reviewerCap := 0
+	if r.projectRoleConfig != nil {
+		reviewerCap = config.ProjectRoleConfigs(*r.projectRoleConfig, loop.ProjectID).Reviewer.Behavior.Loop.MaxPublishesPerPR
+	}
 	_, err := loops.ParkReviewFixBudget(ctx, r.repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: loop,
-		Role:      "fixer",
-		Repo:      derefString(loop.Repo),
-		PRNumber:  derefInt64(loop.PRNumber),
-		Count:     count,
-		Cap:       cap,
-		NowISO:    r.nowISO(),
+		Exhausted:   loop,
+		Role:        "fixer",
+		Repo:        derefString(loop.Repo),
+		PRNumber:    derefInt64(loop.PRNumber),
+		Count:       count,
+		Cap:         cap,
+		NowISO:      r.nowISO(),
+		HITLEnabled: r.hitlEnabled,
+		LiveCaps: loops.ReviewFixBudgetLiveCaps{
+			ReviewerMaxPublishes: reviewerCap,
+			FixerMaxPushes:       cap,
+		},
+		DB: r.db,
 	})
-	return err == nil, err
+	if err != nil {
+		return false, err
+	}
+	// Notify is owned by discovery call sites (and scheduler post-claim), not
+	// shared park — in-run parks must not notify before queue finalization.
+	return true, nil
+}
+
+func (r *Runner) notifyHumanAttentionBestEffort(ctx context.Context, loopID string) {
+	if r.notifyHumanAttention == nil || strings.TrimSpace(loopID) == "" {
+		return
+	}
+	r.notifyHumanAttention(ctx, loopID)
+}
+
+// refusePushIfBudgetExhausted parks and skips when the loop already sits at the
+// live push cap before a counted mutation. Returns refused=true when push must not proceed.
+func (r *Runner) refusePushIfBudgetExhausted(ctx context.Context, input stepInput) (bool, error) {
+	loop := input.Loop
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+			loop = *fresh
+		}
+	}
+	if !loops.ParticipatesInReviewFixBudget(loop) {
+		return false, nil
+	}
+	if loops.IsReviewFixBudgetHold(loop) {
+		if _, err := r.parkFixerBudgetIfExhausted(ctx, loop); err != nil {
+			return true, err
+		}
+		return true, &holdSkipError{summary: "Fixer stopped because review-fix budget is held"}
+	}
+	cap := r.maxPushesPerPR(loop.ProjectID)
+	if !loops.BudgetExhausted(loops.FixerPushCount(loop.MetadataJSON), cap) {
+		return false, nil
+	}
+	if r.livePullRequestClosed(ctx, input.Project, input.Repo, input.PRNumber) {
+		if err := r.terminateLoop(ctx, loop, "pr_closed_or_merged"); err != nil {
+			return true, err
+		}
+		return true, &holdSkipError{summary: "Fixer stopped because pull request is closed"}
+	}
+	if _, err := r.parkFixerBudgetIfExhausted(ctx, loop); err != nil {
+		return true, err
+	}
+	return true, &holdSkipError{summary: "Fixer stopped because review-fix push budget is exhausted"}
 }
 
 func (r *Runner) isForgejoProject(projectID string) bool {
@@ -2465,7 +2532,7 @@ func (r *Runner) schedulePendingRediscoveryAfterRun(ctx context.Context, loop st
 	if current.Status == "paused" || current.Status == "awaiting_human" || current.Status == "human_takeover" || current.Status == "terminated" || current.Status == "stopped" {
 		return false, nil
 	}
-	if r.hitlEnabled && !isManualFixerLoop(*current) {
+	if loops.ParticipatesInReviewFixBudget(*current) {
 		cap := r.maxPushesPerPR(current.ProjectID)
 		count := loops.ReadReviewFixBudgetState(current.MetadataJSON).PushCount
 		if loops.BudgetExhausted(count, cap) {
@@ -2668,9 +2735,15 @@ func (r *Runner) finishHeldFixerQueueItem(ctx context.Context, loop storage.Loop
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil && !errors.Is(err, storage.ErrQueueItemNotActive) {
 		return ProcessResult{}, err
 	}
+	// Do not revive a review-fix budget hold (or other terminal park) that the
+	// step already persisted — only ordinary label/hold skips re-queue.
 	if _, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
-		updated.Status = "queued"
 		updated.LastRunAt = stringPtr(r.nowISO())
+		if loops.IsReviewFixBudgetHold(*updated) || updated.Status == "terminated" || updated.Status == "stopped" || updated.Status == "awaiting_human" || updated.Status == "human_takeover" {
+			updated.NextRunAt = nil
+			return
+		}
+		updated.Status = "queued"
 		updated.NextRunAt = nil
 	}); err != nil {
 		return ProcessResult{}, err
@@ -3338,6 +3411,11 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	if checkpoint.Push != nil && checkpoint.Push.Pushed {
 		return r.ensureFixerPushBudgetCounted(ctx, input, checkpoint)
 	}
+	// Admission at the mutation seam: refuse a counted push when already at the
+	// live cap (observe mid-run cap lowers). PR-closed still wins later.
+	if refused, err := r.refusePushIfBudgetExhausted(ctx, input); refused || err != nil {
+		return checkpoint, err
+	}
 	worktree, err := requireWorktree(checkpoint)
 	if err != nil {
 		return checkpoint, err
@@ -3550,14 +3628,52 @@ func (r *Runner) ensureFixerPushBudgetCounted(ctx context.Context, input stepInp
 	if checkpoint.Push == nil || !checkpoint.Push.Pushed || checkpoint.Push.BudgetCounted {
 		return checkpoint, nil
 	}
-	if _, err := r.incrementFixerPushCount(ctx, input.Loop); err != nil {
+	updated, err := r.incrementFixerPushCount(ctx, input.Loop)
+	if err != nil {
 		return checkpoint, err
 	}
 	checkpoint.Push.BudgetCounted = true
 	if err := r.persistCheckpoint(ctx, input.Run.ID, stepPush, checkpoint); err != nil {
 		return checkpoint, err
 	}
+	// Persist just-pushed head before park so handoff / lastFixHeadSha sees the
+	// current head (runPushStep still merges full evidence metadata afterward).
+	if head := fixerPushBudgetHeadSHA(checkpoint); head != "" {
+		merged, mergeErr := r.mergeLoopMetadata(ctx, updated, map[string]any{"lastFixHeadSha": head})
+		if mergeErr != nil {
+			return checkpoint, mergeErr
+		}
+		updated = merged
+	}
+	// After a successful counted increment, park immediately when now exhausted
+	// and do not continue into resolve-comments / further counted work.
+	// PR-closed still wins over budget park.
+	if r.shouldCreateFixerBudgetPark(updated) {
+		if r.livePullRequestClosed(ctx, input.Project, input.Repo, input.PRNumber) {
+			if termErr := r.terminateLoop(ctx, updated, "pr_closed_or_merged"); termErr != nil {
+				return checkpoint, termErr
+			}
+			return checkpoint, &holdSkipError{summary: "Fixer stopped because pull request is closed"}
+		}
+		if _, parkErr := r.parkFixerBudgetIfExhausted(ctx, updated); parkErr != nil {
+			return checkpoint, parkErr
+		}
+		return checkpoint, &holdSkipError{summary: "Fixer stopped because review-fix push budget is exhausted"}
+	}
 	return checkpoint, nil
+}
+
+func fixerPushBudgetHeadSHA(checkpoint fixerCheckpoint) string {
+	if checkpoint.Push == nil {
+		return ""
+	}
+	if head := strings.TrimSpace(checkpoint.Push.HeadSHA); head != "" {
+		return head
+	}
+	if checkpoint.Push.Evidence != nil {
+		return strings.TrimSpace(checkpoint.Push.Evidence.HeadSHA)
+	}
+	return ""
 }
 
 func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (fixerCheckpoint, error) {
@@ -5222,9 +5338,20 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 		if updatedLoop.Status == "awaiting_human" || updatedLoop.Status == "human_takeover" || updatedLoop.Status == "terminated" || updatedLoop.Status == "stopped" {
 			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
 		}
+		// Sibling pause / exhausted hold must not be revived by discovery enqueue.
+		// Notify only from discovery after a successful park (not from shared park).
+		if loops.IsReviewFixBudgetHold(updatedLoop) {
+			if parked, err := r.parkFixerBudgetIfExhausted(ctx, updatedLoop); err != nil {
+				return loopUpsertResult{}, err
+			} else if parked {
+				r.notifyHumanAttentionBestEffort(ctx, updatedLoop.ID)
+			}
+			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
+		}
 		if parked, err := r.parkFixerBudgetIfExhausted(ctx, updatedLoop); err != nil {
 			return loopUpsertResult{}, err
 		} else if parked {
+			r.notifyHumanAttentionBestEffort(ctx, updatedLoop.ID)
 			updated, getErr := r.repos.Loops.GetByID(ctx, updatedLoop.ID)
 			if getErr != nil {
 				return loopUpsertResult{}, getErr

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -79,6 +79,100 @@ func TestBackoffDelayCapsInfiniteRetryOverflow(t *testing.T) {
 	}
 }
 
+func TestRefusePushIfBudgetExhaustedDoesNotResolveComments(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	// Already at cap before push.
+	meta := `{"reviewFixBudget":{"pushCount":1}}`
+	fixer := storage.LoopRecord{ID: "loop_push_refuse", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &meta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	cfg.HITL.Enabled = false
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: false, GitHub: &fakeGitHubGateway{}})
+	refused, err := runner.refusePushIfBudgetExhausted(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:    fixer, Repo: repo, PRNumber: prNumber,
+	})
+	if !refused {
+		t.Fatalf("refused=%v err=%v, want refused at live cap", refused, err)
+	}
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if after == nil || !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatalf("after refuse = %#v, want budget hold", after)
+	}
+}
+
+func TestEnsureFixerPushBudgetCountedParksWhenCapReached(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	// Cap 1, count 0 — after increment should park and return hold skip.
+	// Prior head must not win over the just-pushed head on handoff.
+	meta := `{"reviewFixBudget":{"pushCount":0},"lastFixHeadSha":"previous-head"}`
+	fixer := storage.LoopRecord{ID: "loop_push_count_park", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &meta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	run := storage.RunRecord{ID: "run_push_count_park", LoopID: fixer.ID, Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	cfg.HITL.Enabled = false
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: false, GitHub: &fakeGitHubGateway{}})
+	pushedHead := "cap-reach-head-sha"
+	checkpoint := fixerCheckpoint{Push: &checkpointPush{Pushed: true, BudgetCounted: false, HeadSHA: pushedHead, Evidence: &fixEvidence{HeadSHA: pushedHead}}}
+	_, err = runner.ensureFixerPushBudgetCounted(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:    fixer, Run: run, Repo: repo, PRNumber: prNumber,
+	}, checkpoint)
+	var hold *holdSkipError
+	if err == nil || !errors.As(err, &hold) {
+		t.Fatalf("err = %v, want holdSkipError after cap-reaching push", err)
+	}
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if after == nil || !loops.IsReviewFixBudgetHold(*after) || loops.FixerPushCount(after.MetadataJSON) != 1 {
+		t.Fatalf("after count+park = %#v, want held with pushCount 1", after)
+	}
+	if after.MetadataJSON == nil || !strings.Contains(*after.MetadataJSON, `"lastFixHeadSha":"`+pushedHead+`"`) {
+		t.Fatalf("lastFixHeadSha missing/stale after cap park: %v", after.MetadataJSON)
+	}
+	events, err := fixture.repos.Events.ListByEntity(context.Background(), "loop", fixer.ID)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	var handoffPayload string
+	for i := range events {
+		if events[i].EventType == "loop.review_fix_budget.exhausted" {
+			handoffPayload = events[i].PayloadJSON
+			break
+		}
+	}
+	if handoffPayload == "" {
+		t.Fatal("missing review-fix budget handoff event")
+	}
+	if !strings.Contains(handoffPayload, `"head":"`+pushedHead+`"`) {
+		t.Fatalf("handoff payload = %s, want head %q", handoffPayload, pushedHead)
+	}
+}
+
 func TestIncrementAndParkFixerBudgetParksSibling(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -289,7 +383,7 @@ func TestParkFixerBudgetBeforePendingRediscoveryDoesNotEnqueue(t *testing.T) {
 	}
 }
 
-func TestParkFixerBudgetIfExhaustedSkipsWhenHITLDisabled(t *testing.T) {
+func TestParkFixerBudgetIfExhaustedParksWhenHITLDisabled(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repo := "acme/looper"
@@ -317,16 +411,19 @@ func TestParkFixerBudgetIfExhaustedSkipsWhenHITLDisabled(t *testing.T) {
 		t.Fatalf("incrementFixerPushCount() error = %v", err)
 	}
 	parked, err := runner.parkFixerBudgetIfExhausted(context.Background(), fixer)
-	if err != nil || parked {
-		t.Fatalf("parkFixerBudgetIfExhausted() = (%v, %v), want skipped under default HITL-off config", parked, err)
+	if err != nil || !parked {
+		t.Fatalf("parkFixerBudgetIfExhausted() = (%v, %v), want no-HITL paired park", parked, err)
 	}
 	updated, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
-	if err != nil || updated == nil || updated.Status != "running" {
-		t.Fatalf("fixer = (%#v, %v), want still running", updated, err)
+	if err != nil || updated == nil || updated.Status != "paused" || !loops.IsReviewFixBudgetExhaustedPause(updated.MetadataJSON) {
+		t.Fatalf("fixer = (%#v, %v), want paused review_fix_budget_exhausted", updated, err)
+	}
+	if _, ok := loops.ReadHITLAsk(updated.MetadataJSON); ok {
+		t.Fatal("no-HITL park must not write a HITL ask")
 	}
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
-	if err != nil || sibling == nil || sibling.Status != "waiting" {
-		t.Fatalf("reviewer sibling = (%#v, %v), want still waiting", sibling, err)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("reviewer sibling = (%#v, %v), want paired budget pause", sibling, err)
 	}
 }
 
@@ -1741,20 +1838,20 @@ func TestProcessClaimedItemCompletesSuccessfulFlow(t *testing.T) {
 	}
 }
 
-func TestProcessClaimedItemDoesNotParkBudgetWhenPushClosesPR(t *testing.T) {
+func TestProcessClaimedItemParksBudgetAfterCapReachingPushWithoutResolve(t *testing.T) {
+	// Cap-reaching push must park immediately and must not continue into resolve-comments.
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
 	target := buildPullRequestTargetID(repo, prNumber)
-	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_closed_pr", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_cap_push", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
 		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
 	}
 	github := &fakeGitHubGateway{
-		closeAfterResolve: true,
-		listOpen:          []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
 		viewResponses: []PullRequestDetail{
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
@@ -1789,60 +1886,70 @@ func TestProcessClaimedItemDoesNotParkBudgetWhenPushClosesPR(t *testing.T) {
 	if err != nil || claim == nil {
 		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
 	}
-	claimedLoop, err := fixture.repos.Loops.GetByID(context.Background(), *claim.LoopID)
-	if err != nil || claimedLoop == nil {
-		t.Fatalf("Loops.GetByID(claimed) = (%#v, %v), want discovered fixer loop", claimedLoop, err)
-	}
-	pendingMeta := mustMarshalJSON(map[string]any{"pendingFixerRediscovery": map[string]any{"headSha": "head-followup", "fixItemsStateHash": "state-followup", "unresolvedThreadIds": []string{"t2"}, "recordedAt": nowISO}})
-	claimedLoop.MetadataJSON = &pendingMeta
-	if err := fixture.repos.Loops.Upsert(context.Background(), *claimedLoop); err != nil {
-		t.Fatalf("Loops.Upsert(pending rediscovery) error = %v", err)
-	}
 	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "success" {
-		t.Fatalf("result = %#v, want success after pushed fix", result)
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped after cap-reaching push park", result)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 (no resolve-comments after budget park)", len(github.resolveCalls))
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
-	if err != nil || loop == nil || loop.Status != "terminated" {
-		t.Fatalf("fixer = (%#v, %v), want terminated product terminal after closed PR", loop, err)
-	}
-	reason := ""
-	if loopMeta, ok := parseJSONObject(loop.MetadataJSON)["loop"].(map[string]any); ok {
-		reason, _ = stringFromAny(loopMeta["terminationReason"])
-	}
-	if reason != "pr_closed_or_merged" {
-		t.Fatalf("terminationReason = %q, want pr_closed_or_merged", reason)
+	if err != nil || loop == nil || loop.Status != "awaiting_human" {
+		t.Fatalf("fixer = (%#v, %v), want awaiting_human budget hold", loop, err)
 	}
 	if loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount < 1 {
-		t.Fatalf("push count = %d, want cap-reaching push before closed-PR terminal", loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount)
+		t.Fatalf("push count = %d, want cap-reaching push counted", loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount)
 	}
-	if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
-		t.Fatalf("HITL ask = %#v, want no budget ask on a closed PR", ask)
+	if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("HITL ask = %#v, want budget ask", ask)
 	}
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
-	if err != nil || sibling == nil || sibling.Status != "waiting" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
-		t.Fatalf("reviewer sibling = (%#v, %v), want still waiting without budget pause", sibling, err)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("reviewer sibling = (%#v, %v), want paused sibling hold", sibling, err)
 	}
-	active, err := fixture.repos.Queue.FindActiveByLoopID(context.Background(), loop.ID)
+}
+
+func TestEnsureFixerPushBudgetCountedTerminatesWhenPRClosed(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	meta := `{"reviewFixBudget":{"pushCount":0}}`
+	fixer := storage.LoopRecord{ID: "loop_push_closed_pr", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &meta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	run := storage.RunRecord{ID: "run_push_closed_pr", LoopID: fixer.ID, Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
 	if err != nil {
-		t.Fatalf("Queue.FindActiveByLoopID() error = %v", err)
+		t.Fatalf("DefaultConfig: %v", err)
 	}
-	if active != nil {
-		t.Fatalf("activeQueue = %#v, want no follow-up after closed-PR terminal", active)
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "MERGED", HeadSHA: "new-head"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: true, GitHub: github})
+	checkpoint := fixerCheckpoint{Push: &checkpointPush{Pushed: true, BudgetCounted: false}}
+	_, err = runner.ensureFixerPushBudgetCounted(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:    fixer, Run: run, Repo: repo, PRNumber: prNumber,
+	}, checkpoint)
+	var hold *holdSkipError
+	if err == nil || !errors.As(err, &hold) {
+		t.Fatalf("err = %v, want holdSkipError for closed PR", err)
 	}
-	parked, err := runner.parkFixerBudgetIfExhausted(context.Background(), *loop)
-	if err != nil || parked {
-		t.Fatalf("parkFixerBudgetIfExhausted() = (%v, %v), want skipped on terminated closed PR", parked, err)
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if after == nil || after.Status != "terminated" {
+		t.Fatalf("after = %#v, want terminated (PR-closed wins over budget park)", after)
 	}
-	scheduled, err := runner.schedulePendingRediscoveryAfterRun(context.Background(), *loop, repo, prNumber)
-	if err != nil {
-		t.Fatalf("schedulePendingRediscoveryAfterRun() error = %v", err)
-	}
-	if scheduled {
-		t.Fatal("schedulePendingRediscoveryAfterRun() = true, want no enqueue after closed-PR terminal")
+	if ask, ok := loops.ReadHITLAsk(after.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("budget ask = %#v, want none when PR closed", ask)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -6944,6 +6944,7 @@ func (f *runnerFixture) nowISO() string {
 
 type fakeGitHubGateway struct {
 	currentUser           string
+	currentUserEmpty      bool // when true, GetCurrentUserLogin returns ("", nil) without defaulting
 	currentUserErr        error
 	authorErr             error
 	listOpen              []PullRequestSummary
@@ -6952,6 +6953,9 @@ type fakeGitHubGateway struct {
 	viewResponses         []PullRequestDetail
 	viewErr               error
 	threads               []ReviewThread
+	listThreadsErr        error
+	listThreadsCalls      []ListReviewThreadsInput
+	viewThreadErr         error
 	viewThreadCalls       []ViewReviewThreadInput
 	viewIndex             int
 	resolveCalls          []ResolveReviewThreadInput
@@ -7007,6 +7011,9 @@ func (f *fakeGitHubGateway) GetCurrentUserLogin(context.Context, string) (string
 	if f.currentUserErr != nil {
 		return "", f.currentUserErr
 	}
+	if f.currentUserEmpty {
+		return "", nil
+	}
 	return firstNonEmpty(f.currentUser, "looper"), nil
 }
 
@@ -7055,7 +7062,11 @@ func (f *fakeGitHubGateway) ViewPullRequest(_ context.Context, input ViewPullReq
 	return result, nil
 }
 
-func (f *fakeGitHubGateway) ListReviewThreads(_ context.Context, _ ListReviewThreadsInput) ([]ReviewThread, error) {
+func (f *fakeGitHubGateway) ListReviewThreads(_ context.Context, input ListReviewThreadsInput) ([]ReviewThread, error) {
+	f.listThreadsCalls = append(f.listThreadsCalls, input)
+	if f.listThreadsErr != nil {
+		return nil, f.listThreadsErr
+	}
 	if f.threads != nil {
 		return append([]ReviewThread(nil), f.threads...), nil
 	}
@@ -7081,7 +7092,13 @@ func (f *fakeGitHubGateway) ListReviewThreads(_ context.Context, _ ListReviewThr
 
 func (f *fakeGitHubGateway) ViewReviewThread(_ context.Context, input ViewReviewThreadInput) (ReviewThread, error) {
 	f.viewThreadCalls = append(f.viewThreadCalls, input)
-	threads, _ := f.ListReviewThreads(context.Background(), ListReviewThreadsInput{})
+	if f.viewThreadErr != nil {
+		return ReviewThread{}, f.viewThreadErr
+	}
+	threads, err := f.ListReviewThreads(context.Background(), ListReviewThreadsInput{})
+	if err != nil {
+		return ReviewThread{}, err
+	}
 	for _, thread := range threads {
 		if thread.ID == input.ThreadID {
 			return thread, nil
@@ -7099,7 +7116,11 @@ func (f *fakeGitHubGateway) AddReviewThreadReply(_ context.Context, input AddRev
 	f.replyCalls = append(f.replyCalls, input)
 	for i := range f.threads {
 		if f.threads[i].ID == input.ThreadID {
-			f.threads[i].Comments = append(f.threads[i].Comments, ReviewThreadComment{ID: fmt.Sprintf("reply-%d", len(f.replyCalls)), Body: input.Body})
+			f.threads[i].Comments = append(f.threads[i].Comments, ReviewThreadComment{
+				ID:     fmt.Sprintf("reply-%d", len(f.replyCalls)),
+				Author: firstNonEmpty(f.currentUser, "looper"),
+				Body:   input.Body,
+			})
 			return f.replyErr
 		}
 	}

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -550,7 +550,7 @@ func TestBuildFixerPromptTreatsReviewFeedbackAsProblemReport(t *testing.T) {
 		"Declining an out-of-scope item is a correct result, not a failure.",
 		"give the reviewer a clear, respectful explanation through the structured per-item response",
 		"respectfully explain why the suggestion was not adopted",
-		"Looper will post it as the thread reply before resolving the thread",
+		"Looper will post it as the thread reply and leave the thread unresolved for Reviewer adjudication",
 		"do not create `.looper/dismiss.json` or dismiss an entire review",
 	} {
 		if !strings.Contains(prompt, want) {
@@ -3578,8 +3578,16 @@ func TestRunResolveCommentsStepResolvesUsingRepairReplyExplanations(t *testing.T
 	}
 }
 
-func TestRunResolveCommentsStepPostsDeclinedReplyAndResolvesThread(t *testing.T) {
+func TestRunResolveCommentsStepPostsDeclinedReplyAndLeavesThreadOpen(t *testing.T) {
 	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopTarget := buildPullRequestTargetID(repo, prNumber)
+	loop := storage.LoopRecord{ID: "loop_decline_leave_open", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
 		Number:      42,
 		State:       "OPEN",
@@ -3594,7 +3602,7 @@ func TestRunResolveCommentsStepPostsDeclinedReplyAndResolvesThread(t *testing.T)
 			"author":   "alice",
 		}},
 	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}}}
-	runner := New(Options{GitHub: github})
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Author: "alice", Summary: "please fix", ThreadFingerprint: "thread-hash-1"}}
 	checkpoint := fixerCheckpoint{
 		FixItems:         fixItems,
@@ -3605,21 +3613,31 @@ func TestRunResolveCommentsStepPostsDeclinedReplyAndResolvesThread(t *testing.T)
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: checkpoint})
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	if len(github.resolveCalls) != 1 || github.resolveCalls[0].ThreadID != "t1" {
-		t.Fatalf("resolve calls = %#v, want declined thread resolved", github.resolveCalls)
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %#v, want none (decline leaves thread open)", github.resolveCalls)
 	}
 	if len(github.replyCalls) != 1 || !strings.Contains(github.replyCalls[0].Body, "Out of scope for this PR.") {
 		t.Fatalf("reply calls = %#v, want declined explanation reply", github.replyCalls)
 	}
-	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "agent_declined" {
-		t.Fatalf("resolved comments = %#v, want agent_declined", updated.ResolvedComments)
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != declinePendingAdjudicationStatus {
+		t.Fatalf("resolved comments = %#v, want %s", updated.ResolvedComments, declinePendingAdjudicationStatus)
 	}
 	if !hasProgressed(updated) {
-		t.Fatalf("hasProgressed() = false, want declined resolution to count as progress")
+		t.Fatalf("hasProgressed() = false, want decline reply to count as progress")
+	}
+	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil {
+		t.Fatalf("Loops.GetByID() error = %v", err)
+	}
+	if records := parseDeclinedThreadRecords(parseJSONObject(persisted.MetadataJSON)); len(records) != 0 {
+		t.Fatalf("declined thread records = %#v, want none (no terminal same-head suppression)", records)
+	}
+	if got := suppressDeclinedFixItems(persisted.MetadataJSON, "new-head", fixItems); len(got) != 1 || got[0].ID != "c1" {
+		t.Fatalf("suppressDeclinedFixItems() = %#v, want original fix item still eligible", got)
 	}
 }
 
@@ -3655,27 +3673,153 @@ func TestRunResolveCommentsStepRechecksLegacyDeclinedThreadState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	if len(github.resolveCalls) != 1 || github.resolveCalls[0].ThreadID != "t1" {
-		t.Fatalf("resolve calls = %#v, want unresolved legacy declined thread resolved", github.resolveCalls)
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %#v, want none for legacy open declined thread", github.resolveCalls)
 	}
 	if len(github.replyCalls) != 0 {
 		t.Fatalf("reply calls = %#v, want no duplicate declined reply", github.replyCalls)
 	}
-	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "agent_declined" {
-		t.Fatalf("resolved comments = %#v, want agent_declined after re-resolve", updated.ResolvedComments)
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != declinePendingAdjudicationStatus {
+		t.Fatalf("resolved comments = %#v, want %s after recheck", updated.ResolvedComments, declinePendingAdjudicationStatus)
 	}
 }
 
-func TestRunResolveCommentsStepDoesNotPersistDeclinedFingerprintWhenResolveFails(t *testing.T) {
+func TestDeclineOnlyResolveThenRecheckCompletesWithoutNoCommitHold(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repo := "acme/looper"
 	prNumber := int64(42)
 	loopTarget := buildPullRequestTargetID(repo, prNumber)
-	loop := storage.LoopRecord{ID: "loop_decline_resolve_failure", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	loop := storage.LoopRecord{ID: "loop_decline_only", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &loopTarget, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
 	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
+	detail := PullRequestDetail{
+		Number:      42,
+		State:       "OPEN",
+		HeadSHA:     "same-head",
+		HeadRefName: "feature/fix-42",
+		BaseRefName: "main",
+		BaseSHA:     "base-1",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "please fix",
+			"author":   "alice",
+		}},
+	}
+	github := &fakeGitHubGateway{
+		viewResponses: []PullRequestDetail{detail, detail},
+		threads:       []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}},
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Author: "alice", Summary: "please fix", ThreadFingerprint: "thread-hash-1"}}
+	checkpoint := fixerCheckpoint{
+		Detail:           &checkpointDetail{State: "OPEN", HeadSHA: "same-head", HeadRefName: "feature/fix-42", BaseRefName: "main"},
+		FixItems:         fixItems,
+		FixItemsHash:     hashFixItems(fixItems),
+		Validation:       &ValidationResult{Passed: true, Summary: "ok", HeadSHA: "same-head"},
+		Push:             &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "c1", ThreadID: "t1", Action: string(replyActionDeclined), Explanation: "Out of scope for this PR; leave for Reviewer adjudication."}}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "same-head", FinalHeadSHA: "same-head", WorkingTreeClean: true},
+	}
+	input := stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: checkpoint}
+
+	afterResolve, err := runner.runResolveCommentsStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %#v, want none (decline leaves thread open)", github.resolveCalls)
+	}
+	if len(github.replyCalls) != 1 || !strings.Contains(github.replyCalls[0].Body, "Out of scope") {
+		t.Fatalf("reply calls = %#v, want declined explanation", github.replyCalls)
+	}
+	if afterResolve.ResolvedComments == nil || afterResolve.ResolvedComments.Items[0].Status != declinePendingAdjudicationStatus {
+		t.Fatalf("resolved comments = %#v, want %s", afterResolve.ResolvedComments, declinePendingAdjudicationStatus)
+	}
+
+	input.Checkpoint = afterResolve
+	afterRecheck, err := runner.runRecheckStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("runRecheckStep() error = %v, want success (decline-only handoff, no no-commits hold)", err)
+	}
+	if afterRecheck.Pause != nil {
+		t.Fatalf("Pause = %#v, want nil for decline-only recheck", afterRecheck.Pause)
+	}
+	if afterRecheck.ResumePolicy != "advance_from_checkpoint" {
+		t.Fatalf("ResumePolicy = %q, want advance_from_checkpoint", afterRecheck.ResumePolicy)
+	}
+	if afterRecheck.Recheck == nil || len(afterRecheck.Recheck.RemainingFixItems) != 1 {
+		t.Fatalf("Recheck = %#v, want open declined thread still listed as remaining", afterRecheck.Recheck)
+	}
+	if shouldBlockResolveWithoutFix(afterRecheck, afterRecheck.Recheck.RemainingFixItems, false) {
+		t.Fatal("shouldBlockResolveWithoutFix() = true, want false when only decline_pending_adjudication remains")
+	}
+}
+
+func TestRunRecheckStepStillBlocksWhenUnresolvedCommentAndNoCommits(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
+		Number:  42,
+		State:   "OPEN",
+		HeadSHA: "same-head",
+		Comments: []map[string]any{{
+			"id":       "c1",
+			"threadId": "t1",
+			"body":     "still open",
+			"author":   "alice",
+		}},
+	}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+	// Mixed: one decline pending adjudication, one comment with no resolve progress.
+	checkpoint := fixerCheckpoint{
+		Detail:       &checkpointDetail{State: "OPEN", HeadSHA: "same-head"},
+		FixItems:     []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}, {Type: "comment", ID: "c2", ThreadID: "t2"}},
+		FixItemsHash: hashFixItemsState([]FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}, {Type: "comment", ID: "c2", ThreadID: "t2"}}),
+		Push:         &checkpointPush{Pushed: false, Branch: "feature/fix-42", Remote: "origin", SkippedReason: "No new commits to push"},
+		ResolvedComments: &checkpointResolvedComments{Items: []checkpointResolvedComment{
+			{FixItemID: "c2", ThreadID: "t2", Action: string(replyActionDeclined), Status: declinePendingAdjudicationStatus, ReplyState: "sent"},
+			// c1 never declined or resolved — still a true unresolved comment.
+		}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "same-head", FinalHeadSHA: "same-head", WorkingTreeClean: true},
+	}
+	// Live PR still has c1 open (and optionally c2); only c1 should force the hold.
+	github.viewResponses = []PullRequestDetail{{
+		Number:  42,
+		State:   "OPEN",
+		HeadSHA: "same-head",
+		Comments: []map[string]any{
+			{"id": "c1", "threadId": "t1", "body": "still open", "author": "alice"},
+			{"id": "c2", "threadId": "t2", "body": "declined open", "author": "alice"},
+		},
+	}}
+
+	updated, err := runner.runRecheckStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:       storage.LoopRecord{ID: "loop_mixed", ProjectID: "project_1"},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: checkpoint,
+	})
+	if err == nil {
+		t.Fatal("runRecheckStep() error = nil, want manual intervention when a non-declined comment remains")
+	}
+	loopErr, ok := err.(*loopError)
+	if !ok || loopErr.kind != FailureManualIntervention {
+		t.Fatalf("runRecheckStep() error = %#v, want manual_intervention", err)
+	}
+	if !strings.Contains(err.Error(), "no new commits to push") {
+		t.Fatalf("error = %q, want no-new-commits message", err.Error())
+	}
+	if updated.Pause == nil || updated.Pause.Reason != string(checkpointPauseReasonNoopResolveNoNewCommits) {
+		t.Fatalf("Pause = %#v, want noop_resolve_no_new_commits", updated.Pause)
+	}
+}
+
+func TestRunResolveCommentsStepLeavesLegacyRemotelyResolvedDeclineResolved(t *testing.T) {
+	t.Parallel()
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{
 		Number:      42,
 		State:       "OPEN",
@@ -3689,8 +3833,8 @@ func TestRunResolveCommentsStepDoesNotPersistDeclinedFingerprintWhenResolveFails
 			"body":     "please fix",
 			"author":   "alice",
 		}},
-	}}, threads: []ReviewThread{{ID: "t1", Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}}, resolveErr: errors.New("graphql mutation failed")}
-	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Logger: fixture.logger, Now: fixture.now})
+	}}, threads: []ReviewThread{{ID: "t1", IsResolved: true, Comments: []ReviewThreadComment{{ID: "c1", Body: "please fix"}}}}}
+	runner := New(Options{GitHub: github})
 	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1", Author: "alice", Summary: "please fix", ThreadFingerprint: "thread-hash-1"}}
 	checkpoint := fixerCheckpoint{
 		FixItems:         fixItems,
@@ -3701,28 +3845,18 @@ func TestRunResolveCommentsStepDoesNotPersistDeclinedFingerprintWhenResolveFails
 		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "base-head", FinalHeadSHA: "base-head", WorkingTreeClean: true},
 	}
 
-	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: loop, Repo: repo, PRNumber: prNumber, Checkpoint: checkpoint})
-	if err == nil || !strings.Contains(err.Error(), "Failed to resolve") {
-		t.Fatalf("runResolveCommentsStep() error = %v, want retryable mutation failure error", err)
-	}
-	if len(github.replyCalls) != 1 || len(github.resolveCalls) != 1 {
-		t.Fatalf("reply/resolve calls = %#v / %#v, want reply then resolve attempt", github.replyCalls, github.resolveCalls)
-	}
-	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "failed_mutation_retry" || updated.ResolvedComments.Items[0].ReplyState != "sent" {
-		t.Fatalf("resolved comments = %#v, want failed_mutation_retry with sent reply state", updated.ResolvedComments)
-	}
-	if updated.ResumePolicy != loops.ResumePolicyReplayStep {
-		t.Fatalf("updated.ResumePolicy = %q, want replay_step", updated.ResumePolicy)
-	}
-	persisted, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
-		t.Fatalf("Loops.GetByID() error = %v", err)
+		t.Fatalf("runResolveCommentsStep() error = %v", err)
 	}
-	if records := parseDeclinedThreadRecords(parseJSONObject(persisted.MetadataJSON)); len(records) != 0 {
-		t.Fatalf("declined thread records = %#v, want none after failed resolve", records)
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %#v, want none for already-resolved legacy decline", github.resolveCalls)
 	}
-	if got := suppressDeclinedFixItems(persisted.MetadataJSON, "new-head", fixItems); len(got) != 1 || got[0].ID != "c1" {
-		t.Fatalf("suppressDeclinedFixItems() = %#v, want original fix item after failed resolve", got)
+	if len(github.replyCalls) != 0 {
+		t.Fatalf("reply calls = %#v, want none for already-resolved legacy decline", github.replyCalls)
+	}
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "already_resolved" {
+		t.Fatalf("resolved comments = %#v, want already_resolved", updated.ResolvedComments)
 	}
 }
 
@@ -4203,14 +4337,14 @@ func TestRunResolveCommentsStepAllowsDeclinedDecisionWithoutObservedThreadSnapsh
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v, want declined path without snapshot", err)
 	}
-	if len(github.resolveCalls) != 1 || github.resolveCalls[0].ThreadID != "t1" {
-		t.Fatalf("resolve calls = %#v, want declined decision to resolve t1", github.resolveCalls)
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %#v, want none for declined without snapshot", github.resolveCalls)
 	}
 	if len(github.replyCalls) != 1 || github.replyCalls[0].ThreadID != "t1" {
 		t.Fatalf("reply calls = %#v, want one declined reply on t1", github.replyCalls)
 	}
-	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != "agent_declined" {
-		t.Fatalf("resolved comments = %#v, want agent_declined", updated.ResolvedComments)
+	if updated.ResolvedComments == nil || updated.ResolvedComments.Items[0].Status != declinePendingAdjudicationStatus {
+		t.Fatalf("resolved comments = %#v, want %s", updated.ResolvedComments, declinePendingAdjudicationStatus)
 	}
 }
 

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -576,6 +576,10 @@ type ListReviewThreadsInput struct {
 	PRNumber int64
 	CWD      string
 	Limit    int
+	// AllPages fetches every review-thread page for authority reads. When true,
+	// Limit is not used as a stop condition. Limit<=0 without AllPages still
+	// defaults to 100 so existing callers are unchanged.
+	AllPages bool
 }
 
 type ViewReviewThreadInput struct {
@@ -1770,18 +1774,31 @@ func (g *Gateway) ViewReviewThread(ctx context.Context, input ViewReviewThreadIn
 }
 
 func (g *Gateway) ListReviewThreads(ctx context.Context, input ListReviewThreadsInput) ([]ReviewThread, error) {
+	unlimited := input.AllPages
 	limit := input.Limit
-	if limit <= 0 {
-		limit = 100
+	if !unlimited {
+		if limit <= 0 {
+			limit = 100
+		}
 	}
 	owner, name, err := parseRepo(input.Repo)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]ReviewThread, 0, min(limit, 100))
+	capHint := 100
+	if !unlimited && limit > 0 {
+		capHint = min(limit, 100)
+	}
+	out := make([]ReviewThread, 0, capHint)
 	threadsCursor := ""
-	for len(out) < limit {
-		pageSize := min(100, limit-len(out))
+	for unlimited || len(out) < limit {
+		pageSize := 100
+		if !unlimited {
+			pageSize = min(100, limit-len(out))
+			if pageSize <= 0 {
+				break
+			}
+		}
 		nodes, nextCursor, hasNextPage, err := g.fetchReviewThreadPage(ctx, input.CWD, owner, name, input.PRNumber, pageSize, threadsCursor)
 		if err != nil {
 			return nil, err
@@ -1811,7 +1828,7 @@ func (g *Gateway) ListReviewThreads(ctx context.Context, input ListReviewThreads
 				thread.URL = thread.Comments[0].URL
 			}
 			out = append(out, thread)
-			if len(out) == limit {
+			if !unlimited && len(out) == limit {
 				break
 			}
 		}

--- a/internal/infra/notify/human_attention.go
+++ b/internal/infra/notify/human_attention.go
@@ -21,6 +21,9 @@ const (
 	HumanAttentionAwaitingHuman HumanAttentionReason = "awaiting_human"
 	// HumanAttentionManualIntervention is a durable manual_intervention hard hold.
 	HumanAttentionManualIntervention HumanAttentionReason = "manual_intervention"
+	// HumanAttentionReviewFixBudget is a no-HITL review-fix budget exhausted hold
+	// (paused + review_fix_budget_exhausted). Sibling-only pause does not notify.
+	HumanAttentionReviewFixBudget HumanAttentionReason = "review_fix_budget"
 )
 
 // HumanAttentionInput describes one durable entry into a state that requires an operator.
@@ -76,7 +79,7 @@ func (g *Gateway) NotifyHumanAttention(ctx context.Context, input HumanAttention
 		return nil
 	}
 	reason := HumanAttentionReason(strings.TrimSpace(string(input.Reason)))
-	if reason != HumanAttentionAwaitingHuman && reason != HumanAttentionManualIntervention {
+	if reason != HumanAttentionAwaitingHuman && reason != HumanAttentionManualIntervention && reason != HumanAttentionReviewFixBudget {
 		return nil
 	}
 	entryKey := strings.TrimSpace(input.EntryKey)
@@ -291,6 +294,8 @@ func humanAttentionReasonLabel(reason HumanAttentionReason) string {
 		return "awaiting human decision"
 	case HumanAttentionManualIntervention:
 		return "manual intervention"
+	case HumanAttentionReviewFixBudget:
+		return "review-fix budget exhausted"
 	default:
 		return string(reason)
 	}

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -699,7 +699,7 @@ func ApplyReviewFixBudgetAnswer(ctx context.Context, repos *storage.Repositories
 		return ReviewFixBudgetAnswerResult{}, fmt.Errorf("review-fix budget answer requires loop storage")
 	}
 	if IsReviewFixBudgetStop(answer) {
-		updated, err := terminateReviewFixPair(ctx, repos, loop, nowISO)
+		updated, err := terminateReviewFixPair(ctx, repos, loop, nowISO, ReviewFixBudgetTerminationReason)
 		if err != nil {
 			return ReviewFixBudgetAnswerResult{}, err
 		}
@@ -783,6 +783,11 @@ func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, l
 			return loop, err
 		}
 	}
+	// If needs_human was deferred under the budget hold, promote to a real
+	// scope park now that budget is no longer the primary hold.
+	if err := promotePendingReviewScopeHumanAfterBudgetRelease(ctx, repos, members, nowISO); err != nil {
+		return loop, err
+	}
 	fresh, err := repos.Loops.GetByID(ctx, loop.ID)
 	if err != nil {
 		return loop, err
@@ -791,6 +796,40 @@ func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, l
 		return loop, fmt.Errorf("review-fix budget continue lost loop %s", loop.ID)
 	}
 	return *fresh, nil
+}
+
+// promotePendingReviewScopeHumanAfterBudgetRelease parks scope when a member
+// still carries deferred needs_human evidence from a publish that hit the cap.
+func promotePendingReviewScopeHumanAfterBudgetRelease(ctx context.Context, repos *storage.Repositories, members []storage.LoopRecord, nowISO string) error {
+	for _, member := range members {
+		fresh, err := repos.Loops.GetByID(ctx, member.ID)
+		if err != nil {
+			return err
+		}
+		if fresh == nil || !HasPendingReviewScopeHuman(*fresh) {
+			continue
+		}
+		state := ReadReviewScopeHumanState(fresh.MetadataJSON)
+		role := strings.TrimSpace(fresh.Type)
+		if role == "" {
+			role = "reviewer"
+		}
+		if _, err := ParkReviewScopeHuman(ctx, repos, ParkReviewScopeHumanInput{
+			Held:        *fresh,
+			Role:        role,
+			Repo:        strings.TrimSpace(derefLoopString(fresh.Repo)),
+			PRNumber:    derefLoopInt64(fresh.PRNumber),
+			NowISO:      nowISO,
+			HITLEnabled: state.PendingHITL,
+			Question:    state.Question,
+			Evidence:    state.Evidence,
+		}); err != nil {
+			return err
+		}
+		// One primary scope park is enough for the pair.
+		return nil
+	}
+	return nil
 }
 
 func reviewFixBudgetPairMembers(all []storage.LoopRecord, loop storage.LoopRecord) []storage.LoopRecord {
@@ -936,25 +975,31 @@ func requeueReviewFixBudgetLoop(ctx context.Context, repos *storage.Repositories
 	return err
 }
 
-func terminateReviewFixPair(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
+func terminateReviewFixPair(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO, terminationReason string) (storage.LoopRecord, error) {
 	// Keep the answered/held loop until every same-lane sibling is terminated so
 	// a later poll can retry the same Stop.
+	if strings.TrimSpace(terminationReason) == "" {
+		terminationReason = ReviewFixBudgetTerminationReason
+	}
 	all, err := repos.Loops.List(ctx)
 	if err != nil {
 		return loop, err
 	}
 	for _, sibling := range FindSiblingReviewFixLoops(all, loop) {
-		if _, err := terminateReviewFixLoop(ctx, repos, sibling, nowISO); err != nil {
+		if _, err := terminateReviewFixLoop(ctx, repos, sibling, nowISO, terminationReason); err != nil {
 			return loop, err
 		}
 	}
-	return terminateReviewFixLoop(ctx, repos, loop, nowISO)
+	return terminateReviewFixLoop(ctx, repos, loop, nowISO, terminationReason)
 }
 
-func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
+func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO, terminationReason string) (storage.LoopRecord, error) {
 	switch loop.Status {
 	case "terminated", "stopped":
 		return loop, nil
+	}
+	if strings.TrimSpace(terminationReason) == "" {
+		terminationReason = ReviewFixBudgetTerminationReason
 	}
 	meta := parseMetadataObject(loop.MetadataJSON)
 	if loop.Type == "reviewer" {
@@ -963,10 +1008,10 @@ func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, lo
 			loopMeta = map[string]any{}
 		}
 		loopMeta["status"] = "terminated"
-		loopMeta["terminationReason"] = ReviewFixBudgetTerminationReason
+		loopMeta["terminationReason"] = terminationReason
 		meta[reviewerLoopMetadataKey] = loopMeta
 	}
-	if reason, _ := stringFromAny(meta["pauseReason"]); reason == ReviewFixBudgetPauseReason || reason == ReviewFixBudgetTerminationReason {
+	if reason, _ := stringFromAny(meta["pauseReason"]); reason == ReviewFixBudgetPauseReason || reason == ReviewFixBudgetTerminationReason || reason == ReviewScopeHumanRequiredReason || reason == ReviewScopeHumanSiblingPauseReason {
 		delete(meta, "pauseReason")
 	}
 	encoded, err := json.Marshal(meta)
@@ -988,6 +1033,17 @@ func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, lo
 	if err != nil {
 		return loop, err
 	}
+	scopeState := ReadReviewScopeHumanState(&cleared)
+	scopeState.HeldBy = ""
+	scopeState.Question = ""
+	if scopeState.PauseReason == ReviewScopeHumanSiblingPauseReason || scopeState.PauseReason == ReviewScopeHumanRequiredReason {
+		scopeState.PauseReason = ""
+	}
+	scopeState.HandoffEventAt = ""
+	cleared, err = WriteReviewScopeHumanState(&cleared, scopeState)
+	if err != nil {
+		return loop, err
+	}
 	updated := loop
 	updated.MetadataJSON = &cleared
 	updated.Status = "terminated"
@@ -997,7 +1053,7 @@ func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, lo
 		return loop, err
 	}
 	if repos.Queue != nil {
-		reason := ReviewFixBudgetTerminationReason
+		reason := terminationReason
 		if _, err := repos.Queue.CancelByLoop(ctx, updated.ID, nowISO, &reason); err != nil {
 			return updated, err
 		}

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -53,6 +53,88 @@ type ReviewFixBudgetLiveCaps struct {
 	FixerMaxPushes       int
 }
 
+// ReviewFixHandoffBrief is the operator-facing snapshot for a budget or scope
+// pair hold. Event payloads capture it at park time; CLI/dashboard rebuild it
+// from loop metadata. It never implies review approval or merge.
+type ReviewFixHandoffBrief struct {
+	Kind                          string   `json:"kind"`
+	Resume                        string   `json:"resume"`
+	NextAction                    string   `json:"nextAction"`
+	HITLEnabled                   bool     `json:"hitlEnabled"`
+	Head                          string   `json:"head,omitempty"`
+	LastReviewedSignalFingerprint string   `json:"lastReviewedSignalFingerprint,omitempty"`
+	ReviewerCount                 int      `json:"reviewerCount"`
+	FixerCount                    int      `json:"fixerCount"`
+	ExhaustedRoles                []string `json:"exhaustedRoles,omitempty"`
+	Question                      string   `json:"question,omitempty"`
+	Evidence                      string   `json:"evidence,omitempty"`
+	PauseReason                   string   `json:"pauseReason,omitempty"`
+}
+
+// BuildReviewFixHandoffBrief returns the current hold brief for inspect/dashboard.
+// ok is false when the loop is not a review-fix pair hold.
+func BuildReviewFixHandoffBrief(loop storage.LoopRecord) (ReviewFixHandoffBrief, bool) {
+	if !IsReviewFixPairHold(loop) {
+		return ReviewFixHandoffBrief{}, false
+	}
+	ask, hasAsk := ReadHITLAsk(loop.MetadataJSON)
+	hitlEnabled := hasAsk && strings.EqualFold(strings.TrimSpace(ask.Status), "awaiting") &&
+		(IsReviewFixBudgetAsk(ask) || IsReviewScopeHumanAsk(ask))
+	kind := HITLKindReviewFixBudget
+	if IsReviewScopeHumanHold(loop) && !IsReviewFixBudgetHold(loop) {
+		kind = HITLKindReviewScopeHuman
+	}
+	cli := reviewFixBudgetHandoffResume(loop, false)
+	next := cli
+	if hitlEnabled {
+		next = ReviewFixBudgetAnswerContinue + " / " + ReviewFixBudgetAnswerStop + "; " + cli
+	}
+	meta := parseMetadataObject(loop.MetadataJSON)
+	pauseReason, _ := stringFromAny(meta["pauseReason"])
+	if strings.TrimSpace(pauseReason) == "" {
+		if kind == HITLKindReviewScopeHuman {
+			pauseReason = ReadReviewScopeHumanState(loop.MetadataJSON).PauseReason
+		} else {
+			pauseReason = ReadReviewFixBudgetState(loop.MetadataJSON).PauseReason
+		}
+	}
+	question := strings.TrimSpace(ask.Question)
+	evidence := ""
+	if kind == HITLKindReviewScopeHuman {
+		scope := ReadReviewScopeHumanState(loop.MetadataJSON)
+		if question == "" {
+			question = strings.TrimSpace(scope.Question)
+		}
+		evidence = strings.TrimSpace(scope.Evidence)
+	}
+	var exhausted []string
+	if budget := ReadReviewFixBudgetState(loop.MetadataJSON); strings.TrimSpace(budget.ExhaustedBy) != "" {
+		exhausted = []string{strings.TrimSpace(budget.ExhaustedBy)}
+	}
+	return ReviewFixHandoffBrief{
+		Kind:                          kind,
+		Resume:                        reviewFixBudgetHandoffResume(loop, hitlEnabled),
+		NextAction:                    next,
+		HITLEnabled:                   hitlEnabled,
+		Head:                          reviewFixBudgetHandoffHead(loop),
+		LastReviewedSignalFingerprint: reviewFixHandoffSignal(loop),
+		ReviewerCount:                 ReviewerPublishCount(loop.MetadataJSON),
+		FixerCount:                    FixerPushCount(loop.MetadataJSON),
+		ExhaustedRoles:                exhausted,
+		Question:                      question,
+		Evidence:                      evidence,
+		PauseReason:                   strings.TrimSpace(pauseReason),
+	}, true
+}
+
+func reviewFixHandoffSignal(loop storage.LoopRecord) string {
+	meta := parseMetadataObject(loop.MetadataJSON)
+	if fp, ok := stringFromAny(meta["lastReviewedSignalFingerprint"]); ok {
+		return strings.TrimSpace(fp)
+	}
+	return ""
+}
+
 func BudgetExhausted(count, cap int) bool {
 	return cap > 0 && count >= cap
 }
@@ -588,6 +670,9 @@ func appendReviewFixBudgetHandoffEvent(ctx context.Context, repos *storage.Repos
 	}
 	if head != "" {
 		payload["head"] = head
+	}
+	if signal := reviewFixHandoffSignal(exhausted); signal != "" {
+		payload["lastReviewedSignalFingerprint"] = signal
 	}
 	return eventlog.Append(ctx, repos, eventlog.AppendInput{
 		EventType:  reviewFixBudgetHandoffEventType,

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -2,6 +2,7 @@ package loops
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -24,7 +25,10 @@ const (
 	reviewFixBudgetMetadataKey = "reviewFixBudget"
 	reviewerLoopMetadataKey    = "loop"
 	reviewerIterationCountKey  = "iterationCount"
-	fixerPushCountKey          = "pushCount"
+
+	reviewFixBudgetLaneAutomatic        = "automatic"
+	reviewFixBudgetLaneContinuousManual = "continuous_manual"
+	reviewFixBudgetHandoffEventType     = "loop.review_fix_budget.exhausted"
 )
 
 // ErrReviewFixBudgetInvalidAnswer is the only ApplyReviewFixBudgetAnswer
@@ -35,10 +39,18 @@ var ErrReviewFixBudgetInvalidAnswer = fmt.Errorf("review-fix budget answer must 
 // Authority for the cap is live config; this record only stores counts and
 // which role exhausted.
 type ReviewFixBudgetState struct {
-	PushCount   int    `json:"pushCount,omitempty"`
-	ExhaustedBy string `json:"exhaustedBy,omitempty"`
-	SiblingOf   string `json:"siblingOf,omitempty"`
-	PauseReason string `json:"pauseReason,omitempty"`
+	PushCount      int    `json:"pushCount,omitempty"`
+	ExhaustedBy    string `json:"exhaustedBy,omitempty"`
+	SiblingOf      string `json:"siblingOf,omitempty"`
+	PauseReason    string `json:"pauseReason,omitempty"`
+	HandoffEventAt string `json:"handoffEventAt,omitempty"`
+}
+
+// ReviewFixBudgetLiveCaps carries live role caps for Continue meter refill.
+// Authority is current project/role config, not stored hold state.
+type ReviewFixBudgetLiveCaps struct {
+	ReviewerMaxPublishes int
+	FixerMaxPushes       int
 }
 
 func BudgetExhausted(count, cap int) bool {
@@ -170,6 +182,10 @@ func ResetFixerPushCount(metadataJSON *string) (string, error) {
 	return WriteReviewFixBudgetState(metadataJSON, state)
 }
 
+func FixerPushCount(metadataJSON *string) int {
+	return ReadReviewFixBudgetState(metadataJSON).PushCount
+}
+
 func IsSiblingReviewFixBudgetPause(metadataJSON *string) bool {
 	if reason, _ := stringFromAny(parseMetadataObject(metadataJSON)["pauseReason"]); reason == ReviewFixBudgetPauseReason {
 		return true
@@ -177,9 +193,49 @@ func IsSiblingReviewFixBudgetPause(metadataJSON *string) bool {
 	return ReadReviewFixBudgetState(metadataJSON).PauseReason == ReviewFixBudgetPauseReason
 }
 
-func isManualReviewFixLoop(loop storage.LoopRecord) bool {
-	manual, _ := parseMetadataObject(loop.MetadataJSON)["manual"].(bool)
-	return manual
+// IsReviewFixBudgetExhaustedPause reports a no-HITL exhausted-role hold.
+func IsReviewFixBudgetExhaustedPause(metadataJSON *string) bool {
+	if reason, _ := stringFromAny(parseMetadataObject(metadataJSON)["pauseReason"]); reason == ReviewFixBudgetTerminationReason {
+		return true
+	}
+	state := ReadReviewFixBudgetState(metadataJSON)
+	return state.PauseReason == ReviewFixBudgetTerminationReason
+}
+
+// IsReviewFixBudgetHold reports whether a loop is part of a review-fix budget
+// hold (HITL ask, exhausted no-ask pause, or sibling paired pause).
+func IsReviewFixBudgetHold(loop storage.LoopRecord) bool {
+	switch strings.TrimSpace(loop.Status) {
+	case "awaiting_human":
+		ask, ok := ReadHITLAsk(loop.MetadataJSON)
+		return ok && IsReviewFixBudgetAsk(ask)
+	case "paused":
+		if IsSiblingReviewFixBudgetPause(loop.MetadataJSON) || IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
+			return true
+		}
+		return strings.TrimSpace(ReadReviewFixBudgetState(loop.MetadataJSON).ExhaustedBy) != ""
+	default:
+		return false
+	}
+}
+
+// ParticipatesInReviewFixBudget is true for automatic loops and continuous
+// manual/takeover loops (manual + followUpdates). One-shot manual is exempt.
+func ParticipatesInReviewFixBudget(loop storage.LoopRecord) bool {
+	return reviewFixBudgetLane(loop) != ""
+}
+
+func reviewFixBudgetLane(loop storage.LoopRecord) string {
+	meta := parseMetadataObject(loop.MetadataJSON)
+	manual, _ := meta["manual"].(bool)
+	followUpdates, _ := meta["followUpdates"].(bool)
+	if !manual {
+		return reviewFixBudgetLaneAutomatic
+	}
+	if followUpdates {
+		return reviewFixBudgetLaneContinuousManual
+	}
+	return ""
 }
 
 func isTerminalReviewFixSiblingStatus(status string) bool {
@@ -200,9 +256,14 @@ func isReviewFixBudgetPauseApplicable(status string) bool {
 	}
 }
 
-// FindSiblingReviewFixLoops returns automatic opposite-role loops on the same
-// project/repo/PR. Manual loops are not part of the review-fix budget pair.
+// FindSiblingReviewFixLoops returns opposite-role loops on the same
+// project/repo/PR in the same derived lane (automatic or continuous_manual).
+// One-shot manual loops are excluded. Automatic never pairs with continuous_manual.
 func FindSiblingReviewFixLoops(all []storage.LoopRecord, loop storage.LoopRecord) []storage.LoopRecord {
+	lane := reviewFixBudgetLane(loop)
+	if lane == "" {
+		return nil
+	}
 	wantType := ""
 	switch strings.TrimSpace(loop.Type) {
 	case "reviewer":
@@ -225,7 +286,7 @@ func FindSiblingReviewFixLoops(all []storage.LoopRecord, loop storage.LoopRecord
 		if derefLoopString(candidate.Repo) != repo || derefLoopInt64(candidate.PRNumber) != pr {
 			continue
 		}
-		if isManualReviewFixLoop(candidate) {
+		if reviewFixBudgetLane(candidate) != lane {
 			continue
 		}
 		siblings = append(siblings, candidate)
@@ -233,79 +294,172 @@ func FindSiblingReviewFixLoops(all []storage.LoopRecord, loop storage.LoopRecord
 	return siblings
 }
 
-// FindSiblingReviewFixLoop returns the preferred automatic sibling: a
-// non-terminal match when one exists, otherwise the first automatic match.
-func FindSiblingReviewFixLoop(all []storage.LoopRecord, loop storage.LoopRecord) *storage.LoopRecord {
-	siblings := FindSiblingReviewFixLoops(all, loop)
-	for i := range siblings {
-		if !isTerminalReviewFixSiblingStatus(siblings[i].Status) {
-			return &siblings[i]
-		}
-	}
-	if len(siblings) > 0 {
-		return &siblings[0]
-	}
-	return nil
-}
-
 type ParkReviewFixBudgetInput struct {
-	Exhausted storage.LoopRecord
-	Role      string
-	Repo      string
-	PRNumber  int64
-	Count     int
-	Cap       int
-	NowISO    string
+	Exhausted   storage.LoopRecord
+	Role        string
+	Repo        string
+	PRNumber    int64
+	Count       int
+	Cap         int
+	NowISO      string
+	HITLEnabled bool
+	// LiveCaps optional; used with pair metadata to snapshot both role meters
+	// on the handoff event. Zero caps mean unknown for that role.
+	LiveCaps ReviewFixBudgetLiveCaps
+	// DB optional. When set, exhausted persist + sibling park + queue cancel
+	// run in one transaction so a partial park cannot leave one role runnable.
+	DB *sql.DB
 }
 
-// ParkReviewFixBudget parks the exhausted loop as awaiting_human with a budget
-// HITL ask and pauses the sibling loop on the same PR. Queue items on both
-// sides are cancelled so discovery cannot immediately restart the ping-pong.
-// Re-entry on an already-awaiting budget loop finishes cancel/sibling park
-// without rewriting a delivered ask.
+// ParkReviewFixBudget parks the exhausted loop and pauses same-lane siblings.
+// When HITLEnabled is true the exhausted role is awaiting_human with a Continue/Stop
+// ask; when false it is paused with reason review_fix_budget_exhausted and no ask.
+// Queue items on both sides are cancelled so discovery cannot immediately restart.
+// Re-entry on an already-held budget loop finishes cancel/sibling park and retries
+// a missing handoff event without rewriting a delivered ask or no-ask hold metadata.
 func ParkReviewFixBudget(ctx context.Context, repos *storage.Repositories, input ParkReviewFixBudgetInput) (storage.LoopRecord, error) {
 	if repos == nil || repos.Loops == nil {
 		return input.Exhausted, fmt.Errorf("review-fix budget park requires loop storage")
 	}
+	if input.DB != nil {
+		var parked storage.LoopRecord
+		err := storage.WithTransaction(ctx, input.DB, nil, func(tx *sql.Tx) error {
+			var parkErr error
+			parked, parkErr = parkReviewFixBudgetBody(ctx, storage.NewRepositories(tx), input)
+			return parkErr
+		})
+		return parked, err
+	}
+	return parkReviewFixBudgetBody(ctx, repos, input)
+}
+
+func parkReviewFixBudgetBody(ctx context.Context, repos *storage.Repositories, input ParkReviewFixBudgetInput) (storage.LoopRecord, error) {
 	exhausted := input.Exhausted
-	if ask, ok := ReadHITLAsk(exhausted.MetadataJSON); ok && IsReviewFixBudgetAsk(ask) && exhausted.Status == "awaiting_human" {
+	if fresh, err := repos.Loops.GetByID(ctx, exhausted.ID); err == nil && fresh != nil {
+		exhausted = *fresh
+	}
+	if isReviewFixBudgetExhaustedHold(exhausted) {
 		if err := finishReviewFixBudgetPark(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
+			return exhausted, err
+		}
+		// Re-entry: retry a missing handoff event after the pair is non-runnable.
+		if err := ensureReviewFixBudgetHandoffEvent(ctx, repos, exhausted, input); err != nil {
 			return exhausted, err
 		}
 		return exhausted, nil
 	}
-	ask := NewReviewFixBudgetAsk(input.Role, input.Repo, input.PRNumber, input.Count, input.Cap, input.NowISO)
-	metadata, err := WriteHITLAsk(exhausted.MetadataJSON, ask)
+
+	// Fail-closed order without relying on outer TX alone: cancel queues and
+	// park siblings before persisting the exhausted hold so a sibling failure
+	// never leaves the sibling runnable while the exhausted side is already held.
+	if err := cancelReviewFixBudgetQueues(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
+		return input.Exhausted, err
+	}
+	if err := parkSiblingReviewFixLoop(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
+		return input.Exhausted, err
+	}
+
+	role := strings.TrimSpace(input.Role)
+	state := ReadReviewFixBudgetState(exhausted.MetadataJSON)
+	state.ExhaustedBy = role
+	state.PauseReason = ""
+	if !input.HITLEnabled {
+		state.PauseReason = ReviewFixBudgetTerminationReason
+	}
+	metadata, err := WriteReviewFixBudgetState(exhausted.MetadataJSON, state)
 	if err != nil {
 		return input.Exhausted, err
 	}
-	state := ReadReviewFixBudgetState(&metadata)
-	state.ExhaustedBy = strings.TrimSpace(input.Role)
-	metadata, err = WriteReviewFixBudgetState(&metadata, state)
-	if err != nil {
-		return input.Exhausted, err
+	if input.HITLEnabled {
+		ask := NewReviewFixBudgetAsk(input.Role, input.Repo, input.PRNumber, input.Count, input.Cap, input.NowISO)
+		metadata, err = WriteHITLAsk(&metadata, ask)
+		if err != nil {
+			return input.Exhausted, err
+		}
+		exhausted.Status = "awaiting_human"
+	} else {
+		if ask, ok := ReadHITLAsk(&metadata); ok && IsReviewFixBudgetAsk(ask) {
+			cleared, clearErr := ClearHITLAsk(&metadata)
+			if clearErr != nil {
+				return input.Exhausted, clearErr
+			}
+			metadata = cleared
+		}
+		meta := parseMetadataObject(&metadata)
+		meta["pauseReason"] = ReviewFixBudgetTerminationReason
+		encoded, marshalErr := json.Marshal(meta)
+		if marshalErr != nil {
+			return input.Exhausted, marshalErr
+		}
+		metadata = string(encoded)
+		exhausted.Status = "paused"
 	}
 	exhausted.MetadataJSON = &metadata
-	exhausted.Status = "awaiting_human"
 	exhausted.NextRunAt = nil
 	exhausted.UpdatedAt = input.NowISO
 	if err := repos.Loops.Upsert(ctx, exhausted); err != nil {
 		return input.Exhausted, err
 	}
-	if err := finishReviewFixBudgetPark(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
+	// Cancel exhausted queue again after status flip (idempotent).
+	if repos.Queue != nil {
+		reason := ReviewFixBudgetTerminationReason
+		if _, err := repos.Queue.CancelByLoop(ctx, exhausted.ID, input.NowISO, &reason); err != nil {
+			return exhausted, err
+		}
+	}
+	if err := ensureReviewFixBudgetHandoffEvent(ctx, repos, exhausted, input); err != nil {
+		// Pair is already non-runnable; surface the error so re-entry retries.
 		return exhausted, err
 	}
 	return exhausted, nil
 }
 
+func isReviewFixBudgetExhaustedHold(loop storage.LoopRecord) bool {
+	switch strings.TrimSpace(loop.Status) {
+	case "awaiting_human":
+		ask, ok := ReadHITLAsk(loop.MetadataJSON)
+		return ok && IsReviewFixBudgetAsk(ask)
+	case "paused":
+		return IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) ||
+			(strings.TrimSpace(ReadReviewFixBudgetState(loop.MetadataJSON).ExhaustedBy) != "" && !IsSiblingReviewFixBudgetPause(loop.MetadataJSON))
+	default:
+		return false
+	}
+}
+
 func finishReviewFixBudgetPark(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, exhaustedBy, nowISO string) error {
-	if repos.Queue != nil {
-		reason := ReviewFixBudgetTerminationReason
-		if _, err := repos.Queue.CancelByLoop(ctx, exhausted.ID, nowISO, &reason); err != nil {
+	if err := cancelReviewFixBudgetQueues(ctx, repos, exhausted, exhaustedBy, nowISO); err != nil {
+		return err
+	}
+	return parkSiblingReviewFixLoop(ctx, repos, exhausted, exhaustedBy, nowISO)
+}
+
+func cancelReviewFixBudgetQueues(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, exhaustedBy, nowISO string) error {
+	if repos.Queue == nil {
+		return nil
+	}
+	reason := ReviewFixBudgetTerminationReason
+	if _, err := repos.Queue.CancelByLoop(ctx, exhausted.ID, nowISO, &reason); err != nil {
+		return err
+	}
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	siblingReason := ReviewFixBudgetPauseReason
+	for _, sibling := range FindSiblingReviewFixLoops(all, exhausted) {
+		if !isReviewFixBudgetPauseApplicable(sibling.Status) {
+			continue
+		}
+		if sibling.Status == "paused" && !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) && !IsReviewFixBudgetExhaustedPause(sibling.MetadataJSON) {
+			continue
+		}
+		if _, err := repos.Queue.CancelByLoop(ctx, sibling.ID, nowISO, &siblingReason); err != nil {
 			return err
 		}
 	}
-	return parkSiblingReviewFixLoop(ctx, repos, exhausted, exhaustedBy, nowISO)
+	_ = exhaustedBy
+	return nil
 }
 
 func parkSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, exhaustedBy, nowISO string) error {
@@ -321,11 +475,34 @@ func parkSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, 
 	return nil
 }
 
+// reviewFixBudgetSiblingParkHook, when set (tests only), runs before sibling
+// persist so failure-path coverage can inject list/upsert errors.
+var reviewFixBudgetSiblingParkHook func(sibling storage.LoopRecord) error
+
+// reviewFixBudgetReleaseHook, when set (tests only), runs after a successful
+// release of one hold so Continue failure after partial release can be injected.
+var reviewFixBudgetReleaseHook func(loopID string) error
+
 func parkOneSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, sibling storage.LoopRecord, exhaustedBy, nowISO string) error {
+	if reviewFixBudgetSiblingParkHook != nil {
+		if err := reviewFixBudgetSiblingParkHook(sibling); err != nil {
+			return err
+		}
+	}
 	if !isReviewFixBudgetPauseApplicable(sibling.Status) {
 		return nil
 	}
-	if sibling.Status == "paused" && !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+	if sibling.Status == "paused" && !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) && !IsReviewFixBudgetExhaustedPause(sibling.MetadataJSON) {
+		return nil
+	}
+	// Already sibling-paused: still cancel queue on re-entry.
+	if sibling.Status == "paused" && IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		if repos.Queue != nil {
+			reason := ReviewFixBudgetPauseReason
+			if _, err := repos.Queue.CancelByLoop(ctx, sibling.ID, nowISO, &reason); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 	state := ReadReviewFixBudgetState(sibling.MetadataJSON)
@@ -359,19 +536,165 @@ func parkOneSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositorie
 	return nil
 }
 
+func ensureReviewFixBudgetHandoffEvent(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, input ParkReviewFixBudgetInput) error {
+	if repos == nil || repos.Events == nil {
+		return nil
+	}
+	state := ReadReviewFixBudgetState(exhausted.MetadataJSON)
+	if strings.TrimSpace(state.HandoffEventAt) != "" {
+		return nil
+	}
+	if err := appendReviewFixBudgetHandoffEvent(ctx, repos, exhausted, input); err != nil {
+		return err
+	}
+	state = ReadReviewFixBudgetState(exhausted.MetadataJSON)
+	state.HandoffEventAt = input.NowISO
+	encoded, err := WriteReviewFixBudgetState(exhausted.MetadataJSON, state)
+	if err != nil {
+		return err
+	}
+	updated := exhausted
+	updated.MetadataJSON = &encoded
+	updated.UpdatedAt = input.NowISO
+	return repos.Loops.Upsert(ctx, updated)
+}
+
+func appendReviewFixBudgetHandoffEvent(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, input ParkReviewFixBudgetInput) error {
+	if repos == nil || repos.Events == nil {
+		return nil
+	}
+	lane := reviewFixBudgetLane(exhausted)
+	resume := reviewFixBudgetHandoffResume(exhausted, input.HITLEnabled)
+	head := reviewFixBudgetHandoffHead(exhausted)
+	reviewerCount, reviewerCap, fixerCount, fixerCap, exhaustedRoles := reviewFixBudgetHandoffMeters(ctx, repos, exhausted, input)
+	projectID := strings.TrimSpace(exhausted.ProjectID)
+	loopID := strings.TrimSpace(exhausted.ID)
+	exhaustedBy := strings.TrimSpace(input.Role)
+	if len(exhaustedRoles) > 1 {
+		exhaustedBy = strings.Join(exhaustedRoles, ",")
+	}
+	payload := map[string]any{
+		"level":          "action_required",
+		"kind":           HITLKindReviewFixBudget,
+		"repo":           strings.TrimSpace(input.Repo),
+		"prNumber":       input.PRNumber,
+		"lane":           lane,
+		"exhaustedBy":    exhaustedBy,
+		"exhaustedRoles": exhaustedRoles,
+		"hitlEnabled":    input.HITLEnabled,
+		"resume":         resume,
+		"reviewer":       map[string]any{"count": reviewerCount, "cap": reviewerCap},
+		"fixer":          map[string]any{"count": fixerCount, "cap": fixerCap},
+	}
+	if head != "" {
+		payload["head"] = head
+	}
+	return eventlog.Append(ctx, repos, eventlog.AppendInput{
+		EventType:  reviewFixBudgetHandoffEventType,
+		ProjectID:  optionalBudgetString(projectID),
+		LoopID:     optionalBudgetString(loopID),
+		EntityType: optionalBudgetString("loop"),
+		EntityID:   optionalBudgetString(loopID),
+		ActorType:  optionalBudgetString("system"),
+		ActorID:    optionalBudgetString("review-fix-budget"),
+		Payload:    payload,
+	})
+}
+
+// reviewFixBudgetHandoffResume returns concrete CLI commands including loop seq
+// (fallback to id when seq is 0). HITL-on keeps Continue/Stop plus the same CLI.
+func reviewFixBudgetHandoffResume(exhausted storage.LoopRecord, hitlEnabled bool) string {
+	selector := strings.TrimSpace(exhausted.ID)
+	if exhausted.Seq > 0 {
+		selector = fmt.Sprintf("%d", exhausted.Seq)
+	}
+	cli := fmt.Sprintf("looper unpause %s / looper stop %s", selector, selector)
+	if hitlEnabled {
+		return ReviewFixBudgetAnswerContinue + " / " + ReviewFixBudgetAnswerStop + "; " + cli
+	}
+	return cli
+}
+
+// reviewFixBudgetHandoffHead prefers lastPublishedHeadSha (reviewer) then
+// lastFixHeadSha (fixer) from exhausted-loop metadata.
+func reviewFixBudgetHandoffHead(exhausted storage.LoopRecord) string {
+	meta := parseMetadataObject(exhausted.MetadataJSON)
+	if head, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && strings.TrimSpace(head) != "" {
+		return strings.TrimSpace(head)
+	}
+	if head, ok := stringFromAny(meta["lastFixHeadSha"]); ok && strings.TrimSpace(head) != "" {
+		return strings.TrimSpace(head)
+	}
+	return ""
+}
+
+func reviewFixBudgetHandoffMeters(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, input ParkReviewFixBudgetInput) (reviewerCount, reviewerCap, fixerCount, fixerCap int, exhaustedRoles []string) {
+	reviewerCap = input.LiveCaps.ReviewerMaxPublishes
+	fixerCap = input.LiveCaps.FixerMaxPushes
+	if reviewerCap == 0 && strings.TrimSpace(exhausted.Type) == "reviewer" {
+		reviewerCap = input.Cap
+	}
+	if fixerCap == 0 && strings.TrimSpace(exhausted.Type) == "fixer" {
+		fixerCap = input.Cap
+	}
+	// Prefer live pair metadata over the single-role Count/Cap snapshot.
+	members := []storage.LoopRecord{exhausted}
+	if repos != nil && repos.Loops != nil {
+		if all, err := repos.Loops.List(ctx); err == nil {
+			members = reviewFixBudgetPairMembers(all, exhausted)
+		}
+	}
+	for _, member := range members {
+		switch strings.TrimSpace(member.Type) {
+		case "reviewer":
+			reviewerCount = ReviewerPublishCount(member.MetadataJSON)
+		case "fixer":
+			fixerCount = FixerPushCount(member.MetadataJSON)
+		}
+	}
+	// Fall back to the triggering role's admission snapshot when pair read is empty.
+	if strings.TrimSpace(exhausted.Type) == "reviewer" && reviewerCount == 0 && input.Count > 0 {
+		reviewerCount = input.Count
+	}
+	if strings.TrimSpace(exhausted.Type) == "fixer" && fixerCount == 0 && input.Count > 0 {
+		fixerCount = input.Count
+	}
+	if BudgetExhausted(reviewerCount, reviewerCap) {
+		exhaustedRoles = append(exhaustedRoles, "reviewer")
+	}
+	if BudgetExhausted(fixerCount, fixerCap) {
+		exhaustedRoles = append(exhaustedRoles, "fixer")
+	}
+	if len(exhaustedRoles) == 0 && strings.TrimSpace(input.Role) != "" {
+		exhaustedRoles = []string{strings.TrimSpace(input.Role)}
+	}
+	return reviewerCount, reviewerCap, fixerCount, fixerCap, exhaustedRoles
+}
+
+func optionalBudgetString(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
 type ReviewFixBudgetAnswerResult struct {
 	Applied bool
 	Action  string
 	Loop    storage.LoopRecord
 }
 
-// ApplyReviewFixBudgetAnswer handles Continue (reset counter, queue, unpause
-// sibling) or Stop (terminate both). Returns Applied=false for mid-run HITL asks.
-func ApplyReviewFixBudgetAnswer(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string) (ReviewFixBudgetAnswerResult, error) {
-	ask, ok := ReadHITLAsk(loop.MetadataJSON)
-	if !ok || !IsReviewFixBudgetAsk(ask) {
+// ApplyReviewFixBudgetAnswer handles Continue (reset at/over-cap meters, queue,
+// release pair) or Stop (terminate both). Works for HITL asks and no-ask holds.
+// Caps must be live config values used to decide which meters to refill.
+// Returns Applied=false when the loop is not a review-fix budget hold.
+func ApplyReviewFixBudgetAnswer(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string, caps ReviewFixBudgetLiveCaps) (ReviewFixBudgetAnswerResult, error) {
+	if !IsReviewFixBudgetHold(loop) {
 		return ReviewFixBudgetAnswerResult{}, nil
 	}
+	// Mid-run agent asks share awaiting_human but are not budget holds; the
+	// IsReviewFixBudgetHold check above already requires a budget ask kind.
 	if repos == nil || repos.Loops == nil {
 		return ReviewFixBudgetAnswerResult{}, fmt.Errorf("review-fix budget answer requires loop storage")
 	}
@@ -385,56 +708,187 @@ func ApplyReviewFixBudgetAnswer(ctx context.Context, repos *storage.Repositories
 	if !IsReviewFixBudgetContinue(answer) {
 		return ReviewFixBudgetAnswerResult{}, ErrReviewFixBudgetInvalidAnswer
 	}
-	updated, err := continueReviewFixBudget(ctx, repos, loop, nowISO)
+	updated, err := continueReviewFixBudget(ctx, repos, loop, nowISO, caps)
 	if err != nil {
 		return ReviewFixBudgetAnswerResult{}, err
 	}
 	return ReviewFixBudgetAnswerResult{Applied: true, Action: "continue", Loop: updated}, nil
 }
 
-func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
-	// Keep awaiting_human + the budget ask until sibling unpause and requeue
-	// succeed so a later GitHub/Feishu poll can retry the same answer.
-	if err := unpauseSiblingReviewFixLoop(ctx, repos, loop, nowISO); err != nil {
+func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string, caps ReviewFixBudgetLiveCaps) (storage.LoopRecord, error) {
+	// Keep holds until every required meter reset succeeds, then release the pair.
+	// Fail-closed: never unpause a sibling until meters are reset and the
+	// exhausted/answered side can complete its transition. Callers that have a
+	// DB should wrap ApplyReviewFixBudgetAnswer in storage.WithTransaction so
+	// release is atomic; without a TX we still release the answered side first
+	// so a later sibling failure cannot leave a sibling queued while the
+	// exhausted side remains held.
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
 		return loop, err
 	}
-	if err := requeueReviewFixBudgetLoop(ctx, repos, loop.ID, nowISO); err != nil {
+	members := reviewFixBudgetPairMembers(all, loop)
+
+	for _, member := range members {
+		fresh, getErr := repos.Loops.GetByID(ctx, member.ID)
+		if getErr != nil {
+			return loop, getErr
+		}
+		if fresh == nil {
+			continue
+		}
+		if !IsReviewFixBudgetHold(*fresh) && fresh.ID != loop.ID {
+			// Independently paused / failed siblings are not budget-held.
+			if fresh.Status == "paused" && !IsSiblingReviewFixBudgetPause(fresh.MetadataJSON) && !IsReviewFixBudgetExhaustedPause(fresh.MetadataJSON) {
+				continue
+			}
+			if fresh.Status == "failed" || fresh.Status == "interrupted" {
+				continue
+			}
+		}
+		encoded, resetErr := resetReviewFixBudgetMetersIfNeeded(fresh.MetadataJSON, fresh.Type, caps)
+		if resetErr != nil {
+			return loop, resetErr
+		}
+		if encoded == nil {
+			continue
+		}
+		// Clear handoff marker on refill so a later park emits a fresh event.
+		state := ReadReviewFixBudgetState(encoded)
+		if state.HandoffEventAt != "" {
+			state.HandoffEventAt = ""
+			cleared, writeErr := WriteReviewFixBudgetState(encoded, state)
+			if writeErr != nil {
+				return loop, writeErr
+			}
+			encoded = &cleared
+		}
+		updated := *fresh
+		updated.MetadataJSON = encoded
+		updated.UpdatedAt = nowISO
+		if err := repos.Loops.Upsert(ctx, updated); err != nil {
+			return loop, err
+		}
+	}
+
+	// Release answered/exhausted side first while siblings stay held.
+	if err := releaseOneReviewFixBudgetHold(ctx, repos, loop.ID, nowISO); err != nil {
 		return loop, err
 	}
-	metadata := loop.MetadataJSON
-	switch loop.Type {
+	for _, member := range members {
+		if member.ID == loop.ID {
+			continue
+		}
+		if err := releaseOneReviewFixBudgetHold(ctx, repos, member.ID, nowISO); err != nil {
+			return loop, err
+		}
+	}
+	fresh, err := repos.Loops.GetByID(ctx, loop.ID)
+	if err != nil {
+		return loop, err
+	}
+	if fresh == nil {
+		return loop, fmt.Errorf("review-fix budget continue lost loop %s", loop.ID)
+	}
+	return *fresh, nil
+}
+
+func reviewFixBudgetPairMembers(all []storage.LoopRecord, loop storage.LoopRecord) []storage.LoopRecord {
+	members := FindSiblingReviewFixLoops(all, loop)
+	members = append(members, loop)
+	return members
+}
+
+func resetReviewFixBudgetMetersIfNeeded(metadataJSON *string, loopType string, caps ReviewFixBudgetLiveCaps) (*string, error) {
+	switch strings.TrimSpace(loopType) {
 	case "reviewer":
-		encoded, resetErr := ResetReviewerPublishCount(metadata)
-		if resetErr != nil {
-			return loop, resetErr
+		if !BudgetExhausted(ReviewerPublishCount(metadataJSON), caps.ReviewerMaxPublishes) {
+			return nil, nil
 		}
-		metadata = &encoded
+		encoded, err := ResetReviewerPublishCount(metadataJSON)
+		if err != nil {
+			return nil, err
+		}
+		// Clear exhausted markers on the meter owner when refilling.
+		state := ReadReviewFixBudgetState(&encoded)
+		state.ExhaustedBy = ""
+		if state.PauseReason == ReviewFixBudgetTerminationReason {
+			state.PauseReason = ""
+		}
+		encoded, err = WriteReviewFixBudgetState(&encoded, state)
+		if err != nil {
+			return nil, err
+		}
+		return &encoded, nil
 	case "fixer":
-		encoded, resetErr := ResetFixerPushCount(metadata)
-		if resetErr != nil {
-			return loop, resetErr
+		if !BudgetExhausted(FixerPushCount(metadataJSON), caps.FixerMaxPushes) {
+			return nil, nil
 		}
-		metadata = &encoded
+		encoded, err := ResetFixerPushCount(metadataJSON)
+		if err != nil {
+			return nil, err
+		}
+		return &encoded, nil
+	default:
+		return nil, nil
 	}
-	cleared, err := ClearHITLAsk(metadata)
+}
+
+func releaseOneReviewFixBudgetHold(ctx context.Context, repos *storage.Repositories, loopID, nowISO string) error {
+	fresh, err := repos.Loops.GetByID(ctx, loopID)
 	if err != nil {
-		return loop, err
+		return err
 	}
-	state := ReadReviewFixBudgetState(&cleared)
+	if fresh == nil {
+		return nil
+	}
+	if !IsReviewFixBudgetHold(*fresh) {
+		return nil
+	}
+	metadata := fresh.MetadataJSON
+	if ask, ok := ReadHITLAsk(metadata); ok && IsReviewFixBudgetAsk(ask) {
+		cleared, clearErr := ClearHITLAsk(metadata)
+		if clearErr != nil {
+			return clearErr
+		}
+		metadata = &cleared
+	}
+	state := ReadReviewFixBudgetState(metadata)
+	state.SiblingOf = ""
+	if state.PauseReason == ReviewFixBudgetPauseReason || state.PauseReason == ReviewFixBudgetTerminationReason {
+		state.PauseReason = ""
+	}
 	state.ExhaustedBy = ""
-	cleared, err = WriteReviewFixBudgetState(&cleared, state)
+	encoded, err := WriteReviewFixBudgetState(metadata, state)
 	if err != nil {
-		return loop, err
+		return err
 	}
-	updated := loop
-	updated.MetadataJSON = &cleared
+	meta := parseMetadataObject(&encoded)
+	if reason, _ := stringFromAny(meta["pauseReason"]); reason == ReviewFixBudgetPauseReason || reason == ReviewFixBudgetTerminationReason {
+		delete(meta, "pauseReason")
+	}
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	text := string(out)
+	updated := *fresh
+	updated.MetadataJSON = &text
 	updated.Status = "queued"
 	updated.NextRunAt = &nowISO
 	updated.UpdatedAt = nowISO
 	if err := repos.Loops.Upsert(ctx, updated); err != nil {
-		return loop, err
+		return err
 	}
-	return updated, nil
+	if err := requeueReviewFixBudgetLoop(ctx, repos, updated.ID, nowISO); err != nil {
+		return err
+	}
+	if reviewFixBudgetReleaseHook != nil {
+		if err := reviewFixBudgetReleaseHook(updated.ID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func requeueReviewFixBudgetLoop(ctx context.Context, repos *storage.Repositories, loopID, nowISO string) error {
@@ -482,51 +936,9 @@ func requeueReviewFixBudgetLoop(ctx context.Context, repos *storage.Repositories
 	return err
 }
 
-func unpauseSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, nowISO string) error {
-	all, err := repos.Loops.List(ctx)
-	if err != nil {
-		return err
-	}
-	for _, sibling := range FindSiblingReviewFixLoops(all, exhausted) {
-		if sibling.Status != "paused" || !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
-			continue
-		}
-		if err := unpauseOneSiblingReviewFixLoop(ctx, repos, sibling, nowISO); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func unpauseOneSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, sibling storage.LoopRecord, nowISO string) error {
-	state := ReadReviewFixBudgetState(sibling.MetadataJSON)
-	state.SiblingOf = ""
-	state.PauseReason = ""
-	metadata, err := WriteReviewFixBudgetState(sibling.MetadataJSON, state)
-	if err != nil {
-		return err
-	}
-	meta := parseMetadataObject(&metadata)
-	delete(meta, "pauseReason")
-	encoded, err := json.Marshal(meta)
-	if err != nil {
-		return err
-	}
-	text := string(encoded)
-	updated := sibling
-	updated.MetadataJSON = &text
-	updated.Status = "queued"
-	updated.NextRunAt = &nowISO
-	updated.UpdatedAt = nowISO
-	if err := repos.Loops.Upsert(ctx, updated); err != nil {
-		return err
-	}
-	return requeueReviewFixBudgetLoop(ctx, repos, updated.ID, nowISO)
-}
-
 func terminateReviewFixPair(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
-	// Keep awaiting_human + the budget ask until every automatic sibling is
-	// terminated so a later GitHub/Feishu poll can retry the same Stop.
+	// Keep the answered/held loop until every same-lane sibling is terminated so
+	// a later poll can retry the same Stop.
 	all, err := repos.Loops.List(ctx)
 	if err != nil {
 		return loop, err
@@ -554,12 +966,25 @@ func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, lo
 		loopMeta["terminationReason"] = ReviewFixBudgetTerminationReason
 		meta[reviewerLoopMetadataKey] = loopMeta
 	}
+	if reason, _ := stringFromAny(meta["pauseReason"]); reason == ReviewFixBudgetPauseReason || reason == ReviewFixBudgetTerminationReason {
+		delete(meta, "pauseReason")
+	}
 	encoded, err := json.Marshal(meta)
 	if err != nil {
 		return loop, err
 	}
 	encodedText := string(encoded)
 	cleared, err := ClearHITLAsk(&encodedText)
+	if err != nil {
+		return loop, err
+	}
+	state := ReadReviewFixBudgetState(&cleared)
+	state.SiblingOf = ""
+	state.ExhaustedBy = ""
+	if state.PauseReason == ReviewFixBudgetPauseReason || state.PauseReason == ReviewFixBudgetTerminationReason {
+		state.PauseReason = ""
+	}
+	cleared, err = WriteReviewFixBudgetState(&cleared, state)
 	if err != nil {
 		return loop, err
 	}

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -2,6 +2,9 @@ package loops
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,7 +53,7 @@ func TestParkAndContinueReviewFixBudget(t *testing.T) {
 	seedBudgetQueue(t, repos, nowISO, "queue_fixer", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -77,7 +80,7 @@ func TestParkAndContinueReviewFixBudget(t *testing.T) {
 		}
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "continue" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -108,7 +111,7 @@ func TestContinueReviewFixBudgetEnqueuesFreshWorkAfterCompletedClaim(t *testing.
 	}
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -122,7 +125,7 @@ func TestContinueReviewFixBudgetEnqueuesFreshWorkAfterCompletedClaim(t *testing.
 		t.Fatalf("sibling queue after park = (%#v, %v), want cancelled", siblingQueue, err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "continue" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -154,7 +157,7 @@ func TestApplyReviewFixBudgetAnswerStopTerminatesPair(t *testing.T) {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, reviewer, "Stop", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, reviewer, "Stop", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "stop" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -167,7 +170,7 @@ func TestApplyReviewFixBudgetAnswerStopTerminatesPair(t *testing.T) {
 	}
 }
 
-func TestFindSiblingReviewFixLoopPrefersActiveAutomatic(t *testing.T) {
+func TestFindSiblingReviewFixLoopsPrefersAutomaticLane(t *testing.T) {
 	t.Parallel()
 	repo := "acme/looper"
 	pr := int64(42)
@@ -177,10 +180,6 @@ func TestFindSiblingReviewFixLoopPrefersActiveAutomatic(t *testing.T) {
 	terminalFixer := storage.LoopRecord{ID: "loop_terminal_fixer", ProjectID: "project_1", Type: "fixer", Status: "terminated", Repo: &repo, PRNumber: &pr}
 	automaticFixer := storage.LoopRecord{ID: "loop_auto_fixer", ProjectID: "project_1", Type: "fixer", Status: "queued", Repo: &repo, PRNumber: &pr}
 
-	got := FindSiblingReviewFixLoop([]storage.LoopRecord{manualFixer, terminalFixer, automaticFixer}, reviewer)
-	if got == nil || got.ID != automaticFixer.ID {
-		t.Fatalf("FindSiblingReviewFixLoop() = %#v, want automatic fixer", got)
-	}
 	siblings := FindSiblingReviewFixLoops([]storage.LoopRecord{manualFixer, terminalFixer, automaticFixer}, reviewer)
 	if len(siblings) != 2 || siblings[0].ID != terminalFixer.ID || siblings[1].ID != automaticFixer.ID {
 		t.Fatalf("FindSiblingReviewFixLoops() = %#v, want automatic siblings only", siblings)
@@ -202,7 +201,7 @@ func TestParkAndStopReviewFixBudgetSkipsManualSibling(t *testing.T) {
 	seedBudgetQueue(t, repos, nowISO, "queue_fixer_auto", automatic.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -216,7 +215,7 @@ func TestParkAndStopReviewFixBudgetSkipsManualSibling(t *testing.T) {
 		t.Fatalf("automatic sibling = (%#v, %v), want paused", automaticAfter, err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "stop" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -259,7 +258,7 @@ func TestParkReviewFixBudgetCompletesSiblingAfterPartialPark(t *testing.T) {
 	}
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -289,16 +288,16 @@ func TestContinueReviewFixBudgetRetriesAfterSiblingAlreadyUnpaused(t *testing.T)
 	seedBudgetQueue(t, repos, nowISO, "queue_fixer_retry", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
 	}
-	if err := unpauseSiblingReviewFixLoop(context.Background(), repos, parked, nowISO); err != nil {
-		t.Fatalf("unpauseSiblingReviewFixLoop() error = %v", err)
+	if err := releaseOneReviewFixBudgetHold(context.Background(), repos, fixer.ID, nowISO); err != nil {
+		t.Fatalf("releaseOneReviewFixBudgetHold(sibling) error = %v", err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "continue" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -328,7 +327,7 @@ func TestParkAndContinueReviewFixBudgetSkipsPreexistingPausedSibling(t *testing.
 	seedBudgetQueue(t, repos, nowISO, "queue_fixer_pre_paused", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -345,7 +344,7 @@ func TestParkAndContinueReviewFixBudgetSkipsPreexistingPausedSibling(t *testing.
 		t.Fatalf("sibling queue after park = (%#v, %v), want still queued", siblingQueue, err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "continue" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -375,7 +374,7 @@ func TestParkAndContinueReviewFixBudgetSkipsFailedSibling(t *testing.T) {
 			seedBudgetQueue(t, repos, nowISO, "queue_fixer_"+status, fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 			parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-				Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+				Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 			})
 			if err != nil {
 				t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -389,7 +388,7 @@ func TestParkAndContinueReviewFixBudgetSkipsFailedSibling(t *testing.T) {
 				t.Fatalf("sibling queue after park = (%#v, %v), want still queued", siblingQueue, err)
 			}
 
-			result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+			result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(8, 8))
 			if err != nil || !result.Applied || result.Action != "continue" {
 				t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 			}
@@ -414,7 +413,7 @@ func TestStopReviewFixBudgetRetriesAfterSiblingAlreadyTerminated(t *testing.T) {
 	seedBudgetQueue(t, repos, nowISO, "queue_fixer_stop_retry", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -423,7 +422,7 @@ func TestStopReviewFixBudgetRetriesAfterSiblingAlreadyTerminated(t *testing.T) {
 		t.Fatalf("terminateReviewFixLoop(sibling) error = %v", err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "stop" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -448,10 +447,481 @@ func TestApplyReviewFixBudgetAnswerIgnoresAgentAsk(t *testing.T) {
 		t.Fatalf("WriteHITLAsk() error = %v", err)
 	}
 	loop.MetadataJSON = &metadata
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, loop, "Continue", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, loop, "Continue", nowISO, testBudgetCaps(8, 8))
 	if err != nil || result.Applied {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v), want not applied", result, err)
 	}
+}
+
+func TestBudgetExhaustedIndependentCapsAndZeroDisablesRole(t *testing.T) {
+	t.Parallel()
+	if BudgetExhausted(3, 0) {
+		t.Fatal("cap 0 must disable only that role")
+	}
+	if !BudgetExhausted(3, 3) {
+		t.Fatal("3/3 must be exhausted")
+	}
+	if BudgetExhausted(2, 3) {
+		t.Fatal("2/3 must not be exhausted")
+	}
+	// Live cap lowered below current count halts on next admission.
+	if !BudgetExhausted(5, 3) {
+		t.Fatal("count above lowered live cap must be exhausted")
+	}
+}
+
+func TestParkNoHITLPausesPairWithoutAsk(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_nohitl", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_nohitl", "fixer", "queued")
+	seedBudgetQueue(t, repos, nowISO, "queue_reviewer_nohitl", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer_nohitl", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	if parked.Status != "paused" || !IsReviewFixBudgetExhaustedPause(parked.MetadataJSON) {
+		t.Fatalf("exhausted = %#v, want paused with review_fix_budget_exhausted", parked)
+	}
+	if _, ok := ReadHITLAsk(parked.MetadataJSON); ok {
+		t.Fatal("no-HITL park must not write a HITL ask")
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling = (%#v, %v), want paired budget pause", sibling, err)
+	}
+	for _, queueID := range []string{"queue_reviewer_nohitl", "queue_fixer_nohitl"} {
+		queue, err := repos.Queue.GetByID(context.Background(), queueID)
+		if err != nil || queue == nil || queue.Status != "cancelled" {
+			t.Fatalf("%s = (%#v, %v), want cancelled", queueID, queue, err)
+		}
+	}
+}
+
+func TestContinueNoHITLFromEitherRoleResetsOnlyExhaustedMeters(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	fixerMeta := `{"reviewFixBudget":{"pushCount":1}}`
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_cont_nohitl", "reviewer", "running")
+	reviewer.MetadataJSON = &reviewerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_cont_nohitl", "fixer", "queued")
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	seedBudgetQueue(t, repos, nowISO, "queue_reviewer_cont_nohitl", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer_cont_nohitl", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	// Unpause from sibling side.
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil {
+		t.Fatalf("sibling get: %v", err)
+	}
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, *sibling, "Continue", nowISO, testBudgetCaps(3, 3))
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("Continue from sibling = (%#v, %v)", result, err)
+	}
+	reviewerAfter, err := repos.Loops.GetByID(context.Background(), parked.ID)
+	if err != nil || reviewerAfter == nil || reviewerAfter.Status != "queued" || ReviewerPublishCount(reviewerAfter.MetadataJSON) != 0 {
+		t.Fatalf("reviewer after continue = (%#v, %v), want queued with reset count", reviewerAfter, err)
+	}
+	fixerAfter, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || fixerAfter == nil || fixerAfter.Status != "queued" || FixerPushCount(fixerAfter.MetadataJSON) != 1 {
+		t.Fatalf("fixer after continue = (%#v, %v), want queued with preserved unused push budget", fixerAfter, err)
+	}
+}
+
+func TestContinueResetsBothMetersWhenBothExhausted(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	fixerMeta := `{"reviewFixBudget":{"pushCount":3}}`
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_both", "reviewer", "running")
+	reviewer.MetadataJSON = &reviewerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_both", "fixer", "queued")
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: true,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(3, 3))
+	if err != nil || !result.Applied {
+		t.Fatalf("Continue = (%#v, %v)", result, err)
+	}
+	if ReviewerPublishCount(result.Loop.MetadataJSON) != 0 {
+		t.Fatalf("reviewer count = %d, want 0", ReviewerPublishCount(result.Loop.MetadataJSON))
+	}
+	fixerAfter, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if fixerAfter == nil || FixerPushCount(fixerAfter.MetadataJSON) != 0 {
+		t.Fatalf("fixer count = %#v, want reset to 0", fixerAfter)
+	}
+}
+
+func TestStopNoHITLFromEitherRoleTerminatesPair(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_stop_nohitl", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_stop_nohitl", "fixer", "queued")
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil {
+		t.Fatalf("sibling get: %v", err)
+	}
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, *sibling, "Stop", nowISO, testBudgetCaps(3, 3))
+	if err != nil || !result.Applied || result.Action != "stop" {
+		t.Fatalf("Stop from sibling = (%#v, %v)", result, err)
+	}
+	reviewerAfter, _ := repos.Loops.GetByID(context.Background(), parked.ID)
+	fixerAfter, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if reviewerAfter == nil || reviewerAfter.Status != "terminated" || fixerAfter == nil || fixerAfter.Status != "terminated" {
+		t.Fatalf("pair after stop = reviewer %#v fixer %#v, want both terminated", reviewerAfter, fixerAfter)
+	}
+}
+
+func TestFindSiblingSameLanePairing(t *testing.T) {
+	t.Parallel()
+	repo := "acme/looper"
+	pr := int64(42)
+	reviewer := storage.LoopRecord{ID: "loop_reviewer", ProjectID: "project_1", Type: "reviewer", Repo: &repo, PRNumber: &pr}
+	oneShot := `{"manual":true,"followUpdates":false}`
+	continuous := `{"manual":true,"followUpdates":true}`
+	oneShotFixer := storage.LoopRecord{ID: "loop_oneshot", ProjectID: "project_1", Type: "fixer", Status: "queued", Repo: &repo, PRNumber: &pr, MetadataJSON: &oneShot}
+	continuousFixer := storage.LoopRecord{ID: "loop_continuous", ProjectID: "project_1", Type: "fixer", Status: "queued", Repo: &repo, PRNumber: &pr, MetadataJSON: &continuous}
+	autoFixer := storage.LoopRecord{ID: "loop_auto", ProjectID: "project_1", Type: "fixer", Status: "queued", Repo: &repo, PRNumber: &pr}
+
+	// Automatic reviewer pairs only with automatic fixer.
+	got := FindSiblingReviewFixLoops([]storage.LoopRecord{oneShotFixer, continuousFixer, autoFixer}, reviewer)
+	if len(got) != 1 || got[0].ID != autoFixer.ID {
+		t.Fatalf("automatic siblings = %#v, want only auto fixer", got)
+	}
+	if ParticipatesInReviewFixBudget(oneShotFixer) {
+		t.Fatal("one-shot manual must not participate")
+	}
+	if !ParticipatesInReviewFixBudget(continuousFixer) {
+		t.Fatal("continuous manual must participate")
+	}
+
+	// Continuous manual reviewer pairs only with continuous manual fixer.
+	contReviewerMeta := continuous
+	contReviewer := storage.LoopRecord{ID: "loop_cont_reviewer", ProjectID: "project_1", Type: "reviewer", Repo: &repo, PRNumber: &pr, MetadataJSON: &contReviewerMeta}
+	got = FindSiblingReviewFixLoops([]storage.LoopRecord{oneShotFixer, continuousFixer, autoFixer}, contReviewer)
+	if len(got) != 1 || got[0].ID != continuousFixer.ID {
+		t.Fatalf("continuous_manual siblings = %#v, want only continuous fixer", got)
+	}
+}
+
+func TestParkContinuousManualPairsWithSameLaneOnly(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	contMeta := `{"manual":true,"followUpdates":true,"loop":{"iterationCount":3}}`
+	autoMeta := `{"loop":{"iterationCount":0}}`
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_cont_rev_park", "reviewer", "running")
+	reviewer.MetadataJSON = &contMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	autoFixer := seedBudgetLoop(t, repos, nowISO, "loop_auto_fix_park", "fixer", "queued")
+	autoFixer.MetadataJSON = &autoMeta
+	if err := repos.Loops.Upsert(context.Background(), autoFixer); err != nil {
+		t.Fatalf("Upsert auto fixer: %v", err)
+	}
+	contFixer := seedBudgetLoop(t, repos, nowISO, "loop_cont_fix_park", "fixer", "queued")
+	contFixerMeta := `{"manual":true,"followUpdates":true}`
+	contFixer.MetadataJSON = &contFixerMeta
+	if err := repos.Loops.Upsert(context.Background(), contFixer); err != nil {
+		t.Fatalf("Upsert cont fixer: %v", err)
+	}
+
+	_, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	autoAfter, _ := repos.Loops.GetByID(context.Background(), autoFixer.ID)
+	contAfter, _ := repos.Loops.GetByID(context.Background(), contFixer.ID)
+	if autoAfter == nil || autoAfter.Status != "queued" || IsSiblingReviewFixBudgetPause(autoAfter.MetadataJSON) {
+		t.Fatalf("automatic fixer = %#v, want untouched", autoAfter)
+	}
+	if contAfter == nil || contAfter.Status != "paused" || !IsSiblingReviewFixBudgetPause(contAfter.MetadataJSON) {
+		t.Fatalf("continuous fixer = %#v, want paired pause", contAfter)
+	}
+}
+
+func TestIsReviewFixBudgetHoldCoversExhaustedAndSibling(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_hold_rev", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_hold_fix", "fixer", "queued")
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	if !IsReviewFixBudgetHold(parked) {
+		t.Fatal("exhausted no-HITL hold must be detected")
+	}
+	sibling, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if sibling == nil || !IsReviewFixBudgetHold(*sibling) {
+		t.Fatalf("sibling hold = %#v", sibling)
+	}
+}
+
+func TestParkSiblingFailureDoesNotLeaveSiblingRunnableWhileExhaustedHeld(t *testing.T) {
+	// Serial: uses package-level inject hook.
+	coordinator := openCoordinator(t)
+	db := coordinator.DB()
+	repos := storage.NewRepositories(db)
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	seedProject(t, repos, now)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_sib_fail_rev", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_sib_fail_fix", "fixer", "queued")
+	seedBudgetQueue(t, repos, nowISO, "queue_sib_fail_fix", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	reviewFixBudgetSiblingParkHook = func(sibling storage.LoopRecord) error {
+		if sibling.ID == fixer.ID {
+			return fmt.Errorf("injected sibling park failure")
+		}
+		return nil
+	}
+	t.Cleanup(func() { reviewFixBudgetSiblingParkHook = nil })
+
+	_, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: false, DB: db,
+		LiveCaps: testBudgetCaps(3, 3),
+	})
+	if err == nil {
+		t.Fatal("ParkReviewFixBudget() error = nil, want injected sibling failure")
+	}
+
+	exhausted, _ := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	sibling, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	// TX rollback: exhausted must not be held while sibling remains runnable.
+	if exhausted != nil && IsReviewFixBudgetHold(*exhausted) && sibling != nil && (sibling.Status == "queued" || sibling.Status == "running") {
+		t.Fatalf("partial park left exhausted held and sibling runnable: exhausted=%#v sibling=%#v", exhausted, sibling)
+	}
+	if sibling != nil && sibling.Status == "queued" && exhausted != nil && exhausted.Status == "paused" {
+		t.Fatalf("sibling still queued while exhausted paused: exhausted=%#v sibling=%#v", exhausted, sibling)
+	}
+}
+
+func TestContinueFailureDoesNotLeaveSiblingQueuedWhileExhaustedHeld(t *testing.T) {
+	// Serial: uses package-level inject hook.
+	coordinator := openCoordinator(t)
+	db := coordinator.DB()
+	repos := storage.NewRepositories(db)
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	seedProject(t, repos, now)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_cont_fail_rev", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_cont_fail_fix", "fixer", "queued")
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: true, DB: db, LiveCaps: testBudgetCaps(3, 3),
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+
+	// Fail after exhausted side is released (first release). With TX, both roll back.
+	released := 0
+	reviewFixBudgetReleaseHook = func(loopID string) error {
+		released++
+		if released == 1 {
+			return fmt.Errorf("injected continue failure after first release")
+		}
+		return nil
+	}
+	t.Cleanup(func() { reviewFixBudgetReleaseHook = nil })
+
+	_, err = storage.WithTransactionValue(context.Background(), db, nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
+		txRepos := storage.NewRepositories(tx)
+		fresh, getErr := txRepos.Loops.GetByID(context.Background(), parked.ID)
+		if getErr != nil || fresh == nil {
+			return storage.LoopRecord{}, fmt.Errorf("fresh: %v", getErr)
+		}
+		result, applyErr := ApplyReviewFixBudgetAnswer(context.Background(), txRepos, *fresh, "Continue", nowISO, testBudgetCaps(3, 3))
+		if applyErr != nil {
+			return storage.LoopRecord{}, applyErr
+		}
+		return result.Loop, nil
+	})
+	if err == nil {
+		t.Fatal("Continue TX error = nil, want injected failure")
+	}
+
+	exhausted, _ := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	sibling, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if sibling != nil && sibling.Status == "queued" && exhausted != nil && IsReviewFixBudgetHold(*exhausted) {
+		t.Fatalf("sibling queued while exhausted still held after failed Continue: exhausted=%#v sibling=%#v", exhausted, sibling)
+	}
+	// TX rollback: pair should still be held.
+	if exhausted == nil || !IsReviewFixBudgetHold(*exhausted) {
+		t.Fatalf("exhausted after failed Continue = %#v, want still held (TX rollback)", exhausted)
+	}
+	if sibling == nil || !IsReviewFixBudgetHold(*sibling) {
+		t.Fatalf("sibling after failed Continue = %#v, want still held (TX rollback)", sibling)
+	}
+}
+
+func TestHandoffEventIncludesHeadAndConcreteResumeCommands(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewerMeta := `{"lastPublishedHeadSha":"abc123def","loop":{"iterationCount":3}}`
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_handoff_head", "reviewer", "running")
+	reviewer.MetadataJSON = &reviewerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("upsert reviewer: %v", err)
+	}
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: true, LiveCaps: testBudgetCaps(3, 3),
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	events, err := repos.Events.ListByEntity(context.Background(), "loop", parked.ID)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	var handoff *storage.EventLogRecord
+	for i := range events {
+		if events[i].EventType == reviewFixBudgetHandoffEventType {
+			handoff = &events[i]
+			break
+		}
+	}
+	if handoff == nil {
+		t.Fatal("missing handoff event")
+	}
+	payloadJSON := handoff.PayloadJSON
+	payload := parseMetadataObject(&payloadJSON)
+	if head, _ := payload["head"].(string); head != "abc123def" {
+		t.Fatalf("head = %q, want abc123def", head)
+	}
+	resume, _ := payload["resume"].(string)
+	wantCLI := fmt.Sprintf("looper unpause %d / looper stop %d", parked.Seq, parked.Seq)
+	if !strings.Contains(resume, "Continue / Stop") || !strings.Contains(resume, wantCLI) {
+		t.Fatalf("resume = %q, want Continue/Stop plus %q", resume, wantCLI)
+	}
+	if lane, _ := payload["lane"].(string); lane != reviewFixBudgetLaneAutomatic {
+		t.Fatalf("lane = %q, want %q", lane, reviewFixBudgetLaneAutomatic)
+	}
+}
+
+func TestHandoffEventIncludesBothRoleMetersAndRetriesOnReentry(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_handoff_rev", "reviewer", "running")
+	reviewer.MetadataJSON = &reviewerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("upsert reviewer: %v", err)
+	}
+	fixerMeta := `{"reviewFixBudget":{"pushCount":2}}`
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_handoff_fix", "fixer", "queued")
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("upsert fixer: %v", err)
+	}
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: false, LiveCaps: testBudgetCaps(3, 5),
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	events, err := repos.Events.ListByEntity(context.Background(), "loop", parked.ID)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	var handoff *storage.EventLogRecord
+	for i := range events {
+		if events[i].EventType == reviewFixBudgetHandoffEventType {
+			handoff = &events[i]
+			break
+		}
+	}
+	if handoff == nil {
+		t.Fatal("missing handoff event")
+	}
+	payloadJSON := handoff.PayloadJSON
+	payload := parseMetadataObject(&payloadJSON)
+	reviewerPayload, _ := payload["reviewer"].(map[string]any)
+	fixerPayload, _ := payload["fixer"].(map[string]any)
+	if intFromMetadata(reviewerPayload["count"]) != 3 || intFromMetadata(reviewerPayload["cap"]) != 3 {
+		t.Fatalf("reviewer meters = %#v, want 3/3", reviewerPayload)
+	}
+	if intFromMetadata(fixerPayload["count"]) != 2 || intFromMetadata(fixerPayload["cap"]) != 5 {
+		t.Fatalf("fixer meters = %#v, want 2/5", fixerPayload)
+	}
+	resume, _ := payload["resume"].(string)
+	wantResume := fmt.Sprintf("looper unpause %d / looper stop %d", parked.Seq, parked.Seq)
+	if resume != wantResume {
+		t.Fatalf("resume = %q, want %q", resume, wantResume)
+	}
+	if _, ok := payload["head"]; ok {
+		t.Fatalf("head = %#v, want omitted when metadata has no head sha", payload["head"])
+	}
+
+	// Clear handoff marker and delete event to force re-entry retry.
+	state := ReadReviewFixBudgetState(parked.MetadataJSON)
+	state.HandoffEventAt = ""
+	encoded, err := WriteReviewFixBudgetState(parked.MetadataJSON, state)
+	if err != nil {
+		t.Fatalf("clear handoff marker: %v", err)
+	}
+	parked.MetadataJSON = &encoded
+	if err := repos.Loops.Upsert(context.Background(), parked); err != nil {
+		t.Fatalf("upsert cleared: %v", err)
+	}
+	// Re-entry should rewrite HandoffEventAt (event append is idempotent enough via marker).
+	if _, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: parked, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: false, LiveCaps: testBudgetCaps(3, 5),
+	}); err != nil {
+		t.Fatalf("re-entry park: %v", err)
+	}
+	fresh, _ := repos.Loops.GetByID(context.Background(), parked.ID)
+	if fresh == nil || strings.TrimSpace(ReadReviewFixBudgetState(fresh.MetadataJSON).HandoffEventAt) == "" {
+		t.Fatalf("re-entry did not restore handoff marker: %#v", fresh)
+	}
+}
+
+func testBudgetCaps(reviewerCap, fixerCap int) ReviewFixBudgetLiveCaps {
+	return ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: reviewerCap, FixerMaxPushes: fixerCap}
 }
 
 func newBudgetFixture(t *testing.T) (*storage.Repositories, string) {
@@ -469,8 +939,16 @@ func seedBudgetLoop(t *testing.T, repos *storage.Repositories, nowISO, id, loopT
 	pr := int64(42)
 	target := "pr:acme/looper:42"
 	metadata := `{"loop":{"iterationCount":8}}`
+	// Stable unique seq from id bytes so parallel tests and multi-loop fixtures do not collide.
+	var seq int64
+	for _, b := range id {
+		seq = seq*33 + int64(b)
+	}
+	if seq < 0 {
+		seq = -seq
+	}
 	loop := storage.LoopRecord{
-		ID: id, Seq: int64(len(id)), ProjectID: "project_1", Type: loopType, TargetType: "pull_request",
+		ID: id, Seq: seq, ProjectID: "project_1", Type: loopType, TargetType: "pull_request",
 		TargetID: &target, Repo: &repo, PRNumber: &pr, Status: status, CreatedAt: nowISO, UpdatedAt: nowISO,
 		MetadataJSON: &metadata,
 	}

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -797,7 +797,7 @@ func TestContinueFailureDoesNotLeaveSiblingQueuedWhileExhaustedHeld(t *testing.T
 func TestHandoffEventIncludesHeadAndConcreteResumeCommands(t *testing.T) {
 	t.Parallel()
 	repos, nowISO := newBudgetFixture(t)
-	reviewerMeta := `{"lastPublishedHeadSha":"abc123def","loop":{"iterationCount":3}}`
+	reviewerMeta := `{"lastPublishedHeadSha":"abc123def","lastReviewedSignalFingerprint":"sig-abc","loop":{"iterationCount":3}}`
 	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_handoff_head", "reviewer", "running")
 	reviewer.MetadataJSON = &reviewerMeta
 	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
@@ -837,6 +837,20 @@ func TestHandoffEventIncludesHeadAndConcreteResumeCommands(t *testing.T) {
 	}
 	if lane, _ := payload["lane"].(string); lane != reviewFixBudgetLaneAutomatic {
 		t.Fatalf("lane = %q, want %q", lane, reviewFixBudgetLaneAutomatic)
+	}
+	if signal, _ := payload["lastReviewedSignalFingerprint"].(string); signal != "sig-abc" {
+		t.Fatalf("lastReviewedSignalFingerprint = %q, want sig-abc", signal)
+	}
+
+	brief, ok := BuildReviewFixHandoffBrief(parked)
+	if !ok {
+		t.Fatal("BuildReviewFixHandoffBrief() = false, want hold brief")
+	}
+	if brief.Kind != HITLKindReviewFixBudget || !brief.HITLEnabled || brief.LastReviewedSignalFingerprint != "sig-abc" {
+		t.Fatalf("brief = %#v, want budget HITL brief with signal", brief)
+	}
+	if !strings.Contains(brief.NextAction, wantCLI) || !strings.Contains(brief.NextAction, "Continue") {
+		t.Fatalf("nextAction = %q, want Continue plus %q", brief.NextAction, wantCLI)
 	}
 }
 

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -418,7 +418,7 @@ func TestStopReviewFixBudgetRetriesAfterSiblingAlreadyTerminated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
 	}
-	if _, err := terminateReviewFixLoop(context.Background(), repos, fixer, nowISO); err != nil {
+	if _, err := terminateReviewFixLoop(context.Background(), repos, fixer, nowISO, ReviewFixBudgetTerminationReason); err != nil {
 		t.Fatalf("terminateReviewFixLoop(sibling) error = %v", err)
 	}
 

--- a/internal/loops/review_scope_hold.go
+++ b/internal/loops/review_scope_hold.go
@@ -485,6 +485,9 @@ func appendReviewScopeHumanHandoffEvent(ctx context.Context, repos *storage.Repo
 	if head := reviewFixBudgetHandoffHead(held); head != "" {
 		payload["head"] = head
 	}
+	if signal := reviewFixHandoffSignal(held); signal != "" {
+		payload["lastReviewedSignalFingerprint"] = signal
+	}
 	return eventlog.Append(ctx, repos, eventlog.AppendInput{
 		EventType:  reviewScopeHumanHandoffEventType,
 		ProjectID:  optionalBudgetString(projectID),

--- a/internal/loops/review_scope_hold.go
+++ b/internal/loops/review_scope_hold.go
@@ -1,0 +1,659 @@
+package loops
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+const (
+	// HITLKindReviewScopeHuman marks a scope-ambiguity ask, not a budget refill.
+	// Continue resumes against current evidence without resetting role meters.
+	HITLKindReviewScopeHuman = "review_scope_human"
+
+	// ReviewScopeHumanRequiredReason is the durable no-HITL / exhausted-role
+	// pause reason when Reviewer emits needs_human.
+	ReviewScopeHumanRequiredReason = "review_scope_human_required"
+
+	// ReviewScopeHumanSiblingPauseReason parks the opposite role while scope is held.
+	ReviewScopeHumanSiblingPauseReason = "sibling_review_scope_human"
+
+	reviewScopeHumanMetadataKey      = "reviewScopeHuman"
+	reviewScopeHumanHandoffEventType = "loop.review_scope_human.required"
+)
+
+// ErrReviewScopeHumanInvalidAnswer is returned when a scope HITL answer is not
+// Continue or Stop.
+var ErrReviewScopeHumanInvalidAnswer = fmt.Errorf("review scope answer must be %q or %q", ReviewFixBudgetAnswerContinue, ReviewFixBudgetAnswerStop)
+
+// ReviewScopeHumanState is durable pair-hold metadata for needs_human scope holds.
+// It does not store role meters; Continue must not refill budgets.
+//
+// Pending marks deferred scope evidence while a budget hold is the sole primary
+// hold (no status/ask change). After budget Continue releases the pair, pending
+// is promoted to a real scope park.
+type ReviewScopeHumanState struct {
+	HeldBy         string `json:"heldBy,omitempty"`
+	PauseReason    string `json:"pauseReason,omitempty"`
+	HandoffEventAt string `json:"handoffEventAt,omitempty"`
+	Question       string `json:"question,omitempty"`
+	Evidence       string `json:"evidence,omitempty"`
+	Pending        bool   `json:"pending,omitempty"`
+	PendingHITL    bool   `json:"pendingHitl,omitempty"`
+}
+
+func NewReviewScopeHumanAsk(role, repo string, prNumber int64, question, nowISO string) HITLAsk {
+	target := strings.TrimSpace(repo)
+	if prNumber > 0 {
+		target = fmt.Sprintf("%s#%d", target, prNumber)
+	}
+	q := strings.TrimSpace(question)
+	if q == "" {
+		q = fmt.Sprintf("%s needs human scope judgment on %s. Clarify the repository rule, PR goal/non-goal, or linked spec that must change before unpause. Continue resumes against current evidence, or stop the pair?", strings.TrimSpace(role), target)
+	}
+	return HITLAsk{
+		Kind:     HITLKindReviewScopeHuman,
+		Question: q,
+		Options:  []string{ReviewFixBudgetAnswerContinue, ReviewFixBudgetAnswerStop},
+		Status:   "awaiting",
+		AskedAt:  nowISO,
+		PRNumber: prNumber,
+	}
+}
+
+func IsReviewScopeHumanAsk(ask HITLAsk) bool {
+	return strings.TrimSpace(ask.Kind) == HITLKindReviewScopeHuman
+}
+
+func ReadReviewScopeHumanState(metadataJSON *string) ReviewScopeHumanState {
+	meta := parseMetadataObject(metadataJSON)
+	raw, ok := meta[reviewScopeHumanMetadataKey]
+	if !ok {
+		return ReviewScopeHumanState{}
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return ReviewScopeHumanState{}
+	}
+	var state ReviewScopeHumanState
+	if err := json.Unmarshal(encoded, &state); err != nil {
+		return ReviewScopeHumanState{}
+	}
+	return state
+}
+
+func WriteReviewScopeHumanState(metadataJSON *string, state ReviewScopeHumanState) (string, error) {
+	meta := parseMetadataObject(metadataJSON)
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(encoded, &asMap); err != nil {
+		return "", err
+	}
+	if len(asMap) == 0 {
+		delete(meta, reviewScopeHumanMetadataKey)
+	} else {
+		meta[reviewScopeHumanMetadataKey] = asMap
+	}
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func IsSiblingReviewScopeHumanPause(metadataJSON *string) bool {
+	if reason, _ := stringFromAny(parseMetadataObject(metadataJSON)["pauseReason"]); reason == ReviewScopeHumanSiblingPauseReason {
+		return true
+	}
+	return ReadReviewScopeHumanState(metadataJSON).PauseReason == ReviewScopeHumanSiblingPauseReason
+}
+
+func IsReviewScopeHumanRequiredPause(metadataJSON *string) bool {
+	if reason, _ := stringFromAny(parseMetadataObject(metadataJSON)["pauseReason"]); reason == ReviewScopeHumanRequiredReason {
+		return true
+	}
+	return ReadReviewScopeHumanState(metadataJSON).PauseReason == ReviewScopeHumanRequiredReason
+}
+
+// IsReviewScopeHumanHold reports a needs_human pair hold (ask, no-ask pause, or sibling).
+// Pure scope holds are not budget holds: Continue must not reset meters.
+// Siblings in failed/interrupted/awaiting_human may carry scope hold metadata without
+// flipping status to paused; HeldBy/pauseReason still gate independent resume.
+// Pending-only evidence (deferred under a budget hold) is not an active scope hold.
+func IsReviewScopeHumanHold(loop storage.LoopRecord) bool {
+	switch strings.TrimSpace(loop.Status) {
+	case "terminated", "stopped", "completed":
+		return false
+	}
+	state := ReadReviewScopeHumanState(loop.MetadataJSON)
+	if strings.TrimSpace(state.HeldBy) != "" {
+		return true
+	}
+	if state.PauseReason == ReviewScopeHumanSiblingPauseReason || state.PauseReason == ReviewScopeHumanRequiredReason {
+		return true
+	}
+	if IsSiblingReviewScopeHumanPause(loop.MetadataJSON) || IsReviewScopeHumanRequiredPause(loop.MetadataJSON) {
+		return true
+	}
+	if strings.TrimSpace(loop.Status) == "awaiting_human" {
+		ask, ok := ReadHITLAsk(loop.MetadataJSON)
+		return ok && IsReviewScopeHumanAsk(ask)
+	}
+	return false
+}
+
+// HasPendingReviewScopeHuman reports deferred needs_human evidence waiting for
+// budget release before a real scope park.
+func HasPendingReviewScopeHuman(loop storage.LoopRecord) bool {
+	state := ReadReviewScopeHumanState(loop.MetadataJSON)
+	return state.Pending && strings.TrimSpace(state.HeldBy) == ""
+}
+
+// PersistPendingReviewScopeHumanEvidence stores needs_human question/evidence
+// without changing status or writing a HITL ask. Used when budget is already the
+// primary hold so the pair never stacks two asks/reasons.
+func PersistPendingReviewScopeHumanEvidence(metadataJSON *string, question, evidence string, hitlEnabled bool) (string, error) {
+	state := ReadReviewScopeHumanState(metadataJSON)
+	if strings.TrimSpace(state.HeldBy) != "" {
+		// Active scope hold already owns the pair; keep existing hold fields.
+		if q := strings.TrimSpace(question); q != "" {
+			state.Question = q
+		}
+		if e := strings.TrimSpace(evidence); e != "" {
+			state.Evidence = e
+		}
+		return WriteReviewScopeHumanState(metadataJSON, state)
+	}
+	state.Pending = true
+	state.PendingHITL = hitlEnabled
+	if q := strings.TrimSpace(question); q != "" {
+		state.Question = q
+	}
+	if e := strings.TrimSpace(evidence); e != "" {
+		state.Evidence = e
+	}
+	// Pending must not look like an active sibling/required pause.
+	if state.PauseReason == ReviewScopeHumanSiblingPauseReason || state.PauseReason == ReviewScopeHumanRequiredReason {
+		state.PauseReason = ""
+	}
+	return WriteReviewScopeHumanState(metadataJSON, state)
+}
+
+// IsReviewFixPairHold is true for budget holds or scope-human holds.
+func IsReviewFixPairHold(loop storage.LoopRecord) bool {
+	return IsReviewFixBudgetHold(loop) || IsReviewScopeHumanHold(loop)
+}
+
+type ParkReviewScopeHumanInput struct {
+	Held        storage.LoopRecord
+	Role        string
+	Repo        string
+	PRNumber    int64
+	NowISO      string
+	HITLEnabled bool
+	// Question is the exact scope question shown on HITL / handoff evidence.
+	Question string
+	// Evidence is optional structured handoff text (authority conflict, etc.).
+	Evidence string
+	DB       *sql.DB
+}
+
+// ParkReviewScopeHuman parks the held role and pauses same-lane siblings for a
+// needs_human scope decision. Does not use budget Continue/Stop refill semantics.
+func ParkReviewScopeHuman(ctx context.Context, repos *storage.Repositories, input ParkReviewScopeHumanInput) (storage.LoopRecord, error) {
+	if repos == nil || repos.Loops == nil {
+		return input.Held, fmt.Errorf("review scope park requires loop storage")
+	}
+	if input.DB != nil {
+		var parked storage.LoopRecord
+		err := storage.WithTransaction(ctx, input.DB, nil, func(tx *sql.Tx) error {
+			var parkErr error
+			parked, parkErr = parkReviewScopeHumanBody(ctx, storage.NewRepositories(tx), input)
+			return parkErr
+		})
+		return parked, err
+	}
+	return parkReviewScopeHumanBody(ctx, repos, input)
+}
+
+func parkReviewScopeHumanBody(ctx context.Context, repos *storage.Repositories, input ParkReviewScopeHumanInput) (storage.LoopRecord, error) {
+	held := input.Held
+	if fresh, err := repos.Loops.GetByID(ctx, held.ID); err == nil && fresh != nil {
+		held = *fresh
+	}
+	if isReviewScopeHumanPrimaryHold(held) {
+		if err := finishReviewScopeHumanPark(ctx, repos, held, input.Role, input.NowISO); err != nil {
+			return held, err
+		}
+		if err := ensureReviewScopeHumanHandoffEvent(ctx, repos, held, input); err != nil {
+			return held, err
+		}
+		return held, nil
+	}
+
+	if err := cancelReviewScopeHumanQueues(ctx, repos, held, input.NowISO); err != nil {
+		return input.Held, err
+	}
+	if err := parkSiblingReviewScopeHumanLoop(ctx, repos, held, input.Role, input.NowISO); err != nil {
+		return input.Held, err
+	}
+
+	role := strings.TrimSpace(input.Role)
+	state := ReadReviewScopeHumanState(held.MetadataJSON)
+	state.HeldBy = role
+	state.Question = strings.TrimSpace(input.Question)
+	if e := strings.TrimSpace(input.Evidence); e != "" {
+		state.Evidence = e
+	}
+	// Promoting from deferred budget path: clear pending markers.
+	state.Pending = false
+	state.PendingHITL = false
+	state.PauseReason = ""
+	if !input.HITLEnabled {
+		state.PauseReason = ReviewScopeHumanRequiredReason
+	}
+	metadata, err := WriteReviewScopeHumanState(held.MetadataJSON, state)
+	if err != nil {
+		return input.Held, err
+	}
+	if input.HITLEnabled {
+		ask := NewReviewScopeHumanAsk(input.Role, input.Repo, input.PRNumber, input.Question, input.NowISO)
+		metadata, err = WriteHITLAsk(&metadata, ask)
+		if err != nil {
+			return input.Held, err
+		}
+		held.Status = "awaiting_human"
+	} else {
+		if ask, ok := ReadHITLAsk(&metadata); ok && IsReviewScopeHumanAsk(ask) {
+			cleared, clearErr := ClearHITLAsk(&metadata)
+			if clearErr != nil {
+				return input.Held, clearErr
+			}
+			metadata = cleared
+		}
+		meta := parseMetadataObject(&metadata)
+		meta["pauseReason"] = ReviewScopeHumanRequiredReason
+		encoded, marshalErr := json.Marshal(meta)
+		if marshalErr != nil {
+			return input.Held, marshalErr
+		}
+		metadata = string(encoded)
+		held.Status = "paused"
+	}
+	held.MetadataJSON = &metadata
+	held.NextRunAt = nil
+	held.UpdatedAt = input.NowISO
+	if err := repos.Loops.Upsert(ctx, held); err != nil {
+		return input.Held, err
+	}
+	if repos.Queue != nil {
+		reason := ReviewScopeHumanRequiredReason
+		if _, err := repos.Queue.CancelByLoop(ctx, held.ID, input.NowISO, &reason); err != nil {
+			return held, err
+		}
+	}
+	if err := ensureReviewScopeHumanHandoffEvent(ctx, repos, held, input); err != nil {
+		return held, err
+	}
+	return held, nil
+}
+
+func isReviewScopeHumanPrimaryHold(loop storage.LoopRecord) bool {
+	switch strings.TrimSpace(loop.Status) {
+	case "awaiting_human":
+		ask, ok := ReadHITLAsk(loop.MetadataJSON)
+		return ok && IsReviewScopeHumanAsk(ask)
+	case "paused":
+		return IsReviewScopeHumanRequiredPause(loop.MetadataJSON) ||
+			(strings.TrimSpace(ReadReviewScopeHumanState(loop.MetadataJSON).HeldBy) != "" && !IsSiblingReviewScopeHumanPause(loop.MetadataJSON))
+	default:
+		return false
+	}
+}
+
+func finishReviewScopeHumanPark(ctx context.Context, repos *storage.Repositories, held storage.LoopRecord, heldBy, nowISO string) error {
+	if err := cancelReviewScopeHumanQueues(ctx, repos, held, nowISO); err != nil {
+		return err
+	}
+	return parkSiblingReviewScopeHumanLoop(ctx, repos, held, heldBy, nowISO)
+}
+
+func cancelReviewScopeHumanQueues(ctx context.Context, repos *storage.Repositories, held storage.LoopRecord, nowISO string) error {
+	if repos.Queue == nil {
+		return nil
+	}
+	reason := ReviewScopeHumanRequiredReason
+	if _, err := repos.Queue.CancelByLoop(ctx, held.ID, nowISO, &reason); err != nil {
+		return err
+	}
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	siblingReason := ReviewScopeHumanSiblingPauseReason
+	for _, sibling := range FindSiblingReviewFixLoops(all, held) {
+		if !isReviewScopeSiblingHoldApplicable(sibling.Status) {
+			continue
+		}
+		if _, err := repos.Queue.CancelByLoop(ctx, sibling.ID, nowISO, &siblingReason); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parkSiblingReviewScopeHumanLoop(ctx context.Context, repos *storage.Repositories, held storage.LoopRecord, heldBy, nowISO string) error {
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, sibling := range FindSiblingReviewFixLoops(all, held) {
+		if err := parkOneSiblingReviewScopeHumanLoop(ctx, repos, sibling, heldBy, nowISO); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isReviewScopeSiblingHoldApplicable is true for every non-terminal opposite-role
+// sibling. Unlike budget park, failed/interrupted/awaiting_human/independently
+// paused siblings still receive scope hold metadata so independent resume is gated.
+func isReviewScopeSiblingHoldApplicable(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "terminated", "stopped", "completed":
+		return false
+	default:
+		return true
+	}
+}
+
+func parkOneSiblingReviewScopeHumanLoop(ctx context.Context, repos *storage.Repositories, sibling storage.LoopRecord, heldBy, nowISO string) error {
+	if !isReviewScopeSiblingHoldApplicable(sibling.Status) {
+		return nil
+	}
+	// Already carrying sibling scope hold: refresh queue cancel only.
+	if IsSiblingReviewScopeHumanPause(sibling.MetadataJSON) && strings.TrimSpace(ReadReviewScopeHumanState(sibling.MetadataJSON).HeldBy) != "" {
+		if repos.Queue != nil {
+			reason := ReviewScopeHumanSiblingPauseReason
+			if _, err := repos.Queue.CancelByLoop(ctx, sibling.ID, nowISO, &reason); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	state := ReadReviewScopeHumanState(sibling.MetadataJSON)
+	state.HeldBy = strings.TrimSpace(heldBy)
+	state.PauseReason = ReviewScopeHumanSiblingPauseReason
+	metadata, err := WriteReviewScopeHumanState(sibling.MetadataJSON, state)
+	if err != nil {
+		return err
+	}
+	updated := sibling
+	updated.MetadataJSON = &metadata
+	updated.UpdatedAt = nowISO
+	// Preserve mid-run HITL asks and non-runnable terminal-ish statuses; only
+	// flip actively schedulable statuses to paused with a top-level pauseReason.
+	switch strings.TrimSpace(sibling.Status) {
+	case "awaiting_human", "failed", "interrupted", "human_takeover":
+		// Keep status and any existing HITL ask body; metadata gates resume.
+		updated.NextRunAt = nil
+	case "paused":
+		// Keep paused. Scope overlay lives only in reviewScopeHuman metadata
+		// (HeldBy / state.PauseReason). Never stamp top-level pauseReason —
+		// manual pause has no reason and must not become scope-primary on Continue.
+		updated.NextRunAt = nil
+	default:
+		// Schedulable → paused with scope sibling as the primary top-level reason.
+		// Continue may requeue only when this top-level stamp is cleared.
+		meta := parseMetadataObject(&metadata)
+		meta["pauseReason"] = ReviewScopeHumanSiblingPauseReason
+		encoded, marshalErr := json.Marshal(meta)
+		if marshalErr != nil {
+			return marshalErr
+		}
+		text := string(encoded)
+		updated.MetadataJSON = &text
+		updated.Status = "paused"
+		updated.NextRunAt = nil
+	}
+	if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		return err
+	}
+	if repos.Queue != nil {
+		reason := ReviewScopeHumanSiblingPauseReason
+		if _, err := repos.Queue.CancelByLoop(ctx, updated.ID, nowISO, &reason); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureReviewScopeHumanHandoffEvent(ctx context.Context, repos *storage.Repositories, held storage.LoopRecord, input ParkReviewScopeHumanInput) error {
+	if repos == nil || repos.Events == nil {
+		return nil
+	}
+	state := ReadReviewScopeHumanState(held.MetadataJSON)
+	if strings.TrimSpace(state.HandoffEventAt) != "" {
+		return nil
+	}
+	if err := appendReviewScopeHumanHandoffEvent(ctx, repos, held, input); err != nil {
+		return err
+	}
+	state = ReadReviewScopeHumanState(held.MetadataJSON)
+	state.HandoffEventAt = input.NowISO
+	encoded, err := WriteReviewScopeHumanState(held.MetadataJSON, state)
+	if err != nil {
+		return err
+	}
+	updated := held
+	updated.MetadataJSON = &encoded
+	updated.UpdatedAt = input.NowISO
+	return repos.Loops.Upsert(ctx, updated)
+}
+
+func appendReviewScopeHumanHandoffEvent(ctx context.Context, repos *storage.Repositories, held storage.LoopRecord, input ParkReviewScopeHumanInput) error {
+	if repos == nil || repos.Events == nil {
+		return nil
+	}
+	lane := reviewFixBudgetLane(held)
+	resume := reviewFixBudgetHandoffResume(held, input.HITLEnabled)
+	projectID := strings.TrimSpace(held.ProjectID)
+	loopID := strings.TrimSpace(held.ID)
+	payload := map[string]any{
+		"level":       "action_required",
+		"kind":        HITLKindReviewScopeHuman,
+		"repo":        strings.TrimSpace(input.Repo),
+		"prNumber":    input.PRNumber,
+		"lane":        lane,
+		"heldBy":      strings.TrimSpace(input.Role),
+		"reason":      ReviewScopeHumanRequiredReason,
+		"hitlEnabled": input.HITLEnabled,
+		"resume":      resume,
+		"question":    strings.TrimSpace(input.Question),
+	}
+	if evidence := strings.TrimSpace(input.Evidence); evidence != "" {
+		payload["evidence"] = evidence
+	}
+	if head := reviewFixBudgetHandoffHead(held); head != "" {
+		payload["head"] = head
+	}
+	return eventlog.Append(ctx, repos, eventlog.AppendInput{
+		EventType:  reviewScopeHumanHandoffEventType,
+		ProjectID:  optionalBudgetString(projectID),
+		LoopID:     optionalBudgetString(loopID),
+		EntityType: optionalBudgetString("loop"),
+		EntityID:   optionalBudgetString(loopID),
+		ActorType:  optionalBudgetString("system"),
+		ActorID:    optionalBudgetString("review-scope-human"),
+		Payload:    payload,
+	})
+}
+
+type ReviewScopeHumanAnswerResult struct {
+	Applied bool
+	Action  string
+	Loop    storage.LoopRecord
+}
+
+// ApplyReviewScopeHumanAnswer handles Continue (release pair, no meter reset) or
+// Stop (terminate both). Returns Applied=false when not a scope hold.
+func ApplyReviewScopeHumanAnswer(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string) (ReviewScopeHumanAnswerResult, error) {
+	if !IsReviewScopeHumanHold(loop) {
+		return ReviewScopeHumanAnswerResult{}, nil
+	}
+	if repos == nil || repos.Loops == nil {
+		return ReviewScopeHumanAnswerResult{}, fmt.Errorf("review scope answer requires loop storage")
+	}
+	if IsReviewFixBudgetStop(answer) {
+		updated, err := terminateReviewFixPair(ctx, repos, loop, nowISO, ReviewScopeHumanRequiredReason)
+		if err != nil {
+			return ReviewScopeHumanAnswerResult{}, err
+		}
+		return ReviewScopeHumanAnswerResult{Applied: true, Action: "stop", Loop: updated}, nil
+	}
+	if !IsReviewFixBudgetContinue(answer) {
+		return ReviewScopeHumanAnswerResult{}, ErrReviewScopeHumanInvalidAnswer
+	}
+	updated, err := continueReviewScopeHuman(ctx, repos, loop, nowISO)
+	if err != nil {
+		return ReviewScopeHumanAnswerResult{}, err
+	}
+	return ReviewScopeHumanAnswerResult{Applied: true, Action: "continue", Loop: updated}, nil
+}
+
+func continueReviewScopeHuman(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return loop, err
+	}
+	members := reviewFixBudgetPairMembers(all, loop)
+
+	// Release answered side first; do not touch role meters.
+	if err := releaseOneReviewScopeHumanHold(ctx, repos, loop.ID, nowISO); err != nil {
+		return loop, err
+	}
+	for _, member := range members {
+		if member.ID == loop.ID {
+			continue
+		}
+		if err := releaseOneReviewScopeHumanHold(ctx, repos, member.ID, nowISO); err != nil {
+			return loop, err
+		}
+	}
+	fresh, err := repos.Loops.GetByID(ctx, loop.ID)
+	if err != nil {
+		return loop, err
+	}
+	if fresh == nil {
+		return loop, fmt.Errorf("review scope continue lost loop %s", loop.ID)
+	}
+	return *fresh, nil
+}
+
+func releaseOneReviewScopeHumanHold(ctx context.Context, repos *storage.Repositories, loopID, nowISO string) error {
+	fresh, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return err
+	}
+	if fresh == nil {
+		return nil
+	}
+	if !IsReviewScopeHumanHold(*fresh) {
+		return nil
+	}
+	priorStatus := strings.TrimSpace(fresh.Status)
+	metadata := fresh.MetadataJSON
+	if ask, ok := ReadHITLAsk(metadata); ok && IsReviewScopeHumanAsk(ask) {
+		cleared, clearErr := ClearHITLAsk(metadata)
+		if clearErr != nil {
+			return clearErr
+		}
+		metadata = &cleared
+	}
+	state := ReadReviewScopeHumanState(metadata)
+	state.HeldBy = ""
+	state.Question = ""
+	state.Evidence = ""
+	state.Pending = false
+	state.PendingHITL = false
+	if state.PauseReason == ReviewScopeHumanSiblingPauseReason || state.PauseReason == ReviewScopeHumanRequiredReason {
+		state.PauseReason = ""
+	}
+	// Clear handoff marker so a later park emits a fresh event.
+	state.HandoffEventAt = ""
+	encoded, err := WriteReviewScopeHumanState(metadata, state)
+	if err != nil {
+		return err
+	}
+	meta := parseMetadataObject(&encoded)
+	// Queue only when scope was the primary top-level reason (park flipped a
+	// schedulable loop to paused with sibling/required stamp). Manual pause and
+	// independent reasons never receive that stamp.
+	clearedScopeTopLevel := false
+	if reason, _ := stringFromAny(meta["pauseReason"]); reason == ReviewScopeHumanSiblingPauseReason || reason == ReviewScopeHumanRequiredReason {
+		delete(meta, "pauseReason")
+		clearedScopeTopLevel = true
+	}
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	text := string(out)
+	updated := *fresh
+	updated.MetadataJSON = &text
+	updated.UpdatedAt = nowISO
+
+	// Preserve a non-scope mid-run HITL ask; do not force-queue over it.
+	if ask, ok := ReadHITLAsk(&text); ok && strings.TrimSpace(ask.Status) == "awaiting" {
+		updated.Status = "awaiting_human"
+		updated.NextRunAt = nil
+		return repos.Loops.Upsert(ctx, updated)
+	}
+	// human_takeover and non-runnable terminal-ish statuses stay put.
+	switch priorStatus {
+	case "human_takeover", "failed", "interrupted":
+		updated.Status = priorStatus
+		updated.NextRunAt = nil
+		return repos.Loops.Upsert(ctx, updated)
+	}
+
+	// After clearing only the scope overlay, restore any independent lifecycle
+	// that remains (budget hold, other pauseReason). Only queue when scope was
+	// the primary reason the loop was non-runnable.
+	updated.Status = priorStatus
+	if IsReviewFixBudgetHold(updated) {
+		if priorStatus != "paused" && priorStatus != "awaiting_human" {
+			updated.Status = "paused"
+		}
+		updated.NextRunAt = nil
+		return repos.Loops.Upsert(ctx, updated)
+	}
+	if reason, ok := stringFromAny(meta["pauseReason"]); ok && reason != "" {
+		// Independent non-scope pause (budget, fixer_zero_progress, etc.).
+		updated.Status = "paused"
+		updated.NextRunAt = nil
+		return repos.Loops.Upsert(ctx, updated)
+	}
+	// Already paused without a top-level scope stamp we just cleared: manual
+	// pause (empty pauseReason) or overlay-only sibling — stay paused.
+	if priorStatus == "paused" && !clearedScopeTopLevel {
+		updated.Status = "paused"
+		updated.NextRunAt = nil
+		return repos.Loops.Upsert(ctx, updated)
+	}
+
+	updated.Status = "queued"
+	updated.NextRunAt = &nowISO
+	if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		return err
+	}
+	return requeueReviewFixBudgetLoop(ctx, repos, updated.ID, nowISO)
+}

--- a/internal/loops/review_scope_hold_test.go
+++ b/internal/loops/review_scope_hold_test.go
@@ -1,0 +1,378 @@
+package loops
+
+import (
+	"context"
+	"testing"
+)
+
+func TestParkAndContinueReviewScopeHumanDoesNotResetMeters(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_reviewer", "reviewer", "running")
+	// iterationCount 2 with cap 8 — not budget-exhausted.
+	meta := `{"loop":{"iterationCount":2},"reviewFixBudget":{"pushCount":1}}`
+	reviewer.MetadataJSON = &meta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("upsert reviewer: %v", err)
+	}
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_fixer", "fixer", "queued")
+	fixerMeta := `{"reviewFixBudget":{"pushCount":1}}`
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("upsert fixer: %v", err)
+	}
+
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: false,
+		Question: "Is this in PR scope?",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman() error = %v", err)
+	}
+	if parked.Status != "paused" || !IsReviewScopeHumanRequiredPause(parked.MetadataJSON) {
+		t.Fatalf("parked = %#v, want no-ask scope pause", parked)
+	}
+	if IsReviewFixBudgetHold(parked) {
+		t.Fatal("scope hold must not report as budget hold")
+	}
+	if !IsReviewFixPairHold(parked) {
+		t.Fatal("scope hold must report as pair hold")
+	}
+	if ReviewerPublishCount(parked.MetadataJSON) != 2 {
+		t.Fatalf("publish count = %d, want 2 preserved through park", ReviewerPublishCount(parked.MetadataJSON))
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !IsSiblingReviewScopeHumanPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling = (%#v, %v), want scope sibling pause", sibling, err)
+	}
+
+	result, err := ApplyReviewScopeHumanAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("ApplyReviewScopeHumanAnswer() = (%#v, %v)", result, err)
+	}
+	if ReviewerPublishCount(result.Loop.MetadataJSON) != 2 {
+		t.Fatalf("after continue publish count = %d, want 2 (no meter reset)", ReviewerPublishCount(result.Loop.MetadataJSON))
+	}
+	if FixerPushCount(result.Loop.MetadataJSON) != 1 && FixerPushCount(sibling.MetadataJSON) != 1 {
+		// Fixer meter lives on fixer loop.
+	}
+	freshFixer, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if freshFixer == nil || FixerPushCount(freshFixer.MetadataJSON) != 1 {
+		t.Fatalf("fixer push count after scope continue = %#v, want 1 preserved", freshFixer)
+	}
+	if result.Loop.Status != "queued" || IsReviewScopeHumanHold(result.Loop) {
+		t.Fatalf("continued loop = %#v, want queued and released", result.Loop)
+	}
+	if freshFixer.Status != "queued" || IsReviewScopeHumanHold(*freshFixer) {
+		t.Fatalf("sibling after continue = %#v, want queued and released", freshFixer)
+	}
+}
+
+func TestParkReviewScopeHumanHITLAskNotBudgetKind(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_hitl_reviewer", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_hitl_fixer", "fixer", "queued")
+	_ = fixer
+
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Does AGENTS.md require this change?",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman() error = %v", err)
+	}
+	if parked.Status != "awaiting_human" {
+		t.Fatalf("status = %s, want awaiting_human", parked.Status)
+	}
+	ask, ok := ReadHITLAsk(parked.MetadataJSON)
+	if !ok || !IsReviewScopeHumanAsk(ask) || IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want scope kind not budget", ask, ok)
+	}
+	if ask.Question == "" || len(ask.Options) != 2 {
+		t.Fatalf("ask = %#v, want question and Continue/Stop options", ask)
+	}
+	if IsReviewFixBudgetHold(parked) {
+		t.Fatal("HITL scope hold must not be a budget hold")
+	}
+}
+
+func TestIsReviewFixBudgetHoldExcludesPureScopeHold(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_only", "reviewer", "running")
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	if IsReviewFixBudgetHold(parked) {
+		t.Fatal("IsReviewFixBudgetHold must be false for pure scope hold")
+	}
+	if !IsReviewScopeHumanHold(parked) || !IsReviewFixPairHold(parked) {
+		t.Fatal("want scope + pair hold")
+	}
+}
+
+func TestParkReviewScopeHumanHoldsFailedAndAwaitingHumanSiblings(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_sib_reviewer", "reviewer", "running")
+
+	// Failed fixer sibling must still receive scope hold metadata.
+	failedFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_sib_failed", "fixer", "failed")
+	// Awaiting-human fixer with a mid-run (non-scope) ask must keep the ask body.
+	awaitingFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_sib_awaiting", "fixer", "awaiting_human")
+	// Use a distinct PR so FindSibling only pairs same PR — seed both on same PR as reviewer.
+	// seedBudgetLoop already uses same repo/PR; having two fixers is ok for the hold check.
+	midAsk := HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO, PRNumber: 42,
+	}
+	meta, err := WriteHITLAsk(awaitingFixer.MetadataJSON, midAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk: %v", err)
+	}
+	awaitingFixer.MetadataJSON = &meta
+	if err := repos.Loops.Upsert(context.Background(), awaitingFixer); err != nil {
+		t.Fatalf("upsert awaiting fixer: %v", err)
+	}
+
+	// Park with only one sibling at a time is not required — park finds all siblings.
+	// First park against failed-only pair: remove awaiting temporarily by using failed only.
+	// Both are siblings of reviewer (same lane/PR).
+	_, err = ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause; finding: ambiguous scope",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	freshFailed, err := repos.Loops.GetByID(context.Background(), failedFixer.ID)
+	if err != nil || freshFailed == nil {
+		t.Fatalf("failed sibling get: (%#v, %v)", freshFailed, err)
+	}
+	if freshFailed.Status != "failed" {
+		t.Fatalf("failed sibling status = %s, want failed preserved", freshFailed.Status)
+	}
+	if !IsReviewFixPairHold(*freshFailed) || !IsReviewScopeHumanHold(*freshFailed) {
+		t.Fatalf("failed sibling must be pair/scope hold: %#v meta=%v", freshFailed, derefMeta(freshFailed.MetadataJSON))
+	}
+
+	freshAwaiting, err := repos.Loops.GetByID(context.Background(), awaitingFixer.ID)
+	if err != nil || freshAwaiting == nil {
+		t.Fatalf("awaiting sibling get: (%#v, %v)", freshAwaiting, err)
+	}
+	if freshAwaiting.Status != "awaiting_human" {
+		t.Fatalf("awaiting sibling status = %s, want awaiting_human preserved", freshAwaiting.Status)
+	}
+	ask, ok := ReadHITLAsk(freshAwaiting.MetadataJSON)
+	if !ok || ask.Question != midAsk.Question || IsReviewScopeHumanAsk(ask) {
+		t.Fatalf("mid-run ask lost or replaced: ok=%v ask=%#v", ok, ask)
+	}
+	if !IsReviewFixPairHold(*freshAwaiting) {
+		t.Fatalf("awaiting sibling must refuse independent resume via pair hold: %#v", freshAwaiting)
+	}
+}
+
+func TestContinueReviewScopeHumanPreservesIndependentAndBudgetSiblingLifecycle(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_cont_rev", "reviewer", "running")
+
+	// Ordinary queued sibling → requeued after scope Continue.
+	queuedFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_cont_queued", "fixer", "queued")
+
+	// Budget-paused sibling must stay paused + budget-held after scope Continue.
+	budgetFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_cont_budget", "fixer", "paused")
+	budgetMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"reviewer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	budgetFixer.MetadataJSON = &budgetMeta
+	if err := repos.Loops.Upsert(context.Background(), budgetFixer); err != nil {
+		t.Fatalf("upsert budget fixer: %v", err)
+	}
+
+	// Independently paused sibling keeps its pauseReason and stays paused.
+	indepFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_cont_indep", "fixer", "paused")
+	indepMeta := `{"pauseReason":"fixer_zero_progress"}`
+	indepFixer.MetadataJSON = &indepMeta
+	if err := repos.Loops.Upsert(context.Background(), indepFixer); err != nil {
+		t.Fatalf("upsert indep fixer: %v", err)
+	}
+
+	// Failed sibling keeps failed.
+	failedFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_cont_failed", "fixer", "failed")
+
+	// Park against reviewer; all same-lane fixers are siblings.
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: false,
+		Question: "Clarify scope",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	result, err := ApplyReviewScopeHumanAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("Continue = (%#v, %v)", result, err)
+	}
+	if result.Loop.Status != "queued" || IsReviewScopeHumanHold(result.Loop) {
+		t.Fatalf("reviewer after continue = %#v, want queued and released", result.Loop)
+	}
+
+	freshQueued, err := repos.Loops.GetByID(context.Background(), queuedFixer.ID)
+	if err != nil || freshQueued == nil || freshQueued.Status != "queued" || IsReviewScopeHumanHold(*freshQueued) {
+		t.Fatalf("queued sibling after continue = (%#v, %v), want queued and released", freshQueued, err)
+	}
+
+	freshBudget, err := repos.Loops.GetByID(context.Background(), budgetFixer.ID)
+	if err != nil || freshBudget == nil {
+		t.Fatalf("budget sibling get: (%#v, %v)", freshBudget, err)
+	}
+	if freshBudget.Status != "paused" || !IsReviewFixBudgetHold(*freshBudget) {
+		t.Fatalf("budget sibling after continue = %#v, want paused + budget hold", freshBudget)
+	}
+	if IsReviewScopeHumanHold(*freshBudget) {
+		t.Fatalf("budget sibling still has scope hold: %#v", freshBudget)
+	}
+	if reason, _ := stringFromAny(parseMetadataObject(freshBudget.MetadataJSON)["pauseReason"]); reason != ReviewFixBudgetPauseReason {
+		t.Fatalf("budget sibling pauseReason = %q, want %q", reason, ReviewFixBudgetPauseReason)
+	}
+
+	freshIndep, err := repos.Loops.GetByID(context.Background(), indepFixer.ID)
+	if err != nil || freshIndep == nil || freshIndep.Status != "paused" {
+		t.Fatalf("indep sibling after continue = (%#v, %v), want paused", freshIndep, err)
+	}
+	if IsReviewScopeHumanHold(*freshIndep) {
+		t.Fatalf("indep sibling still has scope hold: %#v", freshIndep)
+	}
+	if reason, _ := stringFromAny(parseMetadataObject(freshIndep.MetadataJSON)["pauseReason"]); reason != "fixer_zero_progress" {
+		t.Fatalf("indep sibling pauseReason = %q, want fixer_zero_progress", reason)
+	}
+
+	freshFailed, err := repos.Loops.GetByID(context.Background(), failedFixer.ID)
+	if err != nil || freshFailed == nil || freshFailed.Status != "failed" {
+		t.Fatalf("failed sibling after continue = (%#v, %v), want failed", freshFailed, err)
+	}
+	if IsReviewScopeHumanHold(*freshFailed) {
+		t.Fatalf("failed sibling still has scope hold: %#v", freshFailed)
+	}
+}
+
+func TestContinueReviewScopeHumanKeepsManuallyPausedSiblingPaused(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_manual_rev", "reviewer", "running")
+
+	// Manual pause: status=paused, no pauseReason (mutateLoopStatus shape).
+	manualFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_manual_fixer", "fixer", "paused")
+	manualMeta := `{"loop":{"iterationCount":0}}`
+	manualFixer.MetadataJSON = &manualMeta
+	if err := repos.Loops.Upsert(context.Background(), manualFixer); err != nil {
+		t.Fatalf("upsert manual fixer: %v", err)
+	}
+
+	// Budget-paused sibling must still stay budget-held after scope Continue.
+	budgetFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_manual_budget", "fixer", "paused")
+	budgetMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"reviewer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	budgetFixer.MetadataJSON = &budgetMeta
+	if err := repos.Loops.Upsert(context.Background(), budgetFixer); err != nil {
+		t.Fatalf("upsert budget fixer: %v", err)
+	}
+
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: false,
+		Question: "Clarify scope",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	// Manual sibling must carry scope overlay without a top-level scope stamp.
+	freshManual, err := repos.Loops.GetByID(context.Background(), manualFixer.ID)
+	if err != nil || freshManual == nil {
+		t.Fatalf("manual sibling get: (%#v, %v)", freshManual, err)
+	}
+	if freshManual.Status != "paused" {
+		t.Fatalf("manual sibling status after park = %s, want paused", freshManual.Status)
+	}
+	if reason, _ := stringFromAny(parseMetadataObject(freshManual.MetadataJSON)["pauseReason"]); reason != "" {
+		t.Fatalf("manual sibling top-level pauseReason = %q, want empty (overlay only)", reason)
+	}
+	if !IsReviewScopeHumanHold(*freshManual) {
+		t.Fatalf("manual sibling must be scope-held via overlay: %#v", freshManual)
+	}
+
+	result, err := ApplyReviewScopeHumanAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("Continue = (%#v, %v)", result, err)
+	}
+
+	freshManual, err = repos.Loops.GetByID(context.Background(), manualFixer.ID)
+	if err != nil || freshManual == nil {
+		t.Fatalf("manual sibling after continue get: (%#v, %v)", freshManual, err)
+	}
+	if freshManual.Status != "paused" {
+		t.Fatalf("manual sibling after continue = %#v, want paused (not queued)", freshManual)
+	}
+	if IsReviewScopeHumanHold(*freshManual) {
+		t.Fatalf("manual sibling still has scope hold after continue: %#v", freshManual)
+	}
+
+	freshBudget, err := repos.Loops.GetByID(context.Background(), budgetFixer.ID)
+	if err != nil || freshBudget == nil {
+		t.Fatalf("budget sibling get: (%#v, %v)", freshBudget, err)
+	}
+	if freshBudget.Status != "paused" || !IsReviewFixBudgetHold(*freshBudget) {
+		t.Fatalf("budget sibling after continue = %#v, want paused + budget hold", freshBudget)
+	}
+}
+
+func TestApplyReviewScopeHumanStopUsesScopeTerminationReason(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_stop_reviewer", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_stop_fixer", "fixer", "queued")
+	_ = fixer
+
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify scope",
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	result, err := ApplyReviewScopeHumanAnswer(context.Background(), repos, parked, "Stop", nowISO)
+	if err != nil || !result.Applied || result.Action != "stop" {
+		t.Fatalf("Stop = (%#v, %v)", result, err)
+	}
+	if result.Loop.Status != "terminated" {
+		t.Fatalf("status = %s, want terminated", result.Loop.Status)
+	}
+	meta := parseMetadataObject(result.Loop.MetadataJSON)
+	loopMeta, _ := meta["loop"].(map[string]any)
+	if loopMeta == nil {
+		t.Fatalf("missing loop metadata: %#v", meta)
+	}
+	if got, _ := loopMeta["terminationReason"].(string); got != ReviewScopeHumanRequiredReason {
+		t.Fatalf("terminationReason = %q, want %q (not budget exhausted)", got, ReviewScopeHumanRequiredReason)
+	}
+	if got, _ := loopMeta["terminationReason"].(string); got == ReviewFixBudgetTerminationReason {
+		t.Fatal("scope Stop must not write review_fix_budget_exhausted")
+	}
+}
+
+func derefMeta(m *string) string {
+	if m == nil {
+		return ""
+	}
+	return *m
+}

--- a/internal/reviewer/disposition_path_test.go
+++ b/internal/reviewer/disposition_path_test.go
@@ -1,0 +1,2027 @@
+package reviewer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestNarrowDispositionRunsWhenThreadResolutionDisabled(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = false
+	policy.RequireNewHeadSinceThread = true
+	policy.RequireCurrentReviewRequest = true
+
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "old-head"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix out of scope", CreatedAt: "2026-01-02T00:00:00Z", UpdatedAt: "2026-01-02T00:00:00Z"},
+		},
+	}}
+	github := &fakeGitHubGateway{
+		currentLogin:   "looper-bot",
+		reviewRequests: []string{}, // not requested
+		reviewThreads:  threads,
+		viewHeadSHA:    "abc123",
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed",
+		Stdout: `{"decisions":[{"threadId":"thread_1","decision":"accept_wontfix","evidence":"outside PR scope","confidence":"high"}]}`,
+	}}}
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123","lastReviewedSignalFingerprint":"stale-signal"}`
+	loop := storage.LoopRecord{
+		ID: "loop_disp", ProjectID: "project_1", Type: "reviewer", Status: "queued",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: stringPtr("acme/looper"), PRNumber: int64Ptr(42), MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert loop: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+		ThreadResolution: policy,
+		LoopConfig:       testReviewerLoopConfig(),
+	})
+	input := threadResolutionStepInput()
+	input.Loop = loop
+	input.Project = storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Detail.Author = "alice"
+	input.Checkpoint.Detail.HeadSHA = "abc123"
+	input.Checkpoint.Detail.ReviewRequests = []string{}
+	input.Checkpoint.Snapshot.HeadSHA = "abc123"
+
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("runThreadResolutionStep() error = %v", err)
+	}
+	if len(github.addThreadReplyCalls) != 1 {
+		t.Fatalf("replies = %#v, want accept_wontfix reply despite Enabled=false", github.addThreadReplyCalls)
+	}
+	if !strings.Contains(github.addThreadReplyCalls[0].Body, "decision=accept_wontfix") {
+		t.Fatalf("body = %q", github.addThreadReplyCalls[0].Body)
+	}
+	if !strings.Contains(github.addThreadReplyCalls[0].Body, "feedback=") {
+		t.Fatalf("body missing feedback fingerprint: %q", github.addThreadReplyCalls[0].Body)
+	}
+	if len(github.resolveThreadCalls) != 1 {
+		t.Fatalf("resolves = %#v, want accept_wontfix resolve", github.resolveThreadCalls)
+	}
+	// RequireNewHead did not block (same head as thread commit would block objective path).
+	if checkpoint.ThreadResolution == nil || checkpoint.ThreadResolution.Processed != 1 {
+		t.Fatalf("ThreadResolution = %#v", checkpoint.ThreadResolution)
+	}
+}
+
+func TestRequireNewHeadDoesNotBlockDisposition(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = false
+	policy.RequireNewHeadSinceThread = true
+
+	// Thread commit OID equals current head — objective path would skip.
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "abc123"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "MEMBER", Body: "won't fix: intentional", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewRequests: []string{"looper-bot"}, reviewThreads: threads, viewHeadSHA: "abc123"}
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed",
+		Stdout: `{"decisions":[{"threadId":"thread_1","decision":"reject_wontfix","evidence":"required by safety rule","confidence":"high"}]}`,
+	}}}
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123"}`
+	loop := storage.LoopRecord{
+		ID: "loop_disp2", ProjectID: "project_1", Type: "reviewer", Status: "queued",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: stringPtr("acme/looper"), PRNumber: int64Ptr(42), MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy,
+	})
+	input := threadResolutionStepInput()
+	input.Loop = loop
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Detail.Author = "alice"
+	input.Checkpoint.Detail.HeadSHA = "abc123"
+	input.Checkpoint.Snapshot.HeadSHA = "abc123"
+
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if len(github.addThreadReplyCalls) != 1 || !strings.Contains(github.addThreadReplyCalls[0].Body, "reject_wontfix") {
+		t.Fatalf("replies = %#v", github.addThreadReplyCalls)
+	}
+	if len(github.resolveThreadCalls) != 0 {
+		t.Fatalf("reject must keep unresolved, got %#v", github.resolveThreadCalls)
+	}
+	if checkpoint.ThreadResolution == nil {
+		t.Fatal("expected thread resolution result")
+	}
+}
+
+func TestDiscoverySameHeadChangedCommentQueuesReviewer(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	// Prior signal differs from live threads.
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"same-head","lastReviewedSignalFingerprint":"old-fp","loop":{"enabled":true}}`
+	loop := storage.LoopRecord{
+		ID: "loop_same_head", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "completed",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "same-head"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{
+		currentLogin:   "looper-bot",
+		reviewRequests: []string{"looper-bot"},
+		listOpenByLabel: map[string][]PullRequestSummary{
+			"": {{Number: prNumber, Title: "PR", State: "OPEN", HeadSHA: "same-head", ReviewRequests: []string{"looper-bot"}}},
+		},
+		reviewThreads: threads,
+		viewHeadSHA:   "same-head",
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		DiscoveryPolicy:  DiscoveryPolicy{AutoDiscovery: true, RequireReviewRequest: false, EnableSelfReview: true},
+		LoopConfig:       testReviewerLoopConfig(),
+		ThreadResolution: config.ReviewerThreadResolutionConfig{Enabled: false, Mode: config.ReviewerThreadResolutionModeReportOnly, MaxThreadsPerRun: 10},
+	})
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests: %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want 1 disposition enqueue on same head", result.QueueItems)
+	}
+	if result.QueueItems[0].PayloadJSON == nil || !strings.Contains(*result.QueueItems[0].PayloadJSON, "dispositionOnly") {
+		t.Fatalf("payload = %v, want dispositionOnly", result.QueueItems[0].PayloadJSON)
+	}
+}
+
+func TestMaxThreadsPerRunDoesNotPromoteSignalEarly(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = false
+	policy.MaxThreadsPerRun = 1
+
+	makeThread := func(id string) ReviewThread {
+		return ReviewThread{
+			ID: id,
+			Comments: []ReviewThreadComment{
+				{ID: id + "-c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "old"},
+				{ID: id + "-c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix x", CreatedAt: "t2", UpdatedAt: "t2"},
+			},
+		}
+	}
+	threads := []ReviewThread{makeThread("t1"), makeThread("t2")}
+	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewRequests: []string{"looper-bot"}, reviewThreads: threads, viewHeadSHA: "abc123"}
+	agent := &fakeAgentExecutor{results: []AgentResult{
+		{Status: "completed", Stdout: `{"decisions":[{"threadId":"t1","decision":"accept_wontfix","evidence":"scope","confidence":"high"}]}`},
+		{Status: "completed", Stdout: `{"decisions":[{"threadId":"t2","decision":"accept_wontfix","evidence":"scope","confidence":"high"}]}`},
+	}}
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123"}`
+	loop := storage.LoopRecord{
+		ID: "loop_batch", ProjectID: "project_1", Type: "reviewer", Status: "queued",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: stringPtr("acme/looper"), PRNumber: int64Ptr(42), MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy,
+		LoopConfig: testReviewerLoopConfig(),
+	})
+	input := threadResolutionStepInput()
+	input.Loop = loop
+	input.Project = storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Detail.Author = "alice"
+	input.Checkpoint.Detail.HeadSHA = "abc123"
+	input.Checkpoint.Snapshot.HeadSHA = "abc123"
+
+	// First run: one batch only, PartialBatch, no promote.
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("first batch error = %v", err)
+	}
+	if checkpoint.ThreadResolution == nil || !checkpoint.ThreadResolution.PartialBatch {
+		t.Fatalf("ThreadResolution = %#v, want PartialBatch=true", checkpoint.ThreadResolution)
+	}
+	if checkpoint.ThreadResolution.Processed != 1 {
+		t.Fatalf("Processed = %d, want 1", checkpoint.ThreadResolution.Processed)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil || updated.MetadataJSON == nil {
+		t.Fatalf("loop = (%v, %v)", updated, err)
+	}
+	if strings.Contains(*updated.MetadataJSON, metadataLastReviewedSignalFingerprintKey) {
+		t.Fatalf("must not promote fingerprint after partial batch: %s", *updated.MetadataJSON)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("classifier batches = %d, want 1", len(agent.starts))
+	}
+
+	// Continuation: process remaining with captured cursor.
+	input.Checkpoint = checkpoint
+	input.Loop = *updated
+	checkpoint2, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("continuation error = %v", err)
+	}
+	if checkpoint2.ThreadResolution == nil || checkpoint2.ThreadResolution.PartialBatch {
+		t.Fatalf("continuation ThreadResolution = %#v, want complete", checkpoint2.ThreadResolution)
+	}
+	if len(agent.starts) != 2 {
+		t.Fatalf("classifier batches = %d, want 2", len(agent.starts))
+	}
+	updated2, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated2 == nil || updated2.MetadataJSON == nil {
+		t.Fatalf("loop after promote = (%v, %v)", updated2, err)
+	}
+	if !strings.Contains(*updated2.MetadataJSON, metadataLastReviewedSignalFingerprintKey) {
+		t.Fatalf("metadata missing promoted fingerprint: %s", *updated2.MetadataJSON)
+	}
+}
+
+func TestEnqueueCoalescesSameHeadSignalChange(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{
+		ID: "loop_coalesce", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "queued",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert loop: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos,
+		Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: config.ReviewerLoopConfig{QuietPeriodSeconds: 60},
+	})
+	ctx := context.Background()
+	first, err := runner.enqueue(ctx, enqueueInput{
+		ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber,
+		HeadSHA: "same-head", ReviewSignalFingerprint: "sig-a", DispositionOnly: true,
+		AvailableAt: fixture.now().Add(30 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("first enqueue: %v", err)
+	}
+	second, err := runner.enqueue(ctx, enqueueInput{
+		ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber,
+		HeadSHA: "same-head", ReviewSignalFingerprint: "sig-b", DispositionOnly: true,
+		AvailableAt: fixture.now().Add(10 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("second enqueue: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("expected in-place coalesce, got %s vs %s", first.ID, second.ID)
+	}
+	if second.PayloadJSON == nil || !strings.Contains(*second.PayloadJSON, "sig-b") {
+		t.Fatalf("payload = %v, want sig-b", second.PayloadJSON)
+	}
+}
+
+func TestEnqueueRunningCoalescesPendingSignal(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{
+		ID: "loop_run_coalesce", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "running",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert loop: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos,
+		Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: config.ReviewerLoopConfig{QuietPeriodSeconds: 60},
+	})
+	ctx := context.Background()
+	// Seed a running active item.
+	payload := reviewerQueuePayloadJSON("same-head", "sig-old", true)
+	item := storage.QueueItemRecord{
+		ID: "queue_running", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: buildReviewerDedupeKey("project_1", loop.ID, repo, prNumber),
+		Priority:  storage.QueuePriorityReviewer, Status: "running",
+		AvailableAt: fixture.nowISO(), Attempts: 0, MaxAttempts: 5,
+		PayloadJSON: &payload, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Queue.Upsert(ctx, item); err != nil {
+		t.Fatalf("Upsert queue: %v", err)
+	}
+	// Two newer signals while running → only latest pending on same item.
+	if _, err := runner.enqueue(ctx, enqueueInput{
+		ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber,
+		HeadSHA: "same-head", ReviewSignalFingerprint: "sig-mid", DispositionOnly: true,
+	}); err != nil {
+		t.Fatalf("mid enqueue: %v", err)
+	}
+	got, err := runner.enqueue(ctx, enqueueInput{
+		ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber,
+		HeadSHA: "same-head", ReviewSignalFingerprint: "sig-latest", DispositionOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("latest enqueue: %v", err)
+	}
+	if got.ID != item.ID {
+		t.Fatalf("expected same active item, got %s", got.ID)
+	}
+	if got.PayloadJSON == nil || !strings.Contains(*got.PayloadJSON, "sig-latest") {
+		t.Fatalf("payload = %v, want pending sig-latest", got.PayloadJSON)
+	}
+	if !strings.Contains(*got.PayloadJSON, "pendingReviewSignalFingerprint") {
+		t.Fatalf("payload missing pending field: %v", got.PayloadJSON)
+	}
+	// No second active item.
+	active, err := fixture.repos.Queue.FindActiveByDedupe(ctx, item.DedupeKey)
+	if err != nil || active == nil {
+		t.Fatalf("active = (%v, %v)", active, err)
+	}
+	if active.ID != item.ID {
+		t.Fatalf("parallel item created: %s", active.ID)
+	}
+}
+
+func TestDiscoveryLastFilterSkipDoesNotSuppressChangedDisposition(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"same-head","lastReviewedSignalFingerprint":"old-fp","loop":{"enabled":true},"lastFilterSkip":{"kind":"already_published_head","headSha":"same-head"}}`
+	loop := storage.LoopRecord{
+		ID: "loop_skip_disp", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "completed",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "same-head"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix edited", CreatedAt: "t2", UpdatedAt: "t3"},
+		},
+	}}
+	github := &fakeGitHubGateway{
+		currentLogin: "looper-bot",
+		listOpenByLabel: map[string][]PullRequestSummary{
+			"": {{Number: prNumber, Title: "PR", State: "OPEN", HeadSHA: "same-head", Author: "alice"}},
+		},
+		reviewThreads: threads,
+		viewHeadSHA:   "same-head",
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		DiscoveryPolicy:  DiscoveryPolicy{AutoDiscovery: true, RequireReviewRequest: false, EnableSelfReview: true},
+		LoopConfig:       testReviewerLoopConfig(),
+		ThreadResolution: config.ReviewerThreadResolutionConfig{Enabled: false, MaxThreadsPerRun: 10},
+	})
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want disposition despite lastFilterSkip", result.QueueItems)
+	}
+}
+
+func TestDiscoveryRequireReviewRequestAllowsNarrowDisposition(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"same-head","lastReviewedSignalFingerprint":"old","loop":{"enabled":true},"lastFilterSkip":{"kind":"not_requested","headSha":"same-head","reviewerLogin":"looper-bot"}}`
+	loop := storage.LoopRecord{
+		ID: "loop_req_disp", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "completed",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "same-head"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{
+		currentLogin:   "looper-bot",
+		reviewRequests: []string{},
+		listOpenByLabel: map[string][]PullRequestSummary{
+			"": {{Number: prNumber, Title: "PR", State: "OPEN", HeadSHA: "same-head", Author: "alice", ReviewRequests: []string{}}},
+		},
+		reviewThreads: threads,
+		viewHeadSHA:   "same-head",
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		DiscoveryPolicy:  DiscoveryPolicy{AutoDiscovery: true, RequireReviewRequest: true, EnableSelfReview: true},
+		LoopConfig:       testReviewerLoopConfig(),
+		ThreadResolution: config.ReviewerThreadResolutionConfig{Enabled: false, MaxThreadsPerRun: 10},
+	})
+	// discoverExistingReviewerLoop path via follow-up listing of existing loops.
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	// May be 0 if list path doesn't include unrequested PRs — exercise helper directly.
+	if len(result.QueueItems) == 0 {
+		ok, err := runner.hasNarrowDispositionCandidate(context.Background(), "/tmp", repo, prNumber, "same-head", "alice", "looper-bot")
+		if err != nil || !ok {
+			t.Fatalf("hasNarrowDispositionCandidate = (%v, %v), want true", ok, err)
+		}
+		allow, err := runner.allowThreadResolutionFollowUpAfterNotRequestedSkip(context.Background(), "/tmp", repo, PullRequestSummary{Number: prNumber, HeadSHA: "same-head", Author: "alice", ReviewRequests: []string{}}, "looper-bot", parseJSONObject(&meta), DiscoveryPolicy{RequireReviewRequest: true})
+		if err != nil || !allow {
+			t.Fatalf("allowThreadResolutionFollowUpAfterNotRequestedSkip = (%v, %v), want true for narrow disposition", allow, err)
+		}
+	}
+}
+
+func TestSameHeadDiscoveryListErrorIsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"h1","lastReviewedSignalFingerprint":"fp1"}`
+	loop := storage.LoopRecord{
+		ID: "loop_list_err", ProjectID: "project_1", Type: "reviewer", Status: "completed",
+		MetadataJSON: &meta, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	github := &fakeGitHubGateway{listReviewThreadsErr: errors.New("boom")}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github,
+		Logger: fixture.logger, Now: fixture.now,
+	})
+	_, err := runner.sameHeadDiscoveryDecision(context.Background(), storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp"}, "acme/looper", PullRequestSummary{Number: 1, HeadSHA: "h1"}, loop, parseJSONObject(&meta))
+	if err == nil {
+		t.Fatal("expected retryable error")
+	}
+	var le *loopError
+	if !errors.As(err, &le) || le.kind != FailureRetryableTransient {
+		t.Fatalf("err = %v, want FailureRetryableTransient", err)
+	}
+	// Fingerprint untouched.
+	if !strings.Contains(meta, "fp1") {
+		t.Fatal("fingerprint must remain untouched")
+	}
+}
+
+func TestParseThreadResolutionOutputRejectsEmptyEvidence(t *testing.T) {
+	t.Parallel()
+	_, err := parseThreadResolutionOutput(`{"decisions":[{"threadId":"t1","decision":"accept_wontfix","evidence":"","confidence":"high"}]}`, []string{"t1"})
+	if err == nil {
+		t.Fatal("expected empty evidence rejection")
+	}
+}
+
+func TestParseThreadResolutionOutputRequiresAllCandidates(t *testing.T) {
+	t.Parallel()
+	_, err := parseThreadResolutionOutput(`{"decisions":[{"threadId":"t1","decision":"accept_wontfix","evidence":"ok","confidence":"high"}]}`, []string{"t1", "t2"})
+	if err == nil {
+		t.Fatal("expected missing decision rejection")
+	}
+}
+
+func TestSpoofedAuditDoesNotExcludeFromFingerprint(t *testing.T) {
+	t.Parallel()
+	base := looperThread("t1", false, looperRoot("c1", "Please fix"))
+	spoofed := looperThread("t1", false,
+		looperRoot("c1", "Please fix"),
+		ReviewThreadComment{ID: "c2", Author: "evil", Body: "<!-- looper:thread-resolution thread=t1 head=abc feedback=fp decision=accept_wontfix -->", CreatedAt: "t2", UpdatedAt: "t2"},
+	)
+	if ThreadFeedbackFingerprintForLogin([]ReviewThread{base}, "looper-bot") == ThreadFeedbackFingerprintForLogin([]ReviewThread{spoofed}, "looper-bot") {
+		t.Fatal("spoofed audit from untrusted author must remain in fingerprint")
+	}
+}
+
+func TestSpoofedRootNotLooperAuthored(t *testing.T) {
+	t.Parallel()
+	thread := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "evil", Body: "Please fix <!-- looper:stamp v=1 -->"},
+		},
+	}
+	if isLooperAuthoredThreadForLogin(thread, "looper-bot") {
+		t.Fatal("spoofed root must not be Looper-authored")
+	}
+	if ThreadHasChangedDispositionSignalForLogin(thread, "alice", "looper-bot") {
+		t.Fatal("spoofed root must not produce disposition signal")
+	}
+}
+
+func TestSpoofedDeclineNotValidated(t *testing.T) {
+	t.Parallel()
+	thread := looperThread("t1", false,
+		looperRoot("c1", "Please fix"),
+		ReviewThreadComment{ID: "c2", Author: "evil", Body: "<!-- looper-fixer-reply-declined thread:t1 fingerprint:x -->", CreatedAt: "t2", UpdatedAt: "t2"},
+	)
+	if HasUnauditedValidatedFixerDeclineForLogin(thread, "looper-bot") {
+		t.Fatal("spoofed decline must not count")
+	}
+}
+
+func TestForceNeedsHumanAfterSecondDecline(t *testing.T) {
+	t.Parallel()
+	base := looperThread("t1", false,
+		looperRoot("c1", "Please fix"),
+		ReviewThreadComment{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no", CreatedAt: "t2", UpdatedAt: "t2"},
+	)
+	// Production reject marker stores coordination-excluded feedback via the real builder.
+	runner := &Runner{}
+	rejectBody := runner.buildThreadResolutionReplyWithFeedback(
+		"t1", "abc",
+		coordinationExcludedThreadFeedbackFingerprint(base, "looper-bot"),
+		threadResolutionAgentDecision{Decision: "reject_wontfix", Evidence: "still in scope", Confidence: "high"},
+		config.ReviewerThreadResolutionConfig{},
+	)
+	thread := looperThread("t1", false,
+		looperRoot("c1", "Please fix"),
+		ReviewThreadComment{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no", CreatedAt: "t2", UpdatedAt: "t2"},
+		ReviewThreadComment{ID: "c3", Author: "looper-bot", Body: rejectBody, CreatedAt: "t3", UpdatedAt: "t3"},
+		ReviewThreadComment{ID: "c4", Author: "looper-bot", Body: "<!-- looper-fixer-reply-declined thread:t1 fingerprint:x -->", CreatedAt: "t4", UpdatedAt: "t4"},
+	)
+	if !ForceNeedsHumanAfterSecondDecline(thread, "abc", "looper-bot") {
+		t.Fatal("second decline after reject must force needs_human")
+	}
+}
+
+func TestRejectWontfixMarkerUsesCoordinationExcludedFeedback(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = false
+	// Thread already has a Fixer decline when Reviewer rejects — full FP includes it;
+	// marker must store coordination-excluded FP so a later second decline matches.
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "old"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no", CreatedAt: "t2", UpdatedAt: "t2"},
+			{ID: "c3", Author: "looper-bot", Body: "<!-- looper-fixer-reply-declined thread:thread_1 fingerprint:x -->", CreatedAt: "t3", UpdatedAt: "t3"},
+		},
+	}}
+	wantMarkerFP := coordinationExcludedThreadFeedbackFingerprint(threads[0], "looper-bot")
+	fullFP := ThreadFeedbackFingerprintForLogin(threads, "looper-bot")
+	if wantMarkerFP == "" || wantMarkerFP == fullFP {
+		t.Fatalf("fixture needs distinct coordination-excluded vs full FP: excl=%q full=%q", wantMarkerFP, fullFP)
+	}
+	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewThreads: threads, viewHeadSHA: "abc123"}
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed",
+		Stdout: `{"decisions":[{"threadId":"thread_1","decision":"reject_wontfix","evidence":"still needed","confidence":"high"}]}`,
+	}}}
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123"}`
+	loop := storage.LoopRecord{
+		ID: "loop_reject_fp", ProjectID: "project_1", Type: "reviewer", Status: "queued",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: stringPtr("acme/looper"), PRNumber: int64Ptr(42), MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy,
+	})
+	input := threadResolutionStepInput()
+	input.Loop = loop
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Detail.Author = "alice"
+	input.Checkpoint.Detail.HeadSHA = "abc123"
+	input.Checkpoint.Snapshot.HeadSHA = "abc123"
+	if _, err := runner.runThreadResolutionStep(context.Background(), input); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if len(github.addThreadReplyCalls) != 1 {
+		t.Fatalf("replies = %#v, want reject_wontfix", github.addThreadReplyCalls)
+	}
+	body := github.addThreadReplyCalls[0].Body
+	if !strings.Contains(body, "feedback="+wantMarkerFP) {
+		t.Fatalf("marker feedback must be coordination-excluded %q; body=%q", wantMarkerFP, body)
+	}
+	if strings.Contains(body, "feedback="+fullFP) {
+		t.Fatalf("marker must not store full per-thread FP; body=%q", body)
+	}
+	// After reject + another decline with unchanged human text → force needs_human.
+	github.reviewThreads[0].Comments = append(github.reviewThreads[0].Comments,
+		ReviewThreadComment{ID: "c4", Author: "looper-bot", Body: body, CreatedAt: "t4", UpdatedAt: "t4"},
+		ReviewThreadComment{ID: "c5", Author: "looper-bot", Body: "<!-- looper-fixer-reply-declined thread:thread_1 fingerprint:y -->", CreatedAt: "t5", UpdatedAt: "t5"},
+	)
+	if !ForceNeedsHumanAfterSecondDecline(github.reviewThreads[0], "abc123", "looper-bot") {
+		t.Fatal("production reject marker must match ForceNeedsHuman on second decline")
+	}
+}
+
+func TestDispositionNotFixedMapsToNeedsHuman(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = false
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "old"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper reconsider please", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewThreads: threads, viewHeadSHA: "abc123"}
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed",
+		Stdout: `{"decisions":[{"threadId":"thread_1","decision":"not_fixed","evidence":"still open","confidence":"high"}]}`,
+	}}}
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123"}`
+	loop := storage.LoopRecord{
+		ID: "loop_reconsider", ProjectID: "project_1", Type: "reviewer", Status: "queued",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: stringPtr("acme/looper"), PRNumber: int64Ptr(42), MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy,
+	})
+	input := threadResolutionStepInput()
+	input.Loop = loop
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Detail.Author = "alice"
+	input.Checkpoint.Detail.HeadSHA = "abc123"
+	input.Checkpoint.Snapshot.HeadSHA = "abc123"
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	// not_fixed on disposition → needs_human → no accept/reject reply, no silent promote of not_fixed.
+	if len(github.addThreadReplyCalls) != 0 {
+		t.Fatalf("replies = %#v, want none for needs_human", github.addThreadReplyCalls)
+	}
+	if checkpoint.SkipKind != "disposition_only" && checkpoint.ThreadResolution == nil {
+		t.Fatalf("checkpoint = %#v", checkpoint)
+	}
+}
+
+func TestPostMutationRefetchFailureRetriesWithoutClassify(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = false
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "old"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix x", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{
+		currentLogin: "looper-bot", reviewThreads: threads, viewHeadSHA: "abc123",
+		// After mutations, list is called again for post-mutation commit; fail once then succeed.
+		listReviewThreadsErrAfter: 2,
+		listReviewThreadsErr:      errors.New("refetch failed"),
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed",
+		Stdout: `{"decisions":[{"threadId":"thread_1","decision":"accept_wontfix","evidence":"scope","confidence":"high"}]}`,
+	}}}
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123"}`
+	loop := storage.LoopRecord{
+		ID: "loop_post_mut", ProjectID: "project_1", Type: "reviewer", Status: "queued",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: stringPtr("acme/looper"), PRNumber: int64Ptr(42), MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy,
+	})
+	input := threadResolutionStepInput()
+	input.Loop = loop
+	input.Project = storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Detail.Author = "alice"
+	input.Checkpoint.Detail.HeadSHA = "abc123"
+	input.Checkpoint.Snapshot.HeadSHA = "abc123"
+
+	_, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected refetch failure")
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("classify starts = %d, want 1", len(agent.starts))
+	}
+	// Clear error and retry with PostMutationCommitPending.
+	github.listReviewThreadsErr = nil
+	github.listReviewThreadsErrAfter = 0
+	// Simulate resume with pending commit (mutations already on remote via fake).
+	fb := ThreadFeedbackFingerprintForLogin(threads, "looper-bot")
+	input.Checkpoint.ThreadResolution = &threadResolutionCheckpoint{
+		HeadSHA: "abc123", PostMutationCommitPending: true, DispositionOnly: true,
+		CompletedThreadIDs: []string{"thread_1"}, ThreadFeedbackFingerprint: fb,
+	}
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("retry error = %v", err)
+	}
+	if len(agent.starts) != 1 {
+		t.Fatalf("retry must not re-classify, starts = %d", len(agent.starts))
+	}
+	updated, _ := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if updated == nil || updated.MetadataJSON == nil || !strings.Contains(*updated.MetadataJSON, metadataLastReviewedSignalFingerprintKey) {
+		t.Fatalf("expected promote after retry: %#v", updated)
+	}
+	if checkpoint.ThreadResolution != nil && checkpoint.ThreadResolution.PostMutationCommitPending {
+		t.Fatal("PostMutationCommitPending must clear after success")
+	}
+}
+
+func TestStaleFeedbackBlocksMutation(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = false
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "old"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix x", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewThreads: threads, viewHeadSHA: "abc123"}
+	// After classify, human edits the thread before mutate.
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed",
+		Stdout: `{"decisions":[{"threadId":"thread_1","decision":"accept_wontfix","evidence":"scope","confidence":"high"}]}`,
+	}}}
+	// Hook: mutate threads after first list by wrapping — simpler: change threads after agent starts.
+	// Use a custom gateway that edits on AddReviewThreadReply path via ViewPullRequest count.
+	// Instead: change reviewThreads after classify by using list call count.
+	orig := threads
+	_ = orig
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123"}`
+	loop := storage.LoopRecord{
+		ID: "loop_stale", ProjectID: "project_1", Type: "reviewer", Status: "queued",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: stringPtr("acme/looper"), PRNumber: int64Ptr(42), MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	// Drift gateway: after first full list, edit the human comment.
+	driftGH := &driftOnRefreshGateway{fakeGitHubGateway: github, editAfterLists: 1}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: driftGH, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy,
+	})
+	input := threadResolutionStepInput()
+	input.Loop = loop
+	input.Project = storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Detail.Author = "alice"
+	input.Checkpoint.Detail.HeadSHA = "abc123"
+	input.Checkpoint.Snapshot.HeadSHA = "abc123"
+	_, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected stale feedback error")
+	}
+	if len(github.addThreadReplyCalls)+len(driftGH.addThreadReplyCalls) != 0 {
+		t.Fatalf("must not reply on stale feedback")
+	}
+	if len(github.resolveThreadCalls)+len(driftGH.resolveThreadCalls) != 0 {
+		t.Fatalf("must not resolve on stale feedback")
+	}
+}
+
+// driftOnRefreshGateway edits thread feedback after N list calls.
+type driftOnRefreshGateway struct {
+	*fakeGitHubGateway
+	editAfterLists int
+}
+
+func (g *driftOnRefreshGateway) ListReviewThreads(ctx context.Context, in ListReviewThreadsInput) ([]ReviewThread, error) {
+	threads, err := g.fakeGitHubGateway.ListReviewThreads(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if g.listReviewThreadsCalls > g.editAfterLists && len(g.reviewThreads) > 0 && len(g.reviewThreads[0].Comments) > 1 {
+		g.reviewThreads[0].Comments[1].Body = "/looper wontfix EDITED " + fmt.Sprint(g.listReviewThreadsCalls)
+		g.reviewThreads[0].Comments[1].UpdatedAt = "t-edited"
+		out := make([]ReviewThread, len(g.reviewThreads))
+		copy(out, g.reviewThreads)
+		return out, nil
+	}
+	return threads, nil
+}
+
+func TestBudgetHeldDispositionOnlyDiscoveryEnqueues(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	// Minimal budget hold metadata.
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"same-head","lastReviewedSignalFingerprint":"old","loop":{"enabled":true},"reviewFixBudget":{"exhaustedBy":"reviewer","pauseReason":"review_fix_budget_exhausted"}}`
+	loop := storage.LoopRecord{
+		ID: "loop_budget_disp", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "paused",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if !loops.IsReviewFixBudgetHold(loop) {
+		t.Fatal("fixture must be budget hold")
+	}
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "same-head"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{
+		currentLogin: "looper-bot",
+		listOpenByLabel: map[string][]PullRequestSummary{
+			"": {{Number: prNumber, Title: "PR", State: "OPEN", HeadSHA: "same-head", Author: "alice"}},
+		},
+		reviewThreads: threads,
+		viewHeadSHA:   "same-head",
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		DiscoveryPolicy:  DiscoveryPolicy{AutoDiscovery: true, RequireReviewRequest: false, EnableSelfReview: true},
+		LoopConfig:       testReviewerLoopConfig(),
+		ThreadResolution: config.ReviewerThreadResolutionConfig{Enabled: false, MaxThreadsPerRun: 10},
+	})
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want disposition-only on budget hold", result.QueueItems)
+	}
+	if result.QueueItems[0].PayloadJSON == nil || !strings.Contains(*result.QueueItems[0].PayloadJSON, `"dispositionOnly":true`) {
+		t.Fatalf("payload = %v", result.QueueItems[0].PayloadJSON)
+	}
+	// Hold preserved.
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if after == nil || after.Status != "paused" || !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatalf("hold not preserved: %#v", after)
+	}
+}
+
+func TestBudgetHeldHITLDispositionOnlyDiscoveryEnqueues(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	baseMeta := `{"followUpdates":true,"lastPublishedHeadSha":"same-head","lastReviewedSignalFingerprint":"old","loop":{"enabled":true},"reviewFixBudget":{"exhaustedBy":"reviewer","pauseReason":"review_fix_budget_exhausted"}}`
+	meta, err := loops.WriteHITLAsk(&baseMeta, loops.NewReviewFixBudgetAsk("reviewer", repo, prNumber, 8, 8, fixture.nowISO()))
+	if err != nil {
+		t.Fatalf("WriteHITLAsk: %v", err)
+	}
+	loop := storage.LoopRecord{
+		ID: "loop_budget_hitl_disp", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "awaiting_human",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if !loops.IsReviewFixBudgetHold(loop) {
+		t.Fatal("fixture must be HITL budget hold")
+	}
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "same-head"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{
+		currentLogin: "looper-bot",
+		listOpenByLabel: map[string][]PullRequestSummary{
+			"": {{Number: prNumber, Title: "PR", State: "OPEN", HeadSHA: "same-head", Author: "alice"}},
+		},
+		reviewThreads: threads,
+		viewHeadSHA:   "same-head",
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		DiscoveryPolicy:  DiscoveryPolicy{AutoDiscovery: true, RequireReviewRequest: false, EnableSelfReview: true},
+		LoopConfig:       testReviewerLoopConfig(),
+		ThreadResolution: config.ReviewerThreadResolutionConfig{Enabled: false, MaxThreadsPerRun: 10},
+	})
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.QueueItems) != 1 {
+		t.Fatalf("QueueItems = %#v, want disposition-only on HITL budget hold", result.QueueItems)
+	}
+	if result.QueueItems[0].PayloadJSON == nil || !strings.Contains(*result.QueueItems[0].PayloadJSON, `"dispositionOnly":true`) {
+		t.Fatalf("payload = %v", result.QueueItems[0].PayloadJSON)
+	}
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if after == nil || after.Status != "awaiting_human" || !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatalf("HITL hold not preserved: %#v", after)
+	}
+}
+
+func TestSameHeadDiscoveryIdentityLookupFailureIsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"h1","lastReviewedSignalFingerprint":"fp1"}`
+	loop := storage.LoopRecord{
+		ID: "loop_login_err", ProjectID: "project_1", Type: "reviewer", Status: "completed",
+		MetadataJSON: &meta, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	github := &fakeGitHubGateway{currentLoginErr: errors.New("auth boom")}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github,
+		Logger: fixture.logger, Now: fixture.now,
+	})
+	_, err := runner.sameHeadDiscoveryDecision(context.Background(), storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp"}, "acme/looper", PullRequestSummary{Number: 1, HeadSHA: "h1"}, loop, parseJSONObject(&meta))
+	if err == nil {
+		t.Fatal("expected retryable error")
+	}
+	var le *loopError
+	if !errors.As(err, &le) || le.kind != FailureRetryableTransient {
+		t.Fatalf("err = %v, want FailureRetryableTransient", err)
+	}
+}
+
+func TestNonLooperLoginDetectsSameHeadDispositionSignal(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"h1","lastReviewedSignalFingerprint":"old-fp"}`
+	loop := storage.LoopRecord{
+		ID: "loop_bob", ProjectID: "project_1", Type: "reviewer", Status: "completed",
+		MetadataJSON: &meta, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "bob", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "h1"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{currentLogin: "bob", reviewThreads: threads, viewHeadSHA: "h1"}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github,
+		Logger: fixture.logger, Now: fixture.now,
+	})
+	decision, err := runner.sameHeadDiscoveryDecision(context.Background(), storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp"}, "acme/looper", PullRequestSummary{Number: 1, HeadSHA: "h1", Author: "alice"}, loop, parseJSONObject(&meta))
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if decision.action != sameHeadDiscoveryEnqueueDisposition {
+		t.Fatalf("action = %v, want enqueue disposition for bob-authored threads", decision.action)
+	}
+	if decision.signal == "" || decision.signal == "old-fp" {
+		t.Fatalf("signal = %q, want live bob-identity fingerprint", decision.signal)
+	}
+}
+
+func TestNarrowDispositionListingErrorIsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		currentLogin:         "looper-bot",
+		listReviewThreadsErr: errors.New("list boom"),
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github,
+		Logger: fixture.logger, Now: fixture.now,
+	})
+	ok, err := runner.hasNarrowDispositionCandidate(context.Background(), "/tmp", "acme/looper", 42, "head", "alice", "looper-bot")
+	if err == nil {
+		t.Fatal("expected retryable listing error")
+	}
+	if ok {
+		t.Fatal("ok must be false on listing error")
+	}
+	var le *loopError
+	if !errors.As(err, &le) || le.kind != FailureRetryableTransient {
+		t.Fatalf("err = %v, want FailureRetryableTransient", err)
+	}
+}
+
+func TestEnqueueContinuationWhileRunningMergesPartialBatch(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loop := storage.LoopRecord{
+		ID: "loop_partial_run", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "running",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert loop: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos,
+		Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: config.ReviewerLoopConfig{QuietPeriodSeconds: 60},
+	})
+	ctx := context.Background()
+	payload := reviewerQueuePayloadJSON("same-head", "sig-old", true)
+	item := storage.QueueItemRecord{
+		ID: "queue_partial_running", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: buildReviewerDedupeKey("project_1", loop.ID, repo, prNumber),
+		Priority:  storage.QueuePriorityReviewer, Status: "running",
+		AvailableAt: fixture.nowISO(), Attempts: 0, MaxAttempts: 5,
+		PayloadJSON: &payload, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Queue.Upsert(ctx, item); err != nil {
+		t.Fatalf("Upsert queue: %v", err)
+	}
+	input := stepInput{
+		Project:  storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp"},
+		Loop:     loop,
+		Repo:     repo,
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Snapshot: &checkpointSnapshot{HeadSHA: "same-head"},
+		},
+	}
+	result := &threadResolutionCheckpoint{
+		HeadSHA: "same-head", CapturedSignalFingerprint: "sig-live",
+		ReviewSignalFingerprint: "sig-live", ThreadFeedbackFingerprint: "fb-live",
+		CompletedThreadIDs: []string{"t1"}, CapturedCandidateIDs: []string{"t1", "t2"},
+		PartialBatch: true, DispositionOnly: true, Processed: 1,
+	}
+	if err := runner.enqueueThreadResolutionContinuation(ctx, input, input.Checkpoint, result); err != nil {
+		t.Fatalf("enqueue continuation: %v", err)
+	}
+	got, err := fixture.repos.Queue.GetByID(ctx, item.ID)
+	if err != nil || got == nil || got.PayloadJSON == nil {
+		t.Fatalf("queue = (%v, %v)", got, err)
+	}
+	if !strings.Contains(*got.PayloadJSON, "partialBatchContinuation") {
+		t.Fatalf("payload missing partialBatchContinuation: %s", *got.PayloadJSON)
+	}
+	if !strings.Contains(*got.PayloadJSON, `"completedThreadIds"`) || !strings.Contains(*got.PayloadJSON, "t1") {
+		t.Fatalf("payload missing completedThreadIds: %s", *got.PayloadJSON)
+	}
+	// Pending signal fields retained alongside full continuation cursor.
+	if !strings.Contains(*got.PayloadJSON, "pendingReviewSignalFingerprint") {
+		t.Fatalf("payload missing pending signal: %s", *got.PayloadJSON)
+	}
+}
+
+func TestPartialBatchRefetchErrorIsRetryable(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = false
+	policy.MaxThreadsPerRun = 1
+	makeThread := func(id string) ReviewThread {
+		return ReviewThread{
+			ID: id,
+			Comments: []ReviewThreadComment{
+				{ID: id + "-c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "old"},
+				{ID: id + "-c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix x", CreatedAt: "t2", UpdatedAt: "t2"},
+			},
+		}
+	}
+	threads := []ReviewThread{makeThread("t1"), makeThread("t2")}
+	github := &fakeGitHubGateway{
+		currentLogin: "looper-bot", reviewThreads: threads, viewHeadSHA: "abc123",
+		// Lists: (1) classify candidates, (2) pre-comment refresh, (3) partial-batch refetch.
+		listReviewThreadsErrAfter: 3,
+		listReviewThreadsErr:      errors.New("refetch boom"),
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{
+		{Status: "completed", Stdout: `{"decisions":[{"threadId":"t1","decision":"reject_wontfix","evidence":"required","confidence":"high"}]}`},
+	}}
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123"}`
+	loop := storage.LoopRecord{
+		ID: "loop_partial_refetch", ProjectID: "project_1", Type: "reviewer", Status: "queued",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: stringPtr("acme/looper"), PRNumber: int64Ptr(42), MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy,
+		LoopConfig: testReviewerLoopConfig(),
+	})
+	input := threadResolutionStepInput()
+	input.Loop = loop
+	input.Project = storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Detail.Author = "alice"
+	input.Checkpoint.Detail.HeadSHA = "abc123"
+	input.Checkpoint.Snapshot.HeadSHA = "abc123"
+	_, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected partial-batch refetch error")
+	}
+	var le *loopError
+	if !errors.As(err, &le) || le.kind != FailureRetryableTransient {
+		t.Fatalf("err = %v, want FailureRetryableTransient", err)
+	}
+	if !strings.Contains(err.Error(), "partial-batch") {
+		t.Fatalf("err = %v, want partial-batch message", err)
+	}
+}
+
+func TestBudgetHeldNeedsHumanPersistsSignalNoReenqueue(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = false
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "old"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix x", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{currentLogin: "looper-bot", reviewThreads: threads, viewHeadSHA: "abc123"}
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed",
+		Stdout: `{"decisions":[{"threadId":"thread_1","decision":"needs_human","evidence":"ambiguous","confidence":"low"}]}`,
+	}}}
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123","loop":{"enabled":true},"reviewFixBudget":{"exhaustedBy":"reviewer","pauseReason":"review_fix_budget_exhausted"}}`
+	loop := storage.LoopRecord{
+		ID: "loop_nh_budget", ProjectID: "project_1", Type: "reviewer", Status: "paused",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if !loops.IsReviewFixBudgetHold(loop) {
+		t.Fatal("fixture must be budget hold")
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy,
+		LoopConfig: testReviewerLoopConfig(),
+	})
+	input := threadResolutionStepInput()
+	input.Loop = loop
+	input.Project = storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}
+	input.Repo = repo
+	input.PRNumber = prNumber
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Detail.Author = "alice"
+	input.Checkpoint.Detail.HeadSHA = "abc123"
+	input.Checkpoint.Snapshot.HeadSHA = "abc123"
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if len(github.addThreadReplyCalls) != 0 {
+		t.Fatalf("needs_human must not post remote reply: %#v", github.addThreadReplyCalls)
+	}
+	updated, _ := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if updated == nil || updated.MetadataJSON == nil || !strings.Contains(*updated.MetadataJSON, metadataLastReviewedSignalFingerprintKey) {
+		t.Fatalf("expected fingerprint after needs_human: %#v", updated)
+	}
+	liveSignal := ComputeReviewSignalFingerprintForLogin("abc123", threads, "looper-bot")
+	if !strings.Contains(*updated.MetadataJSON, liveSignal) {
+		t.Fatalf("metadata missing live signal %s: %s", liveSignal, *updated.MetadataJSON)
+	}
+	if checkpoint.ReviewSignalFingerprint != liveSignal {
+		t.Fatalf("checkpoint signal = %q, want %q", checkpoint.ReviewSignalFingerprint, liveSignal)
+	}
+	// Next same-head discovery with unchanged threads must skip (not re-enqueue).
+	decision, err := runner.sameHeadDiscoveryDecision(context.Background(), storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}, repo, PullRequestSummary{Number: prNumber, HeadSHA: "abc123", Author: "alice"}, *updated, parseJSONObject(updated.MetadataJSON))
+	if err != nil {
+		t.Fatalf("rediscovery error = %v", err)
+	}
+	if decision.action != sameHeadDiscoverySkip {
+		t.Fatalf("action = %v, want skip after needs_human fingerprint", decision.action)
+	}
+}
+
+func TestCompletionPreservesLivePartialBatchCursorWithPending(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"same-head"}`
+	loop := storage.LoopRecord{
+		ID: "loop_partial_complete", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "running",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert loop: %v", err)
+	}
+	// Claimed snapshot is stale (no partial cursor). Live row has mid-run cursor + pending.
+	claimedPayload := `{"headSha":"same-head","reviewSignalFingerprint":"sig-old","dispositionOnly":true}`
+	livePayload := `{"headSha":"same-head","reviewSignalFingerprint":"sig-old","dispositionOnly":true,"pendingHeadSha":"same-head","pendingReviewSignalFingerprint":"sig-pending","pendingDispositionOnly":true,"partialBatchContinuation":{"headSha":"same-head","completedThreadIds":["t-done-1","t-done-2"],"capturedCandidateIds":["t-done-1","t-done-2","t-left"],"partialBatch":true,"dispositionOnly":true,"capturedSignalFingerprint":"sig-live"}}`
+	dedupe := buildReviewerDedupeKey("project_1", loop.ID, repo, prNumber)
+	item := storage.QueueItemRecord{
+		ID: "queue_partial_complete", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: dedupe, Priority: storage.QueuePriorityReviewer, Status: "running",
+		AvailableAt: fixture.nowISO(), Attempts: 0, MaxAttempts: 5,
+		PayloadJSON: &livePayload, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), item); err != nil {
+		t.Fatalf("Upsert queue: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos,
+		Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: config.ReviewerLoopConfig{QuietPeriodSeconds: 60},
+	})
+	ctx := context.Background()
+	// Mirror completion path: re-read live (not claimed), complete, schedule continuation.
+	claimed := item
+	claimed.PayloadJSON = &claimedPayload
+	pendingHead, pendingSignal, pendingDisp, hasPending := pendingReviewSignalFromQueuePayload(claimed.PayloadJSON)
+	priorForContinuation := claimed
+	liveItem, liveErr := fixture.repos.Queue.GetByID(ctx, item.ID)
+	if liveErr != nil || liveItem == nil {
+		t.Fatalf("live get: %v %v", liveItem, liveErr)
+	}
+	priorForContinuation = *liveItem
+	if h, s, d, ok := pendingReviewSignalFromQueuePayload(liveItem.PayloadJSON); ok {
+		pendingHead, pendingSignal, pendingDisp, hasPending = h, s, d, ok
+	}
+	if !hasPending {
+		t.Fatal("live payload must carry pending signal")
+	}
+	if cont := partialBatchContinuationFromPayload(claimed.PayloadJSON); cont != nil {
+		t.Fatal("claimed snapshot must not carry partial cursor (stale)")
+	}
+	if cont := partialBatchContinuationFromPayload(liveItem.PayloadJSON); cont == nil || len(cont.CompletedThreadIDs) != 2 {
+		t.Fatalf("live must carry partial cursor: %#v", cont)
+	}
+	if err := fixture.repos.Queue.Complete(ctx, item.ID, fixture.nowISO()); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	project := storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp"}
+	if err := runner.schedulePendingReviewerContinuation(ctx, project, loop, priorForContinuation, pendingHead, pendingSignal, pendingDisp); err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	active, err := fixture.repos.Queue.FindActiveByDedupe(ctx, dedupe)
+	if err != nil || active == nil || active.PayloadJSON == nil {
+		t.Fatalf("active continuation = (%v, %v)", active, err)
+	}
+	if active.ID == item.ID {
+		t.Fatal("expected new continuation item after complete")
+	}
+	if !strings.Contains(*active.PayloadJSON, "partialBatchContinuation") {
+		t.Fatalf("continuation missing partialBatchContinuation: %s", *active.PayloadJSON)
+	}
+	if !strings.Contains(*active.PayloadJSON, "t-done-1") || !strings.Contains(*active.PayloadJSON, "t-done-2") {
+		t.Fatalf("continuation missing completedThreadIds from live cursor: %s", *active.PayloadJSON)
+	}
+	if !strings.Contains(*active.PayloadJSON, "sig-pending") {
+		t.Fatalf("continuation missing pending signal: %s", *active.PayloadJSON)
+	}
+	// Control: scheduling from stale claimed would drop the cursor.
+	if err := fixture.repos.Queue.Complete(ctx, active.ID, fixture.nowISO()); err != nil {
+		t.Fatalf("complete continuation: %v", err)
+	}
+	// Re-seed running with live payload again and prove stale prior loses cursor.
+	item2 := item
+	item2.ID = "queue_partial_stale"
+	item2.Status = "running"
+	item2.PayloadJSON = &livePayload
+	item2.CreatedAt = fixture.nowISO()
+	item2.UpdatedAt = fixture.nowISO()
+	if err := fixture.repos.Queue.Upsert(ctx, item2); err != nil {
+		t.Fatalf("Upsert item2: %v", err)
+	}
+	if err := fixture.repos.Queue.Complete(ctx, item2.ID, fixture.nowISO()); err != nil {
+		t.Fatalf("Complete item2: %v", err)
+	}
+	if err := runner.schedulePendingReviewerContinuation(ctx, project, loop, claimed, pendingHead, pendingSignal, pendingDisp); err != nil {
+		t.Fatalf("stale schedule: %v", err)
+	}
+	staleActive, err := fixture.repos.Queue.FindActiveByDedupe(ctx, dedupe)
+	if err != nil || staleActive == nil || staleActive.PayloadJSON == nil {
+		t.Fatalf("stale active = (%v, %v)", staleActive, err)
+	}
+	if strings.Contains(*staleActive.PayloadJSON, "partialBatchContinuation") {
+		t.Fatal("stale claimed prior must not invent partialBatchContinuation (documents the bug)")
+	}
+}
+
+func TestBudgetHeldHITLRetryableStepFailureKeepsAwaitingHuman(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	baseMeta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123","loop":{"enabled":true},"reviewFixBudget":{"exhaustedBy":"reviewer","pauseReason":"review_fix_budget_exhausted"}}`
+	meta, err := loops.WriteHITLAsk(&baseMeta, loops.NewReviewFixBudgetAsk("reviewer", repo, prNumber, 8, 8, fixture.nowISO()))
+	if err != nil {
+		t.Fatalf("WriteHITLAsk: %v", err)
+	}
+	loop := storage.LoopRecord{
+		ID: "loop_hitl_retry_hold", ProjectID: "project_1", Type: "reviewer", Status: "awaiting_human",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if !loops.IsReviewFixBudgetHold(loop) {
+		t.Fatal("fixture must be HITL budget hold")
+	}
+	payload := reviewerQueuePayloadJSON("abc123", "sig-disp", true)
+	item := storage.QueueItemRecord{
+		ID: "queue_hitl_retry", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: buildReviewerDedupeKey("project_1", loop.ID, repo, prNumber),
+		Priority:  storage.QueuePriorityReviewer, Status: "running",
+		AvailableAt: fixture.nowISO(), Attempts: 0, MaxAttempts: 5,
+		PayloadJSON: &payload, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), item); err != nil {
+		t.Fatalf("Upsert queue: %v", err)
+	}
+	// Actionable disposition so budget-held claim enters the step loop; fail listing mid-step.
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "abc123"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{
+		currentLogin:              "looper-bot",
+		viewHeadSHA:               "abc123",
+		author:                    "alice",
+		reviewThreads:             threads,
+		listReviewThreadsErrAfter: 2,
+		listReviewThreadsErr:      errors.New("list boom"),
+		reviewRequests:            []string{"looper-bot"},
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig:       testReviewerLoopConfig(),
+		ThreadResolution: config.ReviewerThreadResolutionConfig{Enabled: false, MaxThreadsPerRun: 10},
+	})
+	result, err := runner.ProcessClaimedItem(context.Background(), item)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem: %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient {
+		t.Fatalf("result = %#v, want retryable failed", result)
+	}
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if after == nil || after.Status != "awaiting_human" {
+		t.Fatalf("status = %#v, want awaiting_human preserved", after)
+	}
+	if !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatal("IsReviewFixBudgetHold must remain true")
+	}
+	if after.NextRunAt == nil || strings.TrimSpace(*after.NextRunAt) == "" {
+		t.Fatal("NextRunAt must be set for disposition retry")
+	}
+	q, _ := fixture.repos.Queue.GetByID(context.Background(), item.ID)
+	if q == nil || q.Status != "queued" {
+		t.Fatalf("queue = %#v, want retryable queued", q)
+	}
+}
+
+func TestBudgetHeldPausedRetryableStepFailureKeepsPaused(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123","loop":{"enabled":true},"reviewFixBudget":{"exhaustedBy":"reviewer","pauseReason":"review_fix_budget_exhausted"}}`
+	loop := storage.LoopRecord{
+		ID: "loop_paused_retry_hold", ProjectID: "project_1", Type: "reviewer", Status: "paused",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if !loops.IsReviewFixBudgetHold(loop) {
+		t.Fatal("fixture must be paused budget hold")
+	}
+	payload := reviewerQueuePayloadJSON("abc123", "sig-disp", true)
+	item := storage.QueueItemRecord{
+		ID: "queue_paused_retry", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: buildReviewerDedupeKey("project_1", loop.ID, repo, prNumber),
+		Priority:  storage.QueuePriorityReviewer, Status: "running",
+		AvailableAt: fixture.nowISO(), Attempts: 0, MaxAttempts: 5,
+		PayloadJSON: &payload, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), item); err != nil {
+		t.Fatalf("Upsert queue: %v", err)
+	}
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "abc123"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{
+		currentLogin:              "looper-bot",
+		viewHeadSHA:               "abc123",
+		author:                    "alice",
+		reviewThreads:             threads,
+		listReviewThreadsErrAfter: 2,
+		listReviewThreadsErr:      errors.New("list boom"),
+		reviewRequests:            []string{"looper-bot"},
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig:       testReviewerLoopConfig(),
+		ThreadResolution: config.ReviewerThreadResolutionConfig{Enabled: false, MaxThreadsPerRun: 10},
+	})
+	result, err := runner.ProcessClaimedItem(context.Background(), item)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem: %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableTransient {
+		t.Fatalf("result = %#v, want retryable failed", result)
+	}
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if after == nil || after.Status != "paused" {
+		t.Fatalf("status = %#v, want paused preserved", after)
+	}
+	if !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatal("IsReviewFixBudgetHold must remain true")
+	}
+	q, _ := fixture.repos.Queue.GetByID(context.Background(), item.ID)
+	if q == nil || q.Status != "queued" {
+		t.Fatalf("queue = %#v, want retryable queued", q)
+	}
+}
+
+func TestBudgetHeldHITLSetupFailureKeepsAwaitingHuman(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	baseMeta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123","loop":{"enabled":true},"reviewFixBudget":{"exhaustedBy":"reviewer","pauseReason":"review_fix_budget_exhausted"}}`
+	meta, err := loops.WriteHITLAsk(&baseMeta, loops.NewReviewFixBudgetAsk("reviewer", repo, prNumber, 8, 8, fixture.nowISO()))
+	if err != nil {
+		t.Fatalf("WriteHITLAsk: %v", err)
+	}
+	loop := storage.LoopRecord{
+		ID: "loop_hitl_setup_hold", ProjectID: "project_1", Type: "reviewer", Status: "awaiting_human",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	payload := reviewerQueuePayloadJSON("abc123", "sig-disp", true)
+	item := storage.QueueItemRecord{
+		ID: "queue_hitl_setup", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: buildReviewerDedupeKey("project_1", loop.ID, repo, prNumber),
+		Priority:  storage.QueuePriorityReviewer, Status: "running",
+		AvailableAt: fixture.nowISO(), Attempts: 0, MaxAttempts: 5,
+		PayloadJSON: &payload, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), item); err != nil {
+		t.Fatalf("Upsert queue: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{currentLogin: "looper-bot"},
+		Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: testReviewerLoopConfig(),
+	})
+	if err := runner.finalizeClaimSetupFailure(context.Background(), item, errors.New("setup boom")); err != nil {
+		t.Fatalf("finalizeClaimSetupFailure: %v", err)
+	}
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if after == nil || after.Status != "awaiting_human" || !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatalf("hold not preserved: %#v", after)
+	}
+	q, _ := fixture.repos.Queue.GetByID(context.Background(), item.ID)
+	if q == nil || q.Status != "queued" {
+		t.Fatalf("queue = %#v, want retryable queued", q)
+	}
+}
+
+func TestDispositionConvergenceIdentityFailureIsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{currentLoginErr: errors.New("auth boom")}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github,
+		Logger: fixture.logger, Now: fixture.now,
+	})
+	input := threadResolutionStepInput()
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Snapshot = &checkpointSnapshot{HeadSHA: "abc123"}
+	ok, err := runner.shouldScheduleDispositionConvergence(context.Background(), input, input.Checkpoint)
+	if err == nil {
+		t.Fatal("expected retryable identity error")
+	}
+	if ok {
+		t.Fatal("ok must be false on identity failure")
+	}
+	var le *loopError
+	if !errors.As(err, &le) || le.kind != FailureRetryableTransient {
+		// requireCurrentUserLogin wraps as loopError retryable
+		if !strings.Contains(err.Error(), "auth boom") && !strings.Contains(err.Error(), "login") {
+			t.Fatalf("err = %v, want identity failure", err)
+		}
+	}
+}
+
+func TestDispositionConvergenceListingFailureIsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{
+		currentLogin:         "looper-bot",
+		listReviewThreadsErr: errors.New("list boom"),
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github,
+		Logger: fixture.logger, Now: fixture.now,
+	})
+	input := threadResolutionStepInput()
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Snapshot = &checkpointSnapshot{HeadSHA: "abc123"}
+	ok, err := runner.shouldScheduleDispositionConvergence(context.Background(), input, input.Checkpoint)
+	if err == nil {
+		t.Fatal("expected retryable listing error")
+	}
+	if ok {
+		t.Fatal("ok must be false on listing error")
+	}
+	var le *loopError
+	if !errors.As(err, &le) || le.kind != FailureRetryableTransient {
+		t.Fatalf("err = %v, want FailureRetryableTransient", err)
+	}
+}
+
+func TestFinishDispositionOnlyPropagatesConvergenceListingError(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = false
+	// Accept clears the only looper thread → convergence decision runs listing again.
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "old"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix x", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{
+		currentLogin: "looper-bot", reviewThreads: threads, viewHeadSHA: "abc123",
+		// Lists: candidates, refresh before comment, refresh before resolve, post-mutation, convergence.
+		// Fail on a late list so accept mutations land then convergence listing errors.
+		listReviewThreadsErrAfter: 5,
+		listReviewThreadsErr:      errors.New("convergence list boom"),
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed",
+		Stdout: `{"decisions":[{"threadId":"thread_1","decision":"accept_wontfix","evidence":"scope","confidence":"high"}]}`,
+	}}}
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123"}`
+	loop := storage.LoopRecord{
+		ID: "loop_conv_list_err", ProjectID: "project_1", Type: "reviewer", Status: "queued",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: stringPtr("acme/looper"), PRNumber: int64Ptr(42), MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy,
+	})
+	input := threadResolutionStepInput()
+	input.Loop = loop
+	input.Project = storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Detail.Author = "alice"
+	input.Checkpoint.Detail.HeadSHA = "abc123"
+	input.Checkpoint.Snapshot.HeadSHA = "abc123"
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err == nil {
+		// If listing count differs, still require that a successful accept does not
+		// silently finish as disposition_only skip when convergence listing fails.
+		if checkpoint.SkipKind == "disposition_only" && len(github.resolveThreadCalls) > 0 {
+			t.Fatal("accept that should converge must not complete as disposition_only skip on listing error")
+		}
+		t.Fatal("expected convergence listing error to surface")
+	}
+	var le *loopError
+	if !errors.As(err, &le) || le.kind != FailureRetryableTransient {
+		t.Fatalf("err = %v, want FailureRetryableTransient", err)
+	}
+	if checkpoint.SkipKind == "disposition_only" {
+		t.Fatal("must not mark disposition_only skip when convergence decision failed")
+	}
+}
+
+func TestFinishDispositionOnlyPropagatesIdentityError(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos,
+		GitHub: &fakeGitHubGateway{currentLoginErr: errors.New("login down")},
+		Logger: fixture.logger, Now: fixture.now,
+	})
+	input := threadResolutionStepInput()
+	input.Loop = storage.LoopRecord{ID: "loop_fin_id", ProjectID: "project_1", Type: "reviewer", Status: "queued"}
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Snapshot = &checkpointSnapshot{HeadSHA: "abc123"}
+	input.Checkpoint.ReviewSignalFingerprint = "sig"
+	_, err := runner.finishDispositionOnlyCheckpoint(context.Background(), input, input.Checkpoint)
+	if err == nil {
+		t.Fatal("expected identity failure from finishDispositionOnlyCheckpoint")
+	}
+	if strings.Contains(err.Error(), "disposition_only") {
+		t.Fatalf("must not swallow into skip: %v", err)
+	}
+}
+
+func TestLiveGetByIDErrorBeforeCompleteIsRetryableItemStillActive(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"same-head"}`
+	loop := storage.LoopRecord{
+		ID: "loop_live_get_fail", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "running",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert loop: %v", err)
+	}
+	payload := `{"headSha":"same-head","reviewSignalFingerprint":"sig","dispositionOnly":true}`
+	item := storage.QueueItemRecord{
+		ID: "queue_live_get_fail", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: buildReviewerDedupeKey("project_1", loop.ID, repo, prNumber),
+		Priority:  storage.QueuePriorityReviewer, Status: "running",
+		AvailableAt: fixture.nowISO(), Attempts: 0, MaxAttempts: 5,
+		PayloadJSON: &payload, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), item); err != nil {
+		t.Fatalf("Upsert queue: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos,
+		Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: config.ReviewerLoopConfig{QuietPeriodSeconds: 60},
+	})
+	if err := fixture.coordinator.DB().Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	_, err := runner.finalizeSuccessfulReviewerQueue(context.Background(),
+		storage.ProjectRecord{ID: "project_1"}, loop, item, "run_1", reviewerCheckpoint{}, "success", "done")
+	if err == nil {
+		t.Fatal("expected retryable live read failure")
+	}
+	var le *loopError
+	if !errors.As(err, &le) || le.kind != FailureRetryableTransient {
+		t.Fatalf("err = %v, want FailureRetryableTransient", err)
+	}
+	if !strings.Contains(err.Error(), "live queue read before complete failed") {
+		t.Fatalf("err = %v, want live queue read message", err)
+	}
+	// Re-seed on a fresh DB to prove Complete did not run while the gate failed
+	// (closed DB cannot re-read; contract is return-before-Complete).
+	fixture2 := newRunnerFixture(t)
+	if err := fixture2.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert loop2: %v", err)
+	}
+	item.CreatedAt = fixture2.nowISO()
+	item.UpdatedAt = fixture2.nowISO()
+	item.Status = "running"
+	if err := fixture2.repos.Queue.Upsert(context.Background(), item); err != nil {
+		t.Fatalf("Upsert queue2: %v", err)
+	}
+	got, err := fixture2.repos.Queue.GetByID(context.Background(), item.ID)
+	if err != nil || got == nil || got.Status != "running" {
+		t.Fatalf("item must remain active when finalize never Completes: %#v %v", got, err)
+	}
+}
+
+func TestSchedulePendingContinuationErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"same-head"}`
+	loop := storage.LoopRecord{
+		ID: "loop_sched_fail", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "running",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert loop: %v", err)
+	}
+	livePayload := `{"headSha":"same-head","reviewSignalFingerprint":"sig-old","dispositionOnly":true,"pendingHeadSha":"same-head","pendingReviewSignalFingerprint":"sig-pending","pendingDispositionOnly":true}`
+	dedupe := buildReviewerDedupeKey("project_1", loop.ID, repo, prNumber)
+	item := storage.QueueItemRecord{
+		ID: "queue_sched_fail", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: dedupe, Priority: storage.QueuePriorityReviewer, Status: "running",
+		AvailableAt: fixture.nowISO(), Attempts: 0, MaxAttempts: 5,
+		PayloadJSON: &livePayload, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), item); err != nil {
+		t.Fatalf("Upsert queue: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos,
+		Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: config.ReviewerLoopConfig{QuietPeriodSeconds: 60},
+	})
+	// Break enqueue after promote+Complete by removing project (enqueue needs valid paths).
+	// Simpler: close DB after a successful live read is impossible in one call.
+	// Use schedulePendingReviewerContinuation directly and assert finalize surfaces it:
+	// complete item first so schedule is the only step, then close DB.
+	ctx := context.Background()
+	// Promote path runs inside finalize; force schedule failure by using a loop with
+	// empty repo on a copy after we verify the error is not swallowed when schedule fails.
+	// Direct unit: schedule error must be non-nil and finalize must return it.
+	prior := item
+	if err := fixture.repos.Queue.Complete(ctx, item.ID, fixture.nowISO()); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if err := fixture.coordinator.DB().Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	err := runner.schedulePendingReviewerContinuation(ctx, storage.ProjectRecord{ID: "project_1"}, loop, prior, "same-head", "sig-pending", true)
+	if err == nil {
+		t.Fatal("expected schedule error (not swallowed)")
+	}
+}
+
+func TestCursorOnlyPartialBatchContinuationWithoutPending(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"same-head"}`
+	loop := storage.LoopRecord{
+		ID: "loop_cursor_only", Seq: 1, ProjectID: "project_1", Type: "reviewer", Status: "running",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: &repo, PRNumber: &prNumber, MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert loop: %v", err)
+	}
+	// No pending* — only partialBatchContinuation cursor on the running item.
+	livePayload := `{"headSha":"same-head","reviewSignalFingerprint":"sig-old","dispositionOnly":true,"partialBatchContinuation":{"headSha":"same-head","completedThreadIds":["t-done-1"],"capturedCandidateIds":["t-done-1","t-left"],"partialBatch":true,"dispositionOnly":true,"capturedSignalFingerprint":"sig-live","reviewSignalFingerprint":"sig-live"}}`
+	dedupe := buildReviewerDedupeKey("project_1", loop.ID, repo, prNumber)
+	item := storage.QueueItemRecord{
+		ID: "queue_cursor_only", ProjectID: stringPtr("project_1"), LoopID: &loop.ID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: "pr:acme/looper:42", Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: dedupe, Priority: storage.QueuePriorityReviewer, Status: "running",
+		AvailableAt: fixture.nowISO(), Attempts: 0, MaxAttempts: 5,
+		PayloadJSON: &livePayload, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), item); err != nil {
+		t.Fatalf("Upsert queue: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos,
+		Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: config.ReviewerLoopConfig{QuietPeriodSeconds: 60},
+	})
+	ctx := context.Background()
+	_, err := runner.finalizeSuccessfulReviewerQueue(ctx,
+		storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp"}, loop, item, "run_cursor",
+		reviewerCheckpoint{SkipReason: "partial", DispositionOnly: true}, "skipped", "partial")
+	if err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	active, err := fixture.repos.Queue.FindActiveByDedupe(ctx, dedupe)
+	if err != nil || active == nil || active.PayloadJSON == nil {
+		t.Fatalf("active continuation = (%v, %v)", active, err)
+	}
+	if active.ID == item.ID {
+		t.Fatal("expected new continuation item after complete")
+	}
+	if !strings.Contains(*active.PayloadJSON, "partialBatchContinuation") {
+		t.Fatalf("missing partialBatchContinuation: %s", *active.PayloadJSON)
+	}
+	if !strings.Contains(*active.PayloadJSON, "t-done-1") {
+		t.Fatalf("missing completedThreadIds: %s", *active.PayloadJSON)
+	}
+	if !strings.Contains(*active.PayloadJSON, "sig-live") {
+		t.Fatalf("missing live signal: %s", *active.PayloadJSON)
+	}
+	completed, err := fixture.repos.Queue.GetByID(ctx, item.ID)
+	if err != nil || completed == nil || completed.Status != "completed" {
+		t.Fatalf("original item completed = %#v %v", completed, err)
+	}
+}
+
+func TestThreadResolutionBatchFullyCompleteRequiresAllCaptured(t *testing.T) {
+	t.Parallel()
+	if threadResolutionBatchFullyComplete(nil) {
+		t.Fatal("nil must be incomplete")
+	}
+	partial := &threadResolutionCheckpoint{
+		PartialBatch: true, CapturedCandidateIDs: []string{"a"}, CompletedThreadIDs: []string{"a"},
+	}
+	if threadResolutionBatchFullyComplete(partial) {
+		t.Fatal("PartialBatch must not be fully complete")
+	}
+	subset := &threadResolutionCheckpoint{
+		CapturedCandidateIDs: []string{"a", "b"}, CompletedThreadIDs: []string{"a"},
+	}
+	if threadResolutionBatchFullyComplete(subset) {
+		t.Fatal("proper subset must not short-circuit as complete")
+	}
+	full := &threadResolutionCheckpoint{
+		CapturedCandidateIDs: []string{"a", "b"}, CompletedThreadIDs: []string{"b", "a"},
+	}
+	if !threadResolutionBatchFullyComplete(full) {
+		t.Fatal("full coverage must be complete")
+	}
+	emptyCaptured := &threadResolutionCheckpoint{CompletedThreadIDs: []string{"a"}}
+	if threadResolutionBatchFullyComplete(emptyCaptured) {
+		t.Fatal("empty captured must not be complete")
+	}
+}
+
+func TestAcceptReplyThenResolveFailureRetriesResolve(t *testing.T) {
+	t.Parallel()
+	policy := defaultThreadResolutionPolicy(t)
+	policy.Enabled = false
+	threads := []ReviewThread{{
+		ID: "thread_1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->", CommitOID: "old"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix x", CreatedAt: "t2", UpdatedAt: "t2"},
+		},
+	}}
+	github := &fakeGitHubGateway{
+		currentLogin: "looper-bot", reviewThreads: threads, viewHeadSHA: "abc123",
+		resolveThreadErr:      errors.New("resolve boom"),
+		resolveThreadErrTimes: 1,
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{
+		{Status: "completed", Stdout: `{"decisions":[{"threadId":"thread_1","decision":"accept_wontfix","evidence":"scope","confidence":"high"}]}`},
+		// Second classify if short-circuit fails incorrectly — should not be needed when audit present.
+		{Status: "completed", Stdout: `{"decisions":[{"threadId":"thread_1","decision":"accept_wontfix","evidence":"scope","confidence":"high"}]}`},
+	}}
+	fixture := newRunnerFixture(t)
+	meta := `{"followUpdates":true,"lastPublishedHeadSha":"abc123"}`
+	loop := storage.LoopRecord{
+		ID: "loop_resolve_retry", ProjectID: "project_1", Type: "reviewer", Status: "queued",
+		TargetType: "pull_request", TargetID: stringPtr("pr:acme/looper:42"),
+		Repo: stringPtr("acme/looper"), PRNumber: int64Ptr(42), MetadataJSON: &meta,
+		CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO(),
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, ThreadResolution: policy,
+		LoopConfig: testReviewerLoopConfig(),
+	})
+	input := threadResolutionStepInput()
+	input.Loop = loop
+	input.Project = storage.ProjectRecord{ID: "project_1", RepoPath: "/tmp/repo"}
+	input.Checkpoint.DispositionOnly = true
+	input.Checkpoint.Detail.Author = "alice"
+	input.Checkpoint.Detail.HeadSHA = "abc123"
+	input.Checkpoint.Snapshot.HeadSHA = "abc123"
+
+	checkpoint, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected resolve failure on first run")
+	}
+	var le *loopError
+	if !errors.As(err, &le) || le.kind != FailureRetryableTransient {
+		t.Fatalf("err = %v, want FailureRetryableTransient", err)
+	}
+	if len(github.addThreadReplyCalls) != 1 {
+		t.Fatalf("replies = %d, want 1", len(github.addThreadReplyCalls))
+	}
+	if len(github.resolveThreadCalls) != 1 {
+		t.Fatalf("resolves = %d, want 1 failed attempt", len(github.resolveThreadCalls))
+	}
+	if checkpoint.ThreadResolution == nil {
+		t.Fatal("expected checkpoint.ThreadResolution persisted for retry")
+	}
+	if threadResolutionBatchFullyComplete(checkpoint.ThreadResolution) {
+		t.Fatal("incomplete batch must not look fully complete after resolve failure")
+	}
+	for _, id := range checkpoint.ThreadResolution.CompletedThreadIDs {
+		if id == "thread_1" {
+			t.Fatal("thread must not be in CompletedThreadIDs after resolve failure")
+		}
+	}
+	// Resume with checkpoint from failed run (same head, incomplete completed set).
+	input.Checkpoint = checkpoint
+	checkpoint2, err := runner.runThreadResolutionStep(context.Background(), input)
+	if err != nil {
+		t.Fatalf("retry error = %v", err)
+	}
+	if len(github.resolveThreadCalls) != 2 {
+		t.Fatalf("resolves after retry = %d, want 2", len(github.resolveThreadCalls))
+	}
+	if !github.reviewThreads[0].IsResolved {
+		t.Fatal("thread must be resolved after successful retry")
+	}
+	if checkpoint2.ThreadResolution == nil {
+		t.Fatal("expected thread resolution on success")
+	}
+	found := false
+	for _, id := range checkpoint2.ThreadResolution.CompletedThreadIDs {
+		if id == "thread_1" {
+			found = true
+		}
+	}
+	if !found && checkpoint2.ThreadResolution.Resolved < 1 {
+		t.Fatalf("expected thread completed or resolved on success: %#v", checkpoint2.ThreadResolution)
+	}
+}
+
+func int64Ptr(v int64) *int64 { return &v }

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -327,6 +327,10 @@ type ListReviewThreadsInput struct {
 	PRNumber int64
 	CWD      string
 	Limit    int
+	// AllPages requests full pagination for authority reads (fingerprints,
+	// post-mutation refetch). When true, Limit is ignored as a stop condition.
+	// Existing Limit<=0 callers keep the historical default page cap.
+	AllPages bool
 }
 
 type ReviewThread struct {
@@ -342,6 +346,7 @@ type ReviewThreadComment struct {
 	ID                string
 	Body              string
 	Author            string
+	AuthorAssociation string
 	CreatedAt         string
 	UpdatedAt         string
 	Path              string
@@ -582,10 +587,14 @@ type reviewerCheckpoint struct {
 	Worktree                     *checkpointWorktree         `json:"worktree,omitempty"`
 	ThreadResolution             *threadResolutionCheckpoint `json:"threadResolution,omitempty"`
 	ThreadResolutionFollowUpOnly bool                        `json:"threadResolutionFollowUpOnly,omitempty"`
-	PendingReview                *pendingReviewCheckpoint    `json:"pendingReview,omitempty"`
-	SkipReason                   string                      `json:"skipReason,omitempty"`
-	SkipKind                     string                      `json:"skipKind,omitempty"`
-	SkipReviewerLogin            string                      `json:"skipReviewerLogin,omitempty"`
+	// DispositionOnly marks a same-head thread-disposition pass that must not
+	// publish a new PR review or apply minPublishIntervalSeconds.
+	DispositionOnly         bool                     `json:"dispositionOnly,omitempty"`
+	ReviewSignalFingerprint string                   `json:"reviewSignalFingerprint,omitempty"`
+	PendingReview           *pendingReviewCheckpoint `json:"pendingReview,omitempty"`
+	SkipReason              string                   `json:"skipReason,omitempty"`
+	SkipKind                string                   `json:"skipKind,omitempty"`
+	SkipReviewerLogin       string                   `json:"skipReviewerLogin,omitempty"`
 }
 
 type checkpointDetail struct {
@@ -668,11 +677,26 @@ const (
 )
 
 type threadResolutionCheckpoint struct {
-	HeadSHA   string `json:"headSha,omitempty"`
-	Processed int    `json:"processed,omitempty"`
-	Commented int    `json:"commented,omitempty"`
-	Resolved  int    `json:"resolved,omitempty"`
-	Reported  int    `json:"reported,omitempty"`
+	HeadSHA                   string `json:"headSha,omitempty"`
+	ThreadFeedbackFingerprint string `json:"threadFeedbackFingerprint,omitempty"`
+	ReviewSignalFingerprint   string `json:"reviewSignalFingerprint,omitempty"`
+	// CapturedSignalFingerprint is the complete live signal at candidate capture;
+	// used to detect inter-batch drift before the next MaxThreadsPerRun batch.
+	CapturedSignalFingerprint string   `json:"capturedSignalFingerprint,omitempty"`
+	CompletedThreadIDs        []string `json:"completedThreadIds,omitempty"`
+	CapturedCandidateIDs      []string `json:"capturedCandidateIds,omitempty"`
+	PartialBatch              bool     `json:"partialBatch,omitempty"`
+	// PostMutationCommitPending is true when remote mutations succeeded but the
+	// authoritative post-mutation fingerprint promote has not yet committed.
+	PostMutationCommitPending bool `json:"postMutationCommitPending,omitempty"`
+	DispositionOnly           bool `json:"dispositionOnly,omitempty"`
+	// ScheduleConvergencePass requests a same-head full-review admission after
+	// disposition cleared blockers on a non-budget-held loop.
+	ScheduleConvergencePass bool `json:"scheduleConvergencePass,omitempty"`
+	Processed               int  `json:"processed,omitempty"`
+	Commented               int  `json:"commented,omitempty"`
+	Resolved                int  `json:"resolved,omitempty"`
+	Reported                int  `json:"reported,omitempty"`
 }
 
 type resumedRunContext struct {
@@ -1057,9 +1081,14 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 			loopResult.record = *recovered
 		}
 	}
-	if terminalReviewerLoopReason(loopResult.record) != "" {
-		result.Skipped++
-		return nil
+	// Budget-held paused / awaiting_human (HITL) loops must reach the
+	// disposition-only exception below (§8.7). Other terminal statuses stay skipped.
+	if reason := terminalReviewerLoopReason(loopResult.record); reason != "" {
+		budgetHold := loops.IsReviewFixBudgetHold(loopResult.record)
+		if !(budgetHold && (reason == "paused" || reason == "awaiting_human")) {
+			result.Skipped++
+			return nil
+		}
 	}
 	if loopResult.created {
 		result.CreatedLoopIDs = append(result.CreatedLoopIDs, loopResult.record.ID)
@@ -1077,21 +1106,75 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		}
 		*currentLogin = normalizeLogin(lookupLogin)
 	}
-	if reviewerDiscoverySuppressedByLastSkip(meta, pr, *currentLogin, policy) && !allowThreadResolutionFollowUp && !r.allowThreadResolutionFollowUpAfterNotRequestedSkip(ctx, project.RepoPath, repo, pr, *currentLogin, meta, policy) {
-		result.Skipped++
-		return nil
-	}
+	samePublishedHead := false
 	if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && last == pr.HeadSHA && pr.HeadSHA != "" {
+		samePublishedHead = true
+	}
+	dispositionOnly := false
+	reviewSignal := ""
+	// For continuous native-thread loops, evaluate same-head signal before
+	// head-based lastFilterSkip suppression so a changed disposition is not
+	// blocked forever by already_published_head / not_requested history.
+	if samePublishedHead {
+		// lastPublishedHeadSha is publication metadata only; discovery identity is
+		// the review signal (head + Looper-authored thread feedback).
+		decision, err := r.sameHeadDiscoveryDecision(ctx, project, repo, pr, loopResult.record, meta)
+		if err != nil {
+			return err
+		}
+		switch decision.action {
+		case sameHeadDiscoverySkip:
+			result.Skipped++
+			return nil
+		case sameHeadDiscoveryBaselineOnly:
+			result.Skipped++
+			return nil
+		case sameHeadDiscoveryEnqueueDisposition:
+			dispositionOnly = true
+			reviewSignal = decision.signal
+		case sameHeadDiscoveryEnqueueFull:
+			reviewSignal = decision.signal
+		}
+	}
+	if !dispositionOnly && reviewerDiscoverySuppressedByLastSkip(meta, pr, *currentLogin, policy) && !allowThreadResolutionFollowUp {
+		allowFollowUp, followErr := r.allowThreadResolutionFollowUpAfterNotRequestedSkip(ctx, project.RepoPath, repo, pr, *currentLogin, meta, policy)
+		if followErr != nil {
+			return followErr
+		}
+		if !allowFollowUp {
+			result.Skipped++
+			return nil
+		}
+	}
+	if loopResult.record.Status == "human_takeover" {
 		result.Skipped++
 		return nil
 	}
-	if loopResult.record.Status == "awaiting_human" || loopResult.record.Status == "human_takeover" {
-		result.Skipped++
-		return nil
-	}
-	// Sibling pause / exhausted / scope hold must not be revived by discovery enqueue.
-	// Notify only from discovery after a successful park (not from shared park).
+	// Scope holds / non-budget awaiting_human: still skip.
+	// Budget holds: allow disposition-only enqueue without releasing the hold.
 	if loops.IsReviewFixPairHold(loopResult.record) {
+		if dispositionOnly && loops.IsReviewFixBudgetHold(loopResult.record) {
+			availableAt := r.nextReviewAvailableAt(meta, true)
+			queueItem, queueErr := r.enqueue(ctx, enqueueInput{
+				ProjectID:               project.ID,
+				LoopID:                  loopResult.record.ID,
+				Repo:                    repo,
+				PRNumber:                pr.Number,
+				HeadSHA:                 pr.HeadSHA,
+				ReviewSignalFingerprint: reviewSignal,
+				DispositionOnly:         true,
+				AvailableAt:             availableAt,
+			})
+			if queueErr != nil {
+				return queueErr
+			}
+			// markLoopQueuedForReview no-ops on pair holds — status/counters stay.
+			if err := r.markLoopQueuedForReview(ctx, loopResult.record, queueItem.AvailableAt); err != nil {
+				return err
+			}
+			result.QueueItems = append(result.QueueItems, queueItem)
+			return nil
+		}
 		if loops.IsReviewFixBudgetHold(loopResult.record) {
 			if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
 				return err
@@ -1102,21 +1185,50 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		result.Skipped++
 		return nil
 	}
+	if loopResult.record.Status == "awaiting_human" {
+		result.Skipped++
+		return nil
+	}
 	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
 		return err
 	} else if parked {
+		// Just parked for budget: still allow disposition-only on the new hold.
+		if dispositionOnly {
+			availableAt := r.nextReviewAvailableAt(meta, true)
+			queueItem, queueErr := r.enqueue(ctx, enqueueInput{
+				ProjectID:               project.ID,
+				LoopID:                  loopResult.record.ID,
+				Repo:                    repo,
+				PRNumber:                pr.Number,
+				HeadSHA:                 pr.HeadSHA,
+				ReviewSignalFingerprint: reviewSignal,
+				DispositionOnly:         true,
+				AvailableAt:             availableAt,
+			})
+			if queueErr != nil {
+				return queueErr
+			}
+			if err := r.markLoopQueuedForReview(ctx, loopResult.record, queueItem.AvailableAt); err != nil {
+				return err
+			}
+			result.QueueItems = append(result.QueueItems, queueItem)
+			r.notifyHumanAttentionBestEffort(ctx, loopResult.record.ID)
+			return nil
+		}
 		r.notifyHumanAttentionBestEffort(ctx, loopResult.record.ID)
 		result.Skipped++
 		return nil
 	}
-	availableAt := r.nextReviewAvailableAt(meta)
+	availableAt := r.nextReviewAvailableAt(meta, dispositionOnly)
 	queueItem, queueErr := r.enqueue(ctx, enqueueInput{
-		ProjectID:   project.ID,
-		LoopID:      loopResult.record.ID,
-		Repo:        repo,
-		PRNumber:    pr.Number,
-		HeadSHA:     pr.HeadSHA,
-		AvailableAt: availableAt,
+		ProjectID:               project.ID,
+		LoopID:                  loopResult.record.ID,
+		Repo:                    repo,
+		PRNumber:                pr.Number,
+		HeadSHA:                 pr.HeadSHA,
+		ReviewSignalFingerprint: reviewSignal,
+		DispositionOnly:         dispositionOnly,
+		AvailableAt:             availableAt,
 	})
 	if queueErr != nil {
 		return queueErr
@@ -1128,23 +1240,138 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 	return nil
 }
 
-func (r *Runner) allowThreadResolutionFollowUpAfterNotRequestedSkip(ctx context.Context, cwd, repo string, pr PullRequestSummary, currentLogin string, meta map[string]any, policy DiscoveryPolicy) bool {
+type sameHeadDiscoveryAction int
+
+const (
+	sameHeadDiscoverySkip sameHeadDiscoveryAction = iota
+	sameHeadDiscoveryBaselineOnly
+	sameHeadDiscoveryEnqueueDisposition
+	sameHeadDiscoveryEnqueueFull
+)
+
+type sameHeadDiscoveryResult struct {
+	action sameHeadDiscoveryAction
+	signal string
+}
+
+// sameHeadDiscoveryDecision decides whether a continuous same-head loop should
+// skip, store a baseline fingerprint, or enqueue disposition/full work.
+func (r *Runner) sameHeadDiscoveryDecision(ctx context.Context, project storage.ProjectRecord, repo string, pr PullRequestSummary, loop storage.LoopRecord, meta map[string]any) (sameHeadDiscoveryResult, error) {
+	if !r.hasNativeThreadCapabilities(project.ID) {
+		// Forgejo / providers without native threads: head-only identity remains.
+		return sameHeadDiscoveryResult{action: sameHeadDiscoverySkip}, nil
+	}
+	if !isContinuousReviewerLoop(loop, meta) {
+		return sameHeadDiscoveryResult{action: sameHeadDiscoverySkip}, nil
+	}
+	looperLogin, err := r.requireCurrentUserLogin(ctx, project.RepoPath)
+	if err != nil {
+		return sameHeadDiscoveryResult{}, err
+	}
+	threads, err := r.listReviewThreadsForSignal(ctx, project.RepoPath, repo, pr.Number)
+	if err != nil {
+		// Fail closed on listing errors: retryable, do not advance or invent a signal.
+		r.logWarn("reviewer same-head signal listing failed", map[string]any{"repo": repo, "prNumber": pr.Number, "error": err.Error()})
+		return sameHeadDiscoveryResult{}, &loopError{message: "same-head signal listing failed: " + err.Error(), kind: FailureRetryableTransient}
+	}
+	signal := ComputeReviewSignalFingerprintForLogin(pr.HeadSHA, threads, looperLogin)
+	lastSignal, _ := stringFromAny(meta[metadataLastReviewedSignalFingerprintKey])
+	if strings.TrimSpace(lastSignal) == "" {
+		// Upgrade path: missing fingerprint.
+		if hasUnresolvedLooperAuthoredThreadsForLogin(threads, looperLogin) {
+			return sameHeadDiscoveryResult{action: sameHeadDiscoveryEnqueueDisposition, signal: signal}, nil
+		}
+		if err := r.persistLastReviewedSignalFingerprint(ctx, loop, signal); err != nil {
+			return sameHeadDiscoveryResult{}, err
+		}
+		return sameHeadDiscoveryResult{action: sameHeadDiscoveryBaselineOnly, signal: signal}, nil
+	}
+	if lastSignal == signal {
+		return sameHeadDiscoveryResult{action: sameHeadDiscoverySkip, signal: signal}, nil
+	}
+	// Signal changed on unchanged head → disposition (or clean convergence) pass.
+	return sameHeadDiscoveryResult{action: sameHeadDiscoveryEnqueueDisposition, signal: signal}, nil
+}
+
+// requireCurrentUserLogin resolves live GitHub identity. Empty login and lookup
+// failures are retryable — production paths must not invent looper* identity.
+func (r *Runner) requireCurrentUserLogin(ctx context.Context, cwd string) (string, error) {
+	if r.github == nil {
+		return "", &loopError{message: "github gateway is not configured", kind: FailureRetryableTransient}
+	}
+	login, err := r.github.GetCurrentUserLogin(ctx, cwd)
+	if err != nil {
+		return "", &loopError{message: err.Error(), kind: FailureRetryableTransient}
+	}
+	login = normalizeLogin(login)
+	if login == "" {
+		return "", &loopError{message: "current user login is empty", kind: FailureRetryableTransient}
+	}
+	return login, nil
+}
+
+func (r *Runner) hasNativeThreadCapabilities(projectID string) bool {
+	return !r.forgejoProject(projectID)
+}
+
+func isContinuousReviewerLoop(loop storage.LoopRecord, meta map[string]any) bool {
+	if meta == nil {
+		meta = parseJSONObject(loop.MetadataJSON)
+	}
+	if enabled, ok := meta["followUpdates"].(bool); ok {
+		return enabled
+	}
+	if loopMeta, ok := meta["loop"].(map[string]any); ok {
+		if enabled, ok := loopMeta["enabled"].(bool); ok {
+			return enabled
+		}
+	}
+	return false
+}
+
+func (r *Runner) listReviewThreadsForSignal(ctx context.Context, cwd, repo string, prNumber int64) ([]ReviewThread, error) {
+	if r.github == nil {
+		return nil, fmt.Errorf("github gateway is not configured")
+	}
+	// Authority reads must page fully; MaxThreadsPerRun only limits classifier batches.
+	return r.github.ListReviewThreads(ctx, ListReviewThreadsInput{Repo: repo, PRNumber: prNumber, CWD: cwd, AllPages: true})
+}
+
+func (r *Runner) persistLastReviewedSignalFingerprint(ctx context.Context, loop storage.LoopRecord, signal string) error {
+	signal = strings.TrimSpace(signal)
+	if signal == "" || r.repos == nil || r.repos.Loops == nil || strings.TrimSpace(loop.ID) == "" {
+		return nil
+	}
+	_, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
+		metadataJSON, metaErr := mergeLoopMetadataJSON(updated.MetadataJSON, map[string]any{metadataLastReviewedSignalFingerprintKey: signal})
+		if metaErr == nil {
+			updated.MetadataJSON = &metadataJSON
+		}
+	})
+	return err
+}
+
+func (r *Runner) allowThreadResolutionFollowUpAfterNotRequestedSkip(ctx context.Context, cwd, repo string, pr PullRequestSummary, currentLogin string, meta map[string]any, policy DiscoveryPolicy) (bool, error) {
 	if networkpolicy.IsRouted(policy.RoutedClaimPolicy) || !policy.RequireReviewRequest {
-		return false
+		return false, nil
 	}
 	raw, _ := meta["lastFilterSkip"].(map[string]any)
 	if raw == nil {
-		return false
+		return false, nil
 	}
 	kind, _ := stringFromAny(raw["kind"])
 	if kind != "not_requested" || !reviewRequestsKnownAbsent(pr.ReviewRequests, currentLogin) {
-		return false
+		return false, nil
 	}
 	reviewerLogin, _ := stringFromAny(raw["reviewerLogin"])
 	if normalizeLogin(reviewerLogin) == "" || normalizeLogin(currentLogin) == "" || normalizeLogin(reviewerLogin) != normalizeLogin(currentLogin) {
-		return false
+		return false, nil
 	}
-	return r.hasThreadResolutionFollowUpCandidate(ctx, cwd, repo, pr.Number, pr.HeadSHA, currentLogin)
+	if r.hasThreadResolutionFollowUpCandidate(ctx, cwd, repo, pr.Number, pr.HeadSHA, currentLogin) {
+		return true, nil
+	}
+	// Narrow disposition is independent of ThreadResolution.Enabled.
+	return r.hasNarrowDispositionCandidate(ctx, cwd, repo, pr.Number, pr.HeadSHA, pr.Author, currentLogin)
 }
 
 func (r *Runner) discoverExistingReviewerLoop(ctx context.Context, project storage.ProjectRecord, repo string, policy DiscoveryPolicy, currentLogin *string, loop storage.LoopRecord, detail PullRequestDetail, result *DiscoveryResult) error {
@@ -1167,6 +1394,14 @@ func (r *Runner) discoverExistingReviewerLoop(ctx context.Context, project stora
 	allowThreadResolutionFollowUp := false
 	if !networkpolicy.IsRouted(policy.RoutedClaimPolicy) && requireReviewRequest && reviewRequestsKnownAbsent(detail.ReviewRequests, *currentLogin) {
 		allowThreadResolutionFollowUp = r.hasThreadResolutionFollowUpCandidate(ctx, project.RepoPath, repo, detail.Number, detail.HeadSHA, *currentLogin)
+		if !allowThreadResolutionFollowUp {
+			// Narrow disposition candidate still allows discovery when Enabled=false.
+			var narrowErr error
+			allowThreadResolutionFollowUp, narrowErr = r.hasNarrowDispositionCandidate(ctx, project.RepoPath, repo, detail.Number, detail.HeadSHA, detail.Author, *currentLogin)
+			if narrowErr != nil {
+				return narrowErr
+			}
+		}
 		if !allowThreadResolutionFollowUp {
 			result.Skipped++
 			return nil
@@ -1600,6 +1835,16 @@ func (r *Runner) finalizeClaimSetupFailure(ctx context.Context, queueItem storag
 	}
 	_, err = r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
 		updated.LastRunAt = stringPtr(r.nowISO())
+		// Budget/scope pair holds must keep awaiting_human/paused presentation.
+		// Still attach NextRunAt when the queue item is retryable.
+		if loops.IsReviewFixPairHold(*updated) {
+			if failedQueue != nil && failedQueue.Status == "queued" {
+				updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
+			} else {
+				updated.NextRunAt = nil
+			}
+			return
+		}
 		if updated.Status == "paused" {
 			updated.NextRunAt = nil
 		} else if failedQueue != nil && failedQueue.Status == "queued" {
@@ -1660,16 +1905,29 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		}
 		return ProcessResult{}, err
 	}
+	dispositionOnlyClaim := payloadDispositionOnly(queueItem.PayloadJSON)
 	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, *loop); err != nil {
 		return ProcessResult{}, err
 	} else if parked {
-		// Crash gap: publish + budget park may have landed without scope
-		// park/defer. Recover pending/scope from the latest checkpoint before
-		// skipping — never start the agent or re-publish on this path.
-		if err := r.recoverPublishedNeedsHumanScopeFromLatestRun(ctx, *project, *loop); err != nil {
-			return ProcessResult{}, err
+		// Budget-held disposition-only with a live changed signal still runs the
+		// narrow path (handoff refresh only; never publish / meter).
+		allowDisposition := false
+		if dispositionOnlyClaim && loop.Repo != nil && loop.PRNumber != nil {
+			if live, liveErr := r.dispositionOnlyStillActionable(ctx, *project, *loop, queueItem); liveErr != nil {
+				return ProcessResult{}, liveErr
+			} else {
+				allowDisposition = live
+			}
 		}
-		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: "review-fix budget exhausted"}, nil
+		if !allowDisposition {
+			// Crash gap: publish + budget park may have landed without scope
+			// park/defer. Recover pending/scope from the latest checkpoint before
+			// skipping — never start the agent or re-publish on this path.
+			if err := r.recoverPublishedNeedsHumanScopeFromLatestRun(ctx, *project, *loop); err != nil {
+				return ProcessResult{}, err
+			}
+			return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: "review-fix budget exhausted"}, nil
+		}
 	}
 	resumedRun, err := r.createRunContext(ctx, *loop)
 	if err != nil {
@@ -1726,7 +1984,10 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		}
 	}
 	updatedLoop, err := r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
-		updated.Status = "running"
+		// Disposition-only on a budget hold must not flip hold status to running.
+		if !(dispositionOnlyClaim && loops.IsReviewFixBudgetHold(*updated)) {
+			updated.Status = "running"
+		}
 		updated.LastRunAt = stringPtr(run.StartedAt)
 		updated.NextRunAt = nil
 		metadataJSON, metaErr := r.recordLoopRunStartMetadata(updated.MetadataJSON, project.ID)
@@ -1818,6 +2079,13 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 				} else if failure.interrupted && terminalReviewerLoopReason(*updated) == "failed" {
 					updated.Status = "paused"
 					updated.NextRunAt = nil
+				} else if loops.IsReviewFixPairHold(*updated) {
+					// Keep awaiting_human/paused hold presentation; still schedule retry.
+					if failedQueue != nil && failedQueue.Status == "queued" {
+						updated.NextRunAt = stringPtr(failedQueue.AvailableAt)
+					} else {
+						updated.NextRunAt = nil
+					}
 				} else if updated.Status == "paused" {
 					updated.NextRunAt = nil
 				} else if failedQueue != nil && failedQueue.Status == "queued" {
@@ -1869,16 +2137,79 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if checkpoint.SkipReason != "" {
 		status = "skipped"
 	}
+	return r.finalizeSuccessfulReviewerQueue(ctx, *project, *loop, queueItem, run.ID, checkpoint, status, summary)
+}
+
+// finalizeSuccessfulReviewerQueue completes the active item and schedules any
+// pending/partial-batch continuation fail-closed (live read required; schedule errors surface).
+func (r *Runner) finalizeSuccessfulReviewerQueue(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord, queueItem storage.QueueItemRecord, runID string, checkpoint reviewerCheckpoint, status, summary string) (ProcessResult, error) {
+	// Capture pending coalesced signal before completing the active item.
+	// Prefer the live row: mid-run may have stashed pending* and/or written
+	// partialBatchContinuation onto the running payload after claim.
+	// Fail closed on live read — do not Complete against a blind/stale snapshot.
+	liveItem, liveErr := r.repos.Queue.GetByID(ctx, queueItem.ID)
+	if liveErr != nil {
+		return ProcessResult{}, &loopError{message: "live queue read before complete failed: " + liveErr.Error(), kind: FailureRetryableTransient}
+	}
+	priorForContinuation := queueItem
+	if liveItem != nil {
+		priorForContinuation = *liveItem
+	}
+	pendingHead, pendingSignal, pendingDisp, hasPending := pendingReviewSignalFromQueuePayload(priorForContinuation.PayloadJSON)
+	partialCont := partialBatchContinuationFromPayload(priorForContinuation.PayloadJSON)
+	// Cursor-only resume: running enqueue may have written partialBatchContinuation
+	// without a distinct pending* signal (or pending was cleared). Still continue.
+	if !hasPending && partialCont != nil {
+		pendingSignal = strings.TrimSpace(partialCont.ReviewSignalFingerprint)
+		if pendingSignal == "" {
+			pendingSignal = strings.TrimSpace(partialCont.CapturedSignalFingerprint)
+		}
+		if pendingSignal == "" {
+			pendingSignal = reviewSignalFromQueuePayload(priorForContinuation.PayloadJSON)
+		}
+		pendingHead = strings.TrimSpace(partialCont.HeadSHA)
+		if pendingHead == "" {
+			pendingHead = headSHAFromQueuePayload(priorForContinuation.PayloadJSON)
+		}
+		pendingDisp = partialCont.DispositionOnly || payloadDispositionOnly(priorForContinuation.PayloadJSON)
+		hasPending = strings.TrimSpace(pendingSignal) != ""
+	}
+	needsContinuation := hasPending || partialCont != nil
+	if needsContinuation && strings.TrimSpace(pendingSignal) == "" {
+		pendingSignal = reviewSignalFromQueuePayload(priorForContinuation.PayloadJSON)
+		hasPending = strings.TrimSpace(pendingSignal) != ""
+		needsContinuation = hasPending || partialCont != nil
+	}
+	// Promote pending*/cursor onto primary payload before Complete so a failed
+	// post-Complete schedule can MarkRetry-resurrect with usable continuation state.
+	if needsContinuation && hasPending {
+		if promoted, promoErr := promoteReviewerContinuationPayload(priorForContinuation.PayloadJSON, pendingHead, pendingSignal, pendingDisp); promoErr != nil {
+			return ProcessResult{}, promoErr
+		} else if promoted != "" {
+			payload := promoted
+			priorForContinuation.PayloadJSON = &payload
+			priorForContinuation.UpdatedAt = r.nowISO()
+			if _, _, upsertErr := r.repos.Queue.UpsertActiveByDedupeOrGetExisting(ctx, priorForContinuation); upsertErr != nil {
+				return ProcessResult{}, upsertErr
+			}
+		}
+	}
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil {
 		if errors.Is(err, storage.ErrQueueItemNotActive) {
-			return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
+			return ProcessResult{LoopID: loop.ID, RunID: runID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
 		}
 		return ProcessResult{}, err
 	}
-	updatedLoop, err = r.updateLoop(ctx, *loop, func(updated *storage.LoopRecord) {
+	updatedLoop, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
 		metadataJSON, metaErr := r.recordLoopSuccessMetadata(updated.MetadataJSON, checkpoint, summary)
 		if metaErr == nil {
 			updated.MetadataJSON = &metadataJSON
+		}
+		// Preserve budget/scope pair hold status after disposition-only work.
+		if loops.IsReviewFixPairHold(*updated) {
+			updated.LastRunAt = stringPtr(r.nowISO())
+			updated.NextRunAt = nil
+			return
 		}
 		if r.shouldParkReviewerBudget(*updated, checkpoint) {
 			updated.LastRunAt = stringPtr(r.nowISO())
@@ -1892,19 +2223,92 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if err != nil {
 		return ProcessResult{}, err
 	}
-	if parked, parkErr := r.parkReviewerBudgetAfterSuccessfulRun(ctx, *project, updatedLoop); parkErr != nil {
+	if parked, parkErr := r.parkReviewerBudgetAfterSuccessfulRun(ctx, project, updatedLoop); parkErr != nil {
 		return ProcessResult{}, parkErr
 	} else if parked {
-		r.cleanupReviewerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
-		return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
+		r.cleanupReviewerWorktreeIfTerminal(context.Background(), project, &checkpoint)
+		// Still schedule disposition / partial-batch continuation on budget hold.
+		// Convergence full-review (pendingDisp=false without partial cursor) waits.
+		if needsContinuation && hasPending && (pendingDisp || partialCont != nil) {
+			if err := r.schedulePendingReviewerContinuation(ctx, project, updatedLoop, priorForContinuation, pendingHead, pendingSignal, pendingDisp); err != nil {
+				return ProcessResult{}, err
+			}
+		}
+		return ProcessResult{LoopID: loop.ID, RunID: runID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
 	}
 	if reason := terminalReviewerLoopReason(updatedLoop); reason != "" {
 		if _, err := r.repos.Queue.CancelByLoop(ctx, updatedLoop.ID, r.nowISO(), &reason); err != nil {
 			return ProcessResult{}, err
 		}
+	} else if needsContinuation && hasPending {
+		if err := r.schedulePendingReviewerContinuation(ctx, project, updatedLoop, priorForContinuation, pendingHead, pendingSignal, pendingDisp); err != nil {
+			return ProcessResult{}, err
+		}
 	}
-	r.cleanupReviewerWorktreeIfTerminal(context.Background(), *project, &checkpoint)
-	return ProcessResult{LoopID: loop.ID, RunID: run.ID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
+	r.cleanupReviewerWorktreeIfTerminal(context.Background(), project, &checkpoint)
+	return ProcessResult{LoopID: loop.ID, RunID: runID, QueueItemID: queueItem.ID, Status: status, Summary: summary}, nil
+}
+
+// promoteReviewerContinuationPayload lifts pending* (or explicit head/signal) onto
+// primary payload fields and drops pending* keys. partialBatchContinuation is kept.
+func promoteReviewerContinuationPayload(payloadJSON *string, head, signal string, dispositionOnly bool) (string, error) {
+	if strings.TrimSpace(signal) == "" {
+		return "", nil
+	}
+	merged := parseJSONObject(payloadJSON)
+	delete(merged, "pendingReviewSignalFingerprint")
+	delete(merged, "pendingHeadSha")
+	delete(merged, "pendingDispositionOnly")
+	merged["reviewSignalFingerprint"] = signal
+	if strings.TrimSpace(head) != "" {
+		merged["headSha"] = head
+	}
+	merged["dispositionOnly"] = dispositionOnly
+	encoded, err := json.Marshal(merged)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func (r *Runner) schedulePendingReviewerContinuation(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord, prior storage.QueueItemRecord, head, signal string, dispositionOnly bool) error {
+	if strings.TrimSpace(signal) == "" || prior.Repo == nil || prior.PRNumber == nil {
+		return nil
+	}
+	if head == "" {
+		head = headSHAFromQueuePayload(prior.PayloadJSON)
+	}
+	meta := parseJSONObject(loop.MetadataJSON)
+	availableAt := r.nextReviewAvailableAt(meta, dispositionOnly)
+	item, err := r.enqueue(ctx, enqueueInput{
+		ProjectID:               project.ID,
+		LoopID:                  loop.ID,
+		Repo:                    *prior.Repo,
+		PRNumber:                *prior.PRNumber,
+		HeadSHA:                 head,
+		ReviewSignalFingerprint: signal,
+		DispositionOnly:         dispositionOnly,
+		AvailableAt:             availableAt,
+	})
+	if err != nil {
+		return err
+	}
+	// Preserve partial-batch cursor from the completed run onto the new item.
+	if contRaw, ok := parseJSONObject(prior.PayloadJSON)["partialBatchContinuation"]; ok && contRaw != nil {
+		merged := parseJSONObject(item.PayloadJSON)
+		merged["partialBatchContinuation"] = contRaw
+		encoded, encErr := json.Marshal(merged)
+		if encErr != nil {
+			return encErr
+		}
+		payload := string(encoded)
+		item.PayloadJSON = &payload
+		item.UpdatedAt = r.nowISO()
+		if _, _, upsertErr := r.repos.Queue.UpsertActiveByDedupeOrGetExisting(ctx, item); upsertErr != nil {
+			return upsertErr
+		}
+	}
+	return nil
 }
 
 func (r *Runner) revalidateRoutedReviewerClaim(ctx context.Context, project storage.ProjectRecord, queueItem storage.QueueItemRecord) error {
@@ -2127,22 +2531,74 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 			return checkpoint, nil
 		}
 	}
+	meta := parseJSONObject(input.Loop.MetadataJSON)
+	samePublishedHead := false
+	if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && checkpoint.Detail.HeadSHA != "" && last == checkpoint.Detail.HeadSHA {
+		samePublishedHead = true
+	}
+	alreadyReviewedHead := false
 	if !isManualReviewerLoop(input.Loop) && len(checkpoint.Detail.Reviews) > 0 {
 		if err := ensureCurrentLogin(); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
 		}
 		if hasReviewByAuthorForHead(checkpoint.Detail.Reviews, currentLogin, checkpoint.Detail.HeadSHA) {
+			alreadyReviewedHead = true
+		}
+	}
+	if samePublishedHead || alreadyReviewedHead {
+		// Allow a thread-disposition pass when the review signal changed even
+		// though the code head (and prior review publication) did not.
+		if admitted, signal, err := r.admitSameHeadDisposition(ctx, input, checkpoint, meta); err != nil {
+			return checkpoint, err
+		} else if admitted {
+			checkpoint.DispositionOnly = true
+			checkpoint.ThreadResolutionFollowUpOnly = true
+			checkpoint.ReviewSignalFingerprint = signal
+			return checkpoint, nil
+		}
+		if alreadyReviewedHead && !samePublishedHead {
 			checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user already reviewed head %s", input.Repo, input.PRNumber, checkpoint.Detail.HeadSHA)
 			checkpoint.SkipKind = "already_reviewed_by_current_user"
 			checkpoint.SkipReviewerLogin = currentLogin
 			return checkpoint, nil
 		}
+		if samePublishedHead {
+			checkpoint.SkipReason = fmt.Sprintf("Skipped already-reviewed head %s for %s#%d", checkpoint.Detail.HeadSHA, input.Repo, input.PRNumber)
+			checkpoint.SkipKind = "already_published_head"
+			return checkpoint, nil
+		}
 	}
-	meta := parseJSONObject(input.Loop.MetadataJSON)
-	if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && checkpoint.Detail.HeadSHA != "" && last == checkpoint.Detail.HeadSHA {
-		checkpoint.SkipReason = fmt.Sprintf("Skipped already-reviewed head %s for %s#%d", checkpoint.Detail.HeadSHA, input.Repo, input.PRNumber)
-		checkpoint.SkipKind = "already_published_head"
-		return checkpoint, nil
+	// Queue payload is a cursor, not authority. Compare to live head/signal.
+	payloadHead := headSHAFromQueuePayload(input.QueueItem.PayloadJSON)
+	payloadSignal := reviewSignalFromQueuePayload(input.QueueItem.PayloadJSON)
+	payloadDispOnly := payloadDispositionOnly(input.QueueItem.PayloadJSON)
+	if payloadDispOnly {
+		liveHead := ""
+		if checkpoint.Detail != nil {
+			liveHead = strings.TrimSpace(checkpoint.Detail.HeadSHA)
+		}
+		if payloadHead != "" && liveHead != "" && payloadHead != liveHead {
+			// Head drifted after disposition-only enqueue → full new-head review.
+			checkpoint.DispositionOnly = false
+			checkpoint.ThreadResolutionFollowUpOnly = false
+			checkpoint.ReviewSignalFingerprint = ""
+		} else {
+			checkpoint.DispositionOnly = true
+			checkpoint.ThreadResolutionFollowUpOnly = true
+			if payloadSignal != "" {
+				checkpoint.ReviewSignalFingerprint = payloadSignal
+			}
+		}
+	} else if payloadSignal != "" {
+		checkpoint.ReviewSignalFingerprint = payloadSignal
+	}
+	// Restore partial-batch continuation cursor from payload when present.
+	if cont := partialBatchContinuationFromPayload(input.QueueItem.PayloadJSON); cont != nil {
+		checkpoint.ThreadResolution = cont
+		checkpoint.DispositionOnly = checkpoint.DispositionOnly || cont.DispositionOnly
+		if cont.DispositionOnly {
+			checkpoint.ThreadResolutionFollowUpOnly = true
+		}
 	}
 	requireReviewRequest := requireReviewRequestForLoop(input.Loop, reviewRequestRequiredForCandidate(policy, checkpoint.Detail.Labels), checkpoint.Detail.HeadSHA)
 	if !isManualReviewerLoop(input.Loop) && networkpolicy.IsRouted(policy.RoutedClaimPolicy) {
@@ -2164,7 +2620,22 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
 		}
 		if reviewRequestsKnownAbsent(checkpoint.Detail.ReviewRequests, currentLogin) {
+			// Disposition-only work is targeted intent and may proceed without a
+			// fresh review request (RequireCurrentReviewRequest does not apply).
+			if checkpoint.DispositionOnly {
+				checkpoint.ThreadResolutionFollowUpOnly = true
+				return checkpoint, nil
+			}
 			if r.hasThreadResolutionFollowUpCandidate(ctx, input.Project.RepoPath, input.Repo, input.PRNumber, checkpoint.Detail.HeadSHA, currentLogin) {
+				checkpoint.ThreadResolutionFollowUpOnly = true
+				return checkpoint, nil
+			}
+			narrowOK, narrowErr := r.hasNarrowDispositionCandidate(ctx, input.Project.RepoPath, input.Repo, input.PRNumber, checkpoint.Detail.HeadSHA, checkpoint.Detail.Author, currentLogin)
+			if narrowErr != nil {
+				return checkpoint, narrowErr
+			}
+			if narrowOK {
+				checkpoint.DispositionOnly = true
 				checkpoint.ThreadResolutionFollowUpOnly = true
 				return checkpoint, nil
 			}
@@ -2174,6 +2645,183 @@ func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCh
 		}
 	}
 	return checkpoint, nil
+}
+
+func reviewSignalFromQueuePayload(payloadJSON *string) string {
+	payload := parseJSONObject(payloadJSON)
+	signal, _ := stringFromAny(payload["reviewSignalFingerprint"])
+	return strings.TrimSpace(signal)
+}
+
+func headSHAFromQueuePayload(payloadJSON *string) string {
+	payload := parseJSONObject(payloadJSON)
+	head, _ := stringFromAny(payload["headSha"])
+	return strings.TrimSpace(head)
+}
+
+func pendingReviewSignalFromQueuePayload(payloadJSON *string) (head, signal string, dispositionOnly bool, ok bool) {
+	payload := parseJSONObject(payloadJSON)
+	signal, _ = stringFromAny(payload["pendingReviewSignalFingerprint"])
+	signal = strings.TrimSpace(signal)
+	if signal == "" {
+		return "", "", false, false
+	}
+	head, _ = stringFromAny(payload["pendingHeadSha"])
+	head = strings.TrimSpace(head)
+	if v, isBool := payload["pendingDispositionOnly"].(bool); isBool {
+		dispositionOnly = v
+	}
+	return head, signal, dispositionOnly, true
+}
+
+func payloadDispositionOnly(payloadJSON *string) bool {
+	payload := parseJSONObject(payloadJSON)
+	if v, ok := payload["dispositionOnly"].(bool); ok {
+		return v
+	}
+	return false
+}
+
+func partialBatchContinuationFromPayload(payloadJSON *string) *threadResolutionCheckpoint {
+	payload := parseJSONObject(payloadJSON)
+	raw, ok := payload["partialBatchContinuation"].(map[string]any)
+	if !ok || raw == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var cont threadResolutionCheckpoint
+	if err := json.Unmarshal(encoded, &cont); err != nil {
+		return nil
+	}
+	if !cont.PartialBatch && !cont.PostMutationCommitPending {
+		return nil
+	}
+	return &cont
+}
+
+// threadResolutionBatchFullyComplete reports whether a prior thread-resolution
+// checkpoint finished every captured candidate for this head. Used to avoid
+// treating a mid-batch mutation failure (PartialBatch=false but incomplete
+// CompletedThreadIDs) as a finished batch on retry.
+func threadResolutionBatchFullyComplete(tr *threadResolutionCheckpoint) bool {
+	if tr == nil || tr.PartialBatch || tr.PostMutationCommitPending {
+		return false
+	}
+	if len(tr.CapturedCandidateIDs) == 0 || len(tr.CompletedThreadIDs) == 0 {
+		return false
+	}
+	completed := make(map[string]struct{}, len(tr.CompletedThreadIDs))
+	for _, id := range tr.CompletedThreadIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		completed[id] = struct{}{}
+	}
+	if len(completed) == 0 {
+		return false
+	}
+	for _, id := range tr.CapturedCandidateIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := completed[id]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// dispositionOnlyStillActionable reports whether a budget-held disposition-only
+// claim still has a live changed disposition signal (payload is not authority).
+func (r *Runner) dispositionOnlyStillActionable(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord, queueItem storage.QueueItemRecord) (bool, error) {
+	if r.github == nil || loop.Repo == nil || loop.PRNumber == nil {
+		return false, nil
+	}
+	looperLogin, err := r.requireCurrentUserLogin(ctx, project.RepoPath)
+	if err != nil {
+		return false, err
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: *loop.Repo, PRNumber: *loop.PRNumber, CWD: project.RepoPath})
+	if err != nil {
+		return false, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+	}
+	threads, err := r.listReviewThreadsForSignal(ctx, project.RepoPath, *loop.Repo, *loop.PRNumber)
+	if err != nil {
+		return false, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+	}
+	if ThreadsHaveChangedDispositionSignalForLogin(threads, detail.Author, looperLogin) {
+		return true, nil
+	}
+	// Also admit when live signal differs from stored fingerprint (upgrade / edit).
+	meta := parseJSONObject(loop.MetadataJSON)
+	live := ComputeReviewSignalFingerprintForLogin(detail.HeadSHA, threads, looperLogin)
+	last, _ := stringFromAny(meta[metadataLastReviewedSignalFingerprintKey])
+	if strings.TrimSpace(last) != "" && last != live {
+		return true, nil
+	}
+	return false, nil
+}
+
+// admitSameHeadDisposition returns true when a continuous native-thread loop has
+// a review signal that differs from lastReviewedSignalFingerprint (or needs the
+// upgrade reconciliation pass). Live listing is authority; payload is a cursor.
+func (r *Runner) admitSameHeadDisposition(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, meta map[string]any) (bool, string, error) {
+	if checkpoint.Detail == nil || !r.hasNativeThreadCapabilities(input.Project.ID) {
+		return false, "", nil
+	}
+	if !isContinuousReviewerLoop(input.Loop, meta) {
+		return false, "", nil
+	}
+	looperLogin, err := r.requireCurrentUserLogin(ctx, input.Project.RepoPath)
+	if err != nil {
+		return false, "", err
+	}
+	threads, err := r.listReviewThreadsForSignal(ctx, input.Project.RepoPath, input.Repo, input.PRNumber)
+	if err != nil {
+		return false, "", &loopError{message: err.Error(), kind: FailureRetryableTransient}
+	}
+	signal := ComputeReviewSignalFingerprintForLogin(checkpoint.Detail.HeadSHA, threads, looperLogin)
+	lastSignal, _ := stringFromAny(meta[metadataLastReviewedSignalFingerprintKey])
+	// Self-webhook / already-reviewed exit only when LIVE signal equals stored.
+	if strings.TrimSpace(lastSignal) != "" && lastSignal == signal {
+		return false, signal, nil
+	}
+	if strings.TrimSpace(lastSignal) == "" {
+		if hasUnresolvedLooperAuthoredThreadsForLogin(threads, looperLogin) {
+			return true, signal, nil
+		}
+		// Baseline without publishing.
+		if err := r.persistLastReviewedSignalFingerprint(ctx, input.Loop, signal); err != nil {
+			return false, "", err
+		}
+		return false, signal, nil
+	}
+	return true, signal, nil
+}
+
+func (r *Runner) hasNarrowDispositionCandidate(ctx context.Context, cwd, repo string, prNumber int64, headSHA, prAuthor, looperLogin string) (bool, error) {
+	if r.github == nil || strings.TrimSpace(headSHA) == "" {
+		return false, nil
+	}
+	looperLogin = normalizeLogin(looperLogin)
+	if looperLogin == "" {
+		var err error
+		looperLogin, err = r.requireCurrentUserLogin(ctx, cwd)
+		if err != nil {
+			return false, err
+		}
+	}
+	threads, err := r.listReviewThreadsForSignal(ctx, cwd, repo, prNumber)
+	if err != nil {
+		r.logWarn("reviewer disposition candidate lookup failed", map[string]any{"repo": repo, "prNumber": prNumber, "error": err.Error()})
+		return false, &loopError{message: "disposition candidate listing failed: " + err.Error(), kind: FailureRetryableTransient}
+	}
+	return ThreadsHaveChangedDispositionSignalForLogin(threads, prAuthor, looperLogin), nil
 }
 
 const conflictedPRNotificationChannel = "github_pr_comment"
@@ -2474,10 +3122,36 @@ type threadResolutionAgentOutput struct {
 func (r *Runner) runThreadResolutionStep(ctx context.Context, input stepInput) (reviewerCheckpoint, error) {
 	checkpoint := input.Checkpoint
 	policy := r.threadResolution
-	if checkpoint.SkipReason != "" || !policy.Enabled {
+	// Partial-batch continuations set SkipReason so the rest of the pipeline
+	// short-circuits, but the next runThreadResolutionStep must still process
+	// remaining candidates from the captured cursor.
+	if checkpoint.SkipReason != "" {
+		if checkpoint.ThreadResolution == nil || !checkpoint.ThreadResolution.PartialBatch {
+			return checkpoint, nil
+		}
+		checkpoint.SkipReason = ""
+		checkpoint.SkipKind = ""
+	}
+	narrowDisposition := r.shouldRunNarrowDispositionPath(input, checkpoint)
+	if !policy.Enabled && !narrowDisposition {
+		// Still promote baseline signal on continuous loops with no work so
+		// discovery does not re-queue forever after upgrade.
+		if checkpoint.DispositionOnly && checkpoint.ReviewSignalFingerprint != "" {
+			_ = r.persistLastReviewedSignalFingerprint(ctx, input.Loop, checkpoint.ReviewSignalFingerprint)
+		}
 		return checkpoint, nil
 	}
-	if checkpoint.ThreadResolution != nil && checkpoint.Snapshot != nil && checkpoint.ThreadResolution.HeadSHA == checkpoint.Snapshot.HeadSHA {
+	// Retry path: mutations done, promote pending — do not re-classify.
+	if checkpoint.ThreadResolution != nil && checkpoint.ThreadResolution.PostMutationCommitPending {
+		return r.commitPostMutationThreadResolution(ctx, input, checkpoint)
+	}
+	if checkpoint.ThreadResolution != nil && checkpoint.Snapshot != nil && checkpoint.ThreadResolution.HeadSHA == checkpoint.Snapshot.HeadSHA && threadResolutionBatchFullyComplete(checkpoint.ThreadResolution) {
+		// Completed single-batch (or final batch) for this head — every captured
+		// candidate must be in CompletedThreadIDs. A mid-batch mutation error
+		// (e.g. reply ok, resolve failed) must not short-circuit as finished.
+		if checkpoint.DispositionOnly {
+			return r.finishDispositionOnlyCheckpoint(ctx, input, checkpoint)
+		}
 		return checkpoint, nil
 	}
 	if checkpoint.Detail == nil || checkpoint.Snapshot == nil {
@@ -2489,101 +3163,372 @@ func (r *Runner) runThreadResolutionStep(ctx context.Context, input stepInput) (
 	if normalizePRState(checkpoint.Detail.State) != "open" {
 		return checkpoint, nil
 	}
-	currentLogin, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
-	if err != nil {
-		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+	if !r.hasNativeThreadCapabilities(input.Project.ID) {
+		// Providers without native threads never claim same-head disposition.
+		if checkpoint.DispositionOnly {
+			return r.finishDispositionOnlyCheckpoint(ctx, input, checkpoint)
+		}
+		return checkpoint, nil
 	}
-	currentLogin = normalizeLogin(currentLogin)
+	currentLogin, err := r.requireCurrentUserLogin(ctx, input.Project.RepoPath)
+	if err != nil {
+		return checkpoint, err
+	}
 	limit := policy.MaxThreadsPerRun
 	if limit <= 0 {
 		limit = 10
 	}
-	fetchLimit := limit * 5
-	if fetchLimit < 100 {
-		fetchLimit = 100
-	}
-	threads, err := r.github.ListReviewThreads(ctx, ListReviewThreadsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath, Limit: fetchLimit})
+	threads, err := r.listReviewThreadsForSignal(ctx, input.Project.RepoPath, input.Repo, input.PRNumber)
 	if err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
 	}
-	candidates := make([]ReviewThread, 0, len(threads))
-	for _, thread := range threads {
-		if len(candidates) >= limit {
-			break
+	threadFeedbackFP := ThreadFeedbackFingerprintForLogin(threads, currentLogin)
+	reviewSignalFP := ReviewSignalFingerprint(checkpoint.Snapshot.HeadSHA, threadFeedbackFP)
+	checkpoint.ReviewSignalFingerprint = reviewSignalFP
+
+	// Self-webhook / post-mutation admission: LIVE stored signal already matches.
+	meta := parseJSONObject(input.Loop.MetadataJSON)
+	if last, ok := stringFromAny(meta[metadataLastReviewedSignalFingerprintKey]); ok && last == reviewSignalFP && checkpoint.DispositionOnly {
+		var finErr error
+		checkpoint, finErr = r.finishDispositionOnlyCheckpoint(ctx, input, checkpoint)
+		if finErr != nil {
+			return checkpoint, finErr
 		}
-		if r.threadResolutionCandidate(thread, checkpoint.Snapshot.HeadSHA, currentLogin, policy) {
-			candidates = append(candidates, thread)
-		}
-	}
-	result := &threadResolutionCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, Reported: len(candidates)}
-	if len(candidates) == 0 {
+		result := &threadResolutionCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, ReviewSignalFingerprint: reviewSignalFP, ThreadFeedbackFingerprint: threadFeedbackFP, DispositionOnly: true}
 		checkpoint.ThreadResolution = result
 		return checkpoint, nil
 	}
-	decisions, err := r.classifyReviewThreads(ctx, input, checkpoint, candidates)
-	if err != nil {
-		return checkpoint, err
+
+	// Inter-batch drift: live complete signal diverged from captured signal.
+	// CapturedSignalFingerprint is refreshed after each partial batch to the
+	// post-mutation live signal so our own accept/resolve/audit does not look
+	// like external drift and wipe the continuation cursor.
+	if checkpoint.ThreadResolution != nil && checkpoint.ThreadResolution.PartialBatch {
+		captured := strings.TrimSpace(checkpoint.ThreadResolution.CapturedSignalFingerprint)
+		if captured != "" && captured != reviewSignalFP {
+			checkpoint.ThreadResolution = nil
+			checkpoint.ResumePolicy = "restart_from_discover"
+			return checkpoint, &loopError{message: "review signal drifted between thread-resolution batches", kind: FailureRetryableAfterResume}
+		}
 	}
+
+	completedSet := map[string]struct{}{}
+	var priorCompleted []string
+	if checkpoint.ThreadResolution != nil {
+		priorCompleted = append(priorCompleted, checkpoint.ThreadResolution.CompletedThreadIDs...)
+		for _, id := range checkpoint.ThreadResolution.CompletedThreadIDs {
+			completedSet[id] = struct{}{}
+		}
+	}
+
+	type candidateEntry struct {
+		thread      ReviewThread
+		disposition bool // narrow disposition path
+		objective   bool // legacy ThreadResolution.Enabled path
+	}
+	// Capture full candidate set once for partial-batch continuation.
+	var capturedIDs []string
+	capturedSignal := reviewSignalFP
+	if checkpoint.ThreadResolution != nil && len(checkpoint.ThreadResolution.CapturedCandidateIDs) > 0 {
+		capturedIDs = append(capturedIDs, checkpoint.ThreadResolution.CapturedCandidateIDs...)
+		if s := strings.TrimSpace(checkpoint.ThreadResolution.CapturedSignalFingerprint); s != "" {
+			capturedSignal = s
+		}
+	}
+	allCandidates := make([]candidateEntry, 0)
+	threadByID := make(map[string]ReviewThread, len(threads))
+	for _, thread := range threads {
+		threadByID[thread.ID] = thread
+		if _, done := completedSet[thread.ID]; done {
+			continue
+		}
+		isDisposition := narrowDisposition && ThreadHasChangedDispositionSignalForLogin(thread, checkpoint.Detail.Author, currentLogin)
+		isObjective := policy.Enabled && r.threadResolutionCandidate(thread, checkpoint.Snapshot.HeadSHA, currentLogin, policy)
+		if !isDisposition && !isObjective {
+			continue
+		}
+		allCandidates = append(allCandidates, candidateEntry{thread: thread, disposition: isDisposition, objective: isObjective})
+	}
+	if len(capturedIDs) == 0 {
+		for _, c := range allCandidates {
+			capturedIDs = append(capturedIDs, c.thread.ID)
+		}
+		slices.Sort(capturedIDs)
+	} else {
+		// Restrict to the originally captured set (stable batches).
+		allowed := map[string]struct{}{}
+		for _, id := range capturedIDs {
+			allowed[id] = struct{}{}
+		}
+		filtered := allCandidates[:0]
+		seen := map[string]struct{}{}
+		for _, c := range allCandidates {
+			if _, ok := allowed[c.thread.ID]; ok {
+				filtered = append(filtered, c)
+				seen[c.thread.ID] = struct{}{}
+			}
+		}
+		// Resume captured-but-incomplete threads that no longer surface as live
+		// disposition candidates (e.g. accept audit posted, resolve failed — the
+		// unaudited signal is gone but resolve must still run).
+		for _, id := range capturedIDs {
+			if _, done := completedSet[id]; done {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			thread, ok := threadByID[id]
+			if !ok {
+				// Gone from provider listing — treat as terminated for the cursor.
+				priorCompleted = appendUniqueString(priorCompleted, id)
+				completedSet[id] = struct{}{}
+				continue
+			}
+			if thread.IsResolved {
+				priorCompleted = appendUniqueString(priorCompleted, id)
+				completedSet[id] = struct{}{}
+				continue
+			}
+			// Prefer disposition resume when narrow path is active; else objective.
+			filtered = append(filtered, candidateEntry{
+				thread:      thread,
+				disposition: narrowDisposition || checkpoint.DispositionOnly,
+				objective:   policy.Enabled && !narrowDisposition && !checkpoint.DispositionOnly,
+			})
+			seen[id] = struct{}{}
+		}
+		allCandidates = filtered
+	}
+
+	result := &threadResolutionCheckpoint{
+		HeadSHA:                   checkpoint.Snapshot.HeadSHA,
+		ThreadFeedbackFingerprint: threadFeedbackFP,
+		ReviewSignalFingerprint:   reviewSignalFP,
+		CapturedSignalFingerprint: capturedSignal,
+		CompletedThreadIDs:        append([]string{}, priorCompleted...),
+		CapturedCandidateIDs:      capturedIDs,
+		DispositionOnly:           checkpoint.DispositionOnly || (narrowDisposition && !policy.Enabled),
+		Reported:                  len(allCandidates) + len(priorCompleted),
+		Processed:                 len(priorCompleted),
+		Commented: func() int {
+			if checkpoint.ThreadResolution != nil {
+				return checkpoint.ThreadResolution.Commented
+			}
+			return 0
+		}(),
+		Resolved: func() int {
+			if checkpoint.ThreadResolution != nil {
+				return checkpoint.ThreadResolution.Resolved
+			}
+			return 0
+		}(),
+	}
+	if len(allCandidates) == 0 {
+		// No remaining candidates: promote baseline / finish.
+		checkpoint.ThreadResolution = result
+		if checkpoint.DispositionOnly || result.DispositionOnly {
+			if err := r.persistLastReviewedSignalFingerprint(ctx, input.Loop, reviewSignalFP); err != nil {
+				return checkpoint, err
+			}
+			var finErr error
+			checkpoint, finErr = r.finishDispositionOnlyCheckpoint(ctx, input, checkpoint)
+			if finErr != nil {
+				return checkpoint, finErr
+			}
+		}
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		return checkpoint, nil
+	}
+
+	// One MaxThreadsPerRun batch per run. Do not promote fingerprint until all
+	// captured candidates terminate and post-mutation refetch succeeds.
+	batch := allCandidates
+	if len(batch) > limit {
+		batch = batch[:limit]
+	}
+	remainingAfter := len(allCandidates) - len(batch)
+	result.PartialBatch = remainingAfter > 0
+
+	candidateThreads := make([]ReviewThread, 0, len(batch))
+	for _, c := range batch {
+		candidateThreads = append(candidateThreads, c.thread)
+	}
+	// Pre-classify one-rejection quota without another classifier call.
 	decisionByID := map[string]threadResolutionAgentDecision{}
-	for _, decision := range decisions {
-		decisionByID[decision.ThreadID] = decision
+	classifyThreads := make([]ReviewThread, 0, len(candidateThreads))
+	for _, thread := range candidateThreads {
+		if ForceNeedsHumanAfterSecondDecline(thread, checkpoint.Snapshot.HeadSHA, currentLogin) {
+			decisionByID[thread.ID] = threadResolutionAgentDecision{
+				ThreadID: thread.ID, Decision: "needs_human",
+				Evidence: "second unchanged-input Fixer decline after reject_wontfix", Confidence: "high",
+			}
+			continue
+		}
+		classifyThreads = append(classifyThreads, thread)
 	}
-	for _, thread := range candidates {
+	if len(classifyThreads) > 0 {
+		decisions, err := r.classifyReviewThreads(ctx, input, checkpoint, classifyThreads, threadFeedbackFP)
+		if err != nil {
+			checkpoint.ThreadResolution = result
+			return checkpoint, err
+		}
+		for _, decision := range decisions {
+			decisionByID[decision.ThreadID] = decision
+		}
+	}
+
+	mutated := false
+	for _, entry := range batch {
+		thread := entry.thread
 		decision, ok := decisionByID[thread.ID]
 		if !ok {
 			decision = threadResolutionAgentDecision{ThreadID: thread.ID, Decision: "needs_human", Evidence: "no classifier decision returned", Confidence: "low"}
 		}
+		decision = normalizeThreadResolutionDecision(decision)
+		isDisposition := entry.disposition
+		decisionValue := strings.ToLower(strings.TrimSpace(decision.Decision))
+		// Narrow disposition path only terminates as accept/reject/needs_human.
+		if isDisposition || checkpoint.DispositionOnly || result.DispositionOnly {
+			switch decisionValue {
+			case "accept_wontfix", "reject_wontfix", "needs_human":
+			case "objectively_fixed", "not_fixed":
+				prior := decisionValue
+				decision.Decision = "needs_human"
+				decisionValue = "needs_human"
+				if strings.TrimSpace(decision.Evidence) == "" {
+					decision.Evidence = "disposition candidate cannot terminate as " + prior
+				}
+			default:
+				decision.Decision = "needs_human"
+				decisionValue = "needs_human"
+			}
+		}
 		result.Processed++
-		auditedForHead := hasSufficientThreadResolutionAuditForDecision(policy, thread, checkpoint.Snapshot.HeadSHA, decision)
 		commented := false
 		resolved := false
 		skippedReason := ""
-		if !auditedForHead && r.threadResolutionShouldComment(policy, decision) {
-			latestThread, refreshedDetail, err := r.refreshThreadResolutionCandidate(ctx, input, checkpoint.Snapshot.HeadSHA, currentLogin, policy, thread.ID, fetchLimit)
+
+		// needs_human on the narrow disposition path: halt pair; no remote
+		// adjudication reply. Persist local signal identity so same-head polling
+		// does not re-enqueue unchanged input (§8.4). Legacy modes may still comment.
+		if decisionValue == "needs_human" && (isDisposition || checkpoint.DispositionOnly || result.DispositionOnly) {
+			result.CompletedThreadIDs = appendUniqueString(result.CompletedThreadIDs, thread.ID)
+			result.ReviewSignalFingerprint = reviewSignalFP
+			result.ThreadFeedbackFingerprint = threadFeedbackFP
+			checkpoint.ReviewSignalFingerprint = reviewSignalFP
+			checkpoint.ThreadResolution = result
+			if err := r.persistLastReviewedSignalFingerprint(ctx, input.Loop, reviewSignalFP); err != nil {
+				return checkpoint, err
+			}
+			r.appendThreadResolutionEvent(ctx, input, checkpoint.Snapshot.HeadSHA, decisionValue, strings.TrimSpace(decision.Evidence), thread.ID, "needs_human", "")
+			if err := r.parkDispositionNeedsHuman(ctx, input, thread.ID, decision.Evidence); err != nil {
+				return checkpoint, err
+			}
+			var finErr error
+			checkpoint, finErr = r.finishDispositionOnlyCheckpoint(ctx, input, checkpoint)
+			if finErr != nil {
+				return checkpoint, finErr
+			}
+			checkpoint.ResumePolicy = "advance_from_checkpoint"
+			return checkpoint, nil
+		}
+
+		// Objective decisions stay behind ThreadResolution.Enabled.
+		if !isDispositionDecision(decisionValue) && isObjectiveThreadResolutionDecision(decision) && !policy.Enabled {
+			decision.Decision = "not_fixed"
+			decisionValue = "not_fixed"
+		}
+
+		// Per-candidate feedback identity for mutation-staleness (full thread FP).
+		candidateFeedbackFP := ThreadFeedbackFingerprintForLogin([]ReviewThread{thread}, currentLogin)
+		// reject_wontfix markers store coordination-excluded FP so §8.4 one-rejection
+		// quota can match later declines without Fixer-decline noise in the marker.
+		markerFeedbackFP := candidateFeedbackFP
+		if decisionValue == "reject_wontfix" {
+			markerFeedbackFP = coordinationExcludedThreadFeedbackFingerprint(thread, currentLogin)
+		}
+
+		audited := false
+		if isDispositionDecision(decisionValue) {
+			audited = hasThreadResolutionAuditForSignalForLogin(thread, thread.ID, checkpoint.Snapshot.HeadSHA, markerFeedbackFP, decisionValue, currentLogin)
+		} else {
+			audited = hasSufficientThreadResolutionAuditForDecision(policy, thread, checkpoint.Snapshot.HeadSHA, decision, currentLogin)
+		}
+
+		shouldComment := false
+		shouldResolve := false
+		if isDispositionDecision(decisionValue) {
+			shouldComment = !audited && (decisionValue == "accept_wontfix" || decisionValue == "reject_wontfix")
+			shouldResolve = decisionValue == "accept_wontfix"
+		} else if policy.Enabled {
+			shouldComment = !audited && r.threadResolutionShouldComment(policy, decision)
+			shouldResolve = r.threadResolutionShouldResolve(policy, decision)
+		}
+
+		if shouldComment {
+			latestThread, refreshedDetail, err := r.refreshThreadResolutionCandidateForPath(ctx, input, checkpoint.Snapshot.HeadSHA, currentLogin, policy, thread.ID, isDisposition, candidateFeedbackFP)
 			if err != nil {
+				checkpoint.ThreadResolution = result
 				checkpoint = markThreadResolutionRediscoveryOnRefreshError(checkpoint, err)
 				return checkpoint, err
 			}
 			if latestThread == nil {
 				skippedReason = "candidate_no_longer_eligible"
-				r.appendThreadResolutionEvent(ctx, input, checkpoint.Snapshot.HeadSHA, strings.TrimSpace(decision.Decision), strings.TrimSpace(decision.Evidence), thread.ID, "skipped", skippedReason)
+				r.appendThreadResolutionEvent(ctx, input, checkpoint.Snapshot.HeadSHA, decisionValue, strings.TrimSpace(decision.Evidence), thread.ID, "skipped", skippedReason)
+				result.CompletedThreadIDs = appendUniqueString(result.CompletedThreadIDs, thread.ID)
 				continue
 			}
 			if !isManualReviewerLoop(input.Loop) && domain.IsAutoLaneHeld(domain.LoopTypeReviewer, refreshedDetail.Labels) {
+				checkpoint.ThreadResolution = result
 				return checkpoint, &holdSkipError{summary: fmt.Sprintf("Reviewer stopped because %s#%d is currently held", input.Repo, input.PRNumber)}
 			}
 			checkpoint.Detail.ReviewRequests = cloneStrings(refreshedDetail.ReviewRequests)
-			body := r.buildThreadResolutionReply(thread.ID, checkpoint.Snapshot.HeadSHA, decision, policy)
+			body := r.buildThreadResolutionReplyWithFeedback(thread.ID, checkpoint.Snapshot.HeadSHA, markerFeedbackFP, decision, policy)
 			disclosureAgent, disclosureModel := r.disclosureIdentity(input.Run)
 			if err := r.github.AddReviewThreadReply(ctx, AddReviewThreadReplyInput{Repo: input.Repo, ThreadID: thread.ID, Body: body, CWD: input.Project.RepoPath, DisclosureAgent: disclosureAgent, DisclosureModel: disclosureModel}); err != nil {
+				checkpoint.ThreadResolution = result
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
 			}
 			result.Commented++
 			commented = true
+			mutated = true
 		}
-		if r.threadResolutionShouldResolve(policy, decision) {
-			latestThread, refreshedDetail, err := r.refreshThreadResolutionCandidate(ctx, input, checkpoint.Snapshot.HeadSHA, currentLogin, policy, thread.ID, fetchLimit)
+		if shouldResolve {
+			latestThread, refreshedDetail, err := r.refreshThreadResolutionCandidateForPath(ctx, input, checkpoint.Snapshot.HeadSHA, currentLogin, policy, thread.ID, isDisposition, candidateFeedbackFP)
 			if err != nil {
+				checkpoint.ThreadResolution = result
 				checkpoint = markThreadResolutionRediscoveryOnRefreshError(checkpoint, err)
 				return checkpoint, err
 			}
 			if latestThread == nil {
 				skippedReason = "candidate_no_longer_eligible"
+				result.CompletedThreadIDs = appendUniqueString(result.CompletedThreadIDs, thread.ID)
 				continue
 			}
 			if !isManualReviewerLoop(input.Loop) && domain.IsAutoLaneHeld(domain.LoopTypeReviewer, refreshedDetail.Labels) {
+				checkpoint.ThreadResolution = result
 				return checkpoint, &holdSkipError{summary: fmt.Sprintf("Reviewer stopped because %s#%d is currently held", input.Repo, input.PRNumber)}
 			}
 			checkpoint.Detail.ReviewRequests = cloneStrings(refreshedDetail.ReviewRequests)
-			if !hasObjectiveThreadResolutionAuditForHead(*latestThread, thread.ID, checkpoint.Snapshot.HeadSHA) && !commented {
+			if isDispositionDecision(decisionValue) {
+				if !hasThreadResolutionAuditForSignalForLogin(*latestThread, thread.ID, checkpoint.Snapshot.HeadSHA, candidateFeedbackFP, decisionValue, currentLogin) && !commented {
+					skippedReason = "missing_disposition_audit_comment"
+					result.CompletedThreadIDs = appendUniqueString(result.CompletedThreadIDs, thread.ID)
+					continue
+				}
+			} else if !hasObjectiveThreadResolutionAuditForHead(*latestThread, thread.ID, checkpoint.Snapshot.HeadSHA, currentLogin) && !commented {
 				skippedReason = "missing_objective_audit_comment"
+				result.CompletedThreadIDs = appendUniqueString(result.CompletedThreadIDs, thread.ID)
 				continue
 			}
 			if err := r.github.ResolveReviewThread(ctx, ResolveReviewThreadInput{Repo: input.Repo, ThreadID: thread.ID, CWD: input.Project.RepoPath}); err != nil {
+				checkpoint.ThreadResolution = result
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableTransient}
 			}
 			result.Resolved++
 			resolved = true
+			mutated = true
 		}
 		action := "reported"
 		if resolved {
@@ -2593,17 +3538,388 @@ func (r *Runner) runThreadResolutionStep(ctx context.Context, input stepInput) (
 		} else if skippedReason != "" {
 			action = "skipped"
 		}
-		r.appendThreadResolutionEvent(ctx, input, checkpoint.Snapshot.HeadSHA, strings.TrimSpace(decision.Decision), strings.TrimSpace(decision.Evidence), thread.ID, action, skippedReason)
+		r.appendThreadResolutionEvent(ctx, input, checkpoint.Snapshot.HeadSHA, decisionValue, strings.TrimSpace(decision.Evidence), thread.ID, action, skippedReason)
+		result.CompletedThreadIDs = appendUniqueString(result.CompletedThreadIDs, thread.ID)
 	}
+
 	checkpoint.ThreadResolution = result
+	if input.Run.ID != "" && r.repos != nil && r.repos.Runs != nil {
+		if err := r.persistCheckpoint(ctx, input.Run.ID, stepThreadResolution, checkpoint); err != nil {
+			return checkpoint, err
+		}
+	}
+
+	// Partial batch: requeue continuation; do not promote fingerprint.
+	if result.PartialBatch {
+		// Anchor the continuation cursor to the post-mutation live signal so the
+		// next batch does not treat our own resolve/audit as inter-batch drift.
+		// Fail closed on listing errors — do not continue with a stale cursor.
+		liveThreads, listErr := r.listReviewThreadsForSignal(ctx, input.Project.RepoPath, input.Repo, input.PRNumber)
+		if listErr != nil {
+			checkpoint.ThreadResolution = result
+			return checkpoint, &loopError{message: "partial-batch signal refetch failed: " + listErr.Error(), kind: FailureRetryableTransient}
+		}
+		liveFP := ThreadFeedbackFingerprintForLogin(liveThreads, currentLogin)
+		liveSignal := ReviewSignalFingerprint(checkpoint.Snapshot.HeadSHA, liveFP)
+		result.ThreadFeedbackFingerprint = liveFP
+		result.ReviewSignalFingerprint = liveSignal
+		result.CapturedSignalFingerprint = liveSignal
+		checkpoint.ReviewSignalFingerprint = liveSignal
+		checkpoint.ThreadResolution = result
+		if err := r.enqueueThreadResolutionContinuation(ctx, input, checkpoint, result); err != nil {
+			return checkpoint, err
+		}
+		if checkpoint.DispositionOnly || result.DispositionOnly {
+			checkpoint.SkipReason = "Partial thread disposition batch; continuation queued"
+			checkpoint.SkipKind = "disposition_partial_batch"
+			checkpoint.PendingReview = nil
+		}
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		return checkpoint, nil
+	}
+
+	// Mark commit pending before refetch so a refetch failure retries promote only.
+	if mutated {
+		result.PostMutationCommitPending = true
+		checkpoint.ThreadResolution = result
+		if input.Run.ID != "" && r.repos != nil && r.repos.Runs != nil {
+			if err := r.persistCheckpoint(ctx, input.Run.ID, stepThreadResolution, checkpoint); err != nil {
+				return checkpoint, err
+			}
+		}
+	}
+	return r.commitPostMutationThreadResolution(ctx, input, checkpoint)
+}
+
+func (r *Runner) shouldRunNarrowDispositionPath(input stepInput, checkpoint reviewerCheckpoint) bool {
+	if !r.hasNativeThreadCapabilities(input.Project.ID) {
+		return false
+	}
+	meta := parseJSONObject(input.Loop.MetadataJSON)
+	if !isContinuousReviewerLoop(input.Loop, meta) {
+		return false
+	}
+	if checkpoint.DispositionOnly {
+		return true
+	}
+	// Also run when ThreadResolutionFollowUpOnly was set for disposition.
+	return checkpoint.ThreadResolutionFollowUpOnly && !r.threadResolution.Enabled
+}
+
+func (r *Runner) finishDispositionOnlyCheckpoint(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint) (reviewerCheckpoint, error) {
+	checkpoint.DispositionOnly = true
+	checkpoint.ThreadResolutionFollowUpOnly = true
+	// Same-head clean convergence: when disposition cleared blockers and the pair
+	// is not budget-held, schedule a distinct full-review admission (not head-only skip).
+	shouldConverge, err := r.shouldScheduleDispositionConvergence(ctx, input, checkpoint)
+	if err != nil {
+		return checkpoint, err
+	}
+	if shouldConverge {
+		checkpoint.SkipReason = ""
+		checkpoint.SkipKind = ""
+		if checkpoint.ThreadResolution != nil {
+			checkpoint.ThreadResolution.ScheduleConvergencePass = true
+		}
+		// Clear disposition-only so skipThreadResolutionFollowUpReview does not block review.
+		checkpoint.DispositionOnly = false
+		checkpoint.ThreadResolutionFollowUpOnly = false
+		if err := r.enqueueDispositionConvergence(ctx, input, checkpoint); err != nil {
+			return checkpoint, err
+		}
+		checkpoint.PendingReview = nil
+		return checkpoint, nil
+	}
+	if checkpoint.SkipReason == "" {
+		checkpoint.SkipReason = "Completed same-head thread disposition pass"
+		checkpoint.SkipKind = "disposition_only"
+	}
+	checkpoint.PendingReview = nil
+	// Budget-held: refresh handoff only (park re-entry), never publish.
+	if loops.IsReviewFixBudgetHold(input.Loop) {
+		if _, err := r.parkReviewerBudgetIfExhausted(ctx, input.Loop); err != nil {
+			return checkpoint, err
+		}
+	}
+	return checkpoint, nil
+}
+
+func (r *Runner) shouldScheduleDispositionConvergence(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint) (bool, error) {
+	if !r.hasNativeThreadCapabilities(input.Project.ID) {
+		return false, nil
+	}
+	if loops.IsReviewFixBudgetHold(input.Loop) || loops.IsReviewFixPairHold(input.Loop) {
+		return false, nil
+	}
+	if checkpoint.Snapshot == nil {
+		return false, nil
+	}
+	login, err := r.requireCurrentUserLogin(ctx, input.Project.RepoPath)
+	if err != nil {
+		// Identity failures are retryable — do not silently skip convergence after
+		// a fingerprint was already persisted (polling would see no change).
+		return false, err
+	}
+	threads, err := r.listReviewThreadsForSignal(ctx, input.Project.RepoPath, input.Repo, input.PRNumber)
+	if err != nil {
+		return false, &loopError{message: "disposition convergence listing failed: " + err.Error(), kind: FailureRetryableTransient}
+	}
+	return !hasUnresolvedLooperAuthoredThreadsForLogin(threads, login), nil
+}
+
+func (r *Runner) enqueueDispositionConvergence(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint) error {
+	if r.repos == nil || r.repos.Queue == nil {
+		return nil
+	}
+	head := ""
+	if checkpoint.Snapshot != nil {
+		head = checkpoint.Snapshot.HeadSHA
+	}
+	signal := strings.TrimSpace(checkpoint.ReviewSignalFingerprint)
+	availableAt := r.nextReviewAvailableAt(parseJSONObject(input.Loop.MetadataJSON), false)
+	_, err := r.enqueue(ctx, enqueueInput{
+		ProjectID:               input.Project.ID,
+		LoopID:                  input.Loop.ID,
+		Repo:                    input.Repo,
+		PRNumber:                input.PRNumber,
+		HeadSHA:                 head,
+		ReviewSignalFingerprint: signal,
+		DispositionOnly:         false,
+		AvailableAt:             availableAt,
+	})
+	return err
+}
+
+func (r *Runner) commitPostMutationThreadResolution(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint) (reviewerCheckpoint, error) {
+	result := checkpoint.ThreadResolution
+	if result == nil {
+		return checkpoint, nil
+	}
+	currentLogin, err := r.requireCurrentUserLogin(ctx, input.Project.RepoPath)
+	if err != nil {
+		result.PostMutationCommitPending = true
+		checkpoint.ThreadResolution = result
+		return checkpoint, err
+	}
+	refetched, err := r.listReviewThreadsForSignal(ctx, input.Project.RepoPath, input.Repo, input.PRNumber)
+	if err != nil {
+		result.PostMutationCommitPending = true
+		result.PartialBatch = false
+		checkpoint.ThreadResolution = result
+		return checkpoint, &loopError{message: "post-mutation thread refetch failed: " + err.Error(), kind: FailureRetryableTransient}
+	}
+	postFeedback := ThreadFeedbackFingerprintForLogin(refetched, currentLogin)
+	head := result.HeadSHA
+	if checkpoint.Snapshot != nil && checkpoint.Snapshot.HeadSHA != "" {
+		head = checkpoint.Snapshot.HeadSHA
+	}
+	postSignal := ReviewSignalFingerprint(head, postFeedback)
+	result.ThreadFeedbackFingerprint = postFeedback
+	result.ReviewSignalFingerprint = postSignal
+	result.PartialBatch = false
+	// Do not clear PostMutationCommitPending until fingerprint write succeeds.
+	result.PostMutationCommitPending = true
+	checkpoint.ReviewSignalFingerprint = postSignal
+	checkpoint.ThreadResolution = result
+	if input.Run.ID != "" && r.repos != nil && r.repos.Runs != nil {
+		if err := r.persistCheckpoint(ctx, input.Run.ID, stepThreadResolution, checkpoint); err != nil {
+			return checkpoint, err
+		}
+	}
+	if err := r.persistLastReviewedSignalFingerprint(ctx, input.Loop, postSignal); err != nil {
+		return checkpoint, err
+	}
+	result.PostMutationCommitPending = false
+	checkpoint.ThreadResolution = result
+	if input.Run.ID != "" && r.repos != nil && r.repos.Runs != nil {
+		_ = r.persistCheckpoint(ctx, input.Run.ID, stepThreadResolution, checkpoint)
+	}
+	if checkpoint.DispositionOnly || result.DispositionOnly {
+		var finErr error
+		checkpoint, finErr = r.finishDispositionOnlyCheckpoint(ctx, input, checkpoint)
+		if finErr != nil {
+			return checkpoint, finErr
+		}
+	}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
 }
 
+func (r *Runner) enqueueThreadResolutionContinuation(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, result *threadResolutionCheckpoint) error {
+	if result == nil {
+		return nil
+	}
+	head := ""
+	if checkpoint.Snapshot != nil {
+		head = checkpoint.Snapshot.HeadSHA
+	}
+	partialCont := map[string]any{
+		"headSha":                   result.HeadSHA,
+		"threadFeedbackFingerprint": result.ThreadFeedbackFingerprint,
+		"reviewSignalFingerprint":   result.ReviewSignalFingerprint,
+		"capturedSignalFingerprint": result.CapturedSignalFingerprint,
+		"completedThreadIds":        result.CompletedThreadIDs,
+		"capturedCandidateIds":      result.CapturedCandidateIDs,
+		"partialBatch":              true,
+		"dispositionOnly":           result.DispositionOnly,
+		"processed":                 result.Processed,
+		"commented":                 result.Commented,
+		"resolved":                  result.Resolved,
+		"reported":                  result.Reported,
+	}
+	availableAt := r.nextReviewAvailableAt(parseJSONObject(input.Loop.MetadataJSON), result.DispositionOnly || checkpoint.DispositionOnly)
+	// Enqueue via stable dedupe; if active item is this run's item (running),
+	// stash as pending signal for post-completion continuation.
+	item, err := r.enqueue(ctx, enqueueInput{
+		ProjectID:               input.Project.ID,
+		LoopID:                  input.Loop.ID,
+		Repo:                    input.Repo,
+		PRNumber:                input.PRNumber,
+		HeadSHA:                 head,
+		ReviewSignalFingerprint: result.CapturedSignalFingerprint,
+		DispositionOnly:         result.DispositionOnly || checkpoint.DispositionOnly,
+		AvailableAt:             availableAt,
+	})
+	if err != nil {
+		return err
+	}
+	// Merge full partial-batch cursor onto the active item. Running/claimed
+	// enqueue only stashes pending* fields; completed/captured IDs must survive.
+	merged := parseJSONObject(item.PayloadJSON)
+	if strings.TrimSpace(head) != "" {
+		merged["headSha"] = head
+	}
+	if strings.TrimSpace(result.CapturedSignalFingerprint) != "" {
+		merged["reviewSignalFingerprint"] = result.CapturedSignalFingerprint
+	}
+	merged["dispositionOnly"] = result.DispositionOnly || checkpoint.DispositionOnly
+	merged["partialBatchContinuation"] = partialCont
+	encoded, err := json.Marshal(merged)
+	if err != nil {
+		return err
+	}
+	payloadStr := string(encoded)
+	item.PayloadJSON = &payloadStr
+	item.UpdatedAt = r.nowISO()
+	if _, _, err := r.repos.Queue.UpsertActiveByDedupeOrGetExisting(ctx, item); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isDispositionDecision(decision string) bool {
+	switch strings.ToLower(strings.TrimSpace(decision)) {
+	case "accept_wontfix", "reject_wontfix":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeThreadResolutionDecision(decision threadResolutionAgentDecision) threadResolutionAgentDecision {
+	decision.Decision = strings.ToLower(strings.TrimSpace(decision.Decision))
+	decision.Confidence = strings.ToLower(strings.TrimSpace(decision.Confidence))
+	switch decision.Decision {
+	case "objectively_fixed", "accept_wontfix", "reject_wontfix", "needs_human", "not_fixed":
+	default:
+		decision.Decision = "needs_human"
+		if strings.TrimSpace(decision.Evidence) == "" {
+			decision.Evidence = "unrecognized classifier decision"
+		}
+	}
+	return decision
+}
+
+func appendUniqueString(values []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func (r *Runner) parkDispositionNeedsHuman(ctx context.Context, input stepInput, threadID, evidence string) error {
+	if r.repos == nil {
+		return nil
+	}
+	// Do not stack a scope hold over an existing budget hold — refresh handoff only.
+	if loops.IsReviewFixBudgetHold(input.Loop) {
+		_, err := r.parkReviewerBudgetIfExhausted(ctx, input.Loop)
+		return err
+	}
+	message := strings.TrimSpace(evidence)
+	if message == "" {
+		message = "Thread disposition requires human judgment"
+	}
+	question := fmt.Sprintf("Review thread %s needs human disposition judgment", strings.TrimSpace(threadID))
+	_, err := loops.ParkReviewScopeHuman(ctx, r.repos, loops.ParkReviewScopeHumanInput{
+		Held:        input.Loop,
+		Role:        "reviewer",
+		Repo:        input.Repo,
+		PRNumber:    input.PRNumber,
+		NowISO:      r.nowISO(),
+		HITLEnabled: r.reviewFixHITLEnabled(),
+		Question:    question,
+		Evidence:    message,
+		DB:          r.db,
+	})
+	if err != nil {
+		return err
+	}
+	r.notifyHumanAttentionBestEffort(ctx, input.Loop.ID)
+	return nil
+}
+
+func (r *Runner) refreshThreadResolutionCandidateForPath(ctx context.Context, input stepInput, headSHA, currentLogin string, policy config.ReviewerThreadResolutionConfig, threadID string, dispositionPath bool, classifiedFeedbackFP string) (*ReviewThread, PullRequestDetail, error) {
+	if dispositionPath {
+		// Bypass RequireCurrentReviewRequest and RequireNewHeadSinceThread.
+		detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
+		if err != nil {
+			return nil, PullRequestDetail{}, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+		}
+		if normalizePRState(detail.State) != "open" || detail.HeadSHA != headSHA {
+			return nil, PullRequestDetail{}, &loopError{message: "PR changed during thread reconciliation", kind: FailureRetryableAfterResume}
+		}
+		latest, err := r.listReviewThreadsForSignal(ctx, input.Project.RepoPath, input.Repo, input.PRNumber)
+		if err != nil {
+			return nil, detail, &loopError{message: err.Error(), kind: FailureRetryableTransient}
+		}
+		for i := range latest {
+			if latest[i].ID != threadID {
+				continue
+			}
+			if latest[i].IsResolved {
+				// Already resolved is idempotent success for accept path.
+				return &latest[i], detail, nil
+			}
+			if !isLooperAuthoredThreadForLogin(latest[i], currentLogin) {
+				return nil, detail, nil
+			}
+			// Stale mutation guard: feedback fingerprint must match classified input.
+			if classifiedFeedbackFP != "" {
+				liveFP := ThreadFeedbackFingerprintForLogin([]ReviewThread{latest[i]}, currentLogin)
+				if liveFP != classifiedFeedbackFP {
+					return nil, detail, &loopError{message: "thread feedback changed during thread reconciliation", kind: FailureRetryableAfterResume}
+				}
+			}
+			return &latest[i], detail, nil
+		}
+		return nil, detail, nil
+	}
+	return r.refreshThreadResolutionCandidate(ctx, input, headSHA, currentLogin, policy, threadID, 100)
+}
+
 func markThreadResolutionRediscoveryOnRefreshError(checkpoint reviewerCheckpoint, err error) reviewerCheckpoint {
 	var typed *loopError
-	if errors.As(err, &typed) && typed.kind == FailureRetryableAfterResume && strings.Contains(typed.message, "PR changed during thread reconciliation") {
-		checkpoint.ResumePolicy = "restart_from_discover"
+	if errors.As(err, &typed) && typed.kind == FailureRetryableAfterResume {
+		if strings.Contains(typed.message, "PR changed during thread reconciliation") || strings.Contains(typed.message, "thread feedback changed") {
+			checkpoint.ResumePolicy = "restart_from_discover"
+		}
 	}
 	return checkpoint
 }
@@ -2642,7 +3958,10 @@ func (r *Runner) threadResolutionCandidate(thread ReviewThread, headSHA, current
 	if policy.Scope == config.ReviewerThreadResolutionScopeLooperAuthoredOnly && normalizeLogin(first.Author) != currentLogin {
 		return false
 	}
-	if policy.Scope == config.ReviewerThreadResolutionScopeLooperAuthoredOnly && !isLooperAuthoredThread(thread) {
+	// Use the live reviewer login so non-looper* identities (e.g. "bob") that
+	// authored stamped roots still count; empty-login isLooperAuthoredThread
+	// only accepts looper* bot names and would drop legitimate follow-ups.
+	if policy.Scope == config.ReviewerThreadResolutionScopeLooperAuthoredOnly && !isLooperAuthoredThreadForLogin(thread, currentLogin) {
 		return false
 	}
 	if policy.RequireNewHeadSinceThread && headSHA != "" {
@@ -2651,7 +3970,7 @@ func (r *Runner) threadResolutionCandidate(thread ReviewThread, headSHA, current
 			return false
 		}
 	}
-	if policy.Mode != config.ReviewerThreadResolutionModeResolveObjective && hasThreadResolutionAuditForHead(thread, headSHA) {
+	if policy.Mode != config.ReviewerThreadResolutionModeResolveObjective && hasValidatedThreadResolutionAuditForHead(thread, headSHA, currentLogin) {
 		return false
 	}
 	return true
@@ -2683,7 +4002,7 @@ func (r *Runner) refreshThreadResolutionCandidate(ctx context.Context, input ste
 	return nil, detail, nil
 }
 
-func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, threads []ReviewThread) ([]threadResolutionAgentDecision, error) {
+func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, threads []ReviewThread, feedbackFingerprint string) ([]threadResolutionAgentDecision, error) {
 	if r.agentExecutor == nil {
 		return nil, &loopError{message: "reviewer agent executor is not configured", kind: FailureRetryableTransient}
 	}
@@ -2697,8 +4016,17 @@ func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, che
 		candidateIDs = append(candidateIDs, thread.ID)
 	}
 	slices.Sort(candidateIDs)
-	idempotencyKey := fmt.Sprintf("reviewer-thread-resolution:%s:%d:%s:%s", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, strings.Join(candidateIDs, ","))
-	prompt := buildThreadResolutionPrompt(input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, threads)
+	feedbackFingerprint = strings.TrimSpace(feedbackFingerprint)
+	if feedbackFingerprint == "" {
+		login := ""
+		if checkpoint.Detail != nil {
+			login = normalizeLogin(checkpoint.Detail.CurrentLogin)
+		}
+		feedbackFingerprint = ThreadFeedbackFingerprintForLogin(threads, login)
+	}
+	// Include classified feedback identity so edits invalidate idempotency.
+	idempotencyKey := fmt.Sprintf("reviewer-thread-resolution:%s:%d:%s:%s:%s", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, feedbackFingerprint, strings.Join(candidateIDs, ","))
+	prompt := buildThreadResolutionPrompt(input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, threads, checkpoint)
 	if r.hasPendingNativeResume(ctx, input.Loop.ID) {
 		prompt = nativeResumeContinuationPrompt("thread-resolution", input.Repo, input.PRNumber, checkpoint.Snapshot.HeadSHA, idempotencyKey)
 	}
@@ -2733,7 +4061,7 @@ func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, che
 		r.markAgentExecutionNativeResumePendingForTransientProvider(ctx, executionID, message)
 		return nil, &loopError{message: message, kind: FailureRetryableTransient}
 	}
-	parsed, err := parseThreadResolutionOutput(result.Stdout)
+	parsed, err := parseThreadResolutionOutput(result.Stdout, candidateIDs)
 	if err == nil {
 		return parsed.Decisions, nil
 	}
@@ -2744,27 +4072,54 @@ func (r *Runner) classifyReviewThreads(ctx context.Context, input stepInput, che
 	return nil, &loopError{message: err.Error(), kind: FailureNonRetryable}
 }
 
-func buildThreadResolutionPrompt(repo string, prNumber int64, headSHA string, threads []ReviewThread) string {
-	payload, _ := json.MarshalIndent(map[string]any{"repo": repo, "prNumber": prNumber, "headSHA": headSHA, "threads": threads}, "", "  ")
+func buildThreadResolutionPrompt(repo string, prNumber int64, headSHA string, threads []ReviewThread, checkpoint reviewerCheckpoint) string {
+	payload := map[string]any{"repo": repo, "prNumber": prNumber, "headSHA": headSHA, "threads": threads}
+	if checkpoint.Detail != nil {
+		payload["prTitle"] = checkpoint.Detail.Title
+		if checkpoint.Snapshot != nil {
+			payload["prBody"] = checkpoint.Snapshot.Body
+			if checkpoint.Snapshot.Title != "" {
+				payload["prTitle"] = checkpoint.Snapshot.Title
+			}
+		}
+	} else if checkpoint.Snapshot != nil {
+		payload["prTitle"] = checkpoint.Snapshot.Title
+		payload["prBody"] = checkpoint.Snapshot.Body
+	}
+	if checkpoint.Snapshot != nil && checkpoint.Snapshot.PayloadJSON != "" {
+		// Linked-intent / instructions already captured on the snapshot when present.
+		payload["snapshotContext"] = checkpoint.Snapshot.PayloadJSON
+	}
+	encoded, _ := json.MarshalIndent(payload, "", "  ")
 	return strings.TrimSpace(`You are running Looper's reviewer thread reconciliation phase.
 
-Inspect the current worktree and the unresolved pull request review threads in the JSON payload below. Classify whether each requested change is objectively addressed at the current head.
+Inspect the current worktree and the unresolved pull request review threads in the JSON payload below. Classify each thread. Use PR title/body and any snapshotContext (repository instructions / linked intent) as scope authority.
+
+Decisions:
+- objectively_fixed: requested behavior is verifiably present at the current head
+- accept_wontfix: finding is outside documented PR scope, optional, incorrect, or superseded by a trusted human wontfix / validated Fixer decline
+- reject_wontfix: finding is required by repository rule/PR intent or is a directly introduced correctness/safety regression; keep unresolved
+- needs_human: authority conflicts, reason missing, or evidence ambiguous
+- not_fixed: no disposition applies and requested behavior is still absent
 
 Safety rules:
 - The current working directory is Looper's prepared reviewer worktree for this PR and is the canonical local checkout. Reuse it for git fetch, git checkout, diff inspection, and local verification. Do not run gh repo clone, git clone, or create any additional checkout for this PR's base or head repository unless the provided worktree is missing or unusable.
 - Return objectively_fixed only for concrete, verifiable code or documentation changes that are present in the worktree.
-- Return needs_human for subjective, product, design, security-sensitive, ambiguous, or partially addressed feedback.
+- An explicit trusted human "/looper wontfix" (or alias) is a request for scope adjudication, not automatic acceptance.
+- "/looper reconsider" is a new disposition signal requiring accept_wontfix, reject_wontfix, or needs_human — never silent not_fixed.
+- A validated Fixer decline marker is a dispute signal for accept/reject, not human authority by itself.
 - Do not treat an author reply like "fixed" as evidence by itself.
+- Every decision MUST include non-empty evidence.
 - Do not call GitHub APIs and do not post comments.
 
 Output only valid JSON in this exact shape:
-{"decisions":[{"threadId":"<id>","decision":"objectively_fixed|needs_human|not_fixed","evidence":"brief concrete evidence","confidence":"high|medium|low"}]}
+{"decisions":[{"threadId":"<id>","decision":"objectively_fixed|accept_wontfix|reject_wontfix|needs_human|not_fixed","evidence":"brief concrete evidence","confidence":"high|medium|low"}]}
 
 Payload:
-` + string(payload))
+` + string(encoded))
 }
 
-func parseThreadResolutionOutput(stdout string) (threadResolutionAgentOutput, error) {
+func parseThreadResolutionOutput(stdout string, requiredThreadIDs []string) (threadResolutionAgentOutput, error) {
 	trimmed := strings.TrimSpace(stdout)
 	start := strings.Index(trimmed, "{")
 	end := strings.LastIndex(trimmed, "}")
@@ -2774,6 +4129,22 @@ func parseThreadResolutionOutput(stdout string) (threadResolutionAgentOutput, er
 	var parsed threadResolutionAgentOutput
 	if err := json.Unmarshal([]byte(trimmed[start:end+1]), &parsed); err != nil {
 		return threadResolutionAgentOutput{}, fmt.Errorf("parse thread resolution classifier output: %w", err)
+	}
+	byID := map[string]threadResolutionAgentDecision{}
+	for _, d := range parsed.Decisions {
+		id := strings.TrimSpace(d.ThreadID)
+		if id == "" {
+			continue
+		}
+		if strings.TrimSpace(d.Evidence) == "" {
+			return threadResolutionAgentOutput{}, fmt.Errorf("thread resolution classifier returned empty evidence for thread %s", id)
+		}
+		byID[id] = d
+	}
+	for _, id := range requiredThreadIDs {
+		if _, ok := byID[id]; !ok {
+			return threadResolutionAgentOutput{}, fmt.Errorf("thread resolution classifier missing decision for thread %s", id)
+		}
 	}
 	return parsed, nil
 }
@@ -2798,6 +4169,10 @@ func isObjectiveThreadResolutionDecision(decision threadResolutionAgentDecision)
 }
 
 func (r *Runner) buildThreadResolutionReply(threadID, headSHA string, decision threadResolutionAgentDecision, policy config.ReviewerThreadResolutionConfig) string {
+	return r.buildThreadResolutionReplyWithFeedback(threadID, headSHA, "", decision, policy)
+}
+
+func (r *Runner) buildThreadResolutionReplyWithFeedback(threadID, headSHA, feedbackFingerprint string, decision threadResolutionAgentDecision, policy config.ReviewerThreadResolutionConfig) string {
 	evidence := strings.TrimSpace(decision.Evidence)
 	if evidence == "" {
 		evidence = "the current head"
@@ -2806,7 +4181,13 @@ func (r *Runner) buildThreadResolutionReply(threadID, headSHA string, decision t
 	if decisionValue == "" {
 		decisionValue = "needs_human"
 	}
-	marker := fmt.Sprintf("<!-- looper:thread-resolution thread=%s head=%s decision=%s -->", threadID, headSHA, decisionValue)
+	marker := threadResolutionMarker(threadID, headSHA, feedbackFingerprint, decisionValue)
+	switch decisionValue {
+	case "accept_wontfix":
+		return fmt.Sprintf("Looper accepts the scope disposition on head `%s`: %s. Resolving this thread.\n%s", headSHA, evidence, marker)
+	case "reject_wontfix":
+		return fmt.Sprintf("Looper rejects the scope disposition on head `%s`: %s. Keeping this thread unresolved so Fixer can address it.\n%s", headSHA, evidence, marker)
+	}
 	if isObjectiveThreadResolutionDecision(decision) {
 		if policy.Mode == config.ReviewerThreadResolutionModeSuggestResolution {
 			return fmt.Sprintf("Looper checked this thread against head `%s`. The requested change appears objectively addressed by %s. Please resolve this thread if you agree.\n%s", headSHA, evidence, marker)
@@ -2819,6 +4200,8 @@ func (r *Runner) buildThreadResolutionReply(threadID, headSHA string, decision t
 	return fmt.Sprintf("Looper checked this thread against head `%s`. I could not verify that this thread is objectively resolved: %s.\n%s", headSHA, evidence, marker)
 }
 
+// hasThreadResolutionAuditForHead is a substring helper retained for unit tests.
+// Production mutation/idempotency paths must use hasValidatedThreadResolutionAuditForHead.
 func hasThreadResolutionAuditForHead(thread ReviewThread, headSHA string) bool {
 	needle := "looper:thread-resolution"
 	headNeedle := "head=" + headSHA
@@ -2830,17 +4213,42 @@ func hasThreadResolutionAuditForHead(thread ReviewThread, headSHA string) bool {
 	return false
 }
 
-func hasSufficientThreadResolutionAuditForDecision(policy config.ReviewerThreadResolutionConfig, thread ReviewThread, headSHA string, decision threadResolutionAgentDecision) bool {
-	if policy.Mode == config.ReviewerThreadResolutionModeResolveObjective && isObjectiveThreadResolutionDecision(decision) {
-		return hasObjectiveThreadResolutionAuditForHead(thread, thread.ID, headSHA)
+// hasValidatedThreadResolutionAuditForHead requires a well-formed marker and
+// Looper identity — not a substring spoof.
+func hasValidatedThreadResolutionAuditForHead(thread ReviewThread, headSHA, looperLogin string) bool {
+	headSHA = strings.TrimSpace(headSHA)
+	for _, comment := range thread.Comments {
+		if !isValidatedThreadResolutionAudit(comment, looperLogin) {
+			continue
+		}
+		fields, ok := parseThreadResolutionMarker(comment.Body)
+		if !ok {
+			continue
+		}
+		if headSHA == "" || fields.HeadSHA == headSHA {
+			return true
+		}
 	}
-	return hasThreadResolutionAuditForHead(thread, headSHA)
+	return false
 }
 
-func hasObjectiveThreadResolutionAuditForHead(thread ReviewThread, threadID, headSHA string) bool {
+func hasSufficientThreadResolutionAuditForDecision(policy config.ReviewerThreadResolutionConfig, thread ReviewThread, headSHA string, decision threadResolutionAgentDecision, looperLogin string) bool {
+	if policy.Mode == config.ReviewerThreadResolutionModeResolveObjective && isObjectiveThreadResolutionDecision(decision) {
+		return hasObjectiveThreadResolutionAuditForHead(thread, thread.ID, headSHA, looperLogin)
+	}
+	return hasValidatedThreadResolutionAuditForHead(thread, headSHA, looperLogin)
+}
+
+func hasObjectiveThreadResolutionAuditForHead(thread ReviewThread, threadID, headSHA, looperLogin string) bool {
 	for _, comment := range thread.Comments {
-		body := comment.Body
-		if strings.Contains(body, "looper:thread-resolution") && strings.Contains(body, "thread="+threadID) && strings.Contains(body, "head="+headSHA) && strings.Contains(body, "decision=objectively_fixed") {
+		if !isValidatedThreadResolutionAudit(comment, looperLogin) {
+			continue
+		}
+		fields, ok := parseThreadResolutionMarker(comment.Body)
+		if !ok {
+			continue
+		}
+		if fields.ThreadID == threadID && fields.HeadSHA == headSHA && fields.Decision == "objectively_fixed" {
 			return true
 		}
 	}
@@ -2848,11 +4256,22 @@ func hasObjectiveThreadResolutionAuditForHead(thread ReviewThread, threadID, hea
 }
 
 func isLooperAuthoredThread(thread ReviewThread) bool {
+	return isLooperAuthoredThreadForLogin(thread, "")
+}
+
+// isLooperAuthoredThreadForLogin requires the root comment to carry a Looper
+// stamp/review marker and, when looperLogin is known, to be authored by that
+// identity. Spoofed stamps from untrusted authors are not Looper-authored.
+func isLooperAuthoredThreadForLogin(thread ReviewThread, looperLogin string) bool {
 	if len(thread.Comments) == 0 {
 		return false
 	}
-	body := thread.Comments[0].Body
-	return strings.Contains(body, "looper:stamp") || strings.Contains(body, "looper:review")
+	root := thread.Comments[0]
+	body := root.Body
+	if !strings.Contains(body, "looper:stamp") && !strings.Contains(body, "looper:review") {
+		return false
+	}
+	return isLooperIdentityAuthor(root.Author, looperLogin)
 }
 
 func latestThreadFeedbackCommitOID(thread ReviewThread) string {
@@ -2939,7 +4358,16 @@ func (r *Runner) startReviewerHeadChangeMonitor(ctx context.Context, input stepI
 }
 
 func (r *Runner) appendThreadResolutionEvent(ctx context.Context, input stepInput, headSHA, decision, evidence, threadID, action, skippedReason string) {
-	r.appendEvent(ctx, eventInput{eventType: "reviewer.thread_resolution", projectID: input.Project.ID, loopID: input.Loop.ID, runID: input.Run.ID, entityType: "pull_request", entityID: fmt.Sprintf("%s#%d", input.Repo, input.PRNumber), payload: map[string]any{"repo": input.Repo, "prNumber": input.PRNumber, "threadId": threadID, "headSha": headSHA, "decision": decision, "evidence": evidence, "action": action, "skippedReason": skippedReason}})
+	payload := map[string]any{"repo": input.Repo, "prNumber": input.PRNumber, "threadId": threadID, "headSha": headSHA, "decision": decision, "evidence": evidence, "action": action, "skippedReason": skippedReason}
+	if isDispositionDecision(decision) {
+		payload["disposition"] = true
+	}
+	if meta := parseJSONObject(input.Loop.MetadataJSON); meta != nil {
+		if signal, ok := stringFromAny(meta[metadataLastReviewedSignalFingerprintKey]); ok && strings.TrimSpace(signal) != "" {
+			payload["lastReviewedSignalFingerprint"] = strings.TrimSpace(signal)
+		}
+	}
+	r.appendEvent(ctx, eventInput{eventType: "reviewer.thread_resolution", projectID: input.Project.ID, loopID: input.Loop.ID, runID: input.Run.ID, entityType: "pull_request", entityID: fmt.Sprintf("%s#%d", input.Repo, input.PRNumber), payload: payload})
 }
 
 func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCheckpoint, error) {
@@ -3501,6 +4929,15 @@ func (r *Runner) finishHeldReviewerQueueItem(ctx context.Context, loop storage.L
 }
 
 func (r *Runner) skipThreadResolutionFollowUpReview(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint) (bool, reviewerCheckpoint, error) {
+	// Disposition-only passes never run a full code review/publish.
+	if checkpoint.DispositionOnly || checkpoint.SkipKind == "disposition_only" {
+		if checkpoint.SkipReason == "" {
+			checkpoint.SkipReason = "Completed same-head thread disposition pass"
+			checkpoint.SkipKind = "disposition_only"
+		}
+		checkpoint.PendingReview = nil
+		return true, checkpoint, nil
+	}
 	if !checkpoint.ThreadResolutionFollowUpOnly {
 		return false, checkpoint, nil
 	}
@@ -5522,13 +6959,23 @@ func (r *Runner) hasActiveRunningRun(ctx context.Context, loopID string) (bool, 
 }
 
 func (r *Runner) listFollowUpLoops(ctx context.Context, projectID, repo string) ([]storage.LoopRecord, error) {
-	loops, err := r.repos.Loops.List(ctx)
+	all, err := r.repos.Loops.List(ctx)
 	if err != nil {
 		return nil, err
 	}
 	result := make([]storage.LoopRecord, 0)
-	for _, loop := range loops {
-		if loop.Type != "reviewer" || loop.ProjectID != projectID || derefString(loop.Repo) != repo || loop.PRNumber == nil || loop.Status == "paused" || loop.Status == "failed" || terminalReviewerLoopReason(loop) != "" {
+	for _, loop := range all {
+		if loop.Type != "reviewer" || loop.ProjectID != projectID || derefString(loop.Repo) != repo || loop.PRNumber == nil || loop.Status == "failed" {
+			continue
+		}
+		// Budget-held paused loops stay visible so discovery can enqueue
+		// disposition-only work (§8.7) without releasing the hold. Other paused
+		// / terminal statuses remain excluded.
+		if loop.Status == "paused" {
+			if !loops.IsReviewFixBudgetHold(loop) {
+				continue
+			}
+		} else if terminalReviewerLoopReason(loop) != "" {
 			continue
 		}
 		meta := parseJSONObject(loop.MetadataJSON)
@@ -5579,12 +7026,14 @@ func needsReviewerEligibilityRediscovery(checkpoint reviewerCheckpoint, startSte
 }
 
 type enqueueInput struct {
-	ProjectID   string
-	LoopID      string
-	Repo        string
-	PRNumber    int64
-	HeadSHA     string
-	AvailableAt time.Time
+	ProjectID               string
+	LoopID                  string
+	Repo                    string
+	PRNumber                int64
+	HeadSHA                 string
+	ReviewSignalFingerprint string
+	DispositionOnly         bool
+	AvailableAt             time.Time
 }
 
 func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.QueueItemRecord, error) {
@@ -5597,23 +7046,29 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 	if !input.AvailableAt.IsZero() {
 		availableAt = eventlog.FormatJavaScriptISOString(input.AvailableAt.UTC())
 	}
-	payloadJSON := ""
-	if strings.TrimSpace(input.HeadSHA) != "" {
-		payload, err := json.Marshal(map[string]any{"headSha": input.HeadSHA})
-		if err != nil {
-			return storage.QueueItemRecord{}, err
-		}
-		payloadJSON = string(payload)
-	}
+	payloadJSON := reviewerQueuePayloadJSON(input.HeadSHA, input.ReviewSignalFingerprint, input.DispositionOnly)
 	if existing != nil {
-		if existing.Status == "queued" && strings.TrimSpace(input.HeadSHA) != "" {
+		// Coalesce queued/retry-wait items in place to the latest head+signal.
+		// Retry-wait items remain status "queued" with a future AvailableAt.
+		if existing.Status == "queued" && (strings.TrimSpace(input.HeadSHA) != "" || strings.TrimSpace(input.ReviewSignalFingerprint) != "") {
 			existingPayload := parseJSONObject(existing.PayloadJSON)
 			existingHeadSHA, _ := stringFromAny(existingPayload["headSha"])
-			if existingHeadSHA != input.HeadSHA && isoTimeAfter(availableAt, existing.AvailableAt) {
+			existingSignal, _ := stringFromAny(existingPayload["reviewSignalFingerprint"])
+			headChanged := strings.TrimSpace(input.HeadSHA) != "" && existingHeadSHA != input.HeadSHA
+			signalChanged := strings.TrimSpace(input.ReviewSignalFingerprint) != "" && existingSignal != input.ReviewSignalFingerprint
+			if headChanged || signalChanged || payloadJSON != derefString(existing.PayloadJSON) {
+				existingAvailableAt := parseRFC3339OrZero(existing.AvailableAt)
+				debounced := loops.DebounceSchedule(r.now(), r.loopConfig.QuietPeriodSeconds, existingAvailableAt)
+				if !input.AvailableAt.IsZero() && input.AvailableAt.After(debounced) {
+					debounced = input.AvailableAt
+				}
+				updatedAvailableAt := eventlog.FormatJavaScriptISOString(debounced.UTC())
 				updated := *existing
-				updated.AvailableAt = availableAt
+				updated.AvailableAt = updatedAvailableAt
 				updated.UpdatedAt = r.nowISO()
-				updated.PayloadJSON = &payloadJSON
+				if payloadJSON != "" {
+					updated.PayloadJSON = &payloadJSON
+				}
 				persisted, _, err := r.repos.Queue.UpsertActiveByDedupeOrGetExisting(ctx, updated)
 				if err != nil {
 					return storage.QueueItemRecord{}, err
@@ -5622,6 +7077,29 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 				r.wakeSchedulerAfterEnqueue()
 				return updated, nil
 			}
+		}
+		// Running/claimed: stash latest pending signal on the active item; do not
+		// create a second active item. Continuation is scheduled after the run.
+		if (existing.Status == "running" || existing.Status == "claimed") && strings.TrimSpace(input.ReviewSignalFingerprint) != "" {
+			updated := *existing
+			merged := parseJSONObject(existing.PayloadJSON)
+			merged["pendingReviewSignalFingerprint"] = input.ReviewSignalFingerprint
+			if strings.TrimSpace(input.HeadSHA) != "" {
+				merged["pendingHeadSha"] = input.HeadSHA
+			}
+			merged["pendingDispositionOnly"] = input.DispositionOnly
+			encoded, err := json.Marshal(merged)
+			if err != nil {
+				return storage.QueueItemRecord{}, err
+			}
+			payload := string(encoded)
+			updated.PayloadJSON = &payload
+			updated.UpdatedAt = r.nowISO()
+			persisted, _, err := r.repos.Queue.UpsertActiveByDedupeOrGetExisting(ctx, updated)
+			if err != nil {
+				return storage.QueueItemRecord{}, err
+			}
+			return persisted, nil
 		}
 		return *existing, nil
 	}
@@ -5644,10 +7122,45 @@ func (r *Runner) enqueue(ctx context.Context, input enqueueInput) (storage.Queue
 	return persisted, nil
 }
 
+func reviewerQueuePayloadJSON(headSHA, reviewSignal string, dispositionOnly bool) string {
+	payload := map[string]any{}
+	if strings.TrimSpace(headSHA) != "" {
+		payload["headSha"] = headSHA
+	}
+	if strings.TrimSpace(reviewSignal) != "" {
+		payload["reviewSignalFingerprint"] = reviewSignal
+	}
+	if dispositionOnly {
+		payload["dispositionOnly"] = true
+	}
+	if len(payload) == 0 {
+		return ""
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
 func (r *Runner) wakeSchedulerAfterEnqueue() {
 	if r.onQueueItemEnqueued != nil {
 		r.onQueueItemEnqueued()
 	}
+}
+
+func parseRFC3339OrZero(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return parsed
+	}
+	if parsed, err := time.Parse(time.RFC3339, value); err == nil {
+		return parsed
+	}
+	return time.Time{}
 }
 
 func isoTimeAfter(candidate, current string) bool {
@@ -6487,12 +8000,14 @@ func (r *Runner) loopEnabled(meta map[string]any) bool {
 	return false
 }
 
-func (r *Runner) nextReviewAvailableAt(meta map[string]any) time.Time {
+func (r *Runner) nextReviewAvailableAt(meta map[string]any, dispositionOnly bool) time.Time {
 	availableAt := r.now()
 	if _, reviewed := stringFromAny(meta["lastPublishedHeadSha"]); reviewed && r.loopConfig.QuietPeriodSeconds > 0 {
 		availableAt = availableAt.Add(time.Duration(r.loopConfig.QuietPeriodSeconds) * time.Second)
 	}
-	if r.loopConfig.MinPublishIntervalSeconds > 0 {
+	// minPublishIntervalSeconds applies to new PR review publication only, not
+	// disposition-only classifier runs.
+	if !dispositionOnly && r.loopConfig.MinPublishIntervalSeconds > 0 {
 		if lastPublishedAt, ok := stringFromAny(meta["lastPublishedAt"]); ok {
 			if parsed, err := time.Parse(time.RFC3339Nano, lastPublishedAt); err == nil {
 				minimum := parsed.Add(time.Duration(r.loopConfig.MinPublishIntervalSeconds) * time.Second)

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -487,6 +487,9 @@ type Options struct {
 	CommentOnlyPublish      bool
 	OnAgentExecutionStarted AgentExecutionStartedFunc
 	OnQueueItemEnqueued     func()
+	// NotifyHumanAttention, when set, observes durable loop state after a new
+	// review-fix budget park (including discovery-time parks before claim).
+	NotifyHumanAttention func(context.Context, string)
 }
 
 type DiscoveryPolicy struct {
@@ -537,6 +540,7 @@ type Runner struct {
 	commentOnlyPublish      bool
 	onAgentExecutionStarted AgentExecutionStartedFunc
 	onQueueItemEnqueued     func()
+	notifyHumanAttention    func(context.Context, string)
 }
 
 type DiscoveryInput struct {
@@ -777,6 +781,7 @@ func New(options Options) *Runner {
 		commentOnlyPublish:      options.CommentOnlyPublish,
 		onAgentExecutionStarted: options.OnAgentExecutionStarted,
 		onQueueItemEnqueued:     options.OnQueueItemEnqueued,
+		notifyHumanAttention:    options.NotifyHumanAttention,
 	}
 }
 
@@ -1072,9 +1077,21 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		result.Skipped++
 		return nil
 	}
+	// Sibling pause / exhausted hold must not be revived by discovery enqueue.
+	// Notify only from discovery after a successful park (not from shared park).
+	if loops.IsReviewFixBudgetHold(loopResult.record) {
+		if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
+			return err
+		} else if parked {
+			r.notifyHumanAttentionBestEffort(ctx, loopResult.record.ID)
+		}
+		result.Skipped++
+		return nil
+	}
 	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
 		return err
 	} else if parked {
+		r.notifyHumanAttentionBestEffort(ctx, loopResult.record.ID)
 		result.Skipped++
 		return nil
 	}
@@ -3132,6 +3149,11 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		checkpoint.SkipReason = fmt.Sprintf("Skipped already-published review for head %s", pending.HeadSHA)
 		return checkpoint, nil
 	}
+	// Admission at the mutation seam: refuse a counted publish when already at
+	// the live cap (observe mid-run cap lowers). PR-closed still wins later.
+	if refused, err := r.refusePublishIfBudgetExhausted(ctx, input); refused || err != nil {
+		return checkpoint, err
+	}
 	if pending.CleanNoop {
 		detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 		if err != nil {
@@ -4632,7 +4654,7 @@ func isValidBlockingReviewEvent(value string) bool {
 }
 
 func (r *Runner) recordPublishedReviewProgress(ctx context.Context, input stepInput, pending pendingReviewCheckpoint, reviewEvent ReviewEvent) error {
-	if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) {
+	updated, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) {
 		previous, _ := stringFromAny(parseJSONObject(updated.MetadataJSON)["lastPublishedHeadSha"])
 		metadataJSON, err := mergeLoopMetadataJSON(updated.MetadataJSON, map[string]any{"lastPublishedHeadSha": pending.HeadSHA, "lastReviewEvent": string(reviewEvent), "lastReviewSummary": pending.Summary, "lastPublishedAt": r.nowISO()})
 		if err != nil {
@@ -4646,11 +4668,56 @@ func (r *Runner) recordPublishedReviewProgress(ctx context.Context, input stepIn
 			metadataJSON = counted
 		}
 		updated.MetadataJSON = stringPtr(metadataJSON)
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
 	r.appendEvent(ctx, eventInput{eventType: "pr.review.posted", projectID: input.Project.ID, loopID: input.Loop.ID, runID: input.Run.ID, entityType: "pull_request", entityID: fmt.Sprintf("%s#%d", input.Repo, input.PRNumber), payload: map[string]any{"repo": input.Repo, "prNumber": input.PRNumber, "event": string(reviewEvent), "headSha": pending.HeadSHA}})
+	// After a successful counted increment, park immediately when now exhausted.
+	if r.shouldCreateReviewerBudgetPark(updated) {
+		if r.livePullRequestClosed(ctx, input.Project, input.Repo, input.PRNumber) {
+			return nil
+		}
+		if _, parkErr := r.parkReviewerBudgetIfExhausted(ctx, updated); parkErr != nil {
+			return parkErr
+		}
+	}
 	return nil
+}
+
+// refusePublishIfBudgetExhausted parks and skips when the loop already sits at
+// the live publish cap before a counted mutation. Returns refused=true when the
+// publish must not proceed.
+func (r *Runner) refusePublishIfBudgetExhausted(ctx context.Context, input stepInput) (bool, error) {
+	loop := input.Loop
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+			loop = *fresh
+		}
+	}
+	if !loops.ParticipatesInReviewFixBudget(loop) {
+		return false, nil
+	}
+	if loops.IsReviewFixBudgetHold(loop) {
+		if _, err := r.parkReviewerBudgetIfExhausted(ctx, loop); err != nil {
+			return true, err
+		}
+		return true, &holdSkipError{summary: "Reviewer stopped because review-fix budget is held"}
+	}
+	cap := r.maxPublishesPerPR(loop.ProjectID)
+	if !loops.BudgetExhausted(loops.ReviewerPublishCount(loop.MetadataJSON), cap) {
+		return false, nil
+	}
+	if r.livePullRequestClosed(ctx, input.Project, input.Repo, input.PRNumber) {
+		if err := r.terminateLoop(ctx, loop, "pr_closed_or_merged"); err != nil {
+			return true, err
+		}
+		return true, &holdSkipError{summary: "Reviewer stopped because pull request is closed"}
+	}
+	if _, err := r.parkReviewerBudgetIfExhausted(ctx, loop); err != nil {
+		return true, err
+	}
+	return true, &holdSkipError{summary: "Reviewer stopped because review-fix publish budget is exhausted"}
 }
 
 type eventInput struct {
@@ -5122,6 +5189,10 @@ func (r *Runner) markLoopQueuedForReview(ctx context.Context, loop storage.LoopR
 		return nil
 	}
 	_, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
+		// Never flip a budget hold (exhausted or sibling pause) back to queued.
+		if loops.IsReviewFixBudgetHold(*updated) {
+			return
+		}
 		if active, activeErr := r.hasActiveRunningRun(ctx, updated.ID); activeErr == nil && active {
 			updated.Status = "running"
 			updated.NextRunAt = nil
@@ -6253,7 +6324,7 @@ func (r *Runner) reviewFixHITLEnabled() bool {
 }
 
 func (r *Runner) shouldParkReviewerBudget(loop storage.LoopRecord, checkpoint reviewerCheckpoint) bool {
-	if !r.reviewFixHITLEnabled() || isManualReviewerLoop(loop) || checkpoint.SkipReason != "" || checkpoint.PendingReview == nil {
+	if !loops.ParticipatesInReviewFixBudget(loop) || checkpoint.SkipReason != "" || checkpoint.PendingReview == nil {
 		return false
 	}
 	if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
@@ -6277,7 +6348,10 @@ func (r *Runner) shouldCreateReviewerBudgetPark(loop storage.LoopRecord) bool {
 	if loop.Status == "terminated" || loop.Status == "stopped" || loop.Status == "awaiting_human" {
 		return false
 	}
-	if !r.reviewFixHITLEnabled() || isManualReviewerLoop(loop) {
+	if loop.Status == "paused" && loops.IsReviewFixBudgetHold(loop) {
+		return false
+	}
+	if !loops.ParticipatesInReviewFixBudget(loop) {
 		return false
 	}
 	if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
@@ -6300,15 +6374,19 @@ func (r *Runner) parkReviewerBudgetIfExhausted(ctx context.Context, loop storage
 	if loop.Status == "terminated" || loop.Status == "stopped" {
 		return false, nil
 	}
+	// Sibling pause is already a hold; finish cancel/sibling work on re-entry
+	// but do not treat "not self-exhausted" as permission to proceed.
+	if loop.Status == "paused" && loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) {
+		return true, nil
+	}
 	if loop.Status == "awaiting_human" {
 		if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
 			return true, nil
 		}
+	} else if loop.Status == "paused" && loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
+		// Re-enter no-ask hold to finish cancel/sibling park / handoff event.
 	} else {
-		if !r.reviewFixHITLEnabled() {
-			return false, nil
-		}
-		if isManualReviewerLoop(loop) {
+		if !loops.ParticipatesInReviewFixBudget(loop) {
 			return false, nil
 		}
 		if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
@@ -6320,16 +6398,39 @@ func (r *Runner) parkReviewerBudgetIfExhausted(ctx context.Context, loop storage
 		}
 	}
 	cap := r.maxPublishesPerPR(loop.ProjectID)
+	count := loops.ReviewerPublishCount(loop.MetadataJSON)
+	fixerCap := 0
+	if r.projectRoleConfig != nil {
+		fixerCap = config.ProjectRoleConfigs(*r.projectRoleConfig, loop.ProjectID).Fixer.Behavior.Loop.MaxPushesPerPR
+	}
 	_, err := loops.ParkReviewFixBudget(ctx, r.repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: loop,
-		Role:      "reviewer",
-		Repo:      derefString(loop.Repo),
-		PRNumber:  derefInt64(loop.PRNumber),
-		Count:     loops.ReviewerPublishCount(loop.MetadataJSON),
-		Cap:       cap,
-		NowISO:    r.nowISO(),
+		Exhausted:   loop,
+		Role:        "reviewer",
+		Repo:        derefString(loop.Repo),
+		PRNumber:    derefInt64(loop.PRNumber),
+		Count:       count,
+		Cap:         cap,
+		NowISO:      r.nowISO(),
+		HITLEnabled: r.reviewFixHITLEnabled(),
+		LiveCaps: loops.ReviewFixBudgetLiveCaps{
+			ReviewerMaxPublishes: cap,
+			FixerMaxPushes:       fixerCap,
+		},
+		DB: r.db,
 	})
-	return err == nil, err
+	if err != nil {
+		return false, err
+	}
+	// Notify is owned by discovery call sites (and scheduler post-claim), not
+	// shared park — in-run parks must not notify before queue finalization.
+	return true, nil
+}
+
+func (r *Runner) notifyHumanAttentionBestEffort(ctx context.Context, loopID string) {
+	if r.notifyHumanAttention == nil || strings.TrimSpace(loopID) == "" {
+		return
+	}
+	r.notifyHumanAttention(ctx, loopID)
 }
 
 func terminalReviewerLoopReason(loop storage.LoopRecord) string {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -2994,8 +2994,9 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 	if err != nil {
 		return checkpoint, fmt.Errorf("resolve run agent identity: %w", err)
 	}
-	prompt, instructionBlock := buildReviewPromptWithInstructions(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint, input.Run.ID, idempotencyKey, reviewEvents, isManualReviewerLoop(input.Loop), requireReviewRequest, reviewRequestBypassReason, r.scope, r.disclosure, agentVendor, derefString(agentModel), r.looperCLIPath, r.reviewerAutoMergeConfigForProject(input.Project.ID).Enabled, commentOnlyCompletion)
-	nativeResumePrompt := r.nativeResumePromptForReview(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey)
+	lastPublishedHeadSHA, _ := stringFromAny(parseJSONObject(input.Loop.MetadataJSON)["lastPublishedHeadSha"])
+	prompt, instructionBlock := buildReviewPromptWithInstructions(input.Project.ID, r.customInstructions, input.Repo, input.PRNumber, checkpoint, input.Run.ID, idempotencyKey, reviewEvents, isManualReviewerLoop(input.Loop), requireReviewRequest, reviewRequestBypassReason, r.scope, r.disclosure, agentVendor, derefString(agentModel), r.looperCLIPath, r.reviewerAutoMergeConfigForProject(input.Project.ID).Enabled, commentOnlyCompletion, lastPublishedHeadSHA)
+	nativeResumePrompt := r.nativeResumePromptForReview(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey, lastPublishedHeadSHA)
 	metadata := map[string]any{
 		"loopType":            "reviewer",
 		"phase":               "review",
@@ -5921,14 +5922,16 @@ func (r *Runner) hasPendingHeadChangeNativeResume(ctx context.Context, loopID st
 	return ok
 }
 
-func (r *Runner) nativeResumePromptForReview(ctx context.Context, input stepInput, currentHeadSHA string, idempotencyKey string) string {
+func (r *Runner) nativeResumePromptForReview(ctx context.Context, input stepInput, currentHeadSHA string, idempotencyKey string, lastPublishedHeadSHA string) string {
 	record := r.pendingNativeResume(ctx, input.Loop.ID)
 	if record == nil {
 		return ""
 	}
 	if r.nativeResume.ReReviewPromptOnHeadChange {
 		if headChange, ok := reviewerNativeResumeHeadChange(record); ok && headChange.matches(input.Repo, input.PRNumber) {
-			return nativeResumeReReviewPrompt(input.Repo, input.PRNumber, headChange.OldHeadSHA, headChange.NewHeadSHA, currentHeadSHA, idempotencyKey)
+			// Only use repair-frontier language when a prior Looper review was
+			// published; otherwise keep the full re-review resume prompt.
+			return nativeResumeReReviewPrompt(input.Repo, input.PRNumber, headChange.OldHeadSHA, headChange.NewHeadSHA, currentHeadSHA, idempotencyKey, lastPublishedHeadSHA)
 		}
 	}
 	return nativeResumeContinuationPrompt("review", input.Repo, input.PRNumber, currentHeadSHA, idempotencyKey)
@@ -6056,7 +6059,37 @@ Before any GitHub side effect, re-check the current PR/head/idempotency guards f
 If the review or thread-resolution result was already posted, report the existing completion marker instead of posting a duplicate.`, strings.TrimSpace(phase), repo, prNumber, headSHA, idempotencyKey)
 }
 
-func nativeResumeReReviewPrompt(repo string, prNumber int64, oldHeadSHA string, interruptedHeadSHA string, currentHeadSHA string, idempotencyKey string) string {
+func nativeResumeReReviewPrompt(repo string, prNumber int64, oldHeadSHA string, interruptedHeadSHA string, currentHeadSHA string, idempotencyKey string, lastPublishedHeadSHA string) string {
+	if isRepairFrontierPass(lastPublishedHeadSHA, currentHeadSHA) {
+		// Resume replaces the normal review prompt, so later-pass native resume
+		// must carry the same late-discovery dispositions and Fixer-decline
+		// adjudication contract as buildReviewPromptWithInstructions.
+		return strings.Join([]string{
+			fmt.Sprintf(`Continue the existing Looper reviewer review task in this resumed native session as a repair-frontier re-review (not a full discard-and-rescan of the original PR diff).
+
+The pull request changed while the prior review was running:
+- PR: %s#%d
+- last published/reviewed head SHA: %s
+- previous session head SHA: %s
+- head SHA observed at interruption: %s
+- current expected head SHA for this run: %s
+- idempotency key for this run: %s
+
+Use prior session context only as background. Inspect only:
+1. every unresolved prior must_fix thread;
+2. the diff from last published head %s to current head %s;
+3. directly affected call sites, contracts, tests, and lifecycle invariants;
+4. evidence that Fixer addressed each prior finding.
+
+Do not rescan untouched original diff merely to invent ordinary P2/P3 hardening. Discard findings, assumptions, anchors, or conclusions that only apply to a previous head and are no longer valid. Keep only findings that are still concrete, actionable, and valid against the current head.
+
+Before any GitHub side effect, re-check that the PR is open, the current head SHA still matches the current expected head SHA, and the current-user review-request/idempotency guards from the existing instructions still pass.
+
+If a matching review for the current expected head and idempotency key was already posted, report the existing completion marker instead of posting a duplicate.`, repo, prNumber, lastPublishedHeadSHA, oldHeadSHA, interruptedHeadSHA, currentHeadSHA, idempotencyKey, lastPublishedHeadSHA, currentHeadSHA),
+			repairFrontierPassContract(lastPublishedHeadSHA, currentHeadSHA, false),
+			fixerDeclineAdjudicationContract(),
+		}, "\n\n")
+	}
 	return fmt.Sprintf(`Continue the existing Looper reviewer review task in this resumed native session, but treat it as a PR update re-review.
 
 The pull request changed while the prior review was running:
@@ -7223,8 +7256,39 @@ func buildPullRequestLockKey(item storage.QueueItemRecord) string {
 func buildReviewPrompt(repo string, prNumber int64, checkpoint reviewerCheckpoint, runID string, idempotencyKey string, reviewEvents config.ReviewerReviewEventsConfig, manual bool, scope config.ReviewerScope, disclosureCfg config.DisclosureConfig, agentRuntime string, agentModel string, looperCLIPath string) string {
 	cfg, _ := config.Normalize("")
 	cfg.Instructions.Enabled = false
-	prompt, _ := buildReviewPromptWithInstructions("", cfg, repo, prNumber, checkpoint, runID, idempotencyKey, reviewEvents, manual, true, "", scope, disclosureCfg, agentRuntime, agentModel, looperCLIPath, false, false)
+	prompt, _ := buildReviewPromptWithInstructions("", cfg, repo, prNumber, checkpoint, runID, idempotencyKey, reviewEvents, manual, true, "", scope, disclosureCfg, agentRuntime, agentModel, looperCLIPath, false, false, "")
 	return prompt
+}
+
+// isRepairFrontierPass is true when a prior Looper review was published for this
+// lane and the PR head has since changed. Budget Continue must not clear
+// lastPublishedHeadSha; that field is the durable frontier base.
+func isRepairFrontierPass(lastPublishedHeadSHA, currentHeadSHA string) bool {
+	last := strings.TrimSpace(lastPublishedHeadSHA)
+	current := strings.TrimSpace(currentHeadSHA)
+	return last != "" && current != "" && last != current
+}
+
+func repairFrontierPassContract(lastPublishedHeadSHA, currentHeadSHA string, commentOnly bool) string {
+	scanVerb := "publishing"
+	if commentOnly {
+		scanVerb = "finalizing"
+	}
+	return fmt.Sprintf(`Repair frontier contract (later pass): a prior Looper review was published for head %s and the current head is %s. This is not a first full-pass rescan. Before %s, inspect only:
+1. every unresolved prior must_fix thread;
+2. the diff from last reviewed head %s to current head %s;
+3. directly affected call sites, contracts, tests, and lifecycle invariants;
+4. evidence that Fixer actually addressed each prior finding.
+Do not rescan untouched original diff merely to invent ordinary new P2/P3 hardening, cleanup, style, or independent-improvement work.
+Late findings discovered in untouched old diff:
+- Clear security, data corruption/loss, broken public contract, or P0/P1 correctness blocker → disposition must_fix; mark late discovery in scopeEvidence (for example prefix with "late_discovery: …") and include it in convergence evidence.
+- Ordinary P2/P3 robustness, cleanup, style, or independent improvement → disposition follow_up; do not feed the current Fixer loop.
+- Scope or severity genuinely ambiguous → disposition needs_human.
+Budget Continue does not reset this repair frontier; lastPublishedHeadSha remains the base until a new head is published.`, lastPublishedHeadSHA, currentHeadSHA, scanVerb, lastPublishedHeadSHA, currentHeadSHA)
+}
+
+func fixerDeclineAdjudicationContract() string {
+	return `Fixer decline adjudication: a validated Fixer declined reply on an existing Looper-authored review thread is a scope dispute, not dismissal authority. Do not open a duplicate thread for the same finding. Adjudicate on the existing thread only: (1) accept the decline when the item is out of scope (leave the thread for later resolution ownership — do not invent a new thread), (2) reject the decline with new concrete authority evidence and keep the thread unresolved so Fixer remains eligible, or (3) disposition needs_human when judgment is required. A second attempted fix to the same subsystem, or a repeated reviewer–fixer scope conflict without new evidence, must be needs_human — not another automatic argument round.`
 }
 
 func buildReviewerMinimalPRSeed(repo string, prNumber int64, checkpoint reviewerCheckpoint, scope config.ReviewerScope) string {
@@ -7305,7 +7369,7 @@ func reviewerProjectProviderKind(cfg config.Config, projectID string) config.Pro
 	return config.ProviderKindGitHub
 }
 
-func buildReviewPromptWithInstructions(projectID string, instructionConfig config.Config, repo string, prNumber int64, checkpoint reviewerCheckpoint, runID string, idempotencyKey string, reviewEvents config.ReviewerReviewEventsConfig, manual bool, requireReviewRequest bool, reviewRequestBypassReason string, scope config.ReviewerScope, disclosureCfg config.DisclosureConfig, agentRuntime string, agentModel string, looperCLIPath string, autoMergeEnabled bool, commentOnlyPublish bool) (string, config.CustomInstructionBlock) {
+func buildReviewPromptWithInstructions(projectID string, instructionConfig config.Config, repo string, prNumber int64, checkpoint reviewerCheckpoint, runID string, idempotencyKey string, reviewEvents config.ReviewerReviewEventsConfig, manual bool, requireReviewRequest bool, reviewRequestBypassReason string, scope config.ReviewerScope, disclosureCfg config.DisclosureConfig, agentRuntime string, agentModel string, looperCLIPath string, autoMergeEnabled bool, commentOnlyPublish bool, lastPublishedHeadSHA string) (string, config.CustomInstructionBlock) {
 	looperCLIPath = normalizeLooperCLIPath(looperCLIPath)
 	looperCLICommand := shellQuote(looperCLIPath)
 	phase := resolvePullRequestPhase(detailLabels(checkpoint.Detail))
@@ -7318,6 +7382,9 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	if forgejoNative {
 		forgeName = "Forgejo"
 	}
+	currentHeadSHA := snapshotHeadSHA(checkpoint)
+	lastPublishedHeadSHA = strings.TrimSpace(lastPublishedHeadSHA)
+	laterPass := isRepairFrontierPass(lastPublishedHeadSHA, currentHeadSHA)
 	publishInstruction := fmt.Sprintf("For actionable must_fix findings, you must publish the %s review yourself by calling looper's enforced review-submit wrapper from the shell (inline comments only for must_fix). For no-actionable-finding results, follow the clean-result publishing instructions for this run. After the agent step, finish with `__LOOPER_RESULT__` JSON that includes `summary`, optional `outcome`, and `findings` using the same disposition fields as comment-only (`disposition`, `severity`, `scopeBasis`, `scopeEvidence`, `title`, `body`, optional `path`/`line`). Looper **does** parse this findings list: `follow_up` is retained locally only and must not be submitted; `needs_human` parks the pair and must not be submitted as change-request comments. Do not smuggle follow_up/needs_human into unstructured top-level review body prose as the only carrier of a blocking finding.", forgeName)
 	if looperCLIPath == "" {
 		publishInstruction = "A trusted Looper CLI review-submit wrapper is unavailable for this run, so fail closed: do not publish any GitHub review, do not add or remove any GitHub reaction, and exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
@@ -7338,7 +7405,11 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		cleanResultCompletionInstruction = "Group findings only when they share the same root cause; keep unrelated concerns separate. Accumulate every independent in-scope must_fix before finalizing. If there is no concrete must_fix feedback, start the final summary with `No actionable findings`. Do not invent feedback."
 		fetchContract = "Provider-supplied Forgejo review context: Looper fetched PR metadata and diff before invoking you. Use the prepared local worktree plus the supplied metadata/diff as the review context; do not use GitHub CLI/API commands or native review/thread features."
 	}
-	parts := []string{fmt.Sprintf("Review pull request %s#%d.", repo, prNumber), buildReviewerMinimalPRSeed(repo, prNumber, checkpoint, scope), fetchContract, "Phase: " + phase, phaseInstruction, reviewerScopeInstruction(scope), publishInstruction, fmt.Sprintf("Review idempotency marker prefix: <!-- looper:review id=%s head=%s outcome=clean|non_blocking|blocking -->", idempotencyKey, snapshotHeadSHA(checkpoint)), outcomeInstruction, "Run ID for logging only, not for idempotency: " + runID}
+	parts := []string{fmt.Sprintf("Review pull request %s#%d.", repo, prNumber), buildReviewerMinimalPRSeed(repo, prNumber, checkpoint, scope), fetchContract, "Phase: " + phase, phaseInstruction, reviewerScopeInstruction(scope), publishInstruction, fmt.Sprintf("Review idempotency marker prefix: <!-- looper:review id=%s head=%s outcome=clean|non_blocking|blocking -->", idempotencyKey, currentHeadSHA), outcomeInstruction, "Run ID for logging only, not for idempotency: " + runID}
+	if laterPass {
+		parts = append(parts, fmt.Sprintf("Last reviewed head SHA: %s", lastPublishedHeadSHA), fmt.Sprintf("Current head SHA for this pass: %s", currentHeadSHA), repairFrontierPassContract(lastPublishedHeadSHA, currentHeadSHA, commentOnlyPublish))
+	}
+	parts = append(parts, fixerDeclineAdjudicationContract())
 	if checkpoint.Detail != nil && len(checkpoint.Detail.Labels) > 0 {
 		parts = append(parts, "Current labels: "+strings.Join(checkpoint.Detail.Labels, ", "))
 	}
@@ -7398,9 +7469,13 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		reviewRequestInstruction = "This reviewer configuration does not require a current-user review request before posting."
 	}
 	if commentOnlyPublish {
+		reviewPassContract := "Review pass contract: complete one full review pass before finalizing. Use the supplied PR metadata, supplied diff, and local worktree to inspect every changed file/range in scope. Do not stop after the first issue. If an in-scope must_fix issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass."
+		if laterPass {
+			reviewPassContract = "Review pass contract (later pass / repair frontier): complete the repair-frontier inspection before finalizing. Do not perform a full first-pass rescan of untouched original diff. Focus on unresolved prior must_fix threads, the last-reviewed-head→current-head delta, directly affected contracts/tests/lifecycle invariants, and Fixer evidence. Do not stop after the first issue within that frontier."
+		}
 		parts = append(parts,
 			"Comment-only publish contract: Looper will post your final completion summary as one top-level PR comment after it verifies the PR is still open, the head SHA still matches, and this head has not already been published locally. Do not publish anything yourself. Only must_fix findings become remote Reviewer Summary items; follow_up and needs_human remain in structured completion only.",
-			"Review pass contract: complete one full review pass before finalizing. Use the supplied PR metadata, supplied diff, and local worktree to inspect every changed file/range in scope. Do not stop after the first issue. If an in-scope must_fix issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass.",
+			reviewPassContract,
 			"Finding disposition contract: every candidate uses disposition must_fix|follow_up|needs_human, severity blocking|non_blocking|nit, scopeBasis (stated_intent|introduced_regression|required_invariant|independent_improvement|ambiguous_intent), scopeEvidence (specific repository rule, PR goal/non-goal, linked spec section, or regression evidence), plus title/body/location. must_fix becomes remote feedback; follow_up is retained only in structured completion; needs_human must not be published as a change request and parks the pair for human judgment.",
 			"Finding accumulator contract: accumulate candidate findings internally before finalizing. For each candidate, track disposition, severity, scopeBasis, scopeEvidence, location, problem, why it matters, and a suggested fix. Deduplicate only the same root cause or a genuinely repeated pattern; keep unrelated concerns separate. Grouping is valid only for a shared root cause with representative locations.",
 			"Severity rubric: mark a finding as BLOCKING only when it can realistically cause incorrect behavior, data loss/corruption, security exposure, broken public API/protocol/config/migration/backward compatibility, failing existing or necessary tests, race/deadlock/resource leak, transaction/lifecycle inconsistency, clear production risk, or failure to satisfy the PR's stated goal. Mark actionable but merge-safe improvements as NON_BLOCKING. Mark tiny style, naming, wording, formatting, or subjective preferences as NIT; NITs must not block merge.",
@@ -7427,11 +7502,15 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		githubOperationContract = "GitHub operation contract: a trusted Looper CLI path was not detected for this reviewer run, so you cannot safely publish a GitHub review. Do not call PATH-based `looper`, repository-local `go run ./cmd/looper`, `gh api repos/.../pulls/.../reviews`, or `gh pr review` directly; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
 		submitPayloadInstruction = ""
 	}
+	reviewPassContract := "Review pass contract: complete one full review pass before publishing. Collect PR metadata, changed-file list, live diffs, prior unresolved feedback, and necessary surrounding context; then scan every changed file/range in scope. Do not stop after the first issue. If an in-scope must_fix issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass."
+	if laterPass {
+		reviewPassContract = "Review pass contract (later pass / repair frontier): complete the repair-frontier inspection before publishing. Do not perform a full first-pass rescan of untouched original diff merely to invent ordinary P2/P3 work. Collect unresolved prior must_fix threads, the last-reviewed-head→current-head delta, directly affected call sites/contracts/tests/lifecycle invariants, and Fixer evidence for each prior finding. Do not stop after the first issue within that frontier."
+	}
 	parts = append(parts,
 		idempotencyInstruction,
 		existingMarkerEventInstruction,
 		githubOperationContract,
-		"Review pass contract: complete one full review pass before publishing. Collect PR metadata, changed-file list, live diffs, prior unresolved feedback, and necessary surrounding context; then scan every changed file/range in scope. Do not stop after the first issue. If an in-scope must_fix issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass.",
+		reviewPassContract,
 		"Finding disposition contract: every candidate uses disposition must_fix|follow_up|needs_human, severity blocking|non_blocking|nit, scopeBasis (stated_intent|introduced_regression|required_invariant|independent_improvement|ambiguous_intent), scopeEvidence (specific repository rule, PR goal/non-goal, linked spec section, or regression evidence), path/line, problem, why, and suggestedChange. Emit the full candidate list in `__LOOPER_RESULT__.findings` — Looper parses this JSON. Only must_fix may be submitted through `looper review submit` as remote actionable feedback. Retain follow_up in structured completion only — do not submit follow_up as review comments. For needs_human, do not submit change-request comments; include them in `__LOOPER_RESULT__.findings` so Looper can park the pair for human judgment. Actionable/blocking reviews must carry must_fix as inline comments, not body-only prose.",
 		"Finding accumulator contract: accumulate candidate findings internally before publishing. For each candidate, track disposition, severity, scopeBasis, scopeEvidence, location, problem, why it matters, and a suggested fix. Before submitting, deduplicate only the same root cause or a genuinely repeated pattern; group repeated patterns into systemic comments with representative examples only when they share a root cause. Keep unrelated concerns as separate comments. The publication budget limits review publications, not findings per publication.",
 		"Severity rubric: mark a finding as BLOCKING only when it can realistically cause incorrect behavior, data loss/corruption, security exposure, broken public API/protocol/config/migration/backward compatibility, failing existing or necessary tests, race/deadlock/resource leak, transaction/lifecycle inconsistency, clear production risk, or failure to satisfy the PR's stated goal. Mark actionable but merge-safe improvements as NON_BLOCKING. Mark tiny style, naming, wording, formatting, or subjective preferences as NIT; NITs must not block merge.",

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -648,12 +648,24 @@ type reviewerCommentOnlyCompletion struct {
 }
 
 type reviewerCommentOnlyFindingResult struct {
-	ReviewItemID string   `json:"review_item_id,omitempty"`
-	Title        string   `json:"title"`
-	Body         string   `json:"body"`
-	Files        []string `json:"files,omitempty"`
-	Supersedes   []string `json:"supersedes,omitempty"`
+	ReviewItemID  string   `json:"review_item_id,omitempty"`
+	Title         string   `json:"title"`
+	Body          string   `json:"body"`
+	Files         []string `json:"files,omitempty"`
+	Path          string   `json:"path,omitempty"`
+	Line          int      `json:"line,omitempty"`
+	Supersedes    []string `json:"supersedes,omitempty"`
+	Disposition   string   `json:"disposition,omitempty"`
+	Severity      string   `json:"severity,omitempty"`
+	ScopeBasis    string   `json:"scopeBasis,omitempty"`
+	ScopeEvidence string   `json:"scopeEvidence,omitempty"`
 }
+
+const (
+	reviewFindingDispositionMustFix    = "must_fix"
+	reviewFindingDispositionFollowUp   = "follow_up"
+	reviewFindingDispositionNeedsHuman = "needs_human"
+)
 
 type threadResolutionCheckpoint struct {
 	HeadSHA   string `json:"headSha,omitempty"`
@@ -1077,13 +1089,15 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		result.Skipped++
 		return nil
 	}
-	// Sibling pause / exhausted hold must not be revived by discovery enqueue.
+	// Sibling pause / exhausted / scope hold must not be revived by discovery enqueue.
 	// Notify only from discovery after a successful park (not from shared park).
-	if loops.IsReviewFixBudgetHold(loopResult.record) {
-		if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
-			return err
-		} else if parked {
-			r.notifyHumanAttentionBestEffort(ctx, loopResult.record.ID)
+	if loops.IsReviewFixPairHold(loopResult.record) {
+		if loops.IsReviewFixBudgetHold(loopResult.record) {
+			if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
+				return err
+			} else if parked {
+				r.notifyHumanAttentionBestEffort(ctx, loopResult.record.ID)
+			}
 		}
 		result.Skipped++
 		return nil
@@ -1614,12 +1628,16 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		return ProcessResult{}, fmt.Errorf("loop not found: %s", *queueItem.LoopID)
 	}
 	if reason := terminalReviewerLoopReason(*loop); reason != "" {
-		cancelReason := "loop_" + reason
-		if _, err := r.repos.Queue.CancelByLoop(ctx, loop.ID, r.nowISO(), &cancelReason); err != nil {
-			return ProcessResult{}, err
+		// Budget holds stay non-terminal for claim preflight so at-cap recovery can
+		// still persist deferred needs_human scope before the budget skip return.
+		if !loops.IsReviewFixBudgetHold(*loop) {
+			cancelReason := "loop_" + reason
+			if _, err := r.repos.Queue.CancelByLoop(ctx, loop.ID, r.nowISO(), &cancelReason); err != nil {
+				return ProcessResult{}, err
+			}
+			summary := fmt.Sprintf("Skipped terminal reviewer loop %s: %s", loop.ID, reason)
+			return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, nil
 		}
-		summary := fmt.Sprintf("Skipped terminal reviewer loop %s: %s", loop.ID, reason)
-		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, nil
 	}
 	project, err := r.repos.Projects.GetByID(ctx, loop.ProjectID)
 	if err != nil {
@@ -1645,6 +1663,12 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, *loop); err != nil {
 		return ProcessResult{}, err
 	} else if parked {
+		// Crash gap: publish + budget park may have landed without scope
+		// park/defer. Recover pending/scope from the latest checkpoint before
+		// skipping — never start the agent or re-publish on this path.
+		if err := r.recoverPublishedNeedsHumanScopeFromLatestRun(ctx, *project, *loop); err != nil {
+			return ProcessResult{}, err
+		}
 		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: "review-fix budget exhausted"}, nil
 	}
 	resumedRun, err := r.createRunContext(ctx, *loop)
@@ -3081,22 +3105,93 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		return checkpoint, &loopError{message: "Reviewer agent did not report a valid completion marker after publishing review", kind: FailureRetryableAfterResume}
 	}
-	if cleanReviewNoopSummary(result.Summary) {
-		if commentOnlyCompletion {
-			completion, err := parseReviewerCommentOnlyCompletion(result)
-			if err != nil {
-				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	if commentOnlyCompletion {
+		completion, err := parseReviewerCommentOnlyCompletion(result)
+		if err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
+		if commentOnlyCompletionHasNeedsHuman(completion) {
+			// Pure needs_human: park without publishing/counting.
+			if len(publishableCommentOnlyFindings(completion.Findings)) == 0 {
+				if err := r.parkOrDeferReviewerScopeHuman(ctx, input.Loop, completion); err != nil {
+					return checkpoint, err
+				}
+				return checkpoint, reviewerScopeOrBudgetHoldSkip(ctx, r, input.Loop)
 			}
-			payload, err := json.Marshal(completion)
-			if err != nil {
-				return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer comment-only completion: %v", err), kind: FailureRetryableAfterResume}
+			// Mixed must_fix + needs_human: publish must_fix first (publish step),
+			// then apply the one-hold rule after recordPublishedReviewProgress.
+			payload, marshalErr := json.Marshal(completion)
+			if marshalErr != nil {
+				return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer comment-only completion: %v", marshalErr), kind: FailureRetryableAfterResume}
 			}
-			checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload), CleanNoop: completion.Outcome == "clean"}
+			checkpoint.PendingReview = &pendingReviewCheckpoint{
+				HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative,
+				Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+			}
 			checkpoint.ResumePolicy = "advance_from_checkpoint"
 			return checkpoint, nil
 		}
+		payload, err := json.Marshal(completion)
+		if err != nil {
+			return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer comment-only completion: %v", err), kind: FailureRetryableAfterResume}
+		}
+		cleanNoop := cleanReviewNoopSummary(result.Summary) && completion.Outcome == "clean"
+		checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload), CleanNoop: cleanNoop}
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		return checkpoint, nil
+	}
+
+	// Native path: parse __LOOPER_RESULT__ findings (same disposition contract).
+	// Summary-only markers without findings stay valid; remote marker is publish authority.
+	nativeCompletion, err := parseReviewerNativeCompletion(result)
+	if err != nil {
+		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if commentOnlyCompletionHasNeedsHuman(nativeCompletion) {
+		// Agent may already have submitted must_fix comments via review submit
+		// before completing with needs_human. Count that publish before parking.
+		if found, markerErr := r.verifyAgentNativeReviewMarker(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey, cleanReviewAuthorLogin(checkpoint, PullRequestDetail{})); markerErr != nil {
+			return checkpoint, &loopError{message: markerErr.Error(), kind: FailureRetryableAfterResume}
+		} else if found.Found {
+			summary := result.Summary
+			if strings.TrimSpace(nativeCompletion.Summary) != "" {
+				summary = nativeCompletion.Summary
+			}
+			outcome := normalizeCommentOnlyOutcome(found.Outcome)
+			if outcome == "" {
+				outcome = normalizeCommentOnlyOutcome(nativeCompletion.Outcome)
+			}
+			pending := pendingReviewCheckpoint{
+				HeadSHA:            checkpoint.Snapshot.HeadSHA,
+				IdempotencyKey:     idempotencyKey,
+				Event:              found.Event,
+				Summary:            summary,
+				Outcome:            outcome,
+				ContentFingerprint: reviewMarkerFingerprint(found),
+			}
+			if err := r.recordPublishedReviewProgress(ctx, input, pending, pendingReviewEvent(pending)); err != nil {
+				return checkpoint, err
+			}
+		}
+		// One authoritative hold: if publish hit the live cap, budget owns the
+		// pair; defer scope evidence without stacking a second ask/reason.
+		if err := r.parkOrDeferReviewerScopeHuman(ctx, input.Loop, nativeCompletion); err != nil {
+			return checkpoint, err
+		}
+		return checkpoint, reviewerScopeOrBudgetHoldSkip(ctx, r, input.Loop)
+	}
+	nativeFindingsJSON := ""
+	if len(nativeCompletion.Findings) > 0 {
+		payload, marshalErr := json.Marshal(nativeCompletion)
+		if marshalErr != nil {
+			return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer native completion: %v", marshalErr), kind: FailureRetryableAfterResume}
+		}
+		nativeFindingsJSON = string(payload)
+	}
+
+	if cleanReviewNoopSummary(result.Summary) {
 		if reviewEvents.Clean == config.ReviewerReviewEventApprove && r.reviewerAutoMergeConfigForProject(input.Project.ID).Enabled && resolvePullRequestPhase(detailLabels(checkpoint.Detail)) != "spec" {
-			checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", CleanNoop: true}
+			checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", ReviewerSummaryJSON: nativeFindingsJSON, CleanNoop: true}
 			checkpoint.ResumePolicy = "advance_from_checkpoint"
 			return checkpoint, nil
 		}
@@ -3107,30 +3202,25 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 				if err := validateCleanApprovedReviewMarkerBody(found, cleanReviewAuthorLogin(checkpoint, PullRequestDetail{})); err != nil {
 					return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 				}
-				checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", ContentFingerprint: reviewMarkerFingerprint(found), CleanNoop: true}
+				checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", ContentFingerprint: reviewMarkerFingerprint(found), ReviewerSummaryJSON: nativeFindingsJSON, CleanNoop: true}
 				checkpoint.ResumePolicy = "advance_from_checkpoint"
 				return checkpoint, nil
 			}
 			return checkpoint, &loopError{message: "Reviewer agent reported a clean summary-only result, but clean review policy requires an APPROVED review marker; submit the APPROVE review through the trusted wrapper or exit non-zero", kind: FailureRetryableAfterResume}
 		}
-		checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", CleanNoop: true}
+		checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", ReviewerSummaryJSON: nativeFindingsJSON, CleanNoop: true}
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		return checkpoint, nil
 	}
-	if commentOnlyCompletion {
-		completion, err := parseReviewerCommentOnlyCompletion(result)
-		if err != nil {
-			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
-		}
-		payload, err := json.Marshal(completion)
-		if err != nil {
-			return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer comment-only completion: %v", err), kind: FailureRetryableAfterResume}
-		}
-		checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload)}
-		checkpoint.ResumePolicy = "advance_from_checkpoint"
-		return checkpoint, nil
+	outcome := normalizeCommentOnlyOutcome(reviewCompletionOutcome(result))
+	if nativeCompletion.Outcome != "" {
+		outcome = nativeCompletion.Outcome
 	}
-	checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: normalizeCommentOnlyOutcome(reviewCompletionOutcome(result))}
+	summary := result.Summary
+	if strings.TrimSpace(nativeCompletion.Summary) != "" {
+		summary = nativeCompletion.Summary
+	}
+	checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: summary, Outcome: outcome, ReviewerSummaryJSON: nativeFindingsJSON}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
 }
@@ -3146,6 +3236,19 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 	pending := *checkpoint.PendingReview
 	meta := parseJSONObject(input.Loop.MetadataJSON)
 	if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && last == pending.HeadSHA {
+		// Crash/retry gap: recordPublishedReviewProgress may have written
+		// lastPublishedHeadSha (and budget park) before
+		// afterCommentOnlyPublishMaybeParkScope ran. Recover park/defer
+		// without re-publishing. Freshness gates refuse stale/closed PRs.
+		// No-ops when pending has no needs_human.
+		next, err := r.recoverAlreadyPublishedScopePark(ctx, input, checkpoint, pending)
+		if err != nil {
+			return next, err
+		}
+		if next.SkipReason != "" || next.SkipKind != "" {
+			return next, nil
+		}
+		checkpoint = next
 		checkpoint.SkipReason = fmt.Sprintf("Skipped already-published review for head %s", pending.HeadSHA)
 		return checkpoint, nil
 	}
@@ -3202,7 +3305,7 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 			if err := r.recordPublishedReviewProgress(ctx, input, pending, ReviewEventComment); err != nil {
 				return checkpoint, err
 			}
-			return checkpoint, nil
+			return r.afterCommentOnlyPublishMaybeParkScope(ctx, input, checkpoint, pending)
 		}
 		if reviewEvents.Clean == config.ReviewerReviewEventApprove {
 			found, err := r.verifyAgentNativeReviewMarker(ctx, input, pending.HeadSHA, pending.IdempotencyKey, cleanReviewAuthorLogin(checkpoint, detail))
@@ -3285,7 +3388,7 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		if err := r.recordPublishedReviewProgress(ctx, input, pending, ReviewEventComment); err != nil {
 			return checkpoint, err
 		}
-		return checkpoint, nil
+		return r.afterCommentOnlyPublishMaybeParkScope(ctx, input, checkpoint, pending)
 	}
 	markerResult := ReviewMarkerResult{}
 	if pending.Event == reviewEventAgentNative {
@@ -3974,6 +4077,14 @@ func (r *Runner) publishCommentOnlyReview(ctx context.Context, input stepInput, 
 	if err != nil {
 		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
+	// Pure needs_human: park without publishing. Mixed must_fix+needs_human
+	// publishes must_fix only; caller parks/defers scope after recordPublished.
+	if commentOnlyCompletionHasNeedsHuman(completion) && len(publishableCommentOnlyFindings(completion.Findings)) == 0 {
+		if err := r.parkOrDeferReviewerScopeHuman(ctx, input.Loop, completion); err != nil {
+			return err
+		}
+		return reviewerScopeOrBudgetHoldSkip(ctx, r, input.Loop)
+	}
 	comments, err := r.github.ListIssueComments(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 	if err != nil {
 		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
@@ -3990,7 +4101,7 @@ func (r *Runner) publishCommentOnlyReview(ctx context.Context, input stepInput, 
 	if err != nil {
 		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
-	body, err := renderReviewerSummaryComment(summary, completion.Summary)
+	body, err := renderReviewerSummaryComment(summary, commentOnlyPublishVisibleSummary(completion))
 	if err != nil {
 		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
@@ -4264,6 +4375,35 @@ func reviewCompletionOutcome(result AgentResult) string {
 }
 
 func parseReviewerCommentOnlyCompletion(result AgentResult) (reviewerCommentOnlyCompletion, error) {
+	completion, err := unmarshalReviewerCompletionMarker(result)
+	if err != nil {
+		return reviewerCommentOnlyCompletion{}, fmt.Errorf("parse reviewer comment-only completion: %w", err)
+	}
+	return validateReviewerCommentOnlyCompletion(completion)
+}
+
+// parseReviewerNativeCompletion parses __LOOPER_RESULT__ after a native review step.
+// Summary-only markers without findings remain valid (remote review marker is publish
+// authority). When findings are present, validation is fail-closed.
+func parseReviewerNativeCompletion(result AgentResult) (reviewerCommentOnlyCompletion, error) {
+	completion, err := unmarshalReviewerCompletionMarker(result)
+	if err != nil {
+		// Native agents historically emit a parsed completion without a strict
+		// findings payload; treat missing marker payload as empty findings.
+		if strings.Contains(err.Error(), "completion marker is required") {
+			return reviewerCommentOnlyCompletion{Summary: strings.TrimSpace(result.Summary)}, nil
+		}
+		return reviewerCommentOnlyCompletion{}, fmt.Errorf("parse reviewer native completion: %w", err)
+	}
+	if len(completion.Findings) == 0 {
+		completion.Summary = strings.TrimSpace(completion.Summary)
+		completion.Outcome = normalizeCommentOnlyOutcome(completion.Outcome)
+		return completion, nil
+	}
+	return validateReviewerCommentOnlyCompletion(completion)
+}
+
+func unmarshalReviewerCompletionMarker(result AgentResult) (reviewerCommentOnlyCompletion, error) {
 	var completion reviewerCommentOnlyCompletion
 	raw := result.Stdout
 	if strings.TrimSpace(result.Stderr) != "" {
@@ -4277,11 +4417,11 @@ func parseReviewerCommentOnlyCompletion(result AgentResult) (reviewerCommentOnly
 		}
 		payload := strings.TrimPrefix(line, agent.CompletionMarkerPrefix)
 		if err := json.Unmarshal([]byte(payload), &completion); err != nil {
-			return reviewerCommentOnlyCompletion{}, fmt.Errorf("parse reviewer comment-only completion: %w", err)
+			return reviewerCommentOnlyCompletion{}, err
 		}
-		return validateReviewerCommentOnlyCompletion(completion)
+		return completion, nil
 	}
-	return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only completion marker is required")
+	return reviewerCommentOnlyCompletion{}, fmt.Errorf("completion marker is required")
 }
 
 func validateReviewerCommentOnlyCompletion(completion reviewerCommentOnlyCompletion) (reviewerCommentOnlyCompletion, error) {
@@ -4293,26 +4433,37 @@ func validateReviewerCommentOnlyCompletion(completion reviewerCommentOnlyComplet
 	if completion.Outcome == "" {
 		return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only completion outcome must be clean, non_blocking, or blocking")
 	}
-	if completion.Outcome == "clean" {
-		if len(completion.Findings) != 0 {
-			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only clean completion must not include findings")
-		}
-		if !cleanReviewNoopSummary(completion.Summary) {
-			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only clean completion summary must start with \"No actionable findings\"")
-		}
-		return completion, nil
-	}
-	if len(completion.Findings) == 0 {
-		return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only actionable completion must include at least one finding")
-	}
 	seenFindingIDs := map[string]struct{}{}
+	mustFixCount := 0
 	for i := range completion.Findings {
 		finding := &completion.Findings[i]
 		finding.ReviewItemID = strings.TrimSpace(finding.ReviewItemID)
 		finding.Title = strings.TrimSpace(finding.Title)
 		finding.Body = strings.TrimSpace(finding.Body)
+		finding.Path = strings.TrimSpace(finding.Path)
+		finding.Disposition = strings.TrimSpace(finding.Disposition)
+		finding.Severity = strings.TrimSpace(finding.Severity)
+		finding.ScopeBasis = strings.TrimSpace(finding.ScopeBasis)
+		finding.ScopeEvidence = strings.TrimSpace(finding.ScopeEvidence)
 		if finding.Title == "" || finding.Body == "" {
 			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d requires title and body", i)
+		}
+		if finding.Disposition == "" {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d requires disposition", i)
+		}
+		if finding.ScopeBasis == "" {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d requires scopeBasis", i)
+		}
+		if finding.ScopeEvidence == "" {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d requires scopeEvidence", i)
+		}
+		switch finding.Disposition {
+		case reviewFindingDispositionMustFix, reviewFindingDispositionFollowUp, reviewFindingDispositionNeedsHuman:
+		default:
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d has invalid disposition %q", i, finding.Disposition)
+		}
+		if finding.Disposition == reviewFindingDispositionMustFix {
+			mustFixCount++
 		}
 		if finding.ReviewItemID != "" {
 			if _, exists := seenFindingIDs[finding.ReviewItemID]; exists {
@@ -4343,7 +4494,153 @@ func validateReviewerCommentOnlyCompletion(completion reviewerCommentOnlyComplet
 		}
 		finding.Supersedes = supersedes
 	}
+	if completion.Outcome == "clean" {
+		if mustFixCount != 0 {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only clean completion must not include must_fix findings")
+		}
+		if !cleanReviewNoopSummary(completion.Summary) {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only clean completion summary must start with \"No actionable findings\"")
+		}
+		return completion, nil
+	}
+	if mustFixCount == 0 && !commentOnlyCompletionHasNeedsHuman(completion) {
+		return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only actionable completion must include at least one must_fix finding")
+	}
 	return completion, nil
+}
+
+func commentOnlyCompletionHasNeedsHuman(completion reviewerCommentOnlyCompletion) bool {
+	for _, finding := range completion.Findings {
+		if strings.TrimSpace(finding.Disposition) == reviewFindingDispositionNeedsHuman {
+			return true
+		}
+	}
+	return false
+}
+
+// publishableCommentOnlyFindings returns only must_fix findings for remote summary items.
+func publishableCommentOnlyFindings(findings []reviewerCommentOnlyFindingResult) []reviewerCommentOnlyFindingResult {
+	out := make([]reviewerCommentOnlyFindingResult, 0, len(findings))
+	for _, finding := range findings {
+		if strings.TrimSpace(finding.Disposition) == reviewFindingDispositionMustFix {
+			out = append(out, finding)
+		}
+	}
+	return out
+}
+
+// commentOnlyPublishVisibleSummary is the remote-visible prose for comment-only
+// publish. It must not smuggle follow_up/needs_human content into the PR comment;
+// those stay in the structured local completion/event only.
+func commentOnlyPublishVisibleSummary(completion reviewerCommentOnlyCompletion) string {
+	mustFix := publishableCommentOnlyFindings(completion.Findings)
+	hasSuppressed := false
+	for _, finding := range completion.Findings {
+		switch strings.TrimSpace(finding.Disposition) {
+		case reviewFindingDispositionFollowUp, reviewFindingDispositionNeedsHuman:
+			hasSuppressed = true
+		}
+	}
+	if !hasSuppressed {
+		return strings.TrimSpace(completion.Summary)
+	}
+	if len(mustFix) == 0 {
+		if cleanReviewNoopSummary(completion.Summary) {
+			return strings.TrimSpace(completion.Summary)
+		}
+		return "No actionable findings"
+	}
+	parts := make([]string, 0, len(mustFix))
+	for _, finding := range mustFix {
+		title := strings.TrimSpace(finding.Title)
+		body := strings.TrimSpace(finding.Body)
+		switch {
+		case title != "" && body != "":
+			parts = append(parts, title+": "+body)
+		case title != "":
+			parts = append(parts, title)
+		case body != "":
+			parts = append(parts, body)
+		}
+	}
+	if len(parts) == 0 {
+		return "Must-fix findings require attention."
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func commentOnlyNeedsHumanQuestion(completion reviewerCommentOnlyCompletion) string {
+	var parts []string
+	for _, finding := range completion.Findings {
+		if strings.TrimSpace(finding.Disposition) != reviewFindingDispositionNeedsHuman {
+			continue
+		}
+		title := strings.TrimSpace(finding.Title)
+		body := strings.TrimSpace(finding.Body)
+		basis := strings.TrimSpace(finding.ScopeBasis)
+		evidence := strings.TrimSpace(finding.ScopeEvidence)
+		if title == "" && body == "" {
+			continue
+		}
+		authority := authorityInputChangeHint(basis, evidence)
+		findingText := title
+		if findingText == "" {
+			findingText = body
+		} else if body != "" {
+			findingText = title + ": " + body
+		}
+		parts = append(parts, fmt.Sprintf("%s before unpause; finding: %s", authority, findingText))
+	}
+	if len(parts) == 0 {
+		return "Clarify the repository rule, PR goal/non-goal, or linked spec that governs this scope before unpause. Continue resumes against current evidence, or stop the pair?"
+	}
+	return strings.Join(parts, " ") + " Continue resumes against current evidence, or stop the pair?"
+}
+
+// authorityInputChangeHint names which authority input must change before unpause.
+func authorityInputChangeHint(scopeBasis, scopeEvidence string) string {
+	basis := strings.TrimSpace(scopeBasis)
+	evidence := strings.TrimSpace(scopeEvidence)
+	switch basis {
+	case "stated_intent":
+		if evidence != "" {
+			return "Clarify PR goal/non-goal or stated intent (" + evidence + ")"
+		}
+		return "Clarify PR goal/non-goal or stated intent"
+	case "required_invariant":
+		if evidence != "" {
+			return "Clarify repository rule / required invariant (" + evidence + ")"
+		}
+		return "Clarify repository rule or required invariant"
+	case "introduced_regression":
+		if evidence != "" {
+			return "Clarify regression evidence or acceptance boundary (" + evidence + ")"
+		}
+		return "Clarify regression evidence or acceptance boundary"
+	case "independent_improvement":
+		if evidence != "" {
+			return "Clarify whether this independent improvement is in PR scope (" + evidence + ")"
+		}
+		return "Clarify whether this independent improvement is in PR scope"
+	case "ambiguous_intent":
+		if evidence != "" {
+			return "Clarify ambiguous PR intent / non-goals or AGENTS.md rule (" + evidence + ")"
+		}
+		return "Clarify ambiguous PR intent, non-goals, or AGENTS.md rule"
+	default:
+		if evidence != "" {
+			return "Clarify authority input (" + evidence + ")"
+		}
+		return "Clarify repository rule, PR goal/non-goal, or linked spec"
+	}
+}
+
+func commentOnlyNeedsHumanEvidence(completion reviewerCommentOnlyCompletion) string {
+	payload, err := json.Marshal(completion.Findings)
+	if err != nil {
+		return ""
+	}
+	return string(payload)
 }
 
 func pendingReviewerCommentOnlyCompletion(pending pendingReviewCheckpoint) (reviewerCommentOnlyCompletion, error) {
@@ -4375,6 +4672,9 @@ func reviewerSummaryPromptContext(issueComments []map[string]any) string {
 }
 
 func buildReviewerSummaryFromCompletion(existing forge.ReviewerSummary, completion reviewerCommentOnlyCompletion) (forge.ReviewerSummary, error) {
+	// Remote Reviewer Summary authority is must_fix only; follow_up/needs_human
+	// stay in the structured completion and must not become open remote items.
+	publishFindings := publishableCommentOnlyFindings(completion.Findings)
 	reviewRoundID := 1
 	if existing.ReviewRoundID > 0 {
 		reviewRoundID = existing.ReviewRoundID + 1
@@ -4388,15 +4688,15 @@ func buildReviewerSummaryFromCompletion(existing forge.ReviewerSummary, completi
 		}
 	}
 	updatedExistingIDs := map[string]struct{}{}
-	for _, finding := range completion.Findings {
+	for _, finding := range publishFindings {
 		if finding.ReviewItemID != "" {
 			updatedExistingIDs[finding.ReviewItemID] = struct{}{}
 		}
 	}
 	assigned := map[string]struct{}{}
 	supersededTargets := map[string]string{}
-	updated := make([]forge.ReviewItem, 0, len(existing.Items)+len(completion.Findings))
-	for _, finding := range completion.Findings {
+	updated := make([]forge.ReviewItem, 0, len(existing.Items)+len(publishFindings))
+	for _, finding := range publishFindings {
 		id := finding.ReviewItemID
 		if id != "" {
 			if _, ok := itemsByID[id]; !ok {
@@ -4698,11 +4998,14 @@ func (r *Runner) refusePublishIfBudgetExhausted(ctx context.Context, input stepI
 	if !loops.ParticipatesInReviewFixBudget(loop) {
 		return false, nil
 	}
-	if loops.IsReviewFixBudgetHold(loop) {
-		if _, err := r.parkReviewerBudgetIfExhausted(ctx, loop); err != nil {
-			return true, err
+	if loops.IsReviewFixPairHold(loop) {
+		if loops.IsReviewFixBudgetHold(loop) {
+			if _, err := r.parkReviewerBudgetIfExhausted(ctx, loop); err != nil {
+				return true, err
+			}
+			return true, &holdSkipError{summary: "Reviewer stopped because review-fix budget is held"}
 		}
-		return true, &holdSkipError{summary: "Reviewer stopped because review-fix budget is held"}
+		return true, &holdSkipError{summary: "Reviewer stopped because review scope requires human judgment"}
 	}
 	cap := r.maxPublishesPerPR(loop.ProjectID)
 	if !loops.BudgetExhausted(loops.ReviewerPublishCount(loop.MetadataJSON), cap) {
@@ -5189,8 +5492,8 @@ func (r *Runner) markLoopQueuedForReview(ctx context.Context, loop storage.LoopR
 		return nil
 	}
 	_, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
-		// Never flip a budget hold (exhausted or sibling pause) back to queued.
-		if loops.IsReviewFixBudgetHold(*updated) {
+		// Never flip a budget/scope pair hold back to queued.
+		if loops.IsReviewFixPairHold(*updated) {
 			return
 		}
 		if active, activeErr := r.hasActiveRunningRun(ctx, updated.ID); activeErr == nil && active {
@@ -6348,7 +6651,7 @@ func (r *Runner) shouldCreateReviewerBudgetPark(loop storage.LoopRecord) bool {
 	if loop.Status == "terminated" || loop.Status == "stopped" || loop.Status == "awaiting_human" {
 		return false
 	}
-	if loop.Status == "paused" && loops.IsReviewFixBudgetHold(loop) {
+	if loop.Status == "paused" && loops.IsReviewFixPairHold(loop) {
 		return false
 	}
 	if !loops.ParticipatesInReviewFixBudget(loop) {
@@ -6374,13 +6677,17 @@ func (r *Runner) parkReviewerBudgetIfExhausted(ctx context.Context, loop storage
 	if loop.Status == "terminated" || loop.Status == "stopped" {
 		return false, nil
 	}
-	// Sibling pause is already a hold; finish cancel/sibling work on re-entry
-	// but do not treat "not self-exhausted" as permission to proceed.
-	if loop.Status == "paused" && loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) {
+	// Sibling pause / scope hold is already a hold; finish cancel/sibling work on
+	// re-entry but do not treat "not self-exhausted" as permission to proceed.
+	if loop.Status == "paused" && (loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) || loops.IsSiblingReviewScopeHumanPause(loop.MetadataJSON)) {
+		return true, nil
+	}
+	if loops.IsReviewScopeHumanHold(loop) && !loops.IsReviewFixBudgetHold(loop) {
 		return true, nil
 	}
 	if loop.Status == "awaiting_human" {
 		if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
+			// Agent ask or scope ask: not a budget park target.
 			return true, nil
 		}
 	} else if loop.Status == "paused" && loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
@@ -6431,6 +6738,184 @@ func (r *Runner) notifyHumanAttentionBestEffort(ctx context.Context, loopID stri
 		return
 	}
 	r.notifyHumanAttention(ctx, loopID)
+}
+
+// parkReviewerScopeHuman parks the review-fix pair for needs_human findings.
+// Does not use budget Continue/Stop refill; notify is best-effort at this site
+// because park can happen outside a claim finalization path.
+func (r *Runner) parkReviewerScopeHuman(ctx context.Context, loop storage.LoopRecord, completion reviewerCommentOnlyCompletion) error {
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+			loop = *fresh
+		}
+	}
+	_, err := loops.ParkReviewScopeHuman(ctx, r.repos, loops.ParkReviewScopeHumanInput{
+		Held: loop, Role: "reviewer", Repo: derefString(loop.Repo), PRNumber: derefInt64(loop.PRNumber),
+		NowISO: r.nowISO(), HITLEnabled: r.reviewFixHITLEnabled(),
+		Question: commentOnlyNeedsHumanQuestion(completion), Evidence: commentOnlyNeedsHumanEvidence(completion),
+		DB: r.db,
+	})
+	if err != nil {
+		return err
+	}
+	r.notifyHumanAttentionBestEffort(ctx, loop.ID)
+	return nil
+}
+
+// parkOrDeferReviewerScopeHuman applies the one-hold rule after a counted publish
+// or pure needs_human: if the loop is already budget-held, persist scope evidence
+// without stacking a second HITL ask/primary pause reason; otherwise park scope.
+func (r *Runner) parkOrDeferReviewerScopeHuman(ctx context.Context, loop storage.LoopRecord, completion reviewerCommentOnlyCompletion) error {
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+			loop = *fresh
+		}
+	}
+	if loops.IsReviewFixBudgetHold(loop) {
+		return r.persistPendingReviewerScopeHuman(ctx, loop, completion)
+	}
+	return r.parkReviewerScopeHuman(ctx, loop, completion)
+}
+
+func (r *Runner) persistPendingReviewerScopeHuman(ctx context.Context, loop storage.LoopRecord, completion reviewerCommentOnlyCompletion) error {
+	encoded, err := loops.PersistPendingReviewScopeHumanEvidence(
+		loop.MetadataJSON,
+		commentOnlyNeedsHumanQuestion(completion),
+		commentOnlyNeedsHumanEvidence(completion),
+		r.reviewFixHITLEnabled(),
+	)
+	if err != nil {
+		return err
+	}
+	updated := loop
+	updated.MetadataJSON = &encoded
+	updated.UpdatedAt = r.nowISO()
+	if r.repos == nil || r.repos.Loops == nil {
+		return fmt.Errorf("persist pending review scope requires loop storage")
+	}
+	return r.repos.Loops.Upsert(ctx, updated)
+}
+
+// afterCommentOnlyPublishMaybeParkScope runs after a successful comment-only
+// publish + counted progress. Mixed must_fix+needs_human parks/defers scope
+// under the one-hold rule; pure must_fix returns nil.
+func (r *Runner) afterCommentOnlyPublishMaybeParkScope(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, pending pendingReviewCheckpoint) (reviewerCheckpoint, error) {
+	completion, err := pendingReviewerCommentOnlyCompletion(pending)
+	if err != nil || !commentOnlyCompletionHasNeedsHuman(completion) {
+		return checkpoint, nil
+	}
+	if err := r.parkOrDeferReviewerScopeHuman(ctx, input.Loop, completion); err != nil {
+		return checkpoint, err
+	}
+	return checkpoint, reviewerScopeOrBudgetHoldSkip(ctx, r, input.Loop)
+}
+
+// recoverAlreadyPublishedScopePark recovers needs_human scope park/defer after a
+// crash between recordPublishedReviewProgress and afterCommentOnlyPublishMaybeParkScope.
+// Applies live PR freshness gates so closed/new-head retries do not pause on
+// obsolete findings. Returns a stale/skip checkpoint without parking when drift
+// is detected; retryable GitHub view failures surface as errors.
+func (r *Runner) recoverAlreadyPublishedScopePark(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, pending pendingReviewCheckpoint) (reviewerCheckpoint, error) {
+	completion, err := pendingReviewerCommentOnlyCompletion(pending)
+	if err != nil || !commentOnlyCompletionHasNeedsHuman(completion) {
+		return checkpoint, nil
+	}
+	staleReason, err := r.scopeParkRecoveryFreshnessBlockReason(ctx, input.Project, input.Repo, input.PRNumber, pending, checkpoint)
+	if err != nil {
+		return checkpoint, err
+	}
+	if staleReason != "" {
+		return markReviewerRunStale(checkpoint, staleReason), nil
+	}
+	return r.afterCommentOnlyPublishMaybeParkScope(ctx, input, checkpoint, pending)
+}
+
+// recoverPublishedNeedsHumanScopeFromLatestRun is the ProcessClaimedItem preflight
+// counterpart: when budget already parks/skips the claim, still recover deferred
+// scope from the latest run checkpoint if publish landed with needs_human.
+// Does not start the agent or re-publish.
+func (r *Runner) recoverPublishedNeedsHumanScopeFromLatestRun(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord) error {
+	if r.repos == nil || r.repos.Runs == nil {
+		return nil
+	}
+	latestRun, err := r.repos.Runs.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil {
+		return err
+	}
+	if latestRun == nil {
+		return nil
+	}
+	checkpoint := parseCheckpoint(latestRun.CheckpointJSON)
+	if checkpoint.PendingReview == nil {
+		return nil
+	}
+	pending := *checkpoint.PendingReview
+	meta := parseJSONObject(loop.MetadataJSON)
+	last, ok := stringFromAny(meta["lastPublishedHeadSha"])
+	if !ok || last == "" || last != pending.HeadSHA {
+		return nil
+	}
+	completion, err := pendingReviewerCommentOnlyCompletion(pending)
+	if err != nil || !commentOnlyCompletionHasNeedsHuman(completion) {
+		return nil
+	}
+	repo := derefString(loop.Repo)
+	prNumber := derefInt64(loop.PRNumber)
+	staleReason, err := r.scopeParkRecoveryFreshnessBlockReason(ctx, project, repo, prNumber, pending, checkpoint)
+	if err != nil {
+		return err
+	}
+	if staleReason != "" {
+		// Closed PR or new head: do not park/defer obsolete scope evidence.
+		return nil
+	}
+	return r.parkOrDeferReviewerScopeHuman(ctx, loop, completion)
+}
+
+// scopeParkRecoveryFreshnessBlockReason views the live PR and returns a non-empty
+// stale/closed reason when scope park/defer must not run. Empty reason means OK
+// to recover. Retryable view failures return an error (fail closed — do not park
+// on unknown state). Missing PRs are treated as non-open drift.
+func (r *Runner) scopeParkRecoveryFreshnessBlockReason(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64, pending pendingReviewCheckpoint, checkpoint reviewerCheckpoint) (string, error) {
+	if r.github == nil || strings.TrimSpace(repo) == "" || prNumber == 0 {
+		return "", nil
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: project.RepoPath})
+	if err != nil {
+		if githubinfra.IsPullRequestNotFoundError(err) {
+			return fmt.Sprintf("PR drift detected before publish: expected PR state OPEN, observed missing for %s#%d", repo, prNumber), nil
+		}
+		return "", &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if detail.HeadSHA != "" && pending.HeadSHA != "" && detail.HeadSHA != pending.HeadSHA {
+		return fmt.Sprintf("PR head changed before publish: expected %s, got %s", pending.HeadSHA, detail.HeadSHA), nil
+	}
+	if reason := reviewerPublishDriftReason(stepInput{Repo: repo, PRNumber: prNumber}, checkpoint, detail); reason != "" {
+		return reason, nil
+	}
+	if normalizePRState(detail.State) != "open" {
+		observed := strings.ToUpper(strings.TrimSpace(detail.State))
+		if observed == "" {
+			observed = "NON_OPEN"
+		}
+		return fmt.Sprintf("PR drift detected before publish: expected PR state OPEN, observed %s for %s#%d", observed, repo, prNumber), nil
+	}
+	return "", nil
+}
+
+func reviewerScopeOrBudgetHoldSkip(ctx context.Context, r *Runner, loop storage.LoopRecord) error {
+	if r != nil && r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+			loop = *fresh
+		}
+	}
+	if loops.IsReviewFixBudgetHold(loop) {
+		return &holdSkipError{summary: "Reviewer stopped because review-fix budget is exhausted"}
+	}
+	if loops.IsReviewScopeHumanHold(loop) || loops.HasPendingReviewScopeHuman(loop) {
+		return &holdSkipError{summary: "Reviewer stopped because review scope requires human judgment"}
+	}
+	return &holdSkipError{summary: "Reviewer stopped because review scope requires human judgment"}
 }
 
 func terminalReviewerLoopReason(loop storage.LoopRecord) string {
@@ -6833,15 +7318,15 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	if forgejoNative {
 		forgeName = "Forgejo"
 	}
-	publishInstruction := fmt.Sprintf("For actionable findings, you must publish the %s review yourself by calling looper's enforced review-submit wrapper from the shell. For no-actionable-finding results, follow the clean-result publishing instructions for this run. Do not return review JSON for looper to parse; looper will not parse review content or post forge comments for you after the agent exits.", forgeName)
+	publishInstruction := fmt.Sprintf("For actionable must_fix findings, you must publish the %s review yourself by calling looper's enforced review-submit wrapper from the shell (inline comments only for must_fix). For no-actionable-finding results, follow the clean-result publishing instructions for this run. After the agent step, finish with `__LOOPER_RESULT__` JSON that includes `summary`, optional `outcome`, and `findings` using the same disposition fields as comment-only (`disposition`, `severity`, `scopeBasis`, `scopeEvidence`, `title`, `body`, optional `path`/`line`). Looper **does** parse this findings list: `follow_up` is retained locally only and must not be submitted; `needs_human` parks the pair and must not be submitted as change-request comments. Do not smuggle follow_up/needs_human into unstructured top-level review body prose as the only carrier of a blocking finding.", forgeName)
 	if looperCLIPath == "" {
 		publishInstruction = "A trusted Looper CLI review-submit wrapper is unavailable for this run, so fail closed: do not publish any GitHub review, do not add or remove any GitHub reaction, and exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
 	}
-	outcomeInstruction := "Use outcome=clean only when there are no blocking or non-blocking findings, outcome=non_blocking for actionable feedback that should not block merge, and outcome=blocking for findings that should block merge. Legacy outcome=actionable may be treated as comment-only compatibility, but prefer non_blocking or blocking. For no-actionable-finding results, follow the clean-result instructions for this run and finish with a completion summary that starts with `No actionable findings`."
-	cleanResultCompletionInstruction := "Prefer 3 deeply specific comments over 10 shallow comments. Group related findings by file, subsystem, function, or rule in a single review round instead of splitting adjacent concerns across multiple small reviews. If there is no concrete actionable feedback, follow the clean-result instructions for this run and finish successfully with a summary beginning `No actionable findings`. Do not invent feedback."
+	outcomeInstruction := "Use outcome=clean only when there are no must_fix findings, outcome=non_blocking for must_fix feedback that should not block merge, and outcome=blocking for must_fix findings that should block merge. Legacy outcome=actionable may be treated as comment-only compatibility, but prefer non_blocking or blocking. For no-actionable-finding results, follow the clean-result instructions for this run and finish with a completion summary that starts with `No actionable findings`."
+	cleanResultCompletionInstruction := "Group findings only when they share the same root cause; keep unrelated concerns as separate findings. Accumulate every independent in-scope must_fix before publishing — do not intentionally defer an already observed in-scope issue. The publication budget limits review publications, not findings per publication. If there is no concrete must_fix feedback, follow the clean-result instructions for this run and finish successfully with a summary beginning `No actionable findings`. Do not invent feedback."
 	if looperCLIPath == "" {
-		outcomeInstruction = "Use outcome=clean only when there are no blocking or non-blocking findings, outcome=non_blocking for actionable feedback that should not block merge, and outcome=blocking for findings that should block merge. Legacy outcome=actionable may be treated as comment-only compatibility, but prefer non_blocking or blocking. For no-actionable-finding results, do not report clean success because the trusted review-submit wrapper is unavailable; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
-		cleanResultCompletionInstruction = "Prefer 3 deeply specific comments over 10 shallow comments. Group related findings by file, subsystem, function, or rule in a single review round instead of splitting adjacent concerns across multiple small reviews. If there is no concrete actionable feedback, do not finish successfully or add a clean signal because the trusted wrapper is unavailable; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`. Do not invent feedback."
+		outcomeInstruction = "Use outcome=clean only when there are no must_fix findings, outcome=non_blocking for must_fix feedback that should not block merge, and outcome=blocking for must_fix findings that should block merge. Legacy outcome=actionable may be treated as comment-only compatibility, but prefer non_blocking or blocking. For no-actionable-finding results, do not report clean success because the trusted review-submit wrapper is unavailable; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
+		cleanResultCompletionInstruction = "Group findings only when they share the same root cause; keep unrelated concerns as separate findings. Accumulate every independent in-scope must_fix before publishing — do not intentionally defer an already observed in-scope issue. The publication budget limits review publications, not findings per publication. If there is no concrete must_fix feedback, do not finish successfully or add a clean signal because the trusted wrapper is unavailable; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`. Do not invent feedback."
 	}
 	fetchContract := reviewerAgentSideGitHubFetchContract()
 	if forgejoNative {
@@ -6849,8 +7334,8 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	}
 	if commentOnlyPublish {
 		publishInstruction = "This provider is comment-only. Looper supplied the PR metadata and diff in this prompt/context and will publish exactly one top-level PR comment from your final completion summary after re-checking local idempotency. Do not publish anything yourself or attempt native review features."
-		outcomeInstruction = "If there are actionable findings, finish successfully with a concise markdown summary and set the final `__LOOPER_RESULT__` JSON fields to include: `summary` (same human summary), `outcome` (`non_blocking` or `blocking`), and `findings` (an array of actionable issues only). Each finding object MUST contain `title`, `body`, and optional `files`; include `review_item_id` when the issue matches an existing Reviewer Summary item unchanged, and include `supersedes` with prior `review_item_id` values only when this finding materially replaces older items. If there are no actionable findings, set `outcome` to `clean`, keep `findings` empty, and start `summary` with `No actionable findings`. Do not include terminal logs, extra JSON payloads, or publishing commands."
-		cleanResultCompletionInstruction = "Prefer a concise, specific final summary over many shallow notes. If there is no concrete actionable feedback, start the final summary with `No actionable findings`. Do not invent feedback."
+		outcomeInstruction = "Classify every candidate finding with disposition `must_fix` | `follow_up` | `needs_human`, plus `severity`, `scopeBasis`, and `scopeEvidence`. Include all candidates in `__LOOPER_RESULT__.findings`. Looper publishes only `must_fix` findings into the remote Reviewer Summary; `follow_up` stays in the structured result only; `needs_human` parks the pair and is never posted as a change request. If there are must_fix findings, finish successfully with a concise markdown summary and set `summary`, `outcome` (`non_blocking` or `blocking`), and `findings`. Each finding object MUST contain `title`, `body`, `disposition`, `severity`, `scopeBasis`, `scopeEvidence`, and optional `files`; include `review_item_id` when the issue matches an existing Reviewer Summary item unchanged, and include `supersedes` with prior `review_item_id` values only when this finding materially replaces older items. If there are no must_fix findings and no needs_human, set `outcome` to `clean` (follow_up-only findings may remain in `findings`), and start `summary` with `No actionable findings` when there are no must_fix items. Do not include terminal logs, extra JSON payloads, or publishing commands."
+		cleanResultCompletionInstruction = "Group findings only when they share the same root cause; keep unrelated concerns separate. Accumulate every independent in-scope must_fix before finalizing. If there is no concrete must_fix feedback, start the final summary with `No actionable findings`. Do not invent feedback."
 		fetchContract = "Provider-supplied Forgejo review context: Looper fetched PR metadata and diff before invoking you. Use the prepared local worktree plus the supplied metadata/diff as the review context; do not use GitHub CLI/API commands or native review/thread features."
 	}
 	parts := []string{fmt.Sprintf("Review pull request %s#%d.", repo, prNumber), buildReviewerMinimalPRSeed(repo, prNumber, checkpoint, scope), fetchContract, "Phase: " + phase, phaseInstruction, reviewerScopeInstruction(scope), publishInstruction, fmt.Sprintf("Review idempotency marker prefix: <!-- looper:review id=%s head=%s outcome=clean|non_blocking|blocking -->", idempotencyKey, snapshotHeadSHA(checkpoint)), outcomeInstruction, "Run ID for logging only, not for idempotency: " + runID}
@@ -6914,25 +7399,26 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	}
 	if commentOnlyPublish {
 		parts = append(parts,
-			"Comment-only publish contract: Looper will post your final completion summary as one top-level PR comment after it verifies the PR is still open, the head SHA still matches, and this head has not already been published locally. Do not publish anything yourself.",
-			"Review pass contract: complete one full review pass before finalizing. Use the supplied PR metadata, supplied diff, and local worktree to inspect every changed file/range in scope. Do not stop after the first issue. If a blocking issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass.",
-			"Finding accumulator contract: accumulate candidate findings internally before finalizing. For each candidate, track location, severity, evidence, why it matters, and a suggested fix. Deduplicate, merge same-root-cause findings, and prefer fewer deep comments over many shallow ones.",
+			"Comment-only publish contract: Looper will post your final completion summary as one top-level PR comment after it verifies the PR is still open, the head SHA still matches, and this head has not already been published locally. Do not publish anything yourself. Only must_fix findings become remote Reviewer Summary items; follow_up and needs_human remain in structured completion only.",
+			"Review pass contract: complete one full review pass before finalizing. Use the supplied PR metadata, supplied diff, and local worktree to inspect every changed file/range in scope. Do not stop after the first issue. If an in-scope must_fix issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass.",
+			"Finding disposition contract: every candidate uses disposition must_fix|follow_up|needs_human, severity blocking|non_blocking|nit, scopeBasis (stated_intent|introduced_regression|required_invariant|independent_improvement|ambiguous_intent), scopeEvidence (specific repository rule, PR goal/non-goal, linked spec section, or regression evidence), plus title/body/location. must_fix becomes remote feedback; follow_up is retained only in structured completion; needs_human must not be published as a change request and parks the pair for human judgment.",
+			"Finding accumulator contract: accumulate candidate findings internally before finalizing. For each candidate, track disposition, severity, scopeBasis, scopeEvidence, location, problem, why it matters, and a suggested fix. Deduplicate only the same root cause or a genuinely repeated pattern; keep unrelated concerns separate. Grouping is valid only for a shared root cause with representative locations.",
 			"Severity rubric: mark a finding as BLOCKING only when it can realistically cause incorrect behavior, data loss/corruption, security exposure, broken public API/protocol/config/migration/backward compatibility, failing existing or necessary tests, race/deadlock/resource leak, transaction/lifecycle inconsistency, clear production risk, or failure to satisfy the PR's stated goal. Mark actionable but merge-safe improvements as NON_BLOCKING. Mark tiny style, naming, wording, formatting, or subjective preferences as NIT; NITs must not block merge.",
-			"Finalization gate before completion: verify that the scoped changed files/ranges were reviewed, all observed blocking findings are included, repeated patterns are consolidated, non-blocking/nit feedback is not escalated, every finding has concrete evidence and a suggested fix, and the summary outcome matches the highest severity.",
+			"Finalization gate before completion: verify that the scoped changed files/ranges were reviewed, all observed in-scope must_fix findings are included, repeated patterns are consolidated only when they share a root cause, non-blocking/nit feedback is not escalated, every finding has disposition/scope evidence and a suggested fix, and the summary outcome matches the highest must_fix severity.",
 			cleanResultCompletionInstruction,
-			"Every finding MUST include: (1) an exact file/section/symbol reference, (2) the concrete problem, (3) why it matters, (4) evidence from the changed lines or spec section, and (5) a specific suggested change.",
+			"Every finding MUST include: (1) disposition/severity/scopeBasis/scopeEvidence, (2) an exact file/section/symbol reference, (3) the concrete problem, (4) why it matters, (5) evidence from the changed lines or spec section, and (6) a specific suggested change.",
 			"Implementation review rubric: check correctness, error handling, tests, concurrency, config compatibility, security, resource lifecycle, observability, migrations, and backward compatibility. Only report issues that are concrete and actionable.",
 		)
 		return agent.AppendCompletionInstruction(strings.Join(parts, "\n\n")), instructionBlock
 	}
 	githubOperationContract := fmt.Sprintf("GitHub operation contract: when there are actionable findings, submit exactly one PR review for this run through the trusted Looper CLI at %s, with the review JSON on stdin. The wrapper validates inline anchors against the live PR diff before it calls GitHub; do not use PATH-based `looper`, repository-local `go run ./cmd/looper`, `gh api repos/%s/pulls/%d/reviews`, or `gh pr review` directly for the review submission.", actionableReviewSubmitCommand, repo, prNumber)
-	submitPayloadInstruction := fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries using GitHub's review comment fields: `path`, `line`, `side` (`RIGHT` for new diff lines, `LEFT` for old diff lines), optional `start_line` and `start_side` for multiline ranges, and `body` for the actionable feedback.", looperCLICommand)
+	submitPayloadInstruction := fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries. Each actionable comment MUST include GitHub fields `path`, `line`, `side` (`RIGHT` for new diff lines, `LEFT` for old diff lines), optional `start_line` and `start_side` for multiline ranges, `body`, plus Looper-only fields `disposition` (must be `must_fix`), `scopeBasis`, and `scopeEvidence` (and preferably `severity`). The trusted wrapper rejects missing disposition/scope fields and rejects `follow_up`/`needs_human` in actionable comments; those dispositions stay out of the submit payload. Looper strips Looper-only fields before calling GitHub/Forgejo.", looperCLICommand)
 	idempotencyInstruction := "Idempotency requirement: before posting anything, use `gh api` to list existing PR reviews for this PR. Only treat an existing marker as satisfying this run when the review body contains the exact idempotency id and expected head SHA, and the review state matches the required outcome-specific policy for this run. If such a matching review already exists, do not post another review. Instead, rely on Looper to validate that marker after the agent exits and to reconcile clean-signal reactions/spec label transitions as needed. If the marker exists but the outcome/review-state combination does not satisfy this run, ignore it and publish the correct review for this run instead."
 	freshnessInstruction := "Before posting, use `gh` to confirm the PR is still open and the head SHA still matches the expected head SHA. If it changed, do not post a review and exit non-zero with the exact message `PR head changed before publish`."
 	anchorInstruction := "Before posting, validate every inline review comment's `path`, `line`, `side`, `start_line`, and `start_side` against the live PR diff fetched with `gh pr diff`. Preserve exact anchors that fit the live diff. If an otherwise useful comment is outside the live diff's anchorable locations, safely downgrade it to top-level review body feedback that starts with clear fallback location text instead of submitting an invalid inline anchor."
 	if forgejoNative {
 		githubOperationContract = fmt.Sprintf("Forgejo operation contract: submit exactly one native PR review for this run through the trusted Looper CLI at %s, with review JSON on stdin. The wrapper validates the expected head, current review request, content safety, provider capability, and idempotency marker before it calls Forgejo. Do not call the Forgejo review API directly.", actionableReviewSubmitCommand)
-		submitPayloadInstruction = fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries using `path`, `line`, `side` (`RIGHT` for new lines, `LEFT` for old lines), and `body`; the wrapper maps validated anchors to Forgejo positions.", looperCLICommand)
+		submitPayloadInstruction = fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries using `path`, `line`, `side` (`RIGHT` for new lines, `LEFT` for old lines), `body`, plus Looper-only `disposition=must_fix`, `scopeBasis`, and `scopeEvidence`; the wrapper validates those fields then maps anchors to Forgejo and strips Looper-only fields before the provider call.", looperCLICommand)
 		idempotencyInstruction = "Idempotency requirement: submit only through the trusted Looper wrapper. The wrapper lists existing native Forgejo reviews and reuses an exact id/head/outcome/state marker match; after the agent exits, the runner verifies the same marker before recording publication. Never call the Forgejo review endpoint directly."
 		freshnessInstruction = "Before posting, rely on the trusted Looper wrapper to confirm the Forgejo PR is still open and the head SHA still matches. If it reports drift, exit non-zero with the exact message `PR head changed before publish`."
 		anchorInstruction = "Before posting, validate every inline review comment against the supplied Forgejo diff and local worktree. Preserve exact changed-file anchors; downgrade unanchorable feedback to a top-level review-body item with an exact file/section/symbol reference."
@@ -6945,10 +7431,11 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		idempotencyInstruction,
 		existingMarkerEventInstruction,
 		githubOperationContract,
-		"Review pass contract: complete one full review pass before publishing. Collect PR metadata, changed-file list, live diffs, prior unresolved feedback, and necessary surrounding context; then scan every changed file/range in scope. Do not stop after the first issue. If a blocking issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass.",
-		"Finding accumulator contract: accumulate candidate findings internally before publishing. For each candidate, track location, severity, evidence, why it matters, and a suggested fix. Before submitting, deduplicate, merge same-root-cause findings, group repeated patterns into systemic comments with representative examples, and prefer fewer deep comments over many shallow ones. If there are more than 15 blocking findings or more than 25 total comments, avoid comment flooding by publishing grouped systemic blockers instead of many repetitive inline comments.",
+		"Review pass contract: complete one full review pass before publishing. Collect PR metadata, changed-file list, live diffs, prior unresolved feedback, and necessary surrounding context; then scan every changed file/range in scope. Do not stop after the first issue. If an in-scope must_fix issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass.",
+		"Finding disposition contract: every candidate uses disposition must_fix|follow_up|needs_human, severity blocking|non_blocking|nit, scopeBasis (stated_intent|introduced_regression|required_invariant|independent_improvement|ambiguous_intent), scopeEvidence (specific repository rule, PR goal/non-goal, linked spec section, or regression evidence), path/line, problem, why, and suggestedChange. Emit the full candidate list in `__LOOPER_RESULT__.findings` — Looper parses this JSON. Only must_fix may be submitted through `looper review submit` as remote actionable feedback. Retain follow_up in structured completion only — do not submit follow_up as review comments. For needs_human, do not submit change-request comments; include them in `__LOOPER_RESULT__.findings` so Looper can park the pair for human judgment. Actionable/blocking reviews must carry must_fix as inline comments, not body-only prose.",
+		"Finding accumulator contract: accumulate candidate findings internally before publishing. For each candidate, track disposition, severity, scopeBasis, scopeEvidence, location, problem, why it matters, and a suggested fix. Before submitting, deduplicate only the same root cause or a genuinely repeated pattern; group repeated patterns into systemic comments with representative examples only when they share a root cause. Keep unrelated concerns as separate comments. The publication budget limits review publications, not findings per publication.",
 		"Severity rubric: mark a finding as BLOCKING only when it can realistically cause incorrect behavior, data loss/corruption, security exposure, broken public API/protocol/config/migration/backward compatibility, failing existing or necessary tests, race/deadlock/resource leak, transaction/lifecycle inconsistency, clear production risk, or failure to satisfy the PR's stated goal. Mark actionable but merge-safe improvements as NON_BLOCKING. Mark tiny style, naming, wording, formatting, or subjective preferences as NIT; NITs must not block merge.",
-		"Finalization gate before submit: verify that the scoped changed files/ranges were reviewed, all observed blocking findings are included, repeated patterns are consolidated, non-blocking/nit feedback is not escalated, every published finding has concrete evidence and a suggested fix, and the review outcome matches the highest published severity.",
+		"Finalization gate before submit: verify that the scoped changed files/ranges were reviewed, all observed in-scope must_fix findings are included in this publication, repeated patterns are consolidated only for a shared root cause, non-blocking/nit feedback is not escalated, every published comment has disposition=must_fix with scopeBasis/scopeEvidence plus concrete evidence and a suggested fix, and the review outcome matches the highest published severity.",
 		freshnessInstruction,
 		reviewRequestInstruction,
 		"Review body style contract: the visible body must be human-authored review prose only. Never post terminal/tool output, ANSI escape sequences, file-read traces, command logs, JSON parsing artifacts, or your internal scratch work as the GitHub review body. If you have actionable findings but do not have concrete actionable prose yet, exit non-zero instead of posting logs. For a clean APPROVE review, write the required author mention, change/verification summary, and warm acknowledgement; never use an LGTM, empty, or disclosure-only clean body as a fallback.",

--- a/internal/reviewer/runner_integration_test.go
+++ b/internal/reviewer/runner_integration_test.go
@@ -337,7 +337,7 @@ func (a reviewerIntegrationGatewayAdapter) RemoveIssueLabels(ctx context.Context
 }
 
 func (a reviewerIntegrationGatewayAdapter) ListReviewThreads(ctx context.Context, input ListReviewThreadsInput) ([]ReviewThread, error) {
-	threads, err := a.Gateway.ListReviewThreads(ctx, githubinfra.ListReviewThreadsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD, Limit: input.Limit})
+	threads, err := a.Gateway.ListReviewThreads(ctx, githubinfra.ListReviewThreadsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD, Limit: input.Limit, AllPages: input.AllPages})
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +345,7 @@ func (a reviewerIntegrationGatewayAdapter) ListReviewThreads(ctx context.Context
 	for _, thread := range threads {
 		comments := make([]ReviewThreadComment, 0, len(thread.Comments))
 		for _, comment := range thread.Comments {
-			comments = append(comments, ReviewThreadComment{ID: comment.ID, Body: comment.Body, Author: comment.Author, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt, Path: comment.Path, Line: comment.Line, OriginalCommitOID: comment.OriginalCommitOID, CommitOID: comment.CommitOID, URL: comment.URL})
+			comments = append(comments, ReviewThreadComment{ID: comment.ID, Body: comment.Body, Author: comment.Author, AuthorAssociation: comment.AuthorAssociation, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt, Path: comment.Path, Line: comment.Line, OriginalCommitOID: comment.OriginalCommitOID, CommitOID: comment.CommitOID, URL: comment.URL})
 		}
 		out = append(out, ReviewThread{ID: thread.ID, IsResolved: thread.IsResolved, Path: thread.Path, Line: thread.Line, URL: thread.URL, Comments: comments})
 	}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -8406,6 +8406,110 @@ func TestNewDefaultsReviewerTimeoutToNinetyMinutes(t *testing.T) {
 	}
 }
 
+func TestBuildReviewPromptLaterPassUsesRepairFrontier(t *testing.T) {
+	t.Parallel()
+
+	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "new-head"}}, "run_1", "reviewer:loop:new-head", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, true, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, false, "old-head")
+	for _, want := range []string{
+		"Repair frontier contract (later pass)",
+		"Last reviewed head SHA: old-head",
+		"Current head SHA for this pass: new-head",
+		"every unresolved prior must_fix thread",
+		"diff from last reviewed head old-head to current head new-head",
+		"Do not rescan untouched original diff",
+		"late_discovery:",
+		"Ordinary P2/P3 robustness",
+		"disposition follow_up",
+		"disposition needs_human",
+		"Review pass contract (later pass / repair frontier)",
+		"Fixer decline adjudication",
+		"scope dispute, not dismissal authority",
+		"Do not open a duplicate thread",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("later-pass prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	for _, forbidden := range []string{
+		"complete one full review pass before publishing",
+		"scan every changed file/range in scope",
+		"rather than deferring it to a later pass",
+	} {
+		if strings.Contains(prompt, forbidden) {
+			t.Fatalf("later-pass prompt retains first-pass-only language %q:\n%s", forbidden, prompt)
+		}
+	}
+}
+
+func TestBuildReviewPromptFirstPassKeepsExhaustiveContract(t *testing.T) {
+	t.Parallel()
+
+	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, true, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, false, "")
+	for _, want := range []string{
+		"Review pass contract: complete one full review pass before publishing",
+		"scan every changed file/range in scope",
+		"rather than deferring it to a later pass",
+		"Fixer decline adjudication",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("first-pass prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	for _, forbidden := range []string{
+		"Repair frontier contract (later pass)",
+		"Do not rescan untouched original diff",
+		"late_discovery:",
+		"Review pass contract (later pass / repair frontier)",
+	} {
+		if strings.Contains(prompt, forbidden) {
+			t.Fatalf("first-pass prompt contains later-pass-only language %q:\n%s", forbidden, prompt)
+		}
+	}
+}
+
+func TestNativeResumeReReviewPromptUsesRepairFrontierWhenLaterPass(t *testing.T) {
+	t.Parallel()
+
+	later := nativeResumeReReviewPrompt("acme/looper", 42, "sess-old", "interrupted", "new-head", "reviewer:loop:new-head", "published-old")
+	for _, want := range []string{
+		"repair-frontier re-review",
+		"not a full discard-and-rescan",
+		"last published/reviewed head SHA: published-old",
+		"diff from last published head published-old to current head new-head",
+		"every unresolved prior must_fix thread",
+		// Self-contained later-pass contracts (resume replaces the normal prompt).
+		"Repair frontier contract (later pass)",
+		"late_discovery:",
+		"disposition must_fix",
+		"Ordinary P2/P3 robustness",
+		"disposition follow_up",
+		"disposition needs_human",
+		"Fixer decline adjudication",
+		"Do not open a duplicate thread",
+		"Adjudicate on the existing thread only",
+	} {
+		if !strings.Contains(later, want) {
+			t.Fatalf("later-pass native resume prompt missing %q:\n%s", want, later)
+		}
+	}
+	first := nativeResumeReReviewPrompt("acme/looper", 42, "sess-old", "interrupted", "new-head", "reviewer:loop:new-head", "")
+	if strings.Contains(first, "repair-frontier re-review") {
+		t.Fatalf("first-pass native resume prompt unexpectedly uses frontier language:\n%s", first)
+	}
+	if !strings.Contains(first, "Discard findings, assumptions, anchors") {
+		t.Fatalf("first-pass native resume prompt missing full re-review language:\n%s", first)
+	}
+	for _, forbidden := range []string{
+		"Repair frontier contract (later pass)",
+		"late_discovery:",
+		"Fixer decline adjudication",
+	} {
+		if strings.Contains(first, forbidden) {
+			t.Fatalf("first-pass native resume prompt contains later-pass-only language %q:\n%s", forbidden, first)
+		}
+	}
+}
+
 func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 	t.Parallel()
 
@@ -9479,7 +9583,7 @@ func TestBuildReviewPromptDoesNotTransitionSpecLabelsWithoutApprove(t *testing.T
 func TestBuildReviewPromptOmitsReviewRequestGuardrailWhenDisabled(t *testing.T) {
 	t.Parallel()
 
-	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, false)
+	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, false, "")
 
 	if strings.Contains(prompt, "review request removed before publish") {
 		t.Fatalf("prompt retained review-request guardrail while disabled:\n%s", prompt)
@@ -9492,7 +9596,7 @@ func TestBuildReviewPromptOmitsReviewRequestGuardrailWhenDisabled(t *testing.T) 
 func TestBuildReviewPromptNamesFollowUpReviewRequestBypass(t *testing.T) {
 	t.Parallel()
 
-	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "follow_up_new_head", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, false)
+	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "follow_up_new_head", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, false, "")
 
 	if strings.Contains(prompt, "review request removed before publish") {
 		t.Fatalf("prompt retained review-request guardrail for follow-up bypass:\n%s", prompt)
@@ -9508,7 +9612,7 @@ func TestBuildReviewPromptNamesFollowUpReviewRequestBypass(t *testing.T) {
 func TestBuildReviewPromptCommentOnlyOmitsGitHubPublishInstructions(t *testing.T) {
 	t.Parallel()
 
-	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, true)
+	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, true, "")
 
 	for _, forbidden := range []string{"gh pr view", "gh pr diff", "gh api", "GitHub operation contract", "review request removed before publish", "trusted Looper CLI at", "review-thread resolution"} {
 		if strings.Contains(prompt, forbidden) {
@@ -9538,7 +9642,7 @@ func TestBuildReviewPromptCommentOnlyIncludesExistingReviewerSummaryAuthority(t 
 	if err != nil {
 		t.Fatalf("renderReviewerSummaryComment() error = %v", err)
 	}
-	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}, Detail: &checkpointDetail{IssueComments: []map[string]any{{"id": int64(91), "body": existingBody}}}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, true)
+	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}, Detail: &checkpointDetail{IssueComments: []map[string]any{{"id": int64(91), "body": existingBody}}}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, false, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, true, "")
 
 	if !strings.Contains(prompt, "Existing Reviewer Summary authority") {
 		t.Fatalf("prompt missing reviewer summary authority:\n%s", prompt)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -8823,7 +8823,7 @@ func TestBuildReviewPromptFullPRScopeUsesAgentSideFetchContract(t *testing.T) {
 func TestBuildThreadResolutionPromptRequiresPreparedWorktreeReuse(t *testing.T) {
 	t.Parallel()
 
-	prompt := buildThreadResolutionPrompt("acme/looper", 42, "abc123", nil)
+	prompt := buildThreadResolutionPrompt("acme/looper", 42, "abc123", nil, reviewerCheckpoint{})
 	for _, want := range []string{
 		"canonical local checkout",
 		"Do not run gh repo clone, git clone, or create any additional checkout for this PR's base or head repository unless the provided worktree is missing or unusable.",
@@ -11600,6 +11600,8 @@ type fakeGitHubGateway struct {
 	updateIssueCommentErr           error
 	reviewThreads                   []ReviewThread
 	listReviewThreadsCalls          int
+	listReviewThreadsErr            error
+	listReviewThreadsErrAfter       int // fail on call N (1-based); 0 = always if err set
 	viewHeadSHA                     string
 	headSHACalls                    int
 	issueCommentCalls               []IssueCommentInput
@@ -11610,7 +11612,11 @@ type fakeGitHubGateway struct {
 	captureSnapshotErrs             []error
 	captureSnapshotCalls            int
 	addThreadReplyCalls             []AddReviewThreadReplyInput
+	addThreadReplyErr               error
 	resolveThreadCalls              []ResolveReviewThreadInput
+	resolveThreadErr                error
+	resolveThreadErrTimes           int // fail this many times then succeed; 0 with err = always
+	resolveThreadFailCount          int
 	addReactionCalls                []PullRequestReactionInput
 	removeReactionCalls             []PullRequestReactionInput
 	addLabelCalls                   []PullRequestLabelsInput
@@ -11992,6 +11998,11 @@ func (g *fakeGitHubGateway) RemoveIssueLabels(_ context.Context, input githubinf
 
 func (g *fakeGitHubGateway) ListReviewThreads(context.Context, ListReviewThreadsInput) ([]ReviewThread, error) {
 	g.listReviewThreadsCalls++
+	if g.listReviewThreadsErr != nil {
+		if g.listReviewThreadsErrAfter == 0 || g.listReviewThreadsCalls == g.listReviewThreadsErrAfter {
+			return nil, g.listReviewThreadsErr
+		}
+	}
 	out := make([]ReviewThread, len(g.reviewThreads))
 	copy(out, g.reviewThreads)
 	return out, nil
@@ -11999,11 +12010,33 @@ func (g *fakeGitHubGateway) ListReviewThreads(context.Context, ListReviewThreads
 
 func (g *fakeGitHubGateway) AddReviewThreadReply(_ context.Context, input AddReviewThreadReplyInput) error {
 	g.addThreadReplyCalls = append(g.addThreadReplyCalls, input)
+	if g.addThreadReplyErr != nil {
+		return g.addThreadReplyErr
+	}
+	// Persist reply onto the in-memory thread so retries see audit markers.
+	for i := range g.reviewThreads {
+		if g.reviewThreads[i].ID == input.ThreadID {
+			g.reviewThreads[i].Comments = append(g.reviewThreads[i].Comments, ReviewThreadComment{
+				ID:        fmt.Sprintf("reply-%d", len(g.addThreadReplyCalls)),
+				Author:    g.currentLogin,
+				Body:      input.Body,
+				CreatedAt: "t-reply",
+				UpdatedAt: "t-reply",
+			})
+			break
+		}
+	}
 	return nil
 }
 
 func (g *fakeGitHubGateway) ResolveReviewThread(_ context.Context, input ResolveReviewThreadInput) error {
 	g.resolveThreadCalls = append(g.resolveThreadCalls, input)
+	if g.resolveThreadErr != nil {
+		if g.resolveThreadErrTimes <= 0 || g.resolveThreadFailCount < g.resolveThreadErrTimes {
+			g.resolveThreadFailCount++
+			return g.resolveThreadErr
+		}
+	}
 	for i := range g.reviewThreads {
 		if g.reviewThreads[i].ID == input.ThreadID {
 			g.reviewThreads[i].IsResolved = true

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -8417,20 +8417,25 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"Spec/docs review rubric",
 		"suggestedChange",
 		"do not write or publish a bare LGTM review body",
-		"Group related findings by file, subsystem, function, or rule",
+		"Group findings only when they share the same root cause",
 		"fixture-matrix tests",
 		"'/opt/looper/bin/looper' review submit acme/looper#42 --event COMMENT --commit-id abc123 --clean-review-event APPROVE --blocking-review-event COMMENT`",
 		"wrapper validates inline anchors against the live PR diff before it calls GitHub",
 		"Review pass contract",
 		"Do not stop after the first issue",
 		"include it in this review rather than deferring it to a later pass",
+		"Finding disposition contract",
+		"disposition must_fix|follow_up|needs_human",
+		"Looper parses this JSON",
+		"__LOOPER_RESULT__.findings",
 		"Finding accumulator contract",
-		"group repeated patterns into systemic comments with representative examples",
+		"group repeated patterns into systemic comments with representative examples only when they share a root cause",
 		"Severity rubric",
 		"mark a finding as BLOCKING only when",
 		"Mark actionable but merge-safe improvements as NON_BLOCKING",
 		"NITs must not block merge",
 		"Finalization gate before submit",
+		"disposition=must_fix with scopeBasis/scopeEvidence",
 		"review outcome matches the highest published severity",
 		"do not use PATH-based `looper`",
 		"repository-local `go run ./cmd/looper`",
@@ -8492,6 +8497,7 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"`path`, `line`, `side`",
 		"`start_line` and `start_side`",
 		"the detailed findings must live in inline `comments`",
+		"Looper **does** parse this findings list",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
@@ -8512,6 +8518,10 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"after the APPROVE review is posted",
 		"ensure +1 reaction",
 		"remove any existing +1 reaction",
+		"Prefer 3 deeply specific comments",
+		"prefer fewer deep comments",
+		"more than 15 blocking findings",
+		"more than 25 total comments",
 	} {
 		if strings.Contains(prompt, forbidden) {
 			t.Fatalf("prompt contains conflicting no-actionable clean-review instruction %q:\n%s", forbidden, prompt)
@@ -9508,9 +9518,14 @@ func TestBuildReviewPromptCommentOnlyOmitsGitHubPublishInstructions(t *testing.T
 	if !strings.Contains(prompt, "comment-only") || !strings.Contains(prompt, "Looper will post your final completion summary") {
 		t.Fatalf("prompt missing comment-only publish instructions:\n%s", prompt)
 	}
-	for _, required := range []string{"`findings`", "`review_item_id`", "`supersedes`"} {
+	for _, required := range []string{"`findings`", "`review_item_id`", "`supersedes`", "disposition `must_fix`", "follow_up", "needs_human", "scopeBasis", "scopeEvidence"} {
 		if !strings.Contains(prompt, required) {
 			t.Fatalf("prompt missing %s contract:\n%s", required, prompt)
+		}
+	}
+	for _, forbidden := range []string{"Prefer 3 deeply specific comments", "prefer fewer deep comments", "more than 15 blocking", "more than 25 total"} {
+		if strings.Contains(prompt, forbidden) {
+			t.Fatalf("comment-only prompt retains flood language %q:\n%s", forbidden, prompt)
 		}
 	}
 }
@@ -9539,7 +9554,7 @@ func TestProcessClaimedItemCommentOnlyPublishesOneCommentAndSkipsRediscoveryForS
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{labels: []string{"looper:review"}, reviewRequests: []string{}, currentLogin: "reviewer"}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "internal/reviewer/runner.go: add a regression test for Forgejo comment-only publish", Stdout: `__LOOPER_RESULT__={"summary":"internal/reviewer/runner.go: add a regression test for Forgejo comment-only publish","outcome":"non_blocking","findings":[{"title":"Regression coverage missing for comment-only publish","body":"Add a focused reviewer test that proves Forgejo comment-only publish upserts the fixed Reviewer Summary comment instead of treating freeform markdown as authority.","files":["internal/reviewer/runner_test.go"]}]}`}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "internal/reviewer/runner.go: add a regression test for Forgejo comment-only publish", Stdout: `__LOOPER_RESULT__={"summary":"internal/reviewer/runner.go: add a regression test for Forgejo comment-only publish","outcome":"non_blocking","findings":[{"title":"Regression coverage missing for comment-only publish","body":"Add a focused reviewer test that proves Forgejo comment-only publish upserts the fixed Reviewer Summary comment instead of treating freeform markdown as authority.","files":["internal/reviewer/runner_test.go"],"disposition":"must_fix","severity":"non_blocking","scopeBasis":"required_invariant","scopeEvidence":"comment-only publish contract"}]}`}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: false, Labels: []string{"looper:review"}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
 
 	discovery, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
@@ -9805,7 +9820,7 @@ func TestProcessClaimedItemCommentOnlyPublishesBlockingOutcome(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{labels: []string{"looper:review"}, reviewRequests: []string{}, currentLogin: "reviewer"}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "internal/reviewer/runner.go: nil worktree cleanup can deadlock reviewer retries", Stdout: `__LOOPER_RESULT__={"summary":"internal/reviewer/runner.go: nil worktree cleanup can deadlock reviewer retries","outcome":"blocking","findings":[{"title":"Nil worktree cleanup can deadlock retries","body":"Guard the cleanup path so retry resume does not block forever when the worktree record is missing.","files":["internal/reviewer/runner.go"]}]}`, ParseStatus: "parsed"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "internal/reviewer/runner.go: nil worktree cleanup can deadlock reviewer retries", Stdout: `__LOOPER_RESULT__={"summary":"internal/reviewer/runner.go: nil worktree cleanup can deadlock reviewer retries","outcome":"blocking","findings":[{"title":"Nil worktree cleanup can deadlock retries","body":"Guard the cleanup path so retry resume does not block forever when the worktree record is missing.","files":["internal/reviewer/runner.go"],"disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"nil worktree path"}]}`, ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: false, Labels: []string{"looper:review"}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
@@ -9846,7 +9861,7 @@ func TestProcessClaimedItemCommentOnlyUpdatesSingleReviewerSummaryCommentAndReus
 		t.Fatalf("renderReviewerSummaryComment() error = %v", err)
 	}
 	github := &fakeGitHubGateway{labels: []string{"looper:review"}, reviewRequests: []string{}, currentLogin: "reviewer", issueComments: []map[string]any{{"id": int64(91), "body": existingBody}}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Updated findings", Stdout: `__LOOPER_RESULT__={"summary":"Updated findings","outcome":"blocking","findings":[{"review_item_id":"R-001","title":"Keep ID","body":"Still broken after the latest patch.","files":["internal/reviewer/runner.go"]},{"title":"Split replacement","body":"This issue replaces the old broad item with a narrower actionable finding.","files":["internal/reviewer/runner.go"],"supersedes":["R-002"]}]}`, ParseStatus: "parsed"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Updated findings", Stdout: `__LOOPER_RESULT__={"summary":"Updated findings","outcome":"blocking","findings":[{"review_item_id":"R-001","title":"Keep ID","body":"Still broken after the latest patch.","files":["internal/reviewer/runner.go"],"disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"still broken"},{"title":"Split replacement","body":"This issue replaces the old broad item with a narrower actionable finding.","files":["internal/reviewer/runner.go"],"supersedes":["R-002"],"disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"narrower split"}]}`, ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: false, Labels: []string{"looper:review"}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
@@ -9897,14 +9912,1062 @@ func TestBuildReviewerSummaryFromCompletionRejectsSupersededUpdatedReviewItemID(
 		Summary: "Updated findings",
 		Outcome: "blocking",
 		Findings: []reviewerCommentOnlyFindingResult{
-			{ReviewItemID: "R-001", Title: "Keep ID", Body: "Still broken after the latest patch."},
-			{Title: "Replacement", Body: "This narrows the old broad issue.", Supersedes: []string{"R-001"}},
+			{ReviewItemID: "R-001", Title: "Keep ID", Body: "Still broken after the latest patch.", Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "still broken"},
+			{Title: "Replacement", Body: "This narrows the old broad issue.", Supersedes: []string{"R-001"}, Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "narrower"},
 		},
 	}
 
 	_, err := buildReviewerSummaryFromCompletion(existing, completion)
 	if err == nil || !strings.Contains(err.Error(), `supersedes updated review_item_id "R-001"`) {
 		t.Fatalf("buildReviewerSummaryFromCompletion() error = %v, want updated supersedes failure", err)
+	}
+}
+
+func TestValidateReviewerCommentOnlyCompletionDispositions(t *testing.T) {
+	t.Parallel()
+
+	ok, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Must fix one",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{
+				Title: "Bug", Body: "Nil deref", Disposition: "must_fix", Severity: "blocking",
+				ScopeBasis: "introduced_regression", ScopeEvidence: "new path",
+			},
+			{
+				Title: "Later", Body: "Nice refactor", Disposition: "follow_up", Severity: "nit",
+				ScopeBasis: "independent_improvement", ScopeEvidence: "not required",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("validate must_fix+follow_up: %v", err)
+	}
+	if len(ok.Findings) != 2 {
+		t.Fatalf("findings = %#v", ok.Findings)
+	}
+
+	// follow_up alone is not actionable remote work; outcome must be clean.
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "No actionable findings",
+		Outcome: "clean",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Later", Body: "Nice", Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "x"},
+		},
+	}); err != nil {
+		t.Fatalf("clean with follow_up only: %v", err)
+	}
+
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "No actionable findings",
+		Outcome: "clean",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "x", Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "y"},
+		},
+	}); err == nil || !strings.Contains(err.Error(), "must_fix") {
+		t.Fatalf("clean with must_fix error = %v", err)
+	}
+
+	// Fail-closed: missing disposition/scope fields are rejected (no default must_fix).
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Missing fields",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "x"},
+		},
+	}); err == nil || !strings.Contains(err.Error(), "requires disposition") {
+		t.Fatalf("missing disposition error = %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Missing scope",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "x", Disposition: "must_fix"},
+		},
+	}); err == nil || !strings.Contains(err.Error(), "requires scopeBasis") {
+		t.Fatalf("missing scopeBasis error = %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Missing evidence",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "x", Disposition: "must_fix", ScopeBasis: "introduced_regression"},
+		},
+	}); err == nil || !strings.Contains(err.Error(), "requires scopeEvidence") {
+		t.Fatalf("missing scopeEvidence error = %v", err)
+	}
+}
+
+func TestBuildReviewerSummaryFromCompletionFiltersFollowUpAndNeedsHuman(t *testing.T) {
+	t.Parallel()
+
+	existing := forge.NewReviewerSummary(1, nil)
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Must", Body: "fix", Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "e1", Files: []string{"a.go"}},
+			{Title: "Later", Body: "follow", Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "e2"},
+			{Title: "Human", Body: "ask", Disposition: "needs_human", ScopeBasis: "ambiguous_intent", ScopeEvidence: "e3"},
+		},
+	}
+	summary, err := buildReviewerSummaryFromCompletion(existing, completion)
+	if err != nil {
+		t.Fatalf("buildReviewerSummaryFromCompletion: %v", err)
+	}
+	if len(summary.Items) != 1 || summary.Items[0].Title != "Must" {
+		t.Fatalf("items = %#v, want only must_fix remote item", summary.Items)
+	}
+}
+
+func TestPublishableCommentOnlyFindingsFiltersNonMustFix(t *testing.T) {
+	t.Parallel()
+	got := publishableCommentOnlyFindings([]reviewerCommentOnlyFindingResult{
+		{Title: "a", Disposition: "must_fix"},
+		{Title: "b", Disposition: "follow_up"},
+		{Title: "c", Disposition: "needs_human"},
+		{Title: "d"}, // empty disposition is not publishable
+	})
+	if len(got) != 1 || got[0].Title != "a" {
+		t.Fatalf("publishable = %#v", got)
+	}
+}
+
+func TestCommentOnlyPublishVisibleSummaryOmitsSuppressedFindings(t *testing.T) {
+	t.Parallel()
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Must fix nil deref. Also needs human on scope and a follow-up rename.",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Nil deref", Body: "Guard the pointer", Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "new path"},
+			{Title: "Rename", Body: "later", Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "style"},
+			{Title: "Scope", Body: "unclear", Disposition: "needs_human", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+		},
+	}
+	visible := commentOnlyPublishVisibleSummary(completion)
+	if !strings.Contains(visible, "Nil deref") {
+		t.Fatalf("visible missing must_fix: %q", visible)
+	}
+	for _, banned := range []string{"needs human", "follow-up", "Rename", "Scope", "unclear", "PR non-goals"} {
+		if strings.Contains(visible, banned) {
+			t.Fatalf("visible smuggles %q: %q", banned, visible)
+		}
+	}
+}
+
+func TestParseReviewerNativeCompletionFindingsAndLegacy(t *testing.T) {
+	t.Parallel()
+	// Legacy summary-only remains valid.
+	legacy, err := parseReviewerNativeCompletion(AgentResult{Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`, Summary: "posted review", ParseStatus: "parsed"})
+	if err != nil {
+		t.Fatalf("legacy native: %v", err)
+	}
+	if legacy.Summary != "posted review" || len(legacy.Findings) != 0 {
+		t.Fatalf("legacy = %#v", legacy)
+	}
+	// Findings present → fail-closed validation.
+	if _, err := parseReviewerNativeCompletion(AgentResult{Stdout: `__LOOPER_RESULT__={"summary":"x","outcome":"blocking","findings":[{"title":"t","body":"b"}]}`}); err == nil {
+		t.Fatal("want disposition rejection when findings lack contract fields")
+	}
+	ok, err := parseReviewerNativeCompletion(AgentResult{Stdout: `__LOOPER_RESULT__={"summary":"Need human","outcome":"blocking","findings":[{"title":"Ambiguous","body":"Unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"AGENTS.md rule X","path":"a.go","line":1}]}`})
+	if err != nil {
+		t.Fatalf("needs_human native: %v", err)
+	}
+	if !commentOnlyCompletionHasNeedsHuman(ok) {
+		t.Fatalf("want needs_human: %#v", ok)
+	}
+}
+
+func TestCommentOnlyNeedsHumanQuestionNamesAuthority(t *testing.T) {
+	t.Parallel()
+	q := commentOnlyNeedsHumanQuestion(reviewerCommentOnlyCompletion{
+		Findings: []reviewerCommentOnlyFindingResult{
+			{
+				Title: "Out of scope?", Body: "Expanding API surface", Disposition: "needs_human",
+				ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals exclude API expansion",
+			},
+		},
+	})
+	for _, want := range []string{"before unpause", "PR non-goals", "Out of scope?", "Continue resumes against current evidence"} {
+		if !strings.Contains(q, want) {
+			t.Fatalf("question missing %q: %s", want, q)
+		}
+	}
+	if strings.Contains(q, "Resume against current evidence, or stop") && !strings.Contains(q, "before unpause") {
+		t.Fatalf("legacy handoff text without authority: %s", q)
+	}
+}
+
+func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name          string
+		markerMissing bool
+		wantPublish   int
+		wantLastHead  string
+	}{
+		{name: "with_marker", markerMissing: false, wantPublish: 1, wantLastHead: "abc123"},
+		{name: "without_marker", markerMissing: true, wantPublish: 0, wantLastHead: ""},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			repo := "acme/looper"
+			prNumber := int64(42)
+			nowISO := fixture.nowISO()
+			target := "pr:acme/looper:42"
+			metadata := `{"loop":{"iterationCount":0}}`
+			loop := storage.LoopRecord{
+				ID: "loop_needs_human_pub_" + tc.name, Seq: 94, ProjectID: "project_1", Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+				Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+				t.Fatalf("upsert loop: %v", err)
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			cfg.HITL.Enabled = false
+			stdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+			agent := &fakeAgentExecutor{results: []AgentResult{{
+				Status: "completed", Summary: "Mixed must_fix and needs_human", Stdout: stdout, ParseStatus: "parsed",
+			}}}
+			github := &fakeGitHubGateway{
+				reviewMarkerMissing: tc.markerMissing,
+				reviewMarkerEvent:   ReviewEventComment,
+				reviewMarkerOutcome: "blocking",
+			}
+			runner := New(Options{
+				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+				AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+				LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+			})
+			project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+			if err != nil || project == nil {
+				t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+			}
+			_, err = runner.runReviewStep(context.Background(), stepInput{
+				Project:  *project,
+				Loop:     loop,
+				Run:      storage.RunRecord{ID: "run_needs_human_pub_" + tc.name},
+				Repo:     repo,
+				PRNumber: prNumber,
+				Checkpoint: reviewerCheckpoint{
+					Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+					Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+					Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: nowISO},
+				},
+			})
+			var hold *holdSkipError
+			if !errors.As(err, &hold) {
+				t.Fatalf("runReviewStep() error = %v, want holdSkipError", err)
+			}
+			updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if err != nil || updated == nil || !loops.IsReviewScopeHumanHold(*updated) {
+				t.Fatalf("after park = (%#v, %v), want scope hold", updated, err)
+			}
+			if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != tc.wantPublish {
+				t.Fatalf("ReviewerPublishCount = %d, want %d", got, tc.wantPublish)
+			}
+			gotHead, _ := stringFromAny(parseJSONObject(updated.MetadataJSON)["lastPublishedHeadSha"])
+			if gotHead != tc.wantLastHead {
+				t.Fatalf("lastPublishedHeadSha = %q, want %q", gotHead, tc.wantLastHead)
+			}
+		})
+	}
+}
+
+func TestRunReviewStepNeedsHumanAtCapBudgetHoldOnlyNoStackedScope(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	// One publish away from cap=1 so recording the marker parks budget.
+	metadata := `{"loop":{"iterationCount":0}}`
+	loop := storage.LoopRecord{
+		ID: "loop_needs_human_at_cap", Seq: 95, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert loop: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 1
+	stdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed", Summary: "Mixed must_fix and needs_human", Stdout: stdout, ParseStatus: "parsed",
+	}}}
+	github := &fakeGitHubGateway{
+		reviewMarkerMissing: false,
+		reviewMarkerEvent:   ReviewEventComment,
+		reviewMarkerOutcome: "blocking",
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+	}
+	_, err = runner.runReviewStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     loop,
+		Run:      storage.RunRecord{ID: "run_needs_human_at_cap"},
+		Repo:     repo,
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: nowISO},
+		},
+	})
+	var hold *holdSkipError
+	if !errors.As(err, &hold) {
+		t.Fatalf("runReviewStep() error = %v, want holdSkipError", err)
+	}
+	if !strings.Contains(hold.summary, "budget") {
+		t.Fatalf("hold summary = %q, want budget hold (not stacked scope ask)", hold.summary)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil {
+		t.Fatalf("after park = (%#v, %v)", updated, err)
+	}
+	if !loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("want budget hold only: status=%s meta=%s", updated.Status, derefString(updated.MetadataJSON))
+	}
+	if loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("must not stack active scope hold under budget: %#v", updated)
+	}
+	if !loops.HasPendingReviewScopeHuman(*updated) {
+		t.Fatalf("want pending scope evidence under budget hold: meta=%s", derefString(updated.MetadataJSON))
+	}
+	ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+	if !ok || !loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want single budget ask", ask, ok)
+	}
+	if loops.IsReviewScopeHumanAsk(ask) {
+		t.Fatal("must not write a second scope HITL ask")
+	}
+	if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != 1 {
+		t.Fatalf("ReviewerPublishCount = %d, want 1", got)
+	}
+}
+
+func TestRunReviewStepNeedsHumanUnderCapScopeHoldOnly(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":0}}`
+	loop := storage.LoopRecord{
+		ID: "loop_needs_human_under_cap", Seq: 96, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert loop: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 8
+	stdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed", Summary: "Mixed", Stdout: stdout, ParseStatus: "parsed",
+	}}}
+	github := &fakeGitHubGateway{
+		reviewMarkerMissing: false,
+		reviewMarkerEvent:   ReviewEventComment,
+		reviewMarkerOutcome: "blocking",
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+	}
+	_, err = runner.runReviewStep(context.Background(), stepInput{
+		Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_needs_human_under_cap"},
+		Repo: repo, PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: nowISO},
+		},
+	})
+	var hold *holdSkipError
+	if !errors.As(err, &hold) {
+		t.Fatalf("runReviewStep() error = %v, want holdSkipError", err)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil || !loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("after park = (%#v, %v), want scope hold", updated, err)
+	}
+	if loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatal("under-cap must not budget-hold")
+	}
+	if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != 1 {
+		t.Fatalf("ReviewerPublishCount = %d, want 1", got)
+	}
+	ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+	if !ok || !loops.IsReviewScopeHumanAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want scope ask only", ask, ok)
+	}
+}
+
+func TestPublishAlreadyPublishedRecoversScopeParkWithoutRepublish(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name        string
+		cap         int
+		budgetHeld  bool
+		wantBudget  bool
+		wantScope   bool
+		wantPending bool
+		wantPublish int
+	}{
+		// lastPublishedHeadSha already set (progress recorded); scope park never ran.
+		{name: "under_cap", cap: 8, budgetHeld: false, wantBudget: false, wantScope: true, wantPending: false, wantPublish: 1},
+		// At cap: budget hold already applied after publish; recover deferred scope evidence only.
+		{name: "at_cap_budget_held", cap: 1, budgetHeld: true, wantBudget: true, wantScope: false, wantPending: true, wantPublish: 1},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			repo := "acme/looper"
+			prNumber := int64(42)
+			nowISO := fixture.nowISO()
+			target := "pr:acme/looper:42"
+			// Simulate crash after recordPublishedReviewProgress wrote the head marker.
+			metadata := `{"lastPublishedHeadSha":"abc123","loop":{"iterationCount":1}}`
+			loop := storage.LoopRecord{
+				ID: "loop_already_pub_scope_" + tc.name, Seq: 98, ProjectID: "project_1", Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+				Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if tc.budgetHeld {
+				parked, err := loops.ParkReviewFixBudget(context.Background(), fixture.repos, loops.ParkReviewFixBudgetInput{
+					Exhausted: loop, Role: "reviewer", Repo: repo, PRNumber: prNumber,
+					Count: 1, Cap: tc.cap, NowISO: nowISO, HITLEnabled: true,
+					LiveCaps: loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: tc.cap},
+					DB:       fixture.coordinator.DB(),
+				})
+				if err != nil {
+					t.Fatalf("ParkReviewFixBudget: %v", err)
+				}
+				loop = parked
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			cfg.HITL.Enabled = true
+			cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = tc.cap
+			cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventComment
+			completion := reviewerCommentOnlyCompletion{
+				Summary: "Mixed must_fix and needs_human",
+				Outcome: "blocking",
+				Findings: []reviewerCommentOnlyFindingResult{
+					{Title: "Bug", Body: "fix it", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+					{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+				},
+			}
+			payload, err := json.Marshal(completion)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			github := &fakeGitHubGateway{}
+			runner := New(Options{
+				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+				Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true,
+				LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+				ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents,
+			})
+			project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+			if err != nil || project == nil {
+				t.Fatalf("project: (%#v, %v)", project, err)
+			}
+			// Reload loop so stepInput sees post-budget-park status/metadata.
+			fresh, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if err != nil || fresh == nil {
+				t.Fatalf("reload loop: (%#v, %v)", fresh, err)
+			}
+			pending := pendingReviewCheckpoint{
+				HeadSHA: "abc123", IdempotencyKey: "idem-already-pub-" + tc.name, Event: reviewEventAgentNative,
+				Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+			}
+			_, err = runner.runPublishStep(context.Background(), stepInput{
+				Project: *project, Loop: *fresh, Run: storage.RunRecord{ID: "run_already_pub_" + tc.name},
+				Repo: repo, PRNumber: prNumber,
+				Checkpoint: reviewerCheckpoint{
+					Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+					Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+					PendingReview: &pending,
+				},
+			})
+			var hold *holdSkipError
+			if !errors.As(err, &hold) {
+				t.Fatalf("runPublishStep() error = %v, want holdSkipError", err)
+			}
+			if len(github.issueCommentCalls) != 0 {
+				t.Fatalf("issueCommentCalls = %d, want 0 (no re-publish)", len(github.issueCommentCalls))
+			}
+			updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if err != nil || updated == nil {
+				t.Fatalf("get loop: (%#v, %v)", updated, err)
+			}
+			if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != tc.wantPublish {
+				t.Fatalf("publish count = %d, want %d", got, tc.wantPublish)
+			}
+			if tc.wantBudget != loops.IsReviewFixBudgetHold(*updated) {
+				t.Fatalf("budget hold = %v, want %v (status=%s)", loops.IsReviewFixBudgetHold(*updated), tc.wantBudget, updated.Status)
+			}
+			if tc.wantScope != loops.IsReviewScopeHumanHold(*updated) {
+				t.Fatalf("scope hold = %v, want %v", loops.IsReviewScopeHumanHold(*updated), tc.wantScope)
+			}
+			if tc.wantPending != loops.HasPendingReviewScopeHuman(*updated) {
+				t.Fatalf("pending scope = %v, want %v meta=%s", loops.HasPendingReviewScopeHuman(*updated), tc.wantPending, derefString(updated.MetadataJSON))
+			}
+			if tc.wantBudget {
+				ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+				if !ok || !loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask) {
+					t.Fatalf("at-cap ask = (%#v, %v), want budget only (no stacked scope ask)", ask, ok)
+				}
+			}
+			if tc.wantScope {
+				ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+				if !ok || !loops.IsReviewScopeHumanAsk(ask) {
+					t.Fatalf("under-cap ask = (%#v, %v), want scope", ask, ok)
+				}
+			}
+		})
+	}
+}
+
+func TestProcessClaimedItemAtCapRecoversPendingScopeWithoutAgent(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	projectID := "project_1"
+	loopID := "loop_claim_at_cap_scope_recover"
+	// Crash after publish + budget park; scope park/defer never ran.
+	metadata := `{"lastPublishedHeadSha":"abc123","loop":{"iterationCount":1}}`
+	loop := storage.LoopRecord{
+		ID: loopID, Seq: 110, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert loop: %v", err)
+	}
+	parked, err := loops.ParkReviewFixBudget(context.Background(), fixture.repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: loop, Role: "reviewer", Repo: repo, PRNumber: prNumber,
+		Count: 1, Cap: 1, NowISO: nowISO, HITLEnabled: true,
+		LiveCaps: loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 1},
+		DB:       fixture.coordinator.DB(),
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+	loop = parked
+	if !loops.IsReviewFixBudgetHold(loop) {
+		t.Fatalf("precondition: want budget hold, got status=%s meta=%s", loop.Status, derefString(loop.MetadataJSON))
+	}
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed must_fix and needs_human",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "fix it", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+			{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+		},
+	}
+	payload, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(reviewerCheckpoint{
+		Detail:   &checkpointDetail{Title: "Review me", State: "OPEN", HeadSHA: "abc123", BaseRefName: "main", HeadRefName: "feature/review-me"},
+		Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+		PendingReview: &pendingReviewCheckpoint{
+			HeadSHA: "abc123", IdempotencyKey: "idem-claim-at-cap", Event: reviewEventAgentNative,
+			Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+		},
+		ResumePolicy: "advance_from_checkpoint",
+	})
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_claim_at_cap_scope", LoopID: loopID, Status: "failed",
+		CurrentStep: stringPtr(string(stepPublish)), LastCompletedStep: stringPtr(string(stepReview)),
+		CheckpointJSON: &checkpointJSON, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert: %v", err)
+	}
+	queueID := "queue_claim_at_cap_scope"
+	lockKey := target
+	queue := storage.QueueItemRecord{
+		ID: queueID, ProjectID: &projectID, LoopID: &loopID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: "reviewer:claim-at-cap-scope", Priority: storage.QueuePriorityReviewer,
+		Status: "running", AvailableAt: nowISO, LockKey: &lockKey, MaxAttempts: 3,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), queue); err != nil {
+		t.Fatalf("Queue.Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 1
+	agent := &fakeAgentExecutor{}
+	github := &fakeGitHubGateway{viewHeadSHA: "abc123", viewState: "OPEN"}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+	})
+
+	result, err := runner.ProcessClaimedItem(context.Background(), queue)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" || !strings.Contains(result.Summary, "budget") {
+		t.Fatalf("result = %#v, want budget skipped", result)
+	}
+	if len(agent.starts) != 0 {
+		t.Fatalf("agent.starts = %#v, want none", agent.starts)
+	}
+	if len(github.issueCommentCalls) != 0 {
+		t.Fatalf("issueCommentCalls = %d, want 0 (no re-publish)", len(github.issueCommentCalls))
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || updated == nil {
+		t.Fatalf("get loop: (%#v, %v)", updated, err)
+	}
+	if !loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("want budget hold retained: status=%s meta=%s", updated.Status, derefString(updated.MetadataJSON))
+	}
+	if loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("must not stack active scope hold under budget: meta=%s", derefString(updated.MetadataJSON))
+	}
+	if !loops.HasPendingReviewScopeHuman(*updated) {
+		t.Fatalf("want pending scope after claim preflight recovery: meta=%s", derefString(updated.MetadataJSON))
+	}
+	ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+	if !ok || !loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want budget only", ask, ok)
+	}
+
+	// Budget Continue promotes deferred scope to a real scope hold.
+	continued, err := loops.ApplyReviewFixBudgetAnswer(context.Background(), fixture.repos, *updated, "Continue", nowISO, loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 1, FixerMaxPushes: 8})
+	if err != nil || !continued.Applied {
+		t.Fatalf("ApplyReviewFixBudgetAnswer = (%#v, %v)", continued, err)
+	}
+	afterContinue, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || afterContinue == nil {
+		t.Fatalf("after continue: (%#v, %v)", afterContinue, err)
+	}
+	if loops.IsReviewFixBudgetHold(*afterContinue) {
+		t.Fatalf("budget hold should clear after Continue: %#v", afterContinue)
+	}
+	if !loops.IsReviewScopeHumanHold(*afterContinue) {
+		t.Fatalf("want scope hold after pending promote: status=%s meta=%s", afterContinue.Status, derefString(afterContinue.MetadataJSON))
+	}
+	if loops.HasPendingReviewScopeHuman(*afterContinue) {
+		t.Fatalf("pending should clear after promote: meta=%s", derefString(afterContinue.MetadataJSON))
+	}
+}
+
+func TestPublishAlreadyPublishedNeedsHumanSkipsScopeOnNewHead(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"lastPublishedHeadSha":"abc123","loop":{"iterationCount":1}}`
+	loop := storage.LoopRecord{
+		ID: "loop_already_pub_new_head", Seq: 111, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 8
+	cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventComment
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed", Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "fix", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+			{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+		},
+	}
+	payload, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	github := &fakeGitHubGateway{viewHeadSHA: "new-head", viewState: "OPEN"}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("project: (%#v, %v)", project, err)
+	}
+	pending := pendingReviewCheckpoint{
+		HeadSHA: "abc123", IdempotencyKey: "idem-new-head", Event: reviewEventAgentNative,
+		Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+	}
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_already_pub_new_head"},
+		Repo: repo, PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pending,
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v, want nil stale skip", err)
+	}
+	if checkpoint.SkipKind != "stale" || !strings.Contains(checkpoint.SkipReason, "head changed") {
+		t.Fatalf("checkpoint = %#v, want stale head-changed skip", checkpoint)
+	}
+	if len(github.issueCommentCalls) != 0 {
+		t.Fatalf("issueCommentCalls = %d, want 0", len(github.issueCommentCalls))
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil {
+		t.Fatalf("get loop: (%#v, %v)", updated, err)
+	}
+	if loops.IsReviewScopeHumanHold(*updated) || loops.HasPendingReviewScopeHuman(*updated) {
+		t.Fatalf("must not park/defer scope on new head: meta=%s", derefString(updated.MetadataJSON))
+	}
+}
+
+func TestPublishAlreadyPublishedNeedsHumanSkipsScopeOnClosedPR(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"lastPublishedHeadSha":"abc123","loop":{"iterationCount":1}}`
+	loop := storage.LoopRecord{
+		ID: "loop_already_pub_closed", Seq: 112, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 8
+	cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventComment
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed", Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "fix", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+			{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+		},
+	}
+	payload, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	github := &fakeGitHubGateway{viewHeadSHA: "abc123", viewState: "CLOSED"}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("project: (%#v, %v)", project, err)
+	}
+	pending := pendingReviewCheckpoint{
+		HeadSHA: "abc123", IdempotencyKey: "idem-closed", Event: reviewEventAgentNative,
+		Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+	}
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_already_pub_closed"},
+		Repo: repo, PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pending,
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v, want nil closed-PR skip", err)
+	}
+	if checkpoint.SkipKind != "stale" || !strings.Contains(checkpoint.SkipReason, "CLOSED") {
+		t.Fatalf("checkpoint = %#v, want stale closed-PR skip", checkpoint)
+	}
+	if len(github.issueCommentCalls) != 0 {
+		t.Fatalf("issueCommentCalls = %d, want 0", len(github.issueCommentCalls))
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil {
+		t.Fatalf("get loop: (%#v, %v)", updated, err)
+	}
+	if loops.IsReviewScopeHumanHold(*updated) || loops.HasPendingReviewScopeHuman(*updated) {
+		t.Fatalf("must not park/defer scope on closed PR: meta=%s", derefString(updated.MetadataJSON))
+	}
+}
+
+func TestPublishCommentOnlyMixedMustFixNeedsHumanPublishesThenParksScope(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name        string
+		cap         int
+		wantBudget  bool
+		wantScope   bool
+		wantPending bool
+		wantPublish int
+	}{
+		{name: "under_cap", cap: 8, wantBudget: false, wantScope: true, wantPending: false, wantPublish: 1},
+		{name: "at_cap_after_publish", cap: 1, wantBudget: true, wantScope: false, wantPending: true, wantPublish: 1},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			repo := "acme/looper"
+			prNumber := int64(42)
+			nowISO := fixture.nowISO()
+			target := "pr:acme/looper:42"
+			metadata := `{"loop":{"iterationCount":0}}`
+			loop := storage.LoopRecord{
+				ID: "loop_mixed_comment_" + tc.name, Seq: 97, ProjectID: "project_1", Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+				Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			cfg.HITL.Enabled = true
+			cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = tc.cap
+			// Comment-only completion path requires Clean != APPROVE (or Forgejo summary mode).
+			cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventComment
+			completion := reviewerCommentOnlyCompletion{
+				Summary: "Mixed must_fix and needs_human",
+				Outcome: "blocking",
+				Findings: []reviewerCommentOnlyFindingResult{
+					{Title: "Bug", Body: "fix it", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+					{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+				},
+			}
+			payload, err := json.Marshal(completion)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			github := &fakeGitHubGateway{}
+			runner := New(Options{
+				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+				Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true,
+				LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+				ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents,
+			})
+			project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+			if err != nil || project == nil {
+				t.Fatalf("project: (%#v, %v)", project, err)
+			}
+			pending := pendingReviewCheckpoint{
+				HeadSHA: "abc123", IdempotencyKey: "idem-mixed-" + tc.name, Event: reviewEventAgentNative,
+				Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+			}
+			_, err = runner.runPublishStep(context.Background(), stepInput{
+				Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_mixed_" + tc.name},
+				Repo: repo, PRNumber: prNumber,
+				Checkpoint: reviewerCheckpoint{
+					Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+					Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+					PendingReview: &pending,
+				},
+			})
+			var hold *holdSkipError
+			if !errors.As(err, &hold) {
+				t.Fatalf("runPublishStep() error = %v, want holdSkipError", err)
+			}
+			if len(github.issueCommentCalls) != 1 {
+				t.Fatalf("issueCommentCalls = %d, want 1 must_fix summary publish", len(github.issueCommentCalls))
+			}
+			body := github.issueCommentCalls[0].Body
+			if strings.Contains(strings.ToLower(body), "ambiguous") || strings.Contains(body, "needs_human") {
+				t.Fatalf("published body smuggles needs_human: %s", body)
+			}
+			updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if err != nil || updated == nil {
+				t.Fatalf("get loop: (%#v, %v)", updated, err)
+			}
+			if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != tc.wantPublish {
+				t.Fatalf("publish count = %d, want %d", got, tc.wantPublish)
+			}
+			if tc.wantBudget != loops.IsReviewFixBudgetHold(*updated) {
+				t.Fatalf("budget hold = %v, want %v (status=%s)", loops.IsReviewFixBudgetHold(*updated), tc.wantBudget, updated.Status)
+			}
+			if tc.wantScope != loops.IsReviewScopeHumanHold(*updated) {
+				t.Fatalf("scope hold = %v, want %v", loops.IsReviewScopeHumanHold(*updated), tc.wantScope)
+			}
+			if tc.wantPending != loops.HasPendingReviewScopeHuman(*updated) {
+				t.Fatalf("pending scope = %v, want %v meta=%s", loops.HasPendingReviewScopeHuman(*updated), tc.wantPending, derefString(updated.MetadataJSON))
+			}
+			if tc.wantBudget {
+				ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+				if !ok || !loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask) {
+					t.Fatalf("at-cap ask = (%#v, %v), want budget only", ask, ok)
+				}
+			}
+			if tc.wantScope {
+				ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+				if !ok || !loops.IsReviewScopeHumanAsk(ask) {
+					t.Fatalf("under-cap ask = (%#v, %v), want scope", ask, ok)
+				}
+			}
+		})
+	}
+}
+
+func TestParkReviewerScopeHumanHITLOffNoAsk(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":1}}`
+	reviewer := storage.LoopRecord{ID: "loop_scope_no_hitl", Seq: 91, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	fixer := storage.LoopRecord{ID: "loop_scope_no_hitl_fixer", Seq: 92, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("upsert reviewer: %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("upsert fixer: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = false
+	var notified []string
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		NotifyHumanAttention: func(_ context.Context, loopID string) { notified = append(notified, loopID) },
+	})
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Need human",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Ambiguous", Body: "Unclear scope", Disposition: "needs_human", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals conflict"},
+		},
+	}
+	if err := runner.parkReviewerScopeHuman(context.Background(), reviewer, completion); err != nil {
+		t.Fatalf("parkReviewerScopeHuman: %v", err)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || updated == nil || updated.Status != "paused" || !loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("reviewer = (%#v, %v), want scope pause", updated, err)
+	}
+	if loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatal("must not be budget hold")
+	}
+	if ask, ok := loops.ReadHITLAsk(updated.MetadataJSON); ok {
+		t.Fatalf("HITL-off must not write ask, got %#v", ask)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewScopeHumanPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling = (%#v, %v), want scope sibling pause", sibling, err)
+	}
+	if len(notified) != 1 || notified[0] != reviewer.ID {
+		t.Fatalf("NotifyHumanAttention = %#v", notified)
+	}
+}
+
+func TestParkReviewerScopeHumanHITLOnAskNotBudgetKind(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":1}}`
+	reviewer := storage.LoopRecord{ID: "loop_scope_hitl", Seq: 93, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+	})
+	if err := runner.parkReviewerScopeHuman(context.Background(), reviewer, reviewerCommentOnlyCompletion{
+		Summary: "Need human", Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Ambiguous", Body: "x", Disposition: "needs_human", ScopeBasis: "ambiguous_intent", ScopeEvidence: "e"},
+		},
+	}); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || updated == nil || updated.Status != "awaiting_human" {
+		t.Fatalf("updated = (%#v, %v)", updated, err)
+	}
+	ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+	if !ok || !loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want scope kind", ask, ok)
+	}
+	if loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatal("scope HITL hold must not be budget hold")
 	}
 }
 
@@ -9917,7 +10980,7 @@ func TestProcessClaimedItemCommentOnlySkipsWhenReviewRequestRemovedBeforePublish
 		currentLogin:                    "reviewer",
 		removeReviewRequestOnSecondView: true,
 	}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Blocking issue remains", Stdout: `__LOOPER_RESULT__={"summary":"Blocking issue remains","outcome":"blocking","findings":[{"title":"Blocking issue remains","body":"Must not publish summary when request was removed.","files":["internal/reviewer/runner.go"]}]}`, ParseStatus: "parsed"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Blocking issue remains", Stdout: `__LOOPER_RESULT__={"summary":"Blocking issue remains","outcome":"blocking","findings":[{"title":"Blocking issue remains","body":"Must not publish summary when request was removed.","files":["internal/reviewer/runner.go"],"disposition":"must_fix","severity":"blocking","scopeBasis":"required_invariant","scopeEvidence":"request gate"}]}`, ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{"looper:review"}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
@@ -9951,7 +11014,7 @@ func TestProcessClaimedItemCommentOnlyDoesNotMarkActionableNoActionSummaryAsClea
 
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{labels: []string{"looper:review"}, reviewRequests: []string{}, currentLogin: "reviewer"}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings, but this still has a blocking issue", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings, but this still has a blocking issue","outcome":"blocking","findings":[{"title":"Blocking issue remains","body":"The structured outcome is still blocking and must publish an open reviewer item.","files":["internal/reviewer/runner.go"]}]}`, ParseStatus: "parsed"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings, but this still has a blocking issue", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings, but this still has a blocking issue","outcome":"blocking","findings":[{"title":"Blocking issue remains","body":"The structured outcome is still blocking and must publish an open reviewer item.","files":["internal/reviewer/runner.go"],"disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"structured outcome"}]}`, ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: false, Labels: []string{"looper:review"}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2152,14 +2152,101 @@ func TestParkReviewerBudgetIfExhaustedParksSibling(t *testing.T) {
 	}
 }
 
-func TestParkReviewerBudgetIfExhaustedSkipsWhenHITLDisabled(t *testing.T) {
+func TestParkReviewerBudgetIfExhaustedDoesNotNotifyHumanAttention(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
 	reviewerTarget := "pr:acme/looper:42"
-	metadata := `{"loop":{"iterationCount":8}}`
+	metadata := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_notify", Seq: 11, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	var notified []string
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		NotifyHumanAttention: func(_ context.Context, loopID string) {
+			notified = append(notified, loopID)
+		},
+	})
+	parked, err := runner.parkReviewerBudgetIfExhausted(context.Background(), reviewer)
+	if err != nil || !parked {
+		t.Fatalf("parkReviewerBudgetIfExhausted() = (%v, %v), want parked", parked, err)
+	}
+	if len(notified) != 0 {
+		t.Fatalf("NotifyHumanAttention = %#v, want none from shared park", notified)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || updated == nil || !loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("reviewer after park = (%#v, %v), want still held", updated, err)
+	}
+}
+
+func TestReviewerDiscoveryParkNotifiesHumanAttention(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	reviewerTarget := "pr:acme/looper:42"
+	// Exhausted automatic loop — discovery enqueue should park and notify.
+	metadata := `{"loop":{"iterationCount":3,"enabled":true}}`
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_disc_notify", Seq: 12, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "waiting", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID = (%v, %v)", project, err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	var notified []string
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		NotifyHumanAttention: func(_ context.Context, loopID string) {
+			notified = append(notified, loopID)
+		},
+	})
+	result := &DiscoveryResult{}
+	login := ""
+	err = runner.enqueueReviewerDiscoveryCandidate(context.Background(), *project, repo, DiscoveryPolicy{AutoDiscovery: true, RequireReviewRequest: false, EnableSelfReview: true}, &login, PullRequestSummary{Number: prNumber, HeadSHA: "new-head-for-discovery", State: "OPEN"}, &reviewer, false, result)
+	if err != nil {
+		t.Fatalf("enqueueReviewerDiscoveryCandidate() error = %v", err)
+	}
+	if result.Skipped == 0 {
+		t.Fatalf("discovery result = %#v, want skipped after budget park", result)
+	}
+	if len(notified) != 1 || notified[0] != reviewer.ID {
+		t.Fatalf("NotifyHumanAttention = %#v, want [%q] from discovery park", notified, reviewer.ID)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || updated == nil || !loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("reviewer after discovery = (%#v, %v), want held", updated, err)
+	}
+}
+
+func TestParkReviewerBudgetIfExhaustedParksWhenHITLDisabled(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	reviewerTarget := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":3}}`
 	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_no_hitl", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
 	fixer := storage.LoopRecord{ID: "loop_fixer_budget_no_hitl", Seq: 2, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
@@ -2175,18 +2262,22 @@ func TestParkReviewerBudgetIfExhaustedSkipsWhenHITLDisabled(t *testing.T) {
 	if cfg.HITL.Enabled {
 		t.Fatal("DefaultConfig HITL.Enabled = true, want false")
 	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg})
 	parked, err := runner.parkReviewerBudgetIfExhausted(context.Background(), reviewer)
-	if err != nil || parked {
-		t.Fatalf("parkReviewerBudgetIfExhausted() = (%v, %v), want skipped under default HITL-off config", parked, err)
+	if err != nil || !parked {
+		t.Fatalf("parkReviewerBudgetIfExhausted() = (%v, %v), want no-HITL paired park", parked, err)
 	}
 	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
-	if err != nil || updated == nil || updated.Status != "running" {
-		t.Fatalf("reviewer = (%#v, %v), want still running", updated, err)
+	if err != nil || updated == nil || updated.Status != "paused" || !loops.IsReviewFixBudgetExhaustedPause(updated.MetadataJSON) {
+		t.Fatalf("reviewer = (%#v, %v), want paused review_fix_budget_exhausted", updated, err)
+	}
+	if _, ok := loops.ReadHITLAsk(updated.MetadataJSON); ok {
+		t.Fatal("no-HITL park must not write a HITL ask")
 	}
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
-	if err != nil || sibling == nil || sibling.Status != "queued" {
-		t.Fatalf("fixer sibling = (%#v, %v), want still queued", sibling, err)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer sibling = (%#v, %v), want paired budget pause", sibling, err)
 	}
 }
 
@@ -2219,6 +2310,87 @@ func TestParkReviewerBudgetIfExhaustedCompletesSiblingAfterPartialPark(t *testin
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
 	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		t.Fatalf("fixer sibling = (%#v, %v), want paused after reconcile", sibling, err)
+	}
+}
+
+func TestReviewerDiscoveryDoesNotReviveSiblingPausedReviewer(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	// Fixer exhausted; Reviewer sibling-paused with unused budget.
+	fixerMeta := `{"reviewFixBudget":{"pushCount":1,"exhaustedBy":"fixer","pauseReason":"review_fix_budget_exhausted"},"pauseReason":"review_fix_budget_exhausted"}`
+	reviewerMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"fixer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	fixer := storage.LoopRecord{ID: "loop_fix_exh_disc", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &fixerMeta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	reviewer := storage.LoopRecord{ID: "loop_rev_sib_disc", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg})
+
+	if err := runner.markLoopQueuedForReview(context.Background(), reviewer, nowISO); err != nil {
+		t.Fatalf("markLoopQueuedForReview: %v", err)
+	}
+	after, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || after == nil || after.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(after.MetadataJSON) {
+		t.Fatalf("reviewer after mark = (%#v, %v), want still sibling-paused", after, err)
+	}
+	// Discovery hold check must also skip.
+	if !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatal("sibling-paused reviewer must be a budget hold")
+	}
+	parked, err := runner.parkReviewerBudgetIfExhausted(context.Background(), *after)
+	if err != nil || !parked {
+		t.Fatalf("parkReviewerBudgetIfExhausted sibling = (%v, %v), want held", parked, err)
+	}
+}
+
+func TestRefusePublishIfBudgetExhaustedAtLiveCap(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":2}}`
+	loop := storage.LoopRecord{ID: "loop_pub_refuse", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 2
+	cfg.HITL.Enabled = false
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg, GitHub: &fakeGitHubGateway{viewState: "OPEN"}})
+	refused, err := runner.refusePublishIfBudgetExhausted(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:    loop, Repo: repo, PRNumber: prNumber,
+	})
+	if !refused {
+		t.Fatalf("refused=%v err=%v, want refused at live cap", refused, err)
+	}
+	if err != nil {
+		var hold *holdSkipError
+		if !errors.As(err, &hold) {
+			t.Fatalf("error = %v, want holdSkipError", err)
+		}
+	}
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if after == nil || !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatalf("after refuse = %#v, want budget hold", after)
 	}
 }
 

--- a/internal/reviewer/thread_signal.go
+++ b/internal/reviewer/thread_signal.go
@@ -1,0 +1,307 @@
+package reviewer
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+const (
+	// metadataLastReviewedSignalFingerprintKey is stored on Reviewer loop metadata.
+	metadataLastReviewedSignalFingerprintKey = "lastReviewedSignalFingerprint"
+
+	threadResolutionMarkerNeedle = "looper:thread-resolution"
+	fixerDeclinedMarkerNeedle    = "looper-fixer-reply-declined"
+	fixerFixedMarkerNeedle       = "looper-fixer-reply thread:"
+)
+
+var (
+	// Exact HTML comment: <!-- looper:thread-resolution thread=... head=... [feedback=...] decision=... -->
+	threadResolutionMarkerRE = regexp.MustCompile(`(?is)<!--\s*looper:thread-resolution\s+([^>]*?)-->`)
+	// Exact Fixer decline marker.
+	fixerDeclinedMarkerRE = regexp.MustCompile(`(?is)<!--\s*looper-fixer-reply-declined\s+thread:(\S+)\s+fingerprint:(\S+)\s*-->`)
+)
+
+// threadResolutionMarkerFields holds parsed audit marker fields.
+type threadResolutionMarkerFields struct {
+	ThreadID    string
+	HeadSHA     string
+	Feedback    string
+	Decision    string
+	HasFeedback bool
+}
+
+// ThreadFeedbackFingerprint returns sha256 hex of the canonical Looper-authored
+// review-thread feedback set. Reviewer audit replies carrying a validated
+// looper:thread-resolution marker from Looper's identity are excluded so
+// accept/reject replies do not re-trigger themselves. Spoofed markers from
+// untrusted authors remain in the fingerprint.
+func ThreadFeedbackFingerprint(threads []ReviewThread) string {
+	return ThreadFeedbackFingerprintForLogin(threads, "")
+}
+
+// ThreadFeedbackFingerprintForLogin is the identity-aware fingerprint. When
+// looperLogin is non-empty, only threads/comments authored by that identity
+// count as Looper-authored / audit exclusions.
+func ThreadFeedbackFingerprintForLogin(threads []ReviewThread, looperLogin string) string {
+	canonical := canonicalThreadFeedbackInput(threads, looperLogin)
+	sum := sha256.Sum256([]byte(canonical))
+	return hex.EncodeToString(sum[:])
+}
+
+// ReviewSignalFingerprint returns sha256 hex of headSha + thread feedback.
+func ReviewSignalFingerprint(headSHA, threadFeedbackFingerprint string) string {
+	payload := strings.TrimSpace(headSHA) + "\x1f" + strings.TrimSpace(threadFeedbackFingerprint)
+	sum := sha256.Sum256([]byte(payload))
+	return hex.EncodeToString(sum[:])
+}
+
+// ComputeReviewSignalFingerprint is a convenience over the two-step hash.
+func ComputeReviewSignalFingerprint(headSHA string, threads []ReviewThread) string {
+	return ComputeReviewSignalFingerprintForLogin(headSHA, threads, "")
+}
+
+// ComputeReviewSignalFingerprintForLogin includes Looper identity in authorship.
+func ComputeReviewSignalFingerprintForLogin(headSHA string, threads []ReviewThread, looperLogin string) string {
+	return ReviewSignalFingerprint(headSHA, ThreadFeedbackFingerprintForLogin(threads, looperLogin))
+}
+
+func canonicalThreadFeedbackInput(threads []ReviewThread, looperLogin string) string {
+	looperThreads := make([]ReviewThread, 0, len(threads))
+	for _, thread := range threads {
+		if !isLooperAuthoredThreadForLogin(thread, looperLogin) {
+			continue
+		}
+		looperThreads = append(looperThreads, thread)
+	}
+	sort.SliceStable(looperThreads, func(i, j int) bool {
+		return looperThreads[i].ID < looperThreads[j].ID
+	})
+	var b strings.Builder
+	for _, thread := range looperThreads {
+		b.WriteString("thread\x1e")
+		b.WriteString(strings.TrimSpace(thread.ID))
+		b.WriteByte('\x1f')
+		if thread.IsResolved {
+			b.WriteString("resolved")
+		} else {
+			b.WriteString("unresolved")
+		}
+		b.WriteByte('\n')
+		comments := make([]ReviewThreadComment, 0, len(thread.Comments))
+		for _, comment := range thread.Comments {
+			if isValidatedThreadResolutionAudit(comment, looperLogin) {
+				continue
+			}
+			comments = append(comments, comment)
+		}
+		sort.SliceStable(comments, func(i, j int) bool {
+			if comments[i].ID != comments[j].ID {
+				return comments[i].ID < comments[j].ID
+			}
+			return comments[i].CreatedAt < comments[j].CreatedAt
+		})
+		for _, comment := range comments {
+			b.WriteString("comment\x1e")
+			b.WriteString(strings.TrimSpace(comment.ID))
+			b.WriteByte('\x1f')
+			b.WriteString(normalizeLogin(comment.Author))
+			b.WriteByte('\x1f')
+			b.WriteString(strings.ToUpper(strings.TrimSpace(comment.AuthorAssociation)))
+			b.WriteByte('\x1f')
+			b.WriteString(strings.TrimSpace(comment.CreatedAt))
+			b.WriteByte('\x1f')
+			b.WriteString(strings.TrimSpace(comment.UpdatedAt))
+			b.WriteByte('\x1f')
+			b.WriteString(normalizedBodyHash(comment.Body))
+			b.WriteByte('\x1f')
+			b.WriteString(strings.TrimSpace(comment.OriginalCommitOID))
+			b.WriteByte('\x1f')
+			b.WriteString(strings.TrimSpace(comment.CommitOID))
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func normalizedBodyHash(body string) string {
+	sum := sha256.Sum256([]byte(normalizeCommentBody(body)))
+	return hex.EncodeToString(sum[:])
+}
+
+// normalizeCommentBody collapses runs of whitespace and trims edges so trivial
+// formatting edits do not thrash the fingerprint while real content changes do.
+func normalizeCommentBody(body string) string {
+	var b strings.Builder
+	b.Grow(len(body))
+	prevSpace := false
+	for _, r := range body {
+		if unicode.IsSpace(r) {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		prevSpace = false
+		b.WriteRune(r)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// parseThreadResolutionMarker extracts fields from the exact HTML comment form.
+// Substring spoofs that are not a well-formed marker return ok=false.
+func parseThreadResolutionMarker(body string) (threadResolutionMarkerFields, bool) {
+	m := threadResolutionMarkerRE.FindStringSubmatch(body)
+	if len(m) < 2 {
+		return threadResolutionMarkerFields{}, false
+	}
+	fields := threadResolutionMarkerFields{}
+	for _, part := range strings.Fields(strings.TrimSpace(m[1])) {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "thread":
+			fields.ThreadID = strings.TrimSpace(value)
+		case "head":
+			fields.HeadSHA = strings.TrimSpace(value)
+		case "feedback":
+			fields.Feedback = strings.TrimSpace(value)
+			fields.HasFeedback = true
+		case "decision":
+			fields.Decision = strings.ToLower(strings.TrimSpace(value))
+		}
+	}
+	if fields.ThreadID == "" || fields.HeadSHA == "" || fields.Decision == "" {
+		return threadResolutionMarkerFields{}, false
+	}
+	return fields, true
+}
+
+// isThreadResolutionAuditComment reports a well-formed audit marker in the body.
+// Callers that authorize actions must also check Looper identity via
+// isValidatedThreadResolutionAudit.
+func isThreadResolutionAuditComment(body string) bool {
+	_, ok := parseThreadResolutionMarker(body)
+	return ok
+}
+
+// isValidatedThreadResolutionAudit requires a well-formed marker and Looper authorship.
+// When looperLogin is empty, only the marker shape is checked (unit-test / baseline paths).
+func isValidatedThreadResolutionAudit(comment ReviewThreadComment, looperLogin string) bool {
+	if !isThreadResolutionAuditComment(comment.Body) {
+		return false
+	}
+	return isLooperIdentityAuthor(comment.Author, looperLogin)
+}
+
+func isLooperIdentityAuthor(author, looperLogin string) bool {
+	author = normalizeLogin(author)
+	if author == "" {
+		return false
+	}
+	if looperLogin = normalizeLogin(looperLogin); looperLogin != "" {
+		return author == looperLogin
+	}
+	// Without a known login, accept known Looper bot logins used in tests/fixtures.
+	return author == "looper-bot" || author == "looper[bot]" || strings.HasPrefix(author, "looper")
+}
+
+func hasUnresolvedLooperAuthoredThreads(threads []ReviewThread) bool {
+	return hasUnresolvedLooperAuthoredThreadsForLogin(threads, "")
+}
+
+func hasUnresolvedLooperAuthoredThreadsForLogin(threads []ReviewThread, looperLogin string) bool {
+	for _, thread := range threads {
+		if thread.IsResolved || thread.ID == "" || len(thread.Comments) == 0 {
+			continue
+		}
+		if isLooperAuthoredThreadForLogin(thread, looperLogin) {
+			return true
+		}
+	}
+	return false
+}
+
+// threadResolutionMarker builds the extended audit HTML comment.
+// feedback may be empty for legacy callers; new adjudication always sets it.
+func threadResolutionMarker(threadID, headSHA, feedbackFingerprint, decision string) string {
+	threadID = strings.TrimSpace(threadID)
+	headSHA = strings.TrimSpace(headSHA)
+	feedbackFingerprint = strings.TrimSpace(feedbackFingerprint)
+	decision = strings.ToLower(strings.TrimSpace(decision))
+	if feedbackFingerprint == "" {
+		return fmt.Sprintf("<!-- looper:thread-resolution thread=%s head=%s decision=%s -->", threadID, headSHA, decision)
+	}
+	return fmt.Sprintf("<!-- looper:thread-resolution thread=%s head=%s feedback=%s decision=%s -->", threadID, headSHA, feedbackFingerprint, decision)
+}
+
+// hasThreadResolutionAuditForSignal reports whether the thread already carries a
+// validated Looper audit for the same head + feedback fingerprint + decision.
+// Markers without a feedback field are historical only and never suppress a new
+// comment state. Spoofed markers from non-Looper authors never match.
+func hasThreadResolutionAuditForSignal(thread ReviewThread, threadID, headSHA, feedbackFingerprint, decision string) bool {
+	return hasThreadResolutionAuditForSignalForLogin(thread, threadID, headSHA, feedbackFingerprint, decision, "")
+}
+
+func hasThreadResolutionAuditForSignalForLogin(thread ReviewThread, threadID, headSHA, feedbackFingerprint, decision, looperLogin string) bool {
+	threadID = strings.TrimSpace(threadID)
+	headSHA = strings.TrimSpace(headSHA)
+	feedbackFingerprint = strings.TrimSpace(feedbackFingerprint)
+	decision = strings.ToLower(strings.TrimSpace(decision))
+	if threadID == "" || headSHA == "" || feedbackFingerprint == "" || decision == "" {
+		return false
+	}
+	for _, comment := range thread.Comments {
+		if !isValidatedThreadResolutionAudit(comment, looperLogin) {
+			continue
+		}
+		fields, ok := parseThreadResolutionMarker(comment.Body)
+		if !ok || !fields.HasFeedback {
+			continue
+		}
+		if fields.ThreadID == threadID && fields.HeadSHA == headSHA && fields.Feedback == feedbackFingerprint && fields.Decision == decision {
+			return true
+		}
+	}
+	return false
+}
+
+// parseFixerDeclinedMarker extracts thread/fingerprint from the exact decline marker.
+func parseFixerDeclinedMarker(body string) (threadID, fingerprint string, ok bool) {
+	m := fixerDeclinedMarkerRE.FindStringSubmatch(body)
+	if len(m) < 3 {
+		return "", "", false
+	}
+	return strings.TrimSpace(m[1]), strings.TrimSpace(m[2]), true
+}
+
+func isValidatedFixerDeclinedComment(body string) bool {
+	_, _, ok := parseFixerDeclinedMarker(body)
+	return ok
+}
+
+// isValidatedFixerDeclinedCommentFromAuthor requires exact marker + Looper/Fixer identity.
+func isValidatedFixerDeclinedCommentFromAuthor(comment ReviewThreadComment, looperLogin string) bool {
+	if !isValidatedFixerDeclinedComment(comment.Body) {
+		return false
+	}
+	return isLooperIdentityAuthor(comment.Author, looperLogin)
+}
+
+func isValidatedFixerFixedComment(body string) bool {
+	return strings.Contains(body, fixerFixedMarkerNeedle) && !isValidatedFixerDeclinedComment(body)
+}
+
+func isValidatedFixerFixedCommentFromAuthor(comment ReviewThreadComment, looperLogin string) bool {
+	if !isValidatedFixerFixedComment(comment.Body) {
+		return false
+	}
+	return isLooperIdentityAuthor(comment.Author, looperLogin)
+}

--- a/internal/reviewer/thread_signal_test.go
+++ b/internal/reviewer/thread_signal_test.go
@@ -1,0 +1,133 @@
+package reviewer
+
+import (
+	"strings"
+	"testing"
+)
+
+func looperThread(id string, resolved bool, comments ...ReviewThreadComment) ReviewThread {
+	return ReviewThread{ID: id, IsResolved: resolved, Comments: comments}
+}
+
+func looperRoot(id, body string) ReviewThreadComment {
+	if !strings.Contains(body, "looper:") {
+		body = body + " <!-- looper:stamp v=1 -->"
+	}
+	return ReviewThreadComment{ID: id, Author: "looper-bot", Body: body, CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T00:00:00Z", CommitOID: "old-head"}
+}
+
+func TestThreadFeedbackFingerprintEditReplyDeleteResolveReopen(t *testing.T) {
+	t.Parallel()
+	base := looperThread("t1", false,
+		looperRoot("c1", "Please fix nil check"),
+	)
+	baseFP := ThreadFeedbackFingerprint([]ReviewThread{base})
+
+	// Edit body → fingerprint changes.
+	edited := looperThread("t1", false,
+		ReviewThreadComment{ID: "c1", Author: "looper-bot", Body: "Please fix nil check carefully <!-- looper:stamp v=1 -->", CreatedAt: "2026-01-01T00:00:00Z", UpdatedAt: "2026-01-01T01:00:00Z", CommitOID: "old-head"},
+	)
+	if ThreadFeedbackFingerprint([]ReviewThread{edited}) == baseFP {
+		t.Fatal("edit should change fingerprint")
+	}
+
+	// Reply → fingerprint changes.
+	replied := looperThread("t1", false,
+		looperRoot("c1", "Please fix nil check"),
+		ReviewThreadComment{ID: "c2", Author: "alice", AuthorAssociation: "MEMBER", Body: "/looper wontfix out of scope", CreatedAt: "2026-01-01T02:00:00Z", UpdatedAt: "2026-01-01T02:00:00Z"},
+	)
+	replyFP := ThreadFeedbackFingerprint([]ReviewThread{replied})
+	if replyFP == baseFP {
+		t.Fatal("reply should change fingerprint")
+	}
+
+	// Delete reply (back to base comments) → fingerprint returns to base.
+	if ThreadFeedbackFingerprint([]ReviewThread{base}) != baseFP {
+		t.Fatal("delete reply should restore base fingerprint")
+	}
+
+	// Resolve → fingerprint changes (isResolved included).
+	resolved := looperThread("t1", true, looperRoot("c1", "Please fix nil check"))
+	if ThreadFeedbackFingerprint([]ReviewThread{resolved}) == baseFP {
+		t.Fatal("resolve should change fingerprint")
+	}
+
+	// Reopen → back to base.
+	reopened := looperThread("t1", false, looperRoot("c1", "Please fix nil check"))
+	if ThreadFeedbackFingerprint([]ReviewThread{reopened}) != baseFP {
+		t.Fatal("reopen should restore base fingerprint")
+	}
+}
+
+func TestThreadFeedbackFingerprintExcludesAuditReplies(t *testing.T) {
+	t.Parallel()
+	withoutAudit := looperThread("t1", false,
+		looperRoot("c1", "Please fix"),
+		ReviewThreadComment{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix nope", CreatedAt: "t2", UpdatedAt: "t2"},
+	)
+	withAudit := looperThread("t1", false,
+		looperRoot("c1", "Please fix"),
+		ReviewThreadComment{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix nope", CreatedAt: "t2", UpdatedAt: "t2"},
+		ReviewThreadComment{ID: "c3", Author: "looper-bot", Body: "accepted <!-- looper:thread-resolution thread=t1 head=abc feedback=fp decision=accept_wontfix -->", CreatedAt: "t3", UpdatedAt: "t3"},
+	)
+	if ThreadFeedbackFingerprint([]ReviewThread{withoutAudit}) != ThreadFeedbackFingerprint([]ReviewThread{withAudit}) {
+		t.Fatal("audit replies must be excluded from fingerprint")
+	}
+}
+
+func TestThreadFeedbackFingerprintStableOrder(t *testing.T) {
+	t.Parallel()
+	a := []ReviewThread{
+		looperThread("t2", false, looperRoot("c2", "second")),
+		looperThread("t1", false, looperRoot("c1", "first")),
+	}
+	b := []ReviewThread{
+		looperThread("t1", false, looperRoot("c1", "first")),
+		looperThread("t2", false, looperRoot("c2", "second")),
+	}
+	if ThreadFeedbackFingerprint(a) != ThreadFeedbackFingerprint(b) {
+		t.Fatal("thread order must be canonicalized")
+	}
+}
+
+func TestReviewSignalFingerprintIncludesHead(t *testing.T) {
+	t.Parallel()
+	threads := []ReviewThread{looperThread("t1", false, looperRoot("c1", "x"))}
+	fb := ThreadFeedbackFingerprint(threads)
+	if ReviewSignalFingerprint("head-a", fb) == ReviewSignalFingerprint("head-b", fb) {
+		t.Fatal("head must affect review signal")
+	}
+	if ComputeReviewSignalFingerprint("head-a", threads) != ReviewSignalFingerprint("head-a", fb) {
+		t.Fatal("ComputeReviewSignalFingerprint mismatch")
+	}
+}
+
+func TestThreadResolutionMarkerExtended(t *testing.T) {
+	t.Parallel()
+	got := threadResolutionMarker("t1", "abc", "fb123", "accept_wontfix")
+	if !strings.Contains(got, "feedback=fb123") || !strings.Contains(got, "decision=accept_wontfix") {
+		t.Fatalf("marker = %q", got)
+	}
+	legacy := threadResolutionMarker("t1", "abc", "", "objectively_fixed")
+	if strings.Contains(legacy, "feedback=") {
+		t.Fatalf("legacy marker should omit feedback: %q", legacy)
+	}
+}
+
+func TestHasThreadResolutionAuditForSignalIgnoresLegacyMarkers(t *testing.T) {
+	t.Parallel()
+	thread := looperThread("t1", false,
+		looperRoot("c1", "Please fix"),
+		ReviewThreadComment{ID: "c2", Author: "looper-bot", Body: "<!-- looper:thread-resolution thread=t1 head=abc decision=accept_wontfix -->"},
+	)
+	if hasThreadResolutionAuditForSignal(thread, "t1", "abc", "fb-new", "accept_wontfix") {
+		t.Fatal("legacy marker without feedback must not suppress new signal")
+	}
+	thread.Comments = append(thread.Comments, ReviewThreadComment{
+		ID: "c3", Author: "looper-bot",
+		Body: "<!-- looper:thread-resolution thread=t1 head=abc feedback=fb-new decision=accept_wontfix -->",
+	})
+	if !hasThreadResolutionAuditForSignal(thread, "t1", "abc", "fb-new", "accept_wontfix") {
+		t.Fatal("extended marker should match")
+	}
+}

--- a/internal/reviewer/wontfix.go
+++ b/internal/reviewer/wontfix.go
@@ -1,0 +1,332 @@
+package reviewer
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// Disposition kinds recognized inside Looper-authored review threads.
+const (
+	DispositionWontfix    = "wontfix"
+	DispositionReconsider = "reconsider"
+)
+
+// TrustedDisposition is a parsed human directive on a Looper-authored thread.
+type TrustedDisposition struct {
+	Kind   string
+	Reason string
+}
+
+var (
+	// Canonical: /looper wontfix <reason>  and  /looper reconsider <reason>
+	looperDirectiveRE = regexp.MustCompile(`(?is)^\s*/looper\s+(wontfix|reconsider)(?:\s+(.+))?\s*$`)
+
+	// Compatibility aliases: entire non-quoted content is one of the phrases,
+	// optionally followed by ": <reason>".
+	wontfixAliasRE = regexp.MustCompile(`(?is)^\s*(wontfix|won't fix|won` + "\u2019" + `t fix)(?:\s*:\s*(.+))?\s*$`)
+)
+
+// stripQuotedMarkdownLines removes block-quoted lines so alias matching applies
+// only to the author's own non-quoted content.
+func stripQuotedMarkdownLines(body string) string {
+	lines := strings.Split(body, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimLeftFunc(line, unicode.IsSpace)
+		if strings.HasPrefix(trimmed, ">") {
+			continue
+		}
+		// Drop HTML comment markers (audit/disclosure) from the parse surface.
+		if strings.Contains(trimmed, "<!--") {
+			// Remove HTML comments inline.
+			cleaned := stripHTMLComments(line)
+			if strings.TrimSpace(cleaned) == "" {
+				continue
+			}
+			kept = append(kept, cleaned)
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
+func stripHTMLComments(s string) string {
+	var b strings.Builder
+	rest := s
+	for {
+		start := strings.Index(rest, "<!--")
+		if start < 0 {
+			b.WriteString(rest)
+			break
+		}
+		b.WriteString(rest[:start])
+		end := strings.Index(rest[start:], "-->")
+		if end < 0 {
+			break
+		}
+		rest = rest[start+end+3:]
+	}
+	return b.String()
+}
+
+// ParseTrustedDispositionDirective parses a single comment body for a trusted
+// disposition directive. Incidental prose containing the word "wontfix" is not
+// a command. Returns ok=false when no directive is present.
+func ParseTrustedDispositionDirective(body string) (TrustedDisposition, bool) {
+	content := stripQuotedMarkdownLines(body)
+	if content == "" {
+		return TrustedDisposition{}, false
+	}
+	if m := looperDirectiveRE.FindStringSubmatch(content); len(m) >= 2 {
+		kind := strings.ToLower(strings.TrimSpace(m[1]))
+		reason := ""
+		if len(m) > 2 {
+			reason = strings.TrimSpace(m[2])
+		}
+		return TrustedDisposition{Kind: kind, Reason: reason}, true
+	}
+	if m := wontfixAliasRE.FindStringSubmatch(content); len(m) >= 2 {
+		reason := ""
+		if len(m) > 2 {
+			reason = strings.TrimSpace(m[2])
+		}
+		return TrustedDisposition{Kind: DispositionWontfix, Reason: reason}, true
+	}
+	return TrustedDisposition{}, false
+}
+
+// IsTrustedDispositionAuthority reports whether the commenter may issue a
+// disposition directive. Authority is the PR author or OWNER/MEMBER/COLLABORATOR.
+// Bots and external users are not authority. Fixer declined markers are never
+// human authority (callers must not pass them here as human directives).
+func IsTrustedDispositionAuthority(authorLogin, prAuthorLogin, authorAssociation string) bool {
+	author := normalizeLogin(authorLogin)
+	if author == "" {
+		return false
+	}
+	if strings.HasSuffix(author, "[bot]") || strings.EqualFold(authorAssociation, "BOT") {
+		return false
+	}
+	if prAuthor := normalizeLogin(prAuthorLogin); prAuthor != "" && author == prAuthor {
+		return true
+	}
+	switch strings.ToUpper(strings.TrimSpace(authorAssociation)) {
+	case "OWNER", "MEMBER", "COLLABORATOR":
+		return true
+	default:
+		return false
+	}
+}
+
+// LatestTrustedDisposition returns the latest valid trusted-human directive on
+// a Looper-authored thread after the most recent Reviewer audit comment. When
+// the thread is not Looper-authored, ok is false.
+func LatestTrustedDisposition(thread ReviewThread, prAuthorLogin string) (TrustedDisposition, ReviewThreadComment, bool) {
+	return LatestTrustedDispositionForLogin(thread, prAuthorLogin, "")
+}
+
+// LatestTrustedDispositionForLogin is identity-aware for Looper audit markers.
+func LatestTrustedDispositionForLogin(thread ReviewThread, prAuthorLogin, looperLogin string) (TrustedDisposition, ReviewThreadComment, bool) {
+	if !isLooperAuthoredThreadForLogin(thread, looperLogin) {
+		return TrustedDisposition{}, ReviewThreadComment{}, false
+	}
+	// Walk newest → oldest; first non-audit trusted directive wins.
+	lastAuditIdx := -1
+	for i, comment := range thread.Comments {
+		if isValidatedThreadResolutionAudit(comment, looperLogin) {
+			lastAuditIdx = i
+		}
+	}
+	for i := len(thread.Comments) - 1; i > lastAuditIdx; i-- {
+		comment := thread.Comments[i]
+		if isValidatedThreadResolutionAudit(comment, looperLogin) {
+			continue
+		}
+		if isValidatedFixerDeclinedCommentFromAuthor(comment, looperLogin) || isValidatedFixerFixedCommentFromAuthor(comment, looperLogin) {
+			continue
+		}
+		directive, ok := ParseTrustedDispositionDirective(comment.Body)
+		if !ok {
+			continue
+		}
+		if !IsTrustedDispositionAuthority(comment.Author, prAuthorLogin, comment.AuthorAssociation) {
+			continue
+		}
+		return directive, comment, true
+	}
+	return TrustedDisposition{}, ReviewThreadComment{}, false
+}
+
+// HasUnauditedTrustedDisposition reports a new trusted human disposition that
+// Reviewer has not yet audited (no matching extended marker after it).
+func HasUnauditedTrustedDisposition(thread ReviewThread, prAuthorLogin string) bool {
+	return HasUnauditedTrustedDispositionForLogin(thread, prAuthorLogin, "")
+}
+
+func HasUnauditedTrustedDispositionForLogin(thread ReviewThread, prAuthorLogin, looperLogin string) bool {
+	if thread.IsResolved {
+		return false
+	}
+	directive, _, ok := LatestTrustedDispositionForLogin(thread, prAuthorLogin, looperLogin)
+	if !ok {
+		return false
+	}
+	// reconsider cancels accepted disposition; still a changed signal for Reviewer.
+	return directive.Kind == DispositionWontfix || directive.Kind == DispositionReconsider
+}
+
+// HasUnauditedValidatedFixerDecline reports a validated Fixer decline reply that
+// has not been followed by a Reviewer audit on the same thread.
+func HasUnauditedValidatedFixerDecline(thread ReviewThread) bool {
+	return HasUnauditedValidatedFixerDeclineForLogin(thread, "")
+}
+
+func HasUnauditedValidatedFixerDeclineForLogin(thread ReviewThread, looperLogin string) bool {
+	if thread.IsResolved || !isLooperAuthoredThreadForLogin(thread, looperLogin) {
+		return false
+	}
+	lastAuditIdx := -1
+	lastDeclineIdx := -1
+	for i, comment := range thread.Comments {
+		if isValidatedThreadResolutionAudit(comment, looperLogin) {
+			lastAuditIdx = i
+		}
+		if isValidatedFixerDeclinedCommentFromAuthor(comment, looperLogin) {
+			lastDeclineIdx = i
+		}
+	}
+	return lastDeclineIdx >= 0 && lastDeclineIdx > lastAuditIdx
+}
+
+// ThreadHasChangedDispositionSignal is true when a Looper-authored unresolved
+// thread carries an unaudited trusted human disposition or validated Fixer decline.
+func ThreadHasChangedDispositionSignal(thread ReviewThread, prAuthorLogin string) bool {
+	return ThreadHasChangedDispositionSignalForLogin(thread, prAuthorLogin, "")
+}
+
+func ThreadHasChangedDispositionSignalForLogin(thread ReviewThread, prAuthorLogin, looperLogin string) bool {
+	if thread.IsResolved || !isLooperAuthoredThreadForLogin(thread, looperLogin) {
+		return false
+	}
+	return HasUnauditedTrustedDispositionForLogin(thread, prAuthorLogin, looperLogin) || HasUnauditedValidatedFixerDeclineForLogin(thread, looperLogin)
+}
+
+// ThreadsHaveChangedDispositionSignal reports whether any thread qualifies.
+func ThreadsHaveChangedDispositionSignal(threads []ReviewThread, prAuthorLogin string) bool {
+	return ThreadsHaveChangedDispositionSignalForLogin(threads, prAuthorLogin, "")
+}
+
+func ThreadsHaveChangedDispositionSignalForLogin(threads []ReviewThread, prAuthorLogin, looperLogin string) bool {
+	for _, thread := range threads {
+		if ThreadHasChangedDispositionSignalForLogin(thread, prAuthorLogin, looperLogin) {
+			return true
+		}
+	}
+	return false
+}
+
+// ForceNeedsHumanAfterSecondDecline reports §8.4 one-rejection quota: after
+// Reviewer reject_wontfix on an input, a later validated Fixer decline with
+// unchanged head + same canonical human/original-finding feedback forces
+// needs_human without another classifier argument. Changed head or changed
+// trusted human directive is new adjudicated input (quota resets).
+func ForceNeedsHumanAfterSecondDecline(thread ReviewThread, headSHA, looperLogin string) bool {
+	if thread.IsResolved || !isLooperAuthoredThreadForLogin(thread, looperLogin) {
+		return false
+	}
+	headSHA = strings.TrimSpace(headSHA)
+	if headSHA == "" {
+		return false
+	}
+	// Find last reject_wontfix audit for this head, then a later validated decline.
+	lastRejectIdx := -1
+	rejectFeedback := ""
+	for i, comment := range thread.Comments {
+		if !isValidatedThreadResolutionAudit(comment, looperLogin) {
+			continue
+		}
+		fields, ok := parseThreadResolutionMarker(comment.Body)
+		if !ok {
+			continue
+		}
+		if fields.Decision != "reject_wontfix" {
+			continue
+		}
+		if fields.HeadSHA != "" && fields.HeadSHA != headSHA {
+			continue
+		}
+		lastRejectIdx = i
+		rejectFeedback = fields.Feedback
+	}
+	if lastRejectIdx < 0 {
+		return false
+	}
+	foundDecline := false
+	for i := lastRejectIdx + 1; i < len(thread.Comments); i++ {
+		comment := thread.Comments[i]
+		// Coordination replies (non-decline audits) do not count.
+		if isValidatedThreadResolutionAudit(comment, looperLogin) {
+			continue
+		}
+		if isValidatedFixerDeclinedCommentFromAuthor(comment, looperLogin) {
+			foundDecline = true
+			break
+		}
+	}
+	if !foundDecline {
+		return false
+	}
+	// Unchanged-input only: coordination-excluded feedback must match the
+	// reject marker's feedback fingerprint (audits + fixer declines excluded).
+	if rejectFeedback == "" {
+		return false
+	}
+	live := coordinationExcludedThreadFeedbackFingerprint(thread, looperLogin)
+	return live != "" && live == rejectFeedback
+}
+
+// coordinationExcludedThreadFeedbackFingerprint hashes human/original-finding
+// feedback on a Looper-authored thread after excluding validated Reviewer audits
+// and validated Fixer decline/fixed coordination replies.
+func coordinationExcludedThreadFeedbackFingerprint(thread ReviewThread, looperLogin string) string {
+	if !isLooperAuthoredThreadForLogin(thread, looperLogin) {
+		return ""
+	}
+	filtered := ReviewThread{ID: thread.ID, IsResolved: thread.IsResolved}
+	for _, comment := range thread.Comments {
+		if isValidatedThreadResolutionAudit(comment, looperLogin) {
+			continue
+		}
+		if isValidatedFixerDeclinedCommentFromAuthor(comment, looperLogin) || isValidatedFixerFixedCommentFromAuthor(comment, looperLogin) {
+			continue
+		}
+		filtered.Comments = append(filtered.Comments, comment)
+	}
+	return ThreadFeedbackFingerprintForLogin([]ReviewThread{filtered}, looperLogin)
+}
+
+// LastReviewerDispositionDecision returns the latest validated Reviewer
+// disposition decision on the thread for the given head, if any.
+func LastReviewerDispositionDecision(thread ReviewThread, headSHA, looperLogin string) (decision string, ok bool) {
+	headSHA = strings.TrimSpace(headSHA)
+	for i := len(thread.Comments) - 1; i >= 0; i-- {
+		comment := thread.Comments[i]
+		if !isValidatedThreadResolutionAudit(comment, looperLogin) {
+			continue
+		}
+		fields, parsed := parseThreadResolutionMarker(comment.Body)
+		if !parsed {
+			continue
+		}
+		if headSHA != "" && fields.HeadSHA != "" && fields.HeadSHA != headSHA {
+			continue
+		}
+		switch fields.Decision {
+		case "accept_wontfix", "reject_wontfix", "needs_human":
+			return fields.Decision, true
+		}
+	}
+	return "", false
+}

--- a/internal/reviewer/wontfix_test.go
+++ b/internal/reviewer/wontfix_test.go
@@ -1,0 +1,159 @@
+package reviewer
+
+import (
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestParseTrustedDispositionDirectiveCanonicalAndAliases(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		body   string
+		wantOK bool
+		kind   string
+		reason string
+	}{
+		{name: "canonical", body: "/looper wontfix out of scope for this PR", wantOK: true, kind: DispositionWontfix, reason: "out of scope for this PR"},
+		{name: "canonical reconsider", body: "/looper reconsider still needed", wantOK: true, kind: DispositionReconsider, reason: "still needed"},
+		{name: "alias plain", body: "wontfix", wantOK: true, kind: DispositionWontfix},
+		{name: "alias ascii apostrophe", body: "won't fix", wantOK: true, kind: DispositionWontfix},
+		{name: "alias unicode apostrophe", body: "won\u2019t fix", wantOK: true, kind: DispositionWontfix},
+		{name: "alias with reason", body: "won't fix: covered elsewhere", wantOK: true, kind: DispositionWontfix, reason: "covered elsewhere"},
+		{name: "incidental prose", body: "I think we should not wontfix this yet", wantOK: false},
+		{name: "quoted only", body: "> wontfix\n\nlooking into it", wantOK: false},
+		{name: "empty", body: "   ", wantOK: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := ParseTrustedDispositionDirective(tc.body)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (got %#v)", ok, tc.wantOK, got)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.Kind != tc.kind || got.Reason != tc.reason {
+				t.Fatalf("got %#v, want kind=%q reason=%q", got, tc.kind, tc.reason)
+			}
+		})
+	}
+}
+
+func TestIsTrustedDispositionAuthority(t *testing.T) {
+	t.Parallel()
+	if !IsTrustedDispositionAuthority("alice", "alice", "") {
+		t.Fatal("PR author should be authority")
+	}
+	if !IsTrustedDispositionAuthority("bob", "alice", "MEMBER") {
+		t.Fatal("MEMBER should be authority")
+	}
+	if !IsTrustedDispositionAuthority("bob", "alice", "OWNER") {
+		t.Fatal("OWNER should be authority")
+	}
+	if !IsTrustedDispositionAuthority("bob", "alice", "COLLABORATOR") {
+		t.Fatal("COLLABORATOR should be authority")
+	}
+	if IsTrustedDispositionAuthority("outsider", "alice", "NONE") {
+		t.Fatal("external user must not be authority")
+	}
+	if IsTrustedDispositionAuthority("helper[bot]", "alice", "NONE") {
+		t.Fatal("bot must not be authority")
+	}
+	if IsTrustedDispositionAuthority("helper", "alice", "BOT") {
+		t.Fatal("BOT association must not be authority")
+	}
+}
+
+func TestLatestTrustedDispositionLooperAuthoredOnly(t *testing.T) {
+	t.Parallel()
+	nonLooper := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "reviewer", Body: "Please fix this"},
+			{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no"},
+		},
+	}
+	if _, _, ok := LatestTrustedDisposition(nonLooper, "alice"); ok {
+		t.Fatal("non-Looper thread must not yield disposition")
+	}
+
+	looper := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: "outsider", AuthorAssociation: "NONE", Body: "/looper wontfix no"},
+			{ID: "c3", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix real reason"},
+		},
+	}
+	got, comment, ok := LatestTrustedDisposition(looper, "alice")
+	if !ok || got.Kind != DispositionWontfix || got.Reason != "real reason" || comment.ID != "c3" {
+		t.Fatalf("got (%#v, %#v, %v)", got, comment, ok)
+	}
+}
+
+func TestHasUnauditedValidatedFixerDecline(t *testing.T) {
+	t.Parallel()
+	thread := ReviewThread{
+		ID: "t1",
+		Comments: []ReviewThreadComment{
+			{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->"},
+			{ID: "c2", Author: "looper-bot", Body: "declined <!-- looper-fixer-reply-declined thread:t1 fingerprint:abc -->"},
+		},
+	}
+	if !HasUnauditedValidatedFixerDecline(thread) {
+		t.Fatal("expected unaudited fixer decline")
+	}
+	thread.Comments = append(thread.Comments, ReviewThreadComment{
+		ID: "c3", Author: "looper-bot",
+		Body: "<!-- looper:thread-resolution thread=t1 head=h feedback=f decision=accept_wontfix -->",
+	})
+	if HasUnauditedValidatedFixerDecline(thread) {
+		t.Fatal("audited decline should not be unaudited")
+	}
+}
+
+func TestForceNeedsHumanUnchangedInputOnly(t *testing.T) {
+	t.Parallel()
+	baseComments := []ReviewThreadComment{
+		{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->"},
+		{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix no", CreatedAt: "t2", UpdatedAt: "t2"},
+	}
+	base := ReviewThread{ID: "t1", Comments: append([]ReviewThreadComment{}, baseComments...)}
+	// Marker feedback must come from the real rejection builder (coordination-excluded FP).
+	runner := &Runner{}
+	rejectBody := runner.buildThreadResolutionReplyWithFeedback(
+		"t1", "abc",
+		coordinationExcludedThreadFeedbackFingerprint(base, "looper-bot"),
+		threadResolutionAgentDecision{Decision: "reject_wontfix", Evidence: "still needed", Confidence: "high"},
+		config.ReviewerThreadResolutionConfig{},
+	)
+
+	// Unchanged human text + post-reject decline → true
+	unchanged := ReviewThread{ID: "t1", Comments: append(append([]ReviewThreadComment{}, baseComments...),
+		ReviewThreadComment{ID: "c3", Author: "looper-bot", Body: rejectBody, CreatedAt: "t3", UpdatedAt: "t3"},
+		ReviewThreadComment{ID: "c4", Author: "looper-bot", Body: "<!-- looper-fixer-reply-declined thread:t1 fingerprint:x -->", CreatedAt: "t4", UpdatedAt: "t4"},
+	)}
+	if !ForceNeedsHumanAfterSecondDecline(unchanged, "abc", "looper-bot") {
+		t.Fatal("unchanged human + decline after reject must force needs_human")
+	}
+
+	// Human edits /looper wontfix after reject, then decline → false
+	edited := ReviewThread{ID: "t1", Comments: []ReviewThreadComment{
+		{ID: "c1", Author: "looper-bot", Body: "Please fix <!-- looper:stamp v=1 -->"},
+		{ID: "c2", Author: "alice", AuthorAssociation: "OWNER", Body: "/looper wontfix EDITED reason", CreatedAt: "t2", UpdatedAt: "t5"},
+		{ID: "c3", Author: "looper-bot", Body: rejectBody, CreatedAt: "t3", UpdatedAt: "t3"},
+		{ID: "c4", Author: "looper-bot", Body: "<!-- looper-fixer-reply-declined thread:t1 fingerprint:x -->", CreatedAt: "t4", UpdatedAt: "t4"},
+	}}
+	if ForceNeedsHumanAfterSecondDecline(edited, "abc", "looper-bot") {
+		t.Fatal("changed human directive must not force needs_human")
+	}
+
+	// Head change → false
+	if ForceNeedsHumanAfterSecondDecline(unchanged, "other-head", "looper-bot") {
+		t.Fatal("head change must not force needs_human")
+	}
+}

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/eventlog"
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
@@ -170,16 +172,22 @@ func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopR
 // an explicit budget Continue/Stop, invokes onAnswered so the live ask card is
 // marked resolved. Card-action delivery already does this; typed decisions must
 // too, or the cached loop-seq buttons can answer a later budget cycle.
-func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, nowISO, loopID, text string, onAnswered func(context.Context, string, string)) error {
+func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, db *sql.DB, cfg *config.Config, nowISO, loopID, text string, onAnswered func(context.Context, string, string)) error {
 	shouldResolve := false
-	if repos != nil && repos.Loops != nil && (loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text)) {
+	caps := reviewFixBudgetLiveCaps(cfg, "")
+	if repos != nil && repos.Loops != nil {
 		if loop, err := repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
-			if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
-				shouldResolve = true
+			caps = reviewFixBudgetLiveCaps(cfg, loop.ProjectID)
+			if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
+				if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+					shouldResolve = true
+				} else if loops.IsReviewFixBudgetHold(*loop) {
+					shouldResolve = true
+				}
 			}
 		}
 	}
-	if err := enqueueHumanMessageToLoop(ctx, repos, nowISO, loopID, text); err != nil {
+	if err := enqueueHumanMessageToLoopWithCaps(ctx, repos, db, nowISO, loopID, text, caps); err != nil {
 		return err
 	}
 	if shouldResolve && onAnswered != nil {
@@ -277,7 +285,11 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 			return loop.ID
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			if err := deliverHITLAnswerToLoop(ctx, input.Repos, nowISO, loopID, answer); err != nil {
+			caps := reviewFixBudgetLiveCaps(input.Config, "")
+			if loop, err := input.Repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
+				caps = reviewFixBudgetLiveCaps(input.Config, loop.ProjectID)
+			}
+			if err := deliverHITLAnswerToLoopWithCaps(ctx, input.Repos, input.DB, nowISO, loopID, answer, caps); err != nil {
 				return err
 			}
 			// Mark the ask card resolved ("✅ 已选:X", brief preserved).
@@ -287,7 +299,7 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 			return nil
 		},
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
-			return enqueueFeishuHITLMessage(ctx, input.Repos, nowISO, loopID, text, input.OnHITLAnswerDelivered)
+			return enqueueFeishuHITLMessage(ctx, input.Repos, input.DB, input.Config, nowISO, loopID, text, input.OnHITLAnswerDelivered)
 		},
 	}
 	if input.Logger != nil {

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -129,7 +129,7 @@ func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopR
 			continue
 		}
 		ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
-		if !ok || !loops.IsReviewFixBudgetAsk(ask) {
+		if !ok || (!loops.IsReviewFixBudgetAsk(ask) && !loops.IsReviewScopeHumanAsk(ask)) {
 			continue
 		}
 		if strings.EqualFold(strings.TrimSpace(ask.Transport), "feishu") {
@@ -179,9 +179,9 @@ func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, 
 		if loop, err := repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
 			caps = reviewFixBudgetLiveCaps(cfg, loop.ProjectID)
 			if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
-				if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+				if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && (loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask)) {
 					shouldResolve = true
-				} else if loops.IsReviewFixBudgetHold(*loop) {
+				} else if loops.IsReviewFixPairHold(*loop) {
 					shouldResolve = true
 				}
 			}

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/worker"
@@ -101,7 +102,7 @@ func TestFeishuHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 	}
 
 	parked, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -152,7 +153,7 @@ func TestFeishuHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 			return ""
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
 		},
 	})
 	if n != 1 || maxID != 20 {
@@ -219,7 +220,7 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 	}
 
 	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	}); err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
 	}
@@ -244,12 +245,12 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 			return ""
 		},
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
-			return enqueueFeishuHITLMessage(ctx, repos, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
+			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
 				resolved = append(resolved, answeredLoopID+"="+answer)
 			})
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
 		},
 	}
 
@@ -293,6 +294,127 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 	}
 	if len(resolved) != 1 || resolved[0] != reviewer.ID+"=Continue" {
 		t.Fatalf("card resolution after typed Continue = %#v, want reviewer Continue", resolved)
+	}
+}
+
+func TestFeishuContinueUsesLiveProjectCaps(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_budget_feishu_caps"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Budget", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	// Reviewer at 2/2 (exhausted); fixer at 1/5 (under cap).
+	reviewerMeta := `{"loop":{"iterationCount":2}}`
+	fixerMeta := `{"reviewFixBudget":{"pushCount":1}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_feishu_caps_rev", Seq: 91, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &reviewerMeta,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_feishu_caps_fix", Seq: 92, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &fixerMeta,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 2, Cap: 2, NowISO: nowISO, HITLEnabled: true,
+		LiveCaps: loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 2, FixerMaxPushes: 5},
+	}); err != nil {
+		t.Fatalf("Park: %v", err)
+	}
+
+	cfg, err := config.DefaultConfig(root)
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 2
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 5
+
+	if err := deliverHITLAnswerToLoopWithCaps(context.Background(), repos, coordinator.DB(), nowISO, reviewer.ID, "Continue", reviewFixBudgetLiveCaps(&cfg, projectID)); err != nil {
+		t.Fatalf("Continue: %v", err)
+	}
+	fresh, _ := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if fresh == nil || fresh.Status != "queued" || loops.ReviewerPublishCount(fresh.MetadataJSON) != 0 {
+		t.Fatalf("reviewer after Continue = %#v, want queued with reset meter", fresh)
+	}
+	sibling, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if sibling == nil || sibling.Status != "queued" || loops.FixerPushCount(sibling.MetadataJSON) != 1 {
+		t.Fatalf("fixer after Continue = %#v, want queued with preserved pushCount 1", sibling)
+	}
+}
+
+func TestGenericMessageDoesNotQueueNoAskBudgetHold(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_budget_noask_msg"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Budget", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_noask_msg_rev", Seq: 101, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &reviewerMeta,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	}); err != nil {
+		t.Fatalf("Park: %v", err)
+	}
+	// Generic message must not queue a no-ask hold.
+	if err := enqueueHumanMessageToLoop(context.Background(), repos, nowISO, reviewer.ID, "please look at this"); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	fresh, _ := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if fresh == nil || fresh.Status != "paused" || !loops.IsReviewFixBudgetExhaustedPause(fresh.MetadataJSON) {
+		t.Fatalf("after generic message = %#v, want still paused exhausted hold", fresh)
+	}
+	if loops.ReviewerPublishCount(fresh.MetadataJSON) != 3 {
+		t.Fatalf("publish count = %d, want unchanged 3", loops.ReviewerPublishCount(fresh.MetadataJSON))
 	}
 }
 

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -106,7 +106,7 @@ func deliverUndeliveredGitHubBudgetAsks(ctx contextType, projectID string, recor
 			continue
 		}
 		ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
-		if !ok || !loops.IsReviewFixBudgetAsk(ask) {
+		if !ok || (!loops.IsReviewFixBudgetAsk(ask) && !loops.IsReviewScopeHumanAsk(ask)) {
 			continue
 		}
 		if ask.AskCommentID != 0 && strings.EqualFold(strings.TrimSpace(ask.Transport), "github") {
@@ -383,11 +383,17 @@ func enqueueHumanMessageToLoopWithCaps(ctx context.Context, repos *storage.Repos
 	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*loop))
 	defer unlockTarget()
 
-	// Budget holds (HITL ask or no-ask exhausted/sibling pause) are never
-	// conversational inbox turns. Only explicit Continue/Stop may unpark.
+	// Budget/scope pair holds (HITL ask or no-ask pause) are never conversational
+	// inbox turns. Only explicit Continue/Stop may unpark.
 	if loops.IsReviewFixBudgetHold(*loop) {
 		if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
 			return applyReviewFixBudgetAnswerTX(ctx, db, repos, *loop, text, nowISO, caps)
+		}
+		return nil
+	}
+	if loops.IsReviewScopeHumanHold(*loop) {
+		if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
+			return applyReviewScopeHumanAnswerTX(ctx, db, repos, *loop, text, nowISO)
 		}
 		return nil
 	}
@@ -448,6 +454,25 @@ func applyReviewFixBudgetAnswerTX(ctx context.Context, db *sql.DB, repos *storag
 	return err
 }
 
+func applyReviewScopeHumanAnswerTX(ctx context.Context, db *sql.DB, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string) error {
+	if db != nil {
+		return storage.WithTransaction(ctx, db, nil, func(tx *sql.Tx) error {
+			txRepos := storage.NewRepositories(tx)
+			fresh, err := txRepos.Loops.GetByID(ctx, loop.ID)
+			if err != nil {
+				return err
+			}
+			if fresh == nil {
+				return nil
+			}
+			_, err = loops.ApplyReviewScopeHumanAnswer(ctx, txRepos, *fresh, answer, nowISO)
+			return err
+		})
+	}
+	_, err := loops.ApplyReviewScopeHumanAnswer(ctx, repos, loop, answer, nowISO)
+	return err
+}
+
 func deliverHITLAnswerToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, answer string) error {
 	return deliverHITLAnswerToLoopWithCaps(ctx, repos, nil, nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
 }
@@ -461,7 +486,7 @@ func deliverHITLAnswerToLoopWithCaps(ctx context.Context, repos *storage.Reposit
 	if err != nil || loop == nil {
 		return err
 	}
-	if loop.Status != "awaiting_human" && !loops.IsReviewFixBudgetHold(*loop) {
+	if loop.Status != "awaiting_human" && !loops.IsReviewFixPairHold(*loop) {
 		return nil
 	}
 	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*loop))
@@ -469,6 +494,9 @@ func deliverHITLAnswerToLoopWithCaps(ctx context.Context, repos *storage.Reposit
 	if loops.IsReviewFixBudgetHold(*loop) {
 		// Budget Continue/Stop (HITL ask or no-ask hold) — fail-closed TX when DB set.
 		return applyReviewFixBudgetAnswerTX(ctx, db, repos, *loop, answer, nowISO, caps)
+	}
+	if loops.IsReviewScopeHumanHold(*loop) {
+		return applyReviewScopeHumanAnswerTX(ctx, db, repos, *loop, answer, nowISO)
 	}
 	if loop.Status != "awaiting_human" {
 		return nil
@@ -578,7 +606,9 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 		awaiting = append(awaiting, githubHITLAwaitingLoop{
 			ID: l.ID, ProjectID: l.ProjectID, Repo: repo,
 			Transport: ask.Transport, AskStatus: ask.Status, PRNumber: ask.PRNumber, AskCommentID: ask.AskCommentID,
-			BudgetAsk: loops.IsReviewFixBudgetAsk(ask),
+			// Scope asks share Continue/Stop-only filtering with budget asks so
+			// unrelated PR chatter does not poison the decision.
+			BudgetAsk: loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask),
 		})
 	}
 	if len(awaiting) == 0 {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -2,9 +2,11 @@ package runtime
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 
+	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/eventlog"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
@@ -356,6 +358,10 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 // is the exception: only Continue/Stop may unpark, and they apply the budget
 // decision instead of enqueueing conversational text.
 func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, text string) error {
+	return enqueueHumanMessageToLoopWithCaps(ctx, repos, nil, nowISO, loopID, text, reviewFixBudgetLiveCaps(nil, ""))
+}
+
+func enqueueHumanMessageToLoopWithCaps(ctx context.Context, repos *storage.Repositories, db *sql.DB, nowISO, loopID, text string, caps loops.ReviewFixBudgetLiveCaps) error {
 	// Share process-wide requeue exclusion with API discard+retry so free-text
 	// inbox delivery cannot requeue paused/waiting/manual_intervention loops
 	// between discard preflight and git reset (see LockLoopRequeue).
@@ -377,13 +383,11 @@ func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories,
 	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*loop))
 	defer unlockTarget()
 
-	if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
-		// Budget holds are Continue/Stop decisions, not conversational inbox
-		// turns. A typed Feishu reply must not flip awaiting_human to queued
-		// without resetting the counter or unpausing the sibling.
+	// Budget holds (HITL ask or no-ask exhausted/sibling pause) are never
+	// conversational inbox turns. Only explicit Continue/Stop may unpark.
+	if loops.IsReviewFixBudgetHold(*loop) {
 		if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
-			_, err = loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, text, nowISO)
-			return err
+			return applyReviewFixBudgetAnswerTX(ctx, db, repos, *loop, text, nowISO, caps)
 		}
 		return nil
 	}
@@ -411,7 +415,44 @@ func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories,
 	return err
 }
 
+func reviewFixBudgetLiveCaps(cfg *config.Config, projectID string) loops.ReviewFixBudgetLiveCaps {
+	if cfg == nil {
+		return loops.ReviewFixBudgetLiveCaps{
+			ReviewerMaxPublishes: config.DefaultReviewFixBudgetCap,
+			FixerMaxPushes:       config.DefaultReviewFixBudgetCap,
+		}
+	}
+	roles := config.ProjectRoleConfigs(*cfg, projectID)
+	return loops.ReviewFixBudgetLiveCaps{
+		ReviewerMaxPublishes: roles.Reviewer.Behavior.Loop.MaxPublishesPerPR,
+		FixerMaxPushes:       roles.Fixer.Behavior.Loop.MaxPushesPerPR,
+	}
+}
+
+func applyReviewFixBudgetAnswerTX(ctx context.Context, db *sql.DB, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string, caps loops.ReviewFixBudgetLiveCaps) error {
+	if db != nil {
+		return storage.WithTransaction(ctx, db, nil, func(tx *sql.Tx) error {
+			txRepos := storage.NewRepositories(tx)
+			fresh, err := txRepos.Loops.GetByID(ctx, loop.ID)
+			if err != nil {
+				return err
+			}
+			if fresh == nil {
+				return nil
+			}
+			_, err = loops.ApplyReviewFixBudgetAnswer(ctx, txRepos, *fresh, answer, nowISO, caps)
+			return err
+		})
+	}
+	_, err := loops.ApplyReviewFixBudgetAnswer(ctx, repos, loop, answer, nowISO, caps)
+	return err
+}
+
 func deliverHITLAnswerToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, answer string) error {
+	return deliverHITLAnswerToLoopWithCaps(ctx, repos, nil, nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
+}
+
+func deliverHITLAnswerToLoopWithCaps(ctx context.Context, repos *storage.Repositories, db *sql.DB, nowISO, loopID, answer string, caps loops.ReviewFixBudgetLiveCaps) error {
 	// Same requeue + target exclusion as free-text enqueue / API discard+retry.
 	unlock := LockLoopRequeue(loopID)
 	defer unlock()
@@ -420,18 +461,21 @@ func deliverHITLAnswerToLoop(ctx context.Context, repos *storage.Repositories, n
 	if err != nil || loop == nil {
 		return err
 	}
-	if loop.Status != "awaiting_human" {
+	if loop.Status != "awaiting_human" && !loops.IsReviewFixBudgetHold(*loop) {
 		return nil
 	}
 	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*loop))
 	defer unlockTarget()
+	if loops.IsReviewFixBudgetHold(*loop) {
+		// Budget Continue/Stop (HITL ask or no-ask hold) — fail-closed TX when DB set.
+		return applyReviewFixBudgetAnswerTX(ctx, db, repos, *loop, answer, nowISO, caps)
+	}
+	if loop.Status != "awaiting_human" {
+		return nil
+	}
 	ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
 	if !ok {
 		return nil
-	}
-	if loops.IsReviewFixBudgetAsk(ask) {
-		_, err = loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO)
-		return err
 	}
 	ask.Answer = answer
 	ask.Status = "answered"
@@ -556,7 +600,7 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 			return out, nil
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			return deliverHITLAnswerToLoop(ctx, input.Repos, nowISO, loopID, answer)
+			return deliverHITLAnswerToLoopWithCaps(ctx, input.Repos, input.DB, nowISO, loopID, answer, reviewFixBudgetLiveCaps(input.Config, project.ID))
 		},
 		clearAwaiting: func(ctx contextType, repo string, pr int64, cwd string) {
 			_ = gw.RemovePullRequestLabels(ctx, githubinfra.PullRequestLabelsInput{Repo: repo, PRNumber: pr, Labels: []string{awaitingLabel}, CWD: cwd})

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -56,6 +56,39 @@ func TestDetectGitHubHITLAnswerSkipsUnrelatedBudgetComments(t *testing.T) {
 	}
 }
 
+func TestPollGitHubHITLAnswersOnceScopeAskSkipsUnrelatedComments(t *testing.T) {
+	// Scope asks must use Continue/Stop-only filtering (same as budget asks).
+	comments := []githubAnswerComment{
+		{ID: 8001, Author: "looper", Body: "<!-- looper:hitl:ask --> Clarify AGENTS.md before unpause"},
+		{ID: 8002, Author: "operator", Body: "unrelated discussion about the PR"},
+		{ID: 8003, Author: "operator", Body: "Continue"},
+	}
+	var delivered []string
+	deps := githubHITLPollDeps{
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return comments, nil
+		},
+		deliverAnswer: func(_ contextType, loopID, answer string) error {
+			delivered = append(delivered, loopID+"="+answer)
+			return nil
+		},
+	}
+	// BudgetAsk=true is set for scope asks at the poll assembly site.
+	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		{ID: "loop-scope", Repo: "acme/x", Transport: "github", AskStatus: "awaiting", PRNumber: 42, AskCommentID: 8001, BudgetAsk: true},
+	}, deps)
+	if n != 1 || len(delivered) != 1 || delivered[0] != "loop-scope=Continue" {
+		t.Fatalf("delivered = %#v n=%d, want only Continue for scope ask", delivered, n)
+	}
+	// Without BudgetAsk filtering, the unrelated comment would win.
+	n = pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		{ID: "loop-scope-open", Repo: "acme/x", Transport: "github", AskStatus: "awaiting", PRNumber: 42, AskCommentID: 8001, BudgetAsk: false},
+	}, deps)
+	if n != 1 || len(delivered) != 2 || delivered[1] != "loop-scope-open=unrelated discussion about the PR" {
+		t.Fatalf("open ask delivered = %#v n=%d, want earliest unrelated comment", delivered, n)
+	}
+}
+
 func TestPollGitHubHITLAnswersOnce(t *testing.T) {
 	commentsByPR := map[int64][]githubAnswerComment{
 		42: {{ID: 500, Author: "lefarcen", Body: "<!-- looper:hitl:ask --> ask"}, {ID: 501, Author: "lefarcen", Body: "go with A"}},

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -136,7 +136,7 @@ func TestGitHubHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 	seedPollBudgetQueue(t, repos, nowISO, "project_budget_github", "queue_budget_fixer", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -301,7 +301,7 @@ func TestGitHubHITLPollRecoversBudgetAskAfterPersistFailure(t *testing.T) {
 	seedPollBudgetQueue(t, repos, nowISO, projectID, "queue_budget_fixer_recover", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -409,7 +409,7 @@ func TestGitHubHITLPollPostsNewAskAfterAPIAnsweredPriorCycle(t *testing.T) {
 	seedPollBudgetQueue(t, repos, firstISO, projectID, "queue_budget_fixer_generation", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: firstISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: firstISO, HITLEnabled: true,
 	}); err != nil {
 		t.Fatalf("ParkReviewFixBudget(first) error = %v", err)
 	}
@@ -435,7 +435,7 @@ func TestGitHubHITLPollPostsNewAskAfterAPIAnsweredPriorCycle(t *testing.T) {
 	if err != nil || fresh == nil {
 		t.Fatalf("Loops.GetByID(reviewer) = (%#v, %v)", fresh, err)
 	}
-	if _, err := loops.ApplyReviewFixBudgetAnswer(context.Background(), repos, *fresh, loops.ReviewFixBudgetAnswerContinue, firstISO); err != nil {
+	if _, err := loops.ApplyReviewFixBudgetAnswer(context.Background(), repos, *fresh, loops.ReviewFixBudgetAnswerContinue, firstISO, loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 8, FixerMaxPushes: 8}); err != nil {
 		t.Fatalf("ApplyReviewFixBudgetAnswer(API Continue) error = %v", err)
 	}
 
@@ -451,7 +451,7 @@ func TestGitHubHITLPollPostsNewAskAfterAPIAnsweredPriorCycle(t *testing.T) {
 		t.Fatalf("Loops.Upsert(re-exhaust) error = %v", err)
 	}
 	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: *fresh, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: secondISO,
+		Exhausted: *fresh, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: secondISO, HITLEnabled: true,
 	}); err != nil {
 		t.Fatalf("ParkReviewFixBudget(second) error = %v", err)
 	}
@@ -536,7 +536,7 @@ func TestGitHubHITLPollDeliversAndStopsReviewFixBudget(t *testing.T) {
 	seedPollBudgetQueue(t, repos, nowISO, projectID, "queue_budget_fixer_stop", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	}); err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
 	}

--- a/internal/runtime/human_attention.go
+++ b/internal/runtime/human_attention.go
@@ -277,9 +277,10 @@ func (r *Runtime) isStopped() bool {
 }
 
 // collectHumanAttentionLoopIDs returns loop IDs that may need human-attention
-// observation after recovery: durable awaiting_human loop status, and latest
-// queue rows parked as manual_intervention. notifyDurableHumanAttention applies
-// the hard-condition filter and permanent entry dedupe.
+// observation after recovery: durable awaiting_human loop status, no-HITL
+// review-fix budget exhausted pauses, and latest queue rows parked as
+// manual_intervention. notifyDurableHumanAttention applies the hard-condition
+// filter and permanent entry dedupe.
 func collectHumanAttentionLoopIDs(ctx context.Context, repos *storage.Repositories) []string {
 	if repos == nil {
 		return nil
@@ -298,10 +299,19 @@ func collectHumanAttentionLoopIDs(ctx context.Context, repos *storage.Repositori
 		ids = append(ids, id)
 	}
 	if repos.Loops != nil {
-		loops, err := repos.Loops.ListByStatuses(ctx, []string{string(domain.LoopStatusAwaitingHuman)})
+		awaiting, err := repos.Loops.ListByStatuses(ctx, []string{string(domain.LoopStatusAwaitingHuman)})
 		if err == nil {
-			for _, loop := range loops {
+			for _, loop := range awaiting {
 				add(loop.ID)
+			}
+		}
+		// No-HITL budget exhausted holds are paused (not awaiting_human).
+		paused, err := repos.Loops.ListByStatuses(ctx, []string{string(domain.LoopStatusPaused)})
+		if err == nil {
+			for _, loop := range paused {
+				if loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
+					add(loop.ID)
+				}
 			}
 		}
 	}
@@ -346,6 +356,28 @@ func notifyDurableHumanAttention(ctx context.Context, gateway *notify.Gateway, r
 			RunID:      latestRunID(ctx, repos, loop.ID),
 			LoopType:   loop.Type,
 			Reason:     notify.HumanAttentionAwaitingHuman,
+			EntryKey:   entryKey,
+			Subtitle:   humanAttentionSubtitle(*loop),
+			EntityType: "loop",
+			EntityID:   loop.ID,
+		})
+		return
+	}
+
+	// No-HITL review-fix budget exhausted: paused + review_fix_budget_exhausted.
+	// Sibling-only pause does not notify separately (exhausted role notifies).
+	if loop.Status == string(domain.LoopStatusPaused) && loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
+		entryKey := humanAttentionEntryKeyForReviewFixBudget(*loop)
+		if entryKey == "" {
+			return
+		}
+		gateway.NotifyHumanAttention(ctx, notify.HumanAttentionInput{
+			ProjectID:  loop.ProjectID,
+			LoopID:     loop.ID,
+			LoopSeq:    loop.Seq,
+			RunID:      latestRunID(ctx, repos, loop.ID),
+			LoopType:   loop.Type,
+			Reason:     notify.HumanAttentionReviewFixBudget,
 			EntryKey:   entryKey,
 			Subtitle:   humanAttentionSubtitle(*loop),
 			EntityType: "loop",
@@ -417,6 +449,17 @@ func humanAttentionEntryKeyForAwaitingHuman(ctx context.Context, repos *storage.
 		return "loop:" + loop.ID + ":" + updated
 	}
 	return "loop:" + loop.ID
+}
+
+func humanAttentionEntryKeyForReviewFixBudget(loop storage.LoopRecord) string {
+	state := loops.ReadReviewFixBudgetState(loop.MetadataJSON)
+	if at := strings.TrimSpace(state.HandoffEventAt); at != "" {
+		return "budget:" + loop.ID + ":" + at
+	}
+	if updated := strings.TrimSpace(loop.UpdatedAt); updated != "" {
+		return "budget:" + loop.ID + ":" + updated
+	}
+	return "budget:" + loop.ID
 }
 
 func humanAttentionEntryKeyForManualIntervention(queue storage.QueueItemRecord) string {

--- a/internal/runtime/human_attention_budget_contract_test.go
+++ b/internal/runtime/human_attention_budget_contract_test.go
@@ -1,0 +1,95 @@
+package runtime
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/infra/notify"
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// No-HITL review-fix budget exhausted hold must produce action-required human attention.
+func TestHumanAttentionContract_ReviewFixBudgetExhausted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	capturePath := filepath.Join(root, "osascript.log")
+	scriptPath := filepath.Join(root, "osascript")
+	writeHumanAttentionOsascript(t, scriptPath, capturePath, false)
+
+	coordinator := openMigratedCoordinator(t, filepath.Join(root, "budget-attention.sqlite"), filepath.Join(root, "backups"))
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 29, 12, 0, 0, 0, time.UTC)
+	nowISO := eventlog.FormatJavaScriptISOString(now)
+
+	projectID := "project_budget_attention"
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{
+		ID: projectID, Name: "Budget Attention", RepoPath: filepath.Join(root, "repo"),
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_attention", Seq: 717, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(ctx, reviewer); err != nil {
+		t.Fatalf("Loops.Upsert: %v", err)
+	}
+	parked, err := loops.ParkReviewFixBudget(ctx, repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: false, LiveCaps: loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 3, FixerMaxPushes: 3},
+	})
+	if err != nil {
+		t.Fatalf("Park: %v", err)
+	}
+	if parked.Status != "paused" || !loops.IsReviewFixBudgetExhaustedPause(parked.MetadataJSON) {
+		t.Fatalf("parked = %#v, want no-HITL exhausted pause", parked)
+	}
+
+	ids := collectHumanAttentionLoopIDs(ctx, repos)
+	found := false
+	for _, id := range ids {
+		if id == reviewer.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("collectHumanAttentionLoopIDs() = %v, want exhausted hold %s", ids, reviewer.ID)
+	}
+
+	gateway := notify.NewGateway(notify.Options{
+		Config: config.NotificationConfig{
+			InApp: true,
+			Osascript: config.OsascriptNotificationConfig{
+				Enabled:               true,
+				SoundForLevels:        []config.NotificationSoundLevel{config.NotificationSoundLevelActionRequired},
+				ThrottleWindowSeconds: 1,
+			},
+		},
+		OsascriptPath: scriptPath,
+		Repositories:  repos,
+		Now:           func() time.Time { return now },
+	})
+
+	notifyDurableHumanAttention(ctx, gateway, repos, reviewer.ID)
+	assertHumanAttentionInAppCount(t, repos, reviewer.ID, 1)
+	assertOsascriptContains(t, capturePath, "display notification")
+
+	// Re-observe must not resend.
+	notifyDurableHumanAttention(ctx, gateway, repos, reviewer.ID)
+	assertHumanAttentionInAppCount(t, repos, reviewer.ID, 1)
+}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -84,6 +85,7 @@ type schedulerAsyncRunner interface {
 
 type defaultSchedulerTickInput struct {
 	Repos             *storage.Repositories
+	DB                *sql.DB
 	GitHubGateway     *githubinfra.Gateway
 	Logger            bootstrap.Logger
 	Now               func() time.Time
@@ -3490,6 +3492,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 			RetryMaxAttempts:        int64(cfg.Scheduler.RetryMaxAttempts),
 			RetryPolicy:             cfg.Roles.Reviewer.Behavior.Retry,
 			OnQueueItemEnqueued:     requestWake,
+			NotifyHumanAttention:    notifyHumanAttention,
 			OnAgentExecutionStarted: func(ctx context.Context, input reviewer.AgentExecutionStartedInput) error {
 				return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Reviewer", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})
 			},
@@ -3531,16 +3534,17 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 				Labels:        append([]string(nil), cfg.Roles.Fixer.Triggers.Labels...),
 				LabelMode:     cfg.Roles.Fixer.Triggers.LabelMode,
 			},
-			Disclosure:          &cfg.Disclosure,
-			AgentRuntime:        string(resolved.Vendor),
-			AgentProfileID:      resolved.ProfileID,
-			CustomInstructions:  &cfg,
-			AgentModel:          agentModel,
-			AgentTimeout:        time.Duration(cfg.Agent.Timeouts.FixerMaxRuntimeSeconds) * time.Second,
-			AgentIdleTimeout:    time.Duration(cfg.Agent.Timeouts.FixerIdleTimeoutSeconds) * time.Second,
-			RetryBaseDelay:      retryBaseDelay,
-			RetryMaxAttempts:    int64(cfg.Scheduler.RetryMaxAttempts),
-			OnQueueItemEnqueued: requestWake,
+			Disclosure:           &cfg.Disclosure,
+			AgentRuntime:         string(resolved.Vendor),
+			AgentProfileID:       resolved.ProfileID,
+			CustomInstructions:   &cfg,
+			AgentModel:           agentModel,
+			AgentTimeout:         time.Duration(cfg.Agent.Timeouts.FixerMaxRuntimeSeconds) * time.Second,
+			AgentIdleTimeout:     time.Duration(cfg.Agent.Timeouts.FixerIdleTimeoutSeconds) * time.Second,
+			RetryBaseDelay:       retryBaseDelay,
+			RetryMaxAttempts:     int64(cfg.Scheduler.RetryMaxAttempts),
+			OnQueueItemEnqueued:  requestWake,
+			NotifyHumanAttention: notifyHumanAttention,
 			OnAgentExecutionStarted: func(ctx context.Context, input fixer.AgentExecutionStartedInput) error {
 				return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Fixer", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})
 			},
@@ -3629,8 +3633,13 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		if githubGateway != nil {
 			snapshotter = githubGateway
 		}
+		var tickDB *sql.DB
+		if services.Coordinator != nil {
+			tickDB = services.Coordinator.DB()
+		}
 		return defaultSchedulerTickInput{
 			Repos:                services.Repositories,
+			DB:                   tickDB,
 			GitHubGateway:        githubGateway,
 			Logger:               logger,
 			Now:                  now,

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -27,6 +27,7 @@ import (
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/notify"
 	"github.com/nexu-io/looper/internal/infra/shell"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/loops/failureclass"
 	networkclient "github.com/nexu-io/looper/internal/network/client"
 	"github.com/nexu-io/looper/internal/network/protocol"
@@ -1720,7 +1721,7 @@ func (a reviewerGitHubAdapter) ListReviewThreads(ctx context.Context, input revi
 	if a.gateway == nil {
 		return nil, fmt.Errorf("github gateway is not configured")
 	}
-	threads, err := a.gateway.ListReviewThreads(ctx, githubinfra.ListReviewThreadsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD, Limit: input.Limit})
+	threads, err := a.gateway.ListReviewThreads(ctx, githubinfra.ListReviewThreadsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD, Limit: input.Limit, AllPages: input.AllPages})
 	if err != nil {
 		return nil, err
 	}
@@ -1728,7 +1729,7 @@ func (a reviewerGitHubAdapter) ListReviewThreads(ctx context.Context, input revi
 	for _, thread := range threads {
 		converted := reviewer.ReviewThread{ID: thread.ID, IsResolved: thread.IsResolved, Path: thread.Path, Line: thread.Line, URL: thread.URL}
 		for _, comment := range thread.Comments {
-			converted.Comments = append(converted.Comments, reviewer.ReviewThreadComment{ID: comment.ID, Body: comment.Body, Author: comment.Author, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt, Path: comment.Path, Line: comment.Line, OriginalCommitOID: comment.OriginalCommitOID, CommitOID: comment.CommitOID, URL: comment.URL})
+			converted.Comments = append(converted.Comments, reviewer.ReviewThreadComment{ID: comment.ID, Body: comment.Body, Author: comment.Author, AuthorAssociation: comment.AuthorAssociation, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt, Path: comment.Path, Line: comment.Line, OriginalCommitOID: comment.OriginalCommitOID, CommitOID: comment.CommitOID, URL: comment.URL})
 		}
 		out = append(out, converted)
 	}
@@ -2268,7 +2269,7 @@ func (a fixerGitHubAdapter) ListReviewThreads(ctx context.Context, input fixer.L
 		}
 		return nil, fmt.Errorf("forgejo fixer does not support native review threads")
 	}
-	threads, err := a.gateway.ListReviewThreads(ctx, githubinfra.ListReviewThreadsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD, Limit: input.Limit})
+	threads, err := a.gateway.ListReviewThreads(ctx, githubinfra.ListReviewThreadsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD, Limit: input.Limit, AllPages: input.AllPages})
 	if err != nil {
 		return nil, err
 	}
@@ -2276,7 +2277,7 @@ func (a fixerGitHubAdapter) ListReviewThreads(ctx context.Context, input fixer.L
 	for _, thread := range threads {
 		comments := make([]fixer.ReviewThreadComment, 0, len(thread.Comments))
 		for _, comment := range thread.Comments {
-			comments = append(comments, fixer.ReviewThreadComment{ID: comment.ID, Body: comment.Body, Author: comment.Author, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt})
+			comments = append(comments, fixer.ReviewThreadComment{ID: comment.ID, Body: comment.Body, Author: comment.Author, AuthorAssociation: comment.AuthorAssociation, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt})
 		}
 		out = append(out, fixer.ReviewThread{ID: thread.ID, IsResolved: thread.IsResolved, Comments: comments})
 	}
@@ -2296,7 +2297,7 @@ func (a fixerGitHubAdapter) ViewReviewThread(ctx context.Context, input fixer.Vi
 	}
 	comments := make([]fixer.ReviewThreadComment, 0, len(thread.Comments))
 	for _, comment := range thread.Comments {
-		comments = append(comments, fixer.ReviewThreadComment{ID: comment.ID, Body: comment.Body, Author: comment.Author, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt})
+		comments = append(comments, fixer.ReviewThreadComment{ID: comment.ID, Body: comment.Body, Author: comment.Author, AuthorAssociation: comment.AuthorAssociation, CreatedAt: comment.CreatedAt, UpdatedAt: comment.UpdatedAt})
 	}
 	return fixer.ReviewThread{ID: thread.ID, IsResolved: thread.IsResolved, Comments: comments}, nil
 }
@@ -4610,6 +4611,10 @@ func dispatchClaimedQueueItems(ctx context.Context, queueItems []storage.QueueIt
 // schedulerLoopParked reports whether a claimed queue item's loop was parked
 // (human takeover / paused) — a state the scheduler may observe AFTER the claim
 // due to a race, and must then decline to run.
+//
+// Exception: a reviewer disposition-only item on a budget-held loop must still
+// run so same-head wontfix adjudication can refresh the handoff without a
+// Continue. Scope holds / human_takeover / non-budget awaiting_human stay parked.
 func schedulerLoopParked(ctx context.Context, item storage.QueueItemRecord, input defaultSchedulerTickInput) bool {
 	if item.LoopID == nil || input.Repos == nil || input.Repos.Loops == nil {
 		return false
@@ -4620,10 +4625,25 @@ func schedulerLoopParked(ctx context.Context, item storage.QueueItemRecord, inpu
 	}
 	switch loop.Status {
 	case "human_takeover", "paused", "awaiting_human":
+		if item.Type == "reviewer" && payloadDispositionOnly(item.PayloadJSON) && loops.IsReviewFixBudgetHold(*loop) {
+			return false
+		}
 		return true
 	default:
 		return false
 	}
+}
+
+func payloadDispositionOnly(payloadJSON *string) bool {
+	if payloadJSON == nil || strings.TrimSpace(*payloadJSON) == "" {
+		return false
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(*payloadJSON), &payload); err != nil {
+		return false
+	}
+	v, ok := payload["dispositionOnly"].(bool)
+	return ok && v
 }
 
 func runScheduledQueueItems(ctx context.Context, queueItems []storage.QueueItemRecord, input defaultSchedulerTickInput) error {

--- a/internal/runtime/webhook.go
+++ b/internal/runtime/webhook.go
@@ -34,7 +34,7 @@ const noConfiguredWebhookReposReason = "no configured GitHub repos are available
 
 var webhookReconcileRetryDelay = 5 * time.Second
 
-var webhookForwardEvents = []string{"pull_request", "issue_comment", "pull_request_review", "pull_request_review_comment", "push", "check_run"}
+var webhookForwardEvents = []string{"pull_request", "issue_comment", "pull_request_review", "pull_request_review_comment", "pull_request_review_thread", "push", "check_run"}
 
 const (
 	webhookForwarderStdoutTailLines = 20

--- a/internal/runtime/webhook_forwarder.go
+++ b/internal/runtime/webhook_forwarder.go
@@ -27,6 +27,7 @@ var webhookForwarderEvents = []string{
 	"issue_comment",
 	"pull_request_review",
 	"pull_request_review_comment",
+	"pull_request_review_thread",
 	"push",
 	"check_run",
 }

--- a/internal/runtime/webhook_forwarder_test.go
+++ b/internal/runtime/webhook_forwarder_test.go
@@ -184,6 +184,12 @@ func TestWebhookForwarderEventsIncludePushAndCheckRun(t *testing.T) {
 	if !slices.Contains(webhookForwarderEvents, "check_run") {
 		t.Fatalf("webhookForwarderEvents = %v, want check_run subscription", webhookForwarderEvents)
 	}
+	if !slices.Contains(webhookForwarderEvents, "pull_request_review_thread") {
+		t.Fatalf("webhookForwarderEvents = %v, want pull_request_review_thread subscription", webhookForwarderEvents)
+	}
+	if !sameWebhookEvents(webhookForwarderEvents, webhookForwardEvents) {
+		t.Fatalf("webhookForwarderEvents = %v, webhookForwardEvents = %v, want identical event sets", webhookForwarderEvents, webhookForwardEvents)
+	}
 }
 
 func TestClassifyForwarderExitTerminalPatterns(t *testing.T) {

--- a/internal/webhookforward/forwarder.go
+++ b/internal/webhookforward/forwarder.go
@@ -751,7 +751,7 @@ func routeDelivery(eventType string, payload []byte) (routedDelivery, bool, erro
 			return routedDelivery{}, false, errors.New("issue_comment webhook missing repository or number")
 		}
 		return routedDelivery{}, false, nil
-	case "pull_request_review", "pull_request_review_comment":
+	case "pull_request_review":
 		var envelope pullRequestEnvelope
 		if err := json.Unmarshal(payload, &envelope); err != nil {
 			return routedDelivery{}, false, fmt.Errorf("decode %s webhook: %w", eventType, err)
@@ -760,6 +760,27 @@ func routeDelivery(eventType string, payload []byte) (routedDelivery, bool, erro
 			return routedDelivery{}, false, fmt.Errorf("%s webhook missing repository or number", eventType)
 		}
 		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", numbers: []int64{envelope.PullRequest.Number}, action: strings.TrimSpace(envelope.Action), lanes: map[Lane]struct{}{LaneFixer: {}}}, true, nil
+	case "pull_request_review_comment":
+		var envelope pullRequestEnvelope
+		if err := json.Unmarshal(payload, &envelope); err != nil {
+			return routedDelivery{}, false, fmt.Errorf("decode %s webhook: %w", eventType, err)
+		}
+		if strings.TrimSpace(envelope.Repository.FullName) == "" || envelope.PullRequest.Number <= 0 {
+			return routedDelivery{}, false, fmt.Errorf("%s webhook missing repository or number", eventType)
+		}
+		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", numbers: []int64{envelope.PullRequest.Number}, action: strings.TrimSpace(envelope.Action), lanes: map[Lane]struct{}{LaneReviewer: {}, LaneFixer: {}}}, true, nil
+	case "pull_request_review_thread":
+		var envelope pullRequestEnvelope
+		if err := json.Unmarshal(payload, &envelope); err != nil {
+			return routedDelivery{}, false, fmt.Errorf("decode %s webhook: %w", eventType, err)
+		}
+		if strings.TrimSpace(envelope.Action) != "resolved" {
+			return routedDelivery{}, false, nil
+		}
+		if strings.TrimSpace(envelope.Repository.FullName) == "" || envelope.PullRequest.Number <= 0 {
+			return routedDelivery{}, false, fmt.Errorf("%s webhook missing repository or number", eventType)
+		}
+		return routedDelivery{repo: strings.TrimSpace(envelope.Repository.FullName), objectType: "pull_request", numbers: []int64{envelope.PullRequest.Number}, action: strings.TrimSpace(envelope.Action), lanes: map[Lane]struct{}{LaneReviewer: {}, LaneFixer: {}}}, true, nil
 	case "push":
 		var envelope pushEnvelope
 		if err := json.Unmarshal(payload, &envelope); err != nil {

--- a/internal/webhookforward/forwarder_test.go
+++ b/internal/webhookforward/forwarder_test.go
@@ -493,6 +493,72 @@ func TestForwardRoutesPullRequestLabelChangesToFixerOnly(t *testing.T) {
 	fixerRunner.assertPRCount(t, 43, 1)
 }
 
+func TestForwardRoutesReviewCommentToReviewerAndFixer(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	reviewerRunner := newFakeTargetedRunner(nil)
+	fixerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: fixerRunner}, MaxConcurrent: 1, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	for i, action := range []string{"created", "edited", "deleted"} {
+		if _, err := forwarder.Forward(context.Background(), DeliveryRequest{
+			DeliveryID: "review-comment-" + action,
+			EventType:  "pull_request_review_comment",
+			Payload:    pullRequestPayload(action, "acme/looper", int64(50+i)),
+		}); err != nil {
+			t.Fatalf("Forward(%s) error = %v", action, err)
+		}
+	}
+
+	reviewerRunner.waitForCalls(t, 3)
+	fixerRunner.waitForCalls(t, 3)
+	for _, pr := range []int64{50, 51, 52} {
+		reviewerRunner.assertPRCount(t, pr, 1)
+		fixerRunner.assertPRCount(t, pr, 1)
+	}
+}
+
+func TestForwardRoutesReviewThreadResolvedToReviewerAndFixer(t *testing.T) {
+	repos := newTestRepositories(t)
+	seedProject(t, repos, "project_1", "acme/looper")
+	reviewerRunner := newFakeTargetedRunner(nil)
+	fixerRunner := newFakeTargetedRunner(nil)
+	forwarder := New(Options{Repos: repos, Config: testConfig(t), Reviewer: reviewerRunner, Fixer: targetedFixerAdapter{runner: fixerRunner}, MaxConcurrent: 1, QueueCapacity: 8})
+	defer forwarder.Close()
+
+	result, err := forwarder.Forward(context.Background(), DeliveryRequest{
+		DeliveryID: "thread-resolved",
+		EventType:  "pull_request_review_thread",
+		Payload:    pullRequestPayload("resolved", "acme/looper", 60),
+	})
+	if err != nil {
+		t.Fatalf("Forward(resolved) error = %v", err)
+	}
+	if result.Status != "accepted" {
+		t.Fatalf("Forward(resolved) status = %q, want accepted", result.Status)
+	}
+
+	ignored, err := forwarder.Forward(context.Background(), DeliveryRequest{
+		DeliveryID: "thread-unresolved",
+		EventType:  "pull_request_review_thread",
+		Payload:    pullRequestPayload("unresolved", "acme/looper", 61),
+	})
+	if err != nil {
+		t.Fatalf("Forward(unresolved) error = %v", err)
+	}
+	if ignored.Status != "ignored" {
+		t.Fatalf("Forward(unresolved) status = %q, want ignored", ignored.Status)
+	}
+
+	reviewerRunner.waitForCalls(t, 1)
+	fixerRunner.waitForCalls(t, 1)
+	reviewerRunner.assertPRCount(t, 60, 1)
+	fixerRunner.assertPRCount(t, 60, 1)
+	reviewerRunner.assertPRCount(t, 61, 0)
+	fixerRunner.assertPRCount(t, 61, 0)
+}
+
 func TestForwardTriggersFixerForFailedCheckWebhookEvents(t *testing.T) {
 	repos := newTestRepositories(t)
 	seedProject(t, repos, "project_1", "acme/looper")

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -371,7 +371,7 @@ scope = "changed_ranges"
 publishMode = "single_review"
 
 [roles.reviewer.behavior.loop]
-maxPublishesPerPR = 8
+maxPublishesPerPR = 3
 
 [roles.reviewer.behavior.reviewEvents]
 clean = "APPROVE"
@@ -379,7 +379,7 @@ blocking = "REQUEST_CHANGES"
 
 [roles.fixer.behavior.loop]
 quietPeriodSeconds = 0
-maxPushesPerPR = 8
+maxPushesPerPR = 3
 
 [roles.fixer.discovery]
 autoDiscovery = true

--- a/specs/2026-08-24-review-fix-convergence/spec.md
+++ b/specs/2026-08-24-review-fix-convergence/spec.md
@@ -1,0 +1,988 @@
+# Review-fix convergence: scope-aware review, reactive dispositions, and bounded automation
+
+## 1. Background
+
+Looper already has several useful pieces:
+
+- Reviewer prompts require a complete pass and finding accumulation.
+- Reviewer and Fixer have independent live caps:
+  `maxPublishesPerPR` and `maxPushesPerPR`.
+- Fixer treats repository instructions and documented PR intent as scope
+  authority, and can decline an out-of-scope review item.
+- Native review data carries thread id/resolution state plus comment-level
+  `updatedAt`, replies, and author association. GitHub's ReviewThread node does
+  not itself expose `updatedAt`.
+- Reviewer has a thread-resolution phase, while Fixer already fingerprints
+  observed thread comments before mutating a thread.
+
+Those pieces do not yet form a convergence protocol.
+
+Two relevant features are disabled by default today. `HITL.Enabled` is `false`,
+and both role budgets are skipped entirely when HITL is off. Reviewer
+`ThreadResolution.Enabled` is also `false`; its default mode is report-only,
+`RequireNewHeadSinceThread` is `true`, and `MaxThreadsPerRun` is `10`. A bounded
+default cannot depend on operators discovering and enabling either feature.
+
+[powerformer/nexus#56](https://github.com/powerformer/nexus/pull/56) is a useful
+failure case: the PR received 17 Codex review passes, 29 inline comments, and 16
+manual `@codex review` triggers over roughly 5 hours 22 minutes. The PR was also
+large (83 files and about 9.9k added lines), so this spec does not claim every
+comment was invalid. The relevant signal is the shape of the interaction:
+independent findings arrived in small batches, later passes expanded into edge
+hardening, and the system had no bounded clean-or-handoff outcome.
+
+There is a second same-head failure mode. A human or Fixer can edit/reply to an
+unresolved thread with a `wontfix`/decline decision, but Reviewer discovery
+currently skips a PR when `lastPublishedHeadSha == currentHeadSha`. Existing
+thread-resolution audit is also keyed primarily by head, not by the current
+thread content. In addition, Fixer currently replies to a validated `declined`
+decision, resolves the thread itself, and suppresses the same decline by a
+head-bound fingerprint. Reviewer candidate selection then ignores the resolved
+thread. Therefore an updated comment can be invisible until another commit, or
+can disappear before Reviewer adjudicates it at all. The review-fix pair can
+wait, repeat, or converge on the wrong authority even though the relevant input
+has changed.
+
+## 2. Product outcome
+
+For each continuously followed PR with finite role caps, Looper must reach one
+of these outcomes within the configured independent role budgets, whether HITL
+is enabled or disabled. Setting a cap to `0` explicitly waives the finite-bound
+guarantee for that role:
+
+1. **Clean convergence:** every in-scope finding is fixed, explicitly disposed,
+   or resolved, and Reviewer publishes the configured clean outcome.
+2. **Human handoff:** the pair is non-runnable—parked with a Continue/Stop ask
+   when HITL is enabled, or paused in a manual hold without an ask when it is
+   disabled—with both meters, every remaining actionable thread, every pending
+   scope dispute, and the exact next action.
+
+Budget exhaustion is operational convergence, not code approval. Looper must
+never publish a clean review, resolve a blocker, or enable auto-merge merely
+because a budget was exhausted.
+
+The full same-head thread-disposition guarantee applies to GitHub projects with
+native review-thread capabilities. Providers without those capabilities still
+receive bounded review-publication/Fixer-push behavior, but cannot claim the
+same-head `wontfix` convergence path. In particular, Forgejo remains explicitly
+exempt until its provider capabilities can supply the required thread identity,
+authorship, edit timestamp, reply, and resolve operations.
+
+## 3. Goals
+
+1. Make the first Reviewer publication contain every independent, concrete,
+   in-scope finding visible in the configured review scope.
+2. Prevent follow-up passes from reopening untouched old diff for ordinary
+   P2/P3 improvements after the first complete pass.
+3. Prevent out-of-scope suggestions from becoming automatic Fixer work or
+   resolvable PR threads by default.
+4. Keep Reviewer and Fixer caps independently configurable and independently
+   counted, while pausing/stopping the pair together when either cap trips.
+5. React to review-thread edits/replies on an unchanged PR head, especially
+   explicit human `wontfix` decisions and structured Fixer declines.
+6. Make same-head disposition handling idempotent across polling, webhooks,
+   retries, and daemon restarts.
+7. Reuse existing loop metadata, event log, HITL, review markers, and thread
+   resolution instead of adding a review-round ledger or workflow engine.
+8. Enforce finite caps in the default `HITL.Enabled=false` configuration without
+   silently dropping a finding that needs human judgment.
+
+## 4. Non-goals (kill list)
+
+1. A total comment-count cap that hides independent blockers
+2. A single opaque `maxReviewFixRounds` replacing the two role caps
+3. Automatic approval, merge, or thread resolution on budget exhaustion
+4. Treating every issue found near changed code as required PR scope
+5. Inferring product scope from changed ranges, test failures, labels, or GitHub
+   state when documented intent says otherwise
+6. Automatically creating GitHub issues for every suppressed follow-up
+7. A new SQL table, epoch id, finding ledger, or persisted scope-status machine
+8. Full rescans of the original PR diff after every Fixer push
+9. Trusting arbitrary commenters or bot text as a `wontfix` authority
+10. Forgejo same-head thread-disposition parity before Forgejo supports the
+    required native thread identity, authorship, edit timestamp, reply, and
+    resolve capabilities; Forgejo is exempt only from that part of §2, not from
+    role-budget enforcement
+11. Solving oversized-PR policy; PR size may be reported in handoff evidence but
+    is not a new admission gate in this change
+
+## 5. Authority
+
+> The authority for whether a finding must be fixed in this PR is repository
+> instructions, the PR's documented intent and linked issue/specification, and
+> correctness or safety invariants directly affected by the PR—not the
+> Reviewer's structured output.
+
+The authority order is:
+
+1. Repository instructions, including `AGENTS.md`
+2. PR title/body, explicit goals and non-goals, and linked issue/specification
+3. A regression introduced by the PR or an invariant directly affected by its
+   changed behavior
+4. Existing intentional PR decisions that predate the current review/fix dispute
+
+Reviewer output is a structured claim with evidence. Fixer must still verify it.
+Changed ranges are location scope, not product scope.
+
+For an explicit human disposition, the authority is the PR author or a provider
+identity whose author association is `OWNER`, `MEMBER`, or `COLLABORATOR`.
+GitHub exposes `authorAssociation` and `updatedAt` on
+[PullRequestReviewComment](https://docs.github.com/en/graphql/reference/pulls#pullrequestreviewcomment).
+Arbitrary external users and bots are not disposition authorities. A Looper
+Fixer reply with a validated `declined` marker is a scope-dispute signal, not
+human authority; Reviewer must adjudicate it.
+
+## 6. Decisions (locked)
+
+| Topic | Decision |
+| --- | --- |
+| Reviewer/Fixer meters | Remain separate: publications vs pushes |
+| Default caps | Lower both defaults from `8` to `3`; explicit config is unchanged |
+| Disabled cap | `0` still disables only that role's cap |
+| Pair behavior | Either exhausted role halts both roles in the same lane: park with a HITL ask or pause in a no-ask manual hold |
+| Continue | Replenish only meters currently at/over their live cap; preserve unused sibling budget |
+| Stop | Terminate both roles in the lane |
+| Budget enforcement | Independent of `HITL.Enabled`; HITL selects answer delivery, not whether the pair halts |
+| HITL disabled at cap | Pause both roles in a paired manual hold, cancel queues, persist counters/reason + handoff event, and notify action-required; no ask or automatic resume |
+| No-HITL resume | `looper unpause` on either budget-held role delegates to paired Continue; `looper stop` delegates to paired Stop |
+| `needs_human` with HITL disabled | Pause the pair with reason `review_scope_human_required` and the same handoff evidence; never suppress and continue |
+| First pass | Full configured PR scope; accumulate before publishing |
+| Later code pass | Prior findings + new head delta + affected invariants |
+| Later thread pass | Changed thread feedback only; no full code rescan by default |
+| Finding disposition | `must_fix`, `follow_up`, or `needs_human` |
+| Remote comments | Only `must_fix` becomes actionable PR feedback by default |
+| `follow_up` | Retained in the run result/event; no remote comment or Fixer item by default |
+| Scope ambiguity | `needs_human`; no code or thread mutation until answered |
+| Human command | Canonical `/looper wontfix <reason>`; exact standalone `wontfix`, `won't fix`, and `won’t fix` are compatibility aliases |
+| Fixer decline | Reply with evidence and leave unresolved; Reviewer owns accept/reject/resolve |
+| Disposition feature gate | Always on for continuous Looper-authored GitHub threads; legacy ThreadResolution config continues to govern objective-fix reconciliation only |
+| Same-head gate | `RequireNewHeadSinceThread` never blocks a human/Fixer disposition change |
+| Same-head reactivity | Review signal includes current thread feedback, not only head SHA |
+| Budget at human reply | Either hold may run disposition-only reconciliation, but it cannot release the hold, refill a meter, publish a review, or push code |
+| Persistence | One review-signal fingerprint in existing loop metadata; no new table/ledger |
+| Queue dedupe | Keep the stable per-loop/PR dedupe key; coalesce the latest signal into one active item |
+
+## 7. Reviewer convergence protocol
+
+### 7.1 First pass: exhaustive within authority scope
+
+A pass is an initial pass when no validated prior Looper review marker exists for
+the PR lane.
+
+Before publication, Reviewer must:
+
+1. Read repository instructions, PR intent, linked specification when available,
+   complete configured diff scope, prior review history, and necessary context.
+2. Accumulate candidate findings without publishing.
+3. Classify every candidate by disposition, severity, scope basis, and concrete
+   evidence.
+4. Deduplicate only the same root cause or a genuinely repeated pattern.
+5. Keep unrelated concerns separate even when there are many of them.
+6. Submit one review containing every independent `must_fix` finding found in
+   that pass.
+
+Remove prompt language that says to “prefer fewer” comments and remove numeric
+comment-flood thresholds as completeness signals. Grouping is valid only for a
+shared root cause with representative locations; it must not hide unrelated
+findings. The budget limits review publications, not findings per publication.
+
+The Reviewer is not required to find unknowable issues. It is required not to
+intentionally defer an already observed in-scope issue to a later publication.
+
+### 7.2 Follow-up code pass: review the repair frontier
+
+When a validated prior Looper review exists and the head changed, Reviewer must
+inspect:
+
+- every unresolved prior `must_fix` thread;
+- the diff from the last reviewed head to the current head;
+- directly affected call sites, contracts, tests, and lifecycle invariants;
+- evidence that the Fixer actually addressed each prior finding.
+
+Reviewer must not rescan untouched original diff merely to invent ordinary new
+hardening work. A newly discovered issue in untouched old diff is handled as:
+
+| Late finding | Disposition |
+| --- | --- |
+| Clear security, data corruption/loss, broken public contract, or P0/P1 correctness blocker | Publish as `must_fix`, mark as late discovery, and include it in convergence evidence |
+| Ordinary P2/P3 robustness, cleanup, style, or independent improvement | `follow_up`; do not feed the current Fixer loop |
+| Scope or severity is genuinely ambiguous | `needs_human` |
+
+Continue/reset of a budget meter does not reset this review frontier.
+
+### 7.3 Finding disposition contract
+
+Every candidate uses this logical shape:
+
+```json
+{
+  "disposition": "must_fix | follow_up | needs_human",
+  "severity": "blocking | non_blocking | nit",
+  "scopeBasis": "stated_intent | introduced_regression | required_invariant | independent_improvement | ambiguous_intent",
+  "scopeEvidence": "specific repository rule, PR goal/non-goal, linked spec section, or regression evidence",
+  "path": "internal/example.go",
+  "line": 42,
+  "problem": "concrete problem",
+  "why": "observable consequence",
+  "suggestedChange": "smallest complete repair"
+}
+```
+
+Publication rules:
+
+- `must_fix`: publish as inline feedback when anchorable; it becomes Fixer input.
+- `follow_up`: retain in the structured completion/event record. Do not create a
+  GitHub review thread or top-level action item unless repository instructions
+  explicitly require all such observations to be published.
+- `needs_human`: do not publish it as a change request and do not let Fixer edit.
+  With HITL enabled, park the pair with the conflicting evidence and exact
+  question. With HITL disabled, pause the pair in a manual hold with reason
+  `review_scope_human_required`, the same structured handoff evidence, and an
+  action-required event/notification. The handoff must say which authority
+  input must change before `looper unpause`; never suppress the finding and
+  continue.
+
+For native review submission, each actionable comment must carry transient
+`disposition`, `scopeBasis`, and `scopeEvidence` fields. The trusted review-submit
+Seam rejects missing fields and rejects `follow_up`/`needs_human` in an
+actionable comment payload. The provider Adapter removes Looper-only fields
+before calling GitHub/Forgejo. The fields are a declaration and validation
+surface, not the authority itself.
+
+The actionable review body may summarize published `must_fix` findings but must
+not smuggle suppressed findings into unstructured top-level prose. Comment-only
+publish mode must apply the same dispositions before it posts remote content.
+
+### 7.4 Fixer remains a second scope check
+
+Fixer keeps its current scope authority and may return `declined` or
+`needs_human` even when Reviewer emitted `must_fix`.
+
+When Fixer declines with concrete scope evidence:
+
+- it makes no code change for that item;
+- it replies on the existing thread through the structured response path;
+- it does **not** resolve the thread or treat its own output as dismissal
+  authority;
+- it records the existing decline marker as pending Reviewer adjudication, not
+  as a terminal suppression for the current head;
+- Reviewer treats the reply as a changed disposition signal;
+- Reviewer must not open a duplicate thread for the same fingerprint;
+- Reviewer either accepts the decline, rejects it with new authority evidence,
+  or requests HITL.
+
+Only Reviewer `accept_wontfix` (or an already-resolved human action) makes the
+decline terminal. Reviewer `reject_wontfix` invalidates Fixer's pending decline
+suppression for that exact feedback fingerprint and returns the existing thread
+to Fixer; it does not create a new thread.
+
+A second attempted fix to the same subsystem or a reviewer/fixer scope conflict
+that repeats without new evidence is `needs_human`, not another automatic round.
+
+## 8. Same-head `wontfix` and decline reactivity
+
+### 8.1 Feature ownership and existing ThreadResolution config
+
+Same-head scope disposition is a narrow convergence path, not an implicit
+enablement of the broader optional ThreadResolution feature.
+
+It runs only when all are true:
+
+- the Reviewer loop is continuous;
+- the provider exposes the required native thread capabilities;
+- the thread is Looper-authored; and
+- there is a changed trusted-human disposition or validated Fixer decline.
+
+Existing settings retain these meanings:
+
+| Existing setting | Locked meaning after this change |
+| --- | --- |
+| `ThreadResolution.Enabled` | Gates general objective-fix reconciliation only; it does not disable the narrow disposition path |
+| `Mode`, `AutoResolve`, `RequireAuditComment` | Govern objective-fix report/reply/resolve behavior only |
+| `RequireNewHeadSinceThread` | Applies to objective code-fix detection only; a changed disposition signal bypasses it |
+| `RequireCurrentReviewRequest` | Applies to general objective reconciliation/full review; an explicit Looper-thread disposition is targeted work intent and may receive the narrow adjudication without a fresh review request |
+| `MaxThreadsPerRun` | Shared batch-size ceiling for classifier work; default remains `10` |
+
+Therefore the defaults remain `Enabled=false`, report-only,
+`RequireNewHeadSinceThread=true`, and `MaxThreadsPerRun=10`. The new path does
+not start scanning or resolving arbitrary stale threads. Its only remote
+mutations are an audited accept/reject reply and, for `accept_wontfix`, resolution
+of that same Looper-authored thread.
+
+### 8.2 Review signal identity
+
+`lastPublishedHeadSha` remains publication/audit metadata, but it is no longer
+the sole discovery identity for a continuous Reviewer loop.
+
+Define:
+
+```text
+threadFeedbackFingerprint = sha256(canonical Looper-authored review threads)
+reviewSignalFingerprint   = sha256(headSha + threadFeedbackFingerprint)
+```
+
+The canonical thread input includes, in stable thread/comment order:
+
+- thread id and `isResolved`;
+- each comment id, author, author association, `createdAt`, `updatedAt`, and a
+  hash of normalized body content;
+- original/current commit ids when available.
+
+Every Reviewer thread-resolution or disposition reply must carry the extended
+`looper:thread-resolution` audit marker. Exclude all such Reviewer audit replies
+from the fingerprint, otherwise accept/reject replies trigger themselves.
+Include the original Looper review comment, trusted human edits/replies, and
+validated Fixer fixed/declined replies. Keep `isResolved` in the input because a
+human resolve/reopen is real state change.
+
+Store only `lastReviewedSignalFingerprint` in existing Reviewer loop metadata;
+do not persist comment bodies or a per-thread ledger. The queue dedupe key stays
+stable at the existing per-loop/PR identity and does **not** include the
+fingerprint. The signal fingerprint travels in queue payload/checkpoint data and
+in remote idempotency/audit markers.
+
+For a single-batch disposition, after Reviewer performs its own reply/resolve
+mutation, it must:
+
+1. refetch the authoritative, fully paginated relevant thread set;
+2. recompute the post-mutation fingerprint, including the new `isResolved`;
+3. persist the checkpoint and promote the post-mutation fingerprint to
+   `lastReviewedSignalFingerprint` in one fail-closed local commit before
+   completing the run.
+
+If the refetch or local persistence fails, do not run the classifier again just
+because Reviewer's own mutation changed the signal. Retry observes the existing
+remote audit marker, completes the missing post-mutation fingerprint commit,
+and remains idempotent.
+
+A webhook caused by Reviewer's own mutation may race that local commit. It may
+coalesce discovery work, but after the commit the Reviewer admission check must
+recognize the already-recorded post-mutation signal and exit before starting an
+agent execution.
+
+When more than `MaxThreadsPerRun` candidates exist, process stable batches. Each
+partial batch stores its refetched post-mutation fingerprint and completed
+thread ids in the active run checkpoint, but does **not** promote it to loop
+`lastReviewedSignalFingerprint`. Requeue a continuation through the same stable
+queue item. Promote only after every candidate from the captured signal is
+adjudicated or has a terminal per-thread outcome and a final full refetch is
+stable. A partial batch must not make the remaining threads invisible.
+
+The active checkpoint is a crash-recovery cursor, not decision authority.
+Current provider thread state plus Looper's remote audit markers remain the
+authority for whether a thread mutation already happened; any freshness drift
+invalidates the cursor before another mutation.
+
+If external feedback arrives between batches, freshness detection invalidates
+the captured set, retains already idempotent remote decisions, and coalesces the
+latest complete signal. It must not promote either the stale captured signal or
+an intermediate post-mutation signal.
+
+### 8.3 Disposition directives
+
+The canonical command is:
+
+```text
+/looper wontfix <reason>
+```
+
+Directive parsing applies only inside Looper-authored review threads. For
+compatibility, a trusted human comment whose entire non-quoted content is
+`wontfix`, `won't fix`, `won’t fix` (Unicode apostrophe), or any of those
+followed by `: <reason>` is equivalent. Do not interpret incidental prose
+containing the word as a command.
+
+`/looper reconsider <reason>` cancels the latest accepted disposition for an
+unresolved/reopened thread. The latest valid trusted-human directive after the
+last Reviewer audit is the input to adjudicate.
+
+### 8.4 Reviewer decisions
+
+Extend thread reconciliation beyond objective code resolution:
+
+| Decision | Required evidence | Remote action |
+| --- | --- | --- |
+| `objectively_fixed` | Requested behavior is verifiably present at current head | Existing audit/resolve policy |
+| `accept_wontfix` | Finding is outside documented PR scope, optional, incorrect, or superseded by trusted intent | Reply with scope evidence and resolve thread |
+| `reject_wontfix` | Finding is required by repository rule/PR intent or is a directly introduced correctness/safety regression | Reply on same thread with concrete authority; keep unresolved |
+| `needs_human` | Authority conflicts, reason is missing, or evidence is ambiguous | Halt pair; ask if HITL is enabled, no-ask manual hold otherwise; no later mutation |
+| `not_fixed` | No disposition applies and requested behavior is still absent | Keep unresolved; Fixer remains eligible |
+
+The classifier prompt must receive PR title/body, relevant linked intent when
+available, repository instructions, current head, and full candidate thread
+history. An author reply like “fixed” remains insufficient objective evidence;
+an explicit trusted `wontfix` is a request for scope adjudication, not automatic
+acceptance.
+
+The existing `looper:thread-resolution` audit identity becomes keyed by
+`threadId + headSha + threadFeedbackFingerprint + decision`. Every remote
+Reviewer adjudication reply (`accept_wontfix`, `reject_wontfix`,
+`objectively_fixed`, or `not_fixed`) carries the extended marker and is excluded
+from the next fingerprint. A `needs_human` outcome writes the same identity to
+the local checkpoint/handoff but posts no remote adjudication reply. A prior
+audit for the same head but older comment fingerprint must not suppress a new
+decision.
+
+The automatic dispute quota is one Reviewer rejection per unchanged adjudicated
+input. If Fixer emits `declined` again after `reject_wontfix`, and the head plus
+canonical human/original-finding feedback are unchanged after excluding Looper
+Fixer-decline and Reviewer-audit coordination replies, force `needs_human`.
+Another Reviewer/Fixer argument is forbidden. A changed head or changed trusted
+human directive creates a new adjudicated input.
+
+### 8.5 Discovery, coalescing, and responsiveness
+
+Correctness must not depend on webhooks:
+
+1. Polling discovery checks thread feedback for active continuous Reviewer
+   loops, even when the code head is unchanged.
+2. GitHub `pull_request_review_comment` create/edit/delete and
+   `pull_request_review_thread` resolve events trigger targeted discovery as an
+   acceleration path; these are documented
+   [GitHub webhook events](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request_review_comment).
+3. A changed review signal queues a thread-disposition pass after the configured
+   **Reviewer** quiet period (default `60s`); it does not use the Fixer quiet
+   period (default `0`) and does not wait for another commit.
+4. The thread-disposition pass does not perform a full code rescan unless the
+   decision itself exposes a code-scope conflict requiring one.
+5. `minPublishIntervalSeconds` applies to a new PR review publication, not to a
+   disposition-only classifier run.
+
+Responsiveness target: absent provider/rate-limit failure, a same-head trusted
+directive should start adjudication within one discovery interval plus the
+configured quiet period. Webhook mode should normally be faster.
+
+Keep exactly one active Reviewer queue item for a PR/lane:
+
+- Keep the existing stable dedupe key
+  `reviewer:{project}:{loop}:{repo}:{pr}`.
+- If the item is queued/retry-wait, update it in place to the latest head/signal
+  and extend its eligibility with
+  `DebounceSchedule(now, reviewerQuietPeriod, existingAvailableAt)`.
+- If the item is running, retain only the latest pending signal. The running
+  pass must freshness-check before mutation; on completion/drift it schedules
+  one continuation for the latest signal.
+- Never create old-signal and new-signal active items side by side. Because the
+  fingerprint represents complete current state, coalescing intermediate
+  signals cannot lose work.
+
+Polling may use PR `updatedAt` and a short-lived thread-list cache as a
+non-authoritative negative-cache hint. An unchanged hint may skip a thread list
+only until the cache TTL; a forced periodic full refresh remains required.
+`updatedAt` never advances `lastReviewedSignalFingerprint` and never proves that
+thread state is unchanged.
+
+Webhook implementation is not a one-case addition:
+
+- route `pull_request_review_comment` to both Reviewer and Fixer lanes instead
+  of the current Fixer-only route;
+- add `pull_request_review_thread` to `routeDelivery` and route `resolved` to
+  both lanes;
+- add the event to every runtime forwarding/subscription list, including
+  `internal/runtime/webhook.go`, `internal/runtime/webhook_forwarder.go`, and
+  the CLI/netadmin hook event lists;
+- update advertised event lists and forwarder contract tests together so a
+  managed hook and an external forwarder subscribe to the same events.
+
+### 8.6 Fixer race and same-head clean outcome
+
+An unresolved thread with a new, unaudited trusted disposition directive or a
+validated Fixer decline is temporarily withheld from further Fixer edits.
+Reviewer has first right to adjudicate it.
+
+- Accepted `wontfix` removes the thread from Fixer input by resolving it.
+- Rejected `wontfix` restores it as actionable without opening a new thread.
+- A Fixer decline follows the same accept/reject path; Fixer never resolves its
+  own scope dispute.
+- `needs_human` parks the pair in both modes: with an ask when HITL is enabled,
+  or with a structured no-ask manual hold when it is disabled.
+- If all blockers disappear without a code-head change, Reviewer may run a
+  same-head convergence pass and publish the configured clean outcome. Review
+  admission is keyed by the new review signal, so head-only idempotency must not
+  suppress it.
+
+Fixer's existing pre-mutation thread snapshot/drift check remains mandatory. If
+a comment changes after Fixer starts, Fixer must make no thread mutation from
+the stale decision and must return to discovery.
+
+### 8.7 Interaction with budget hold
+
+A budget-held pair may run a disposition-only reconciliation in response to a
+new trusted human directive or validated Fixer decline, whether or not HITL is
+enabled. This is allowed because it cannot push code or publish a new PR review
+and can only reduce or clarify the outstanding set.
+
+It does not reset either meter, release the pair, or imply `Continue`. A new
+clean/finding review publication and every Fixer push remain held until an
+explicit Continue. The handoff brief must refresh when disposition state
+changes.
+
+When HITL is disabled, no background disposition run may revive the pair. A
+trusted human edit can resolve a scope dispute and update the handoff, but
+continuing counted automation still requires `looper unpause` on the held pair.
+Polling, webhooks, daemon restart, and enabling HITL are never interpreted as an
+implicit Continue.
+
+## 9. Independent budgets with a paired circuit breaker
+
+### 9.1 Configuration and counting
+
+| Path | Unit | New default |
+| --- | --- | --- |
+| `roles.reviewer.behavior.loop.maxPublishesPerPR` | Successful native/top-level review publications | `3` |
+| `roles.fixer.behavior.loop.maxPushesPerPR` | Successful head-changing Fixer pushes | `3` |
+
+These are independent meters because the work units and risk differ. A project
+may configure Reviewer `2` / Fixer `5`, Reviewer `5` / Fixer `2`, or disable one
+cap with `0`.
+
+Do not introduce a “round” counter. Reviewer and Fixer are asynchronous: a
+review may produce no Fixer push, one push may address many reviews, and a human
+thread disposition may change convergence without a commit. “Round” has no
+stable authority.
+
+Thread-disposition audit replies are not Reviewer review publications. Failed
+agent executions, rejected outbound payloads, no-op Fixer runs, and failed
+pushes do not consume these meters; their existing retry/terminal policies still
+apply.
+
+### 9.2 Which loops participate
+
+Budget participation is based on continuity, not only `manual`:
+
+```text
+participates = automatic || followUpdates == true
+```
+
+- Automatic Reviewer/Fixer loops participate.
+- `looper takeover` loops (`manual=true`, `followUpdates=true`) participate.
+- One-shot manual loops (`manual=true`, `followUpdates=false`) remain exempt.
+
+Pair only loops in the same derived lane:
+
+- `automatic`
+- `continuous_manual`
+
+Do not cross-pair a takeover loop with an automatic loop. Preserve the invariant
+of at most one non-terminal loop per role per PR/lane; discovery coalesces
+duplicates. No persisted pair id is added unless implementation evidence proves
+that invariant cannot be maintained.
+
+### 9.3 Exhaustion
+
+Before any counted mutation and after every successful counted mutation, read
+live caps and current counters. Product terminal states (closed/merged PR,
+accepted clean outcome, explicit stop) win over opening a budget ask.
+
+Budget admission does not check `HITL.Enabled`; caps are always enforced. When
+either role is at its live cap and more counted work is required:
+
+1. Cancel pending queue entries for both roles in the lane.
+2. Persist counters/reason and append the handoff event described below.
+3. Emit an event and action-required notification.
+4. Do not allow discovery or daemon restart to revive either side.
+
+The hold presentation depends only on whether HITL answer delivery is enabled:
+
+| `HITL.Enabled` | Exhausted role | Sibling | Resume path |
+| --- | --- | --- | --- |
+| `true` | `awaiting_human` with one Continue/Stop budget ask | budget-paused | Answer the existing ask |
+| `false` | `paused`, reason `review_fix_budget_exhausted`, no ask | paired budget-paused | `looper unpause <either-seq>` for Continue or `looper stop <either-seq>` for Stop |
+
+Do not use `human_takeover` for the HITL-disabled case. That status means a real
+interactive agent session is pinned and can be handed back; a budget hold has
+no such session. Do not use `terminated` for the initial no-HITL handoff
+either: it is irreversible and would force the operator to reconstruct the
+continuous lane even though the existing paired pause is sufficient.
+
+### 9.4 Continue and Stop
+
+`Continue` is a role-specific refill with pair-wide release. It comes from the
+HITL answer when enabled; when disabled, `looper unpause` on either member of a
+budget-held pair must delegate to the same budget Continue operation instead of
+the generic single-loop resume:
+
+- Reset every meter that is currently at/over its live cap.
+- Preserve a sibling meter that still has unused budget.
+- Clear the budget ask and pair pause only after all required resets succeed.
+- Requeue both eligible sides against current PR/thread state.
+
+This avoids wasting unused Fixer budget when Reviewer alone exhausts, while also
+avoiding an immediate second HITL when both meters are already exhausted.
+
+`Stop` terminates both roles in the lane and cancels their queue work. It does
+not resolve threads, approve, merge, or delete worktrees outside existing
+terminal cleanup policy. For a no-HITL budget hold, `looper stop` on either role
+must delegate to the paired Stop operation.
+
+For a no-HITL `review_scope_human_required` hold, the handoff names the
+repository/PR/thread authority evidence that must be clarified. `looper
+unpause` resumes the pair against current evidence without resetting a meter
+unless one is also exhausted. If the authority input is unchanged, admission
+returns to the same manual hold without a counted mutation.
+
+Pair transitions must be idempotent and fail closed. A partial storage/queue
+failure must leave both roles non-runnable until reconciliation completes. Do
+not unpause a sibling before the exhausted counters and pair transition are in
+a safe state. In HITL-disabled mode, a partial paired hold likewise cannot leave
+one role runnable.
+
+### 9.5 Handoff brief
+
+The budget ask (when enabled), event/notification, and CLI/dashboard detail must
+show:
+
+- PR, lane, current head, and last reviewed signal;
+- Reviewer publications: `count / live cap`;
+- Fixer pushes: `count / live cap`;
+- which role(s) are exhausted;
+- unresolved `must_fix` thread links/titles;
+- pending `wontfix`/decline decisions and their latest trusted reason;
+- late-discovery blockers;
+- last Reviewer/Fixer outcome and whether progress decreased the outstanding
+  set;
+- exact semantics: Continue refills exhausted meter(s); Stop terminates both.
+
+When HITL is enabled, the only required ask choices remain `Continue` and
+`Stop`. When HITL is disabled, the handoff has no answer widget; it shows the
+exact `looper unpause` and `looper stop` commands instead. Better evidence is
+more valuable than another configurable answer matrix.
+
+Do not add a persisted handoff record. The action-required event payload
+captures the decision-time snapshot; loop metadata remains authority for
+counters/reason; CLI/dashboard may refresh thread links and PR state from the
+provider. This keeps historical evidence without another state copy to
+reconcile.
+
+## 10. Module design
+
+### 10.1 Reviewer convergence Module
+
+Deepen the existing Reviewer Module instead of adding a workflow layer.
+
+- **Interface:** phase-specific review instructions, structured finding
+  validation, review-signal calculation, and thread-disposition decisions.
+- **Implementation:** full-pass accumulator, repair frontier, scope evidence,
+  same-head signal discovery, and audit idempotency stay local to Reviewer.
+- **Seam:** trusted review-submit accepts only validated actionable
+  findings.
+- **Adapter:** existing GitHub/Forgejo publishers map accepted fields to provider
+  payloads; no new provider interface is justified.
+- **Depth:** callers see one review signal and one disposition result, while the
+  Module hides prompt, fingerprint, frontier, and provider-publication details.
+- **Leverage:** the same finding rules serve native review and comment-only
+  modes; the same signal drives polling and webhook-targeted discovery.
+- **Locality:** scope and convergence changes should not require edits across
+  Reviewer, Fixer, scheduler, and every provider Adapter.
+
+The deletion test is positive: delete head-only discovery authority, numeric
+comment batching language, and direct publication of unclassified findings.
+
+### 10.2 Review-fix budget Module
+
+Deepen `internal/loops/review_fix_budget.go`.
+
+- **Interface:** check admission, halt a lane, apply Continue/Stop when
+  available, and build the handoff brief.
+- **Implementation:** lane matching, independent meter reads/resets, queue
+  cancellation, HITL ask vs no-ask paired pause, pair status
+  transitions, handoff evidence, and idempotent recovery live together.
+- Reviewer and Fixer runners report successful counted mutations; they do not
+  implement their own sibling/pause/reset ordering.
+
+Do not add a Go interface with one implementation. Exported functions on the
+existing Module are sufficient until a second implementation exists.
+
+## 11. New-concept trade-offs
+
+### 11.1 Structured finding disposition
+
+**Failure prevented:** Reviewer publishes a plausible but independent
+improvement; Fixer treats the remote thread as mandatory; both roles spend
+rounds arguing about work the PR never promised.
+
+**Cost:** new transient result fields, validator branches, prompt fixtures, and
+provider payload stripping must remain compatible across native and
+comment-only publication. The model may still provide bad evidence, so Fixer
+must retain its independent check.
+
+**Why simpler alternatives are insufficient:** prompt-only wording is already
+present and is not an enforceable outbound Seam. Inferring scope from diff
+or GitHub state would make infrastructure pretend to be product authority.
+Structured agent output plus explicit documented evidence is the smaller path.
+
+### 11.2 Review-signal fingerprint
+
+**Failure prevented:** a human edits/replies `wontfix` or Fixer posts a decline
+on an unchanged head; Reviewer keeps skipping by head SHA; unresolved state and
+the review-fix loop never converge.
+
+**Cost:** polling active thread lists consumes provider quota; canonicalization
+must handle edits, deletes, pagination, bot/audit exclusions, Reviewer
+self-mutations, partial `MaxThreadsPerRun` batches, and provider timestamp
+quirks; one new loop-metadata field plus queue payload/coalescing state must
+remain consistent across restart and webhook/poll races. Existing active-run
+checkpoint storage also carries a partial batch's completed thread ids and
+post-mutation fingerprint until final promotion; this is another retry path to
+test, but not a new per-thread history ledger.
+
+**Why simpler alternatives are insufficient:** head SHA cannot represent thread
+state. PR `updatedAt` is too broad and is not a reliable per-thread authority.
+Webhook-only detection loses events during daemon/network downtime. Persisting a
+full thread ledger would add much more state and recovery surface than one
+content fingerprint. A bounded cache and PR `updatedAt` are useful negative
+cache hints, but a periodic full refresh is still required.
+
+### 11.3 Always-on narrow disposition path
+
+**Failure prevented:** the same-head protocol is implemented inside the
+existing ThreadResolution feature, which remains disabled by default, so the
+documented convergence behavior never runs for default users.
+
+**Cost:** continuous GitHub Reviewer loops gain a narrow default thread query,
+classifier, reply, and accepted-disposition resolve path. It must coexist with
+legacy ThreadResolution modes without making arbitrary stale threads eligible.
+
+**Why simpler alternatives are insufficient:** enabling all ThreadResolution by
+default would broaden behavior far beyond `wontfix`/decline convergence and
+would change report/resolve policy for existing users. Leaving the new behavior
+behind `Enabled=false` makes §2 false. A capability-checked, Looper-authored,
+changed-disposition-only path is the smaller Interface.
+
+### 11.4 Fixer-decline handshake
+
+**Failure prevented:** Fixer decides a Reviewer request is out of scope, then
+uses its own structured output as authority to resolve and suppress the thread.
+Reviewer cannot accept or reject that scope dispute, and the PR can become
+stuck or falsely clean.
+
+**Cost:** a declined thread stays unresolved for one additional adjudication
+pass; Fixer suppression must distinguish pending, accepted, and rejected audit
+evidence; retry tests must cover a crash between reply and Reviewer action.
+
+**Why simpler alternatives are insufficient:** allowing Fixer to reply and
+resolve is fast but assigns authority to the party disputing the request.
+Leaving the thread unresolved forever just moves the deadlock. Reusing the
+existing decline reply and thread-resolution audit markers creates a two-phase
+handshake without a new persisted status field or table.
+
+### 11.5 Paired circuit breaker over independent meters
+
+**Failure prevented:** one role exhausts but the sibling continues publishing or
+pushing, or two nearly simultaneous exhaustions produce contradictory HITL
+asks.
+
+**Cost:** pair-wide queue/status transitions and partial-failure recovery are
+cross-loop lifecycle behavior and require integration coverage. Default
+HITL-disabled users now enter a paired manual hold at a finite cap instead of
+silently ignoring it, so migration, pair-aware `unpause`/`stop`, and
+action-required observability are product-visible.
+
+**Why simpler alternatives are insufficient:** fully independent pauses permit
+the other role to mutate stale state. One shared counter loses the flexible
+Reviewer/Fixer risk budgets requested by operators. Keeping enforcement behind
+HITL would preserve compatibility by making the default cap fictional. A
+notification without halting would still allow unbounded mutation. Independent
+meters with one paired halt keep flexibility and the finite guarantee.
+Terminating a no-HITL pair would discard an otherwise resumable lane; a generic
+single-loop unpause would either trip the same exhausted cap immediately or
+revive only one side. Reusing the paired budget pause and routing unpause/stop
+through the existing budget Module avoids both failures. No epoch id or ledger
+is needed; existing counters plus event history are sufficient.
+
+## 12. Failure modes and required behavior
+
+| Failure | Required behavior |
+| --- | --- |
+| Reviewer omits disposition/scope evidence | Trusted Seam rejects before remote publication; retry same signal |
+| Comment changes while Reviewer/Fixer runs | Freshness check detects fingerprint drift; no stale reply/resolve; rediscover |
+| Same-head directive arrives after prior audit | New fingerprint invalidates old audit and queues adjudication |
+| Reviewer reply/resolve changes its own thread | Refetch and commit post-mutation fingerprint; do not spend another classifier run |
+| More than `MaxThreadsPerRun` candidates | Continue stable batches; do not advance stored signal until all captured candidates terminate |
+| Several signals arrive while one item is queued/running | Coalesce latest signal into the one stable-dedupe work item; never run stale items side by side |
+| Untrusted user/bot says `wontfix` | Treat as context, not authority; do not auto-resolve |
+| Trusted `wontfix` conflicts with repository safety rule | `reject_wontfix` or `needs_human`; never silently accept |
+| Fixer emits `declined` | Reply with evidence, leave unresolved, and queue Reviewer adjudication |
+| Fixer declines again after one unchanged-input rejection | Force `needs_human`; no third automatic argument |
+| Thread is manually resolved before mutation | Treat as idempotent success; do not recreate it |
+| Thread is reopened or accepted directive edited/deleted | Fingerprint changes; adjudicate current state |
+| Provider thread listing is partial/rate-limited | Fail retryably; do not advance stored review signal |
+| Budget config lowers below current count | Halt on next admission check: ask-backed park with HITL, no-ask paired pause without it |
+| HITL-disabled budget exhausts | Pause pair, persist handoff/event, notify, and require pair-aware unpause/stop; never continue silently |
+| HITL-disabled `needs_human` occurs | Pause pair with unresolved evidence; never discard the finding or auto-resume |
+| Handoff notification delivery fails | Pair remains non-runnable; CLI/dashboard/event evidence remains retryable/visible |
+| Continue partially fails | Keep pair non-runnable and original ask retryable |
+| Generic `looper unpause` targets a budget-held role | Delegate to paired Continue; never resume only one role or preserve an exhausted counter |
+| Daemon restarts after a halt | Discovery cannot revive either held side; ask/handoff remains authoritative |
+| No sibling exists | Halt the existing role idempotently using the configured HITL mode; do not invent a phantom loop |
+| `ThreadResolution.Enabled=false` | Narrow changed-disposition path still runs; objective stale-thread reconciliation remains off |
+| Provider lacks native thread capabilities | Enforce budgets but do not claim same-head disposition convergence |
+| Legacy Looper comment has no new disposition fields | Fixer applies existing scope classification; no comment is lost |
+
+## 13. Migration and compatibility
+
+1. Existing explicit numeric cap values are preserved. Their enforcement is no
+   longer conditional on HITL, which is an intentional behavior change for
+   HITL-disabled installations.
+2. The normalized defaults change from `8/8` to `3/3`. A running loop already
+   over the live cap halts on its next admission check: `awaiting_human`/paused
+   with HITL enabled, or a no-ask paired pause with HITL disabled. Neither path
+   approves, resolves, or merges.
+3. Existing Reviewer `iterationCount` and Fixer
+   `reviewFixBudget.pushCount` remain the meter storage.
+4. `HITL.Enabled` remains `false` by default. The change does not silently turn
+   on GitHub/Feishu asks; it adds an action-required event/notification/dashboard
+   handoff and pair-aware `looper unpause`/`looper stop` path when no answer
+   transport is enabled.
+5. Continue resets only exhausted meters. A no-HITL budget `unpause` delegates
+   to this same operation. Existing event history remains the audit trail; no
+   epoch history is added.
+6. Existing automatic loops retain pairing. Continuous manual/takeover loops
+   become budget participants based on `followUpdates=true`.
+7. Existing ThreadResolution defaults remain unchanged. `Enabled`, mode,
+   auto-resolve, new-head, current-review-request, and max-thread settings keep
+   governing objective reconciliation as defined in §8.1. Only the narrow
+   Looper-authored changed-disposition path becomes default behavior on capable
+   providers.
+8. `lastReviewedSignalFingerprint` is absent on upgrade. For a same-head loop:
+   if it has unresolved Looper-authored threads, run one bounded reconciliation
+   pass; otherwise store the baseline without publishing a new review.
+   Upgrade backfill must use the normal stable-dedupe queue, Reviewer quiet
+   period, scheduler concurrency limit, and discovery limits; it must not launch
+   all legacy PR reconciliations outside normal admission.
+9. The Reviewer queue dedupe key remains unchanged. New signal data is added to
+   payload/checkpoint/coalescing state, so no old/new fingerprint queue pair can
+   coexist.
+10. Managed webhook reconciliation adds `pull_request_review_thread` to existing
+    GitHub hooks and advertised forwarder event lists; review-comment events are
+    re-routed to Reviewer as well as Fixer. Polling remains the correctness
+    fallback during rollout.
+11. `lastPublishedHeadSha` remains for provider publication history and backwards
+   compatibility but no longer suppresses a changed thread signal.
+12. Existing `looper:thread-resolution` markers without a feedback fingerprint
+   are valid historical audits only; they do not suppress newer comment state.
+13. Legacy Fixer declines that are already remotely resolved remain resolved;
+   migration does not reopen historical threads. New declines use the Reviewer
+   handshake.
+14. Forgejo keeps its existing ThreadResolution/provider limitations and is
+    explicitly exempt from same-head disposition convergence; its Reviewer and
+    Fixer budgets are still enforced independently of HITL.
+15. Unmarked third-party review comments retain current Fixer behavior and scope
+   checks.
+
+## 14. Verification
+
+Minimum credible evidence:
+
+| Level | Required case |
+| --- | --- |
+| Unit | Finding disposition/schema validation and provider-field stripping |
+| Unit | Same-root grouping does not merge independent findings |
+| Unit | Initial vs changed-head vs same-head-thread prompt/frontier selection |
+| Unit | Review-signal canonicalization: edit, reply, delete, resolve, reopen, audit exclusion |
+| Unit | Reviewer post-mutation refetch commits the new signal; self-webhook starts no agent |
+| Unit | Trusted directive parser, aliases, incidental-word rejection, and author authority |
+| Unit | Directive parser is limited to Looper-authored threads and accepts ASCII/Unicode apostrophes |
+| Unit | Thread decision matrix for fixed/accept/reject/needs-human/not-fixed |
+| Unit | ThreadResolution gate matrix: legacy disabled/report-only/new-head settings do not disable narrow disposition |
+| Unit | `MaxThreadsPerRun+1` candidates require continuation and do not advance the signal early |
+| Unit | Independent cap matrix, `0`, live cap changes, and “reset exhausted only” |
+| Unit | HITL-disabled cap/needs-human produces a no-ask paired hold; HITL-enabled produces a resumable ask |
+| Unit | No-HITL scope hold with unchanged evidence re-holds without consuming a meter |
+| Unit | Stable queue dedupe coalesces queued/retry-wait signals with Reviewer debounce |
+| Integration | First pass publishes all independent in-scope findings in one review |
+| Integration | `follow_up` never becomes a remote thread or Fixer item by default |
+| Integration | Fixer decline triggers same-head Reviewer adjudication and no duplicate thread |
+| Integration | Fixer decline reply does not resolve; accept resolves; reject re-enables the existing Fixer item |
+| Integration | Edited `wontfix` comment queues within one polling cycle on unchanged head |
+| Integration | Accepted `wontfix` resolves, rejected remains actionable, ambiguous halts pair according to HITL mode |
+| Integration | Same-head accepted disposition can lead to a clean convergence review |
+| Integration | Comment drift between classification and mutation performs no stale mutation |
+| Integration | Running old signal plus two new signals yields one latest-signal continuation, not parallel/back-to-back stale work |
+| Integration | Second unchanged-input Fixer decline after Reviewer reject goes directly to `needs_human` |
+| Integration | HITL-off default enforces `3/3`, pauses pair, preserves handoff, and cannot be rediscovered |
+| Lifecycle integration | Reviewer cap halts Fixer; Fixer cap halts Reviewer; ask/no-ask hold follows HITL mode and restart cannot revive pair |
+| Lifecycle integration | Continue refills only exhausted meter(s) and releases pair fail-closed |
+| Lifecycle integration | No-HITL `looper unpause` delegates to paired Continue; `looper stop` delegates to paired Stop |
+| Lifecycle integration | `manual=true,followUpdates=true` participates; one-shot manual remains exempt |
+| Lifecycle integration | Upgrade baseline reconciliation respects queue dedupe, Reviewer quiet period, scheduler concurrency, and discovery limits |
+| GitHub contract | Review-comment create/edit/delete routes Reviewer+Fixer; thread resolved routes both; polling remains fallback |
+| GitHub contract | Runtime, forwarder, CLI, and netadmin managed-hook event lists remain identical |
+| GitHub contract | Paginated thread timestamps/body hashes and audit markers preserve idempotency |
+| GitHub contract | `updatedAt` negative cache expires into forced full refresh and never advances authority state |
+| Provider contract | Forgejo enforces role budgets but advertises no same-head disposition guarantee |
+
+Because this changes cross-Module lifecycle, GitHub command, worktree review,
+and resolve-comments behavior, unit-only coverage is insufficient. Prefer the
+existing fake-`gh` contract and invariant integration harness. Escalate to real
+GitHub sandbox E2E only if implementation changes auth, scopes, provider thread
+mutation shape, or rate-limit behavior; adding transient Looper fields that are
+stripped before the existing provider call does not by itself require sandbox
+E2E.
+
+Repository verification for implementation PRs:
+
+```sh
+gofmt -l .
+go vet ./...
+go test ./...
+go build ./...
+```
+
+## 15. Ship slices
+
+1. **Budget semantics:** HITL-independent enforcement, default `3/3`,
+   continuous-manual participation, ask/no-ask paired holds, independent
+   refill, and lifecycle integration tests.
+2. **Reviewer finding contract:** scope authority, dispositions, complete first
+   pass, trusted outbound validation, prompt/contract tests.
+3. **Repair frontier:** changed-head delta rules, late-discovery handling, and
+   duplicate decline protection.
+4. **Thread signal:** narrow feature gate, fingerprint, stable queue coalescing,
+   same-head polling/webhook trigger, extended decisions, post-mutation signal
+   commit, and stale-mutation guard tests.
+5. **Docs/observability:** configuration guide, user guide, dashboard/CLI handoff
+   detail, metrics/events for disposition and budget outcomes.
+
+Each slice must leave existing authority and lifecycle invariants intact. Do not
+merge a prompt-only partial that publishes new disposition words without the
+trusted outbound gate, or a thread fingerprint that can enqueue but cannot
+dedupe across restart.
+
+## 16. Done bar
+
+- [ ] Reviewer and Fixer retain separately configurable caps and counters
+- [ ] Defaults are `3` Reviewer publications and `3` Fixer pushes
+- [ ] Caps enforce with HITL on or off; default HITL-off produces a no-ask paired hold
+- [ ] HITL-on exhaustion parks the pair; Continue refills exhausted meters only
+- [ ] HITL-off budget hold resumes only through pair-aware unpause; stop terminates both
+- [ ] HITL-off `needs_human` pauses with evidence instead of dropping the finding
+- [ ] Takeover continuous loops participate; one-shot manual loops do not
+- [ ] First Reviewer pass reports every independent in-scope finding observed
+- [ ] Later passes use repair/thread frontiers instead of full old-diff rescans
+- [ ] Out-of-scope follow-ups do not become remote actionable comments by default
+- [ ] Fixer still independently verifies scope and may decline/ask for human
+- [ ] Fixer cannot resolve its own decline; Reviewer adjudicates the existing thread
+- [ ] Same-head thread edits/replies change Reviewer discovery identity
+- [ ] Legacy ThreadResolution defaults remain unchanged; narrow disposition works anyway
+- [ ] Reviewer adjudication replies cannot self-trigger another agent execution
+- [ ] More than ten changed threads complete in bounded batches without signal loss
+- [ ] Stable queue dedupe coalesces latest signal; fingerprint is not part of the key
+- [ ] Trusted `wontfix` is accepted, rejected, or escalated with evidence
+- [ ] One unchanged-input reject/decline recurrence forces `needs_human`
+- [ ] Fixer cannot race an unaudited disposition or mutate a stale thread
+- [ ] Accepted same-head dispositions can reach a clean review without a new commit
+- [ ] Budget exhaustion never implies approve/resolve/merge
+- [ ] No new SQL table, epoch id, pair id, or finding ledger is introduced
+- [ ] Forgejo budget guarantee and same-head disposition exemption are explicit
+- [ ] Contract/invariant integration coverage passes with Go CI commands
+
+## 17. Open implementation choices (not product locks)
+
+- Exact metadata key spelling for `lastReviewedSignalFingerprint`
+- Whether polling computes the aggregate hash directly or through a small cache
+- Exact event names and dashboard presentation of the handoff brief
+- Whether `/looper reconsider` ships in the same PR as `wontfix` or immediately
+  after, provided edit/delete/reopen still invalidates prior audit
+- Exact default quiet-period interaction for webhook-triggered thread changes,
+  provided the responsiveness target and burst dedupe hold

--- a/web/dashboard/src/lib/reviewFixHandoff.test.ts
+++ b/web/dashboard/src/lib/reviewFixHandoff.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  readReviewFixHandoff,
+  reviewFixHandoffTitle,
+} from "@/lib/reviewFixHandoff";
+
+describe("readReviewFixHandoff", () => {
+  it("builds a no-HITL budget brief with exact resume commands", () => {
+    const handoff = readReviewFixHandoff({
+      seq: 12,
+      status: "paused",
+      type: "reviewer",
+      metadataJson: JSON.stringify({
+        pauseReason: "review_fix_budget_exhausted",
+        lastPublishedHeadSha: "abc123",
+        lastReviewedSignalFingerprint: "sig-abc",
+        loop: { iterationCount: 3 },
+        reviewFixBudget: {
+          exhaustedBy: "reviewer",
+          pauseReason: "review_fix_budget_exhausted",
+        },
+      }),
+    });
+    expect(handoff).toMatchObject({
+      kind: "review_fix_budget",
+      hitlEnabled: false,
+      unpauseCommand: "looper unpause 12",
+      stopCommand: "looper stop 12",
+      resume: "looper unpause 12 / looper stop 12",
+      nextAction: "looper unpause 12 / looper stop 12",
+      head: "abc123",
+      lastReviewedSignalFingerprint: "sig-abc",
+      reviewerCount: 3,
+      exhaustedBy: "reviewer",
+    });
+    expect(reviewFixHandoffTitle(handoff!)).toBe("Review-fix budget exhausted");
+  });
+
+  it("keeps HITL budget asks on Continue/Stop without implying approval", () => {
+    const handoff = readReviewFixHandoff({
+      seq: 4,
+      status: "awaiting_human",
+      metadataJson: JSON.stringify({
+        hitl: {
+          kind: "review_fix_budget",
+          status: "awaiting",
+          question: "reviewer hit its review-fix budget on acme/looper#42 (3/3).",
+        },
+        loop: { iterationCount: 3 },
+      }),
+    });
+    expect(handoff?.hitlEnabled).toBe(true);
+    expect(handoff?.nextAction).toContain("Continue / Stop");
+    expect(handoff?.nextAction).toContain("looper unpause 4");
+    expect(handoff?.question).toContain("review-fix budget");
+  });
+
+  it("surfaces a no-HITL scope hold with evidence", () => {
+    const handoff = readReviewFixHandoff({
+      seq: 9,
+      status: "paused",
+      metadataJson: JSON.stringify({
+        pauseReason: "review_scope_human_required",
+        reviewScopeHuman: {
+          question: "Clarify AGENTS.md vs PR non-goals before unpause.",
+          evidence: "thread PRRT_1 conflicts with stated non-goal",
+          pauseReason: "review_scope_human_required",
+        },
+      }),
+    });
+    expect(handoff).toMatchObject({
+      kind: "review_scope_human",
+      hitlEnabled: false,
+      question: "Clarify AGENTS.md vs PR non-goals before unpause.",
+      evidence: "thread PRRT_1 conflicts with stated non-goal",
+      resume: "looper unpause 9 / looper stop 9",
+    });
+    expect(reviewFixHandoffTitle(handoff!)).toBe(
+      "Human scope decision required",
+    );
+  });
+
+  it("ignores ordinary paused loops", () => {
+    expect(
+      readReviewFixHandoff({
+        seq: 1,
+        status: "paused",
+        metadataJson: JSON.stringify({ pauseReason: "manual" }),
+      }),
+    ).toBeNull();
+  });
+});

--- a/web/dashboard/src/lib/reviewFixHandoff.ts
+++ b/web/dashboard/src/lib/reviewFixHandoff.ts
@@ -1,0 +1,152 @@
+export type ReviewFixHandoffKind =
+  | "review_fix_budget"
+  | "review_scope_human";
+
+export type ReviewFixHandoff = {
+  kind: ReviewFixHandoffKind;
+  hitlEnabled: boolean;
+  resume: string;
+  nextAction: string;
+  unpauseCommand: string;
+  stopCommand: string;
+  head?: string;
+  lastReviewedSignalFingerprint?: string;
+  reviewerCount?: number;
+  fixerCount?: number;
+  exhaustedBy?: string;
+  question?: string;
+  evidence?: string;
+  pauseReason?: string;
+};
+
+type LoopLike = {
+  seq: number;
+  status?: string | null;
+  type?: string | null;
+  metadataJson?: string | null;
+};
+
+type hitlAsk = {
+  kind?: string;
+  question?: string;
+  status?: string;
+};
+
+type loopMetadata = {
+  hitl?: hitlAsk;
+  pauseReason?: string;
+  lastPublishedHeadSha?: string;
+  lastFixHeadSha?: string;
+  lastReviewedSignalFingerprint?: string;
+  loop?: { iterationCount?: number };
+  reviewFixBudget?: {
+    pushCount?: number;
+    exhaustedBy?: string;
+    pauseReason?: string;
+  };
+  reviewScopeHuman?: {
+    question?: string;
+    evidence?: string;
+    pauseReason?: string;
+  };
+};
+const BUDGET_REASONS: Record<string, true> = {
+  review_fix_budget_exhausted: true,
+  sibling_review_fix_budget: true,
+};
+const SCOPE_REASONS: Record<string, true> = {
+  review_scope_human_required: true,
+  sibling_review_scope_human: true,
+};
+
+function parseMetadata(raw?: string | null): loopMetadata {
+  if (!raw?.trim()) return {};
+  try {
+    return JSON.parse(raw) as loopMetadata;
+  } catch {
+    return {};
+  }
+}
+
+function awaitingAsk(ask: hitlAsk | undefined, kind: ReviewFixHandoffKind): boolean {
+  return (
+    (ask?.kind ?? "").trim() === kind &&
+    (ask?.status ?? "").trim().toLowerCase() === "awaiting"
+  );
+}
+
+export function readReviewFixHandoff(loop: LoopLike): ReviewFixHandoff | null {
+  const meta = parseMetadata(loop.metadataJson);
+  const status = (loop.status ?? "").trim().toLowerCase();
+  const pauseReason = (meta.pauseReason ?? "").trim();
+  const budgetAsk = awaitingAsk(meta.hitl, "review_fix_budget");
+  const scopeAsk = awaitingAsk(meta.hitl, "review_scope_human");
+  const budgetPaused =
+    status === "paused" &&
+    (BUDGET_REASONS[pauseReason] === true ||
+      BUDGET_REASONS[(meta.reviewFixBudget?.pauseReason ?? "").trim()] === true);
+  const scopePaused =
+    status === "paused" &&
+    (SCOPE_REASONS[pauseReason] === true ||
+      SCOPE_REASONS[(meta.reviewScopeHuman?.pauseReason ?? "").trim()] === true);
+
+  const isBudget = budgetAsk || budgetPaused;
+  const isScope = !isBudget && (scopeAsk || scopePaused);
+  if (!isBudget && !isScope) return null;
+
+  const kind: ReviewFixHandoffKind = isBudget
+    ? "review_fix_budget"
+    : "review_scope_human";
+  const hitlEnabled = kind === "review_fix_budget" ? budgetAsk : scopeAsk;
+  const selector = String(loop.seq);
+  const unpauseCommand = `looper unpause ${selector}`;
+  const stopCommand = `looper stop ${selector}`;
+  const resume = `${unpauseCommand} / ${stopCommand}`;
+  const nextAction = hitlEnabled
+    ? `Continue / Stop; ${resume}`
+    : resume;
+  const head =
+    (meta.lastPublishedHeadSha ?? "").trim() ||
+    (meta.lastFixHeadSha ?? "").trim() ||
+    undefined;
+  const question =
+    (meta.hitl?.question ?? "").trim() ||
+    (meta.reviewScopeHuman?.question ?? "").trim() ||
+    undefined;
+  const evidence = (meta.reviewScopeHuman?.evidence ?? "").trim() || undefined;
+
+  return {
+    kind,
+    hitlEnabled,
+    resume,
+    nextAction,
+    unpauseCommand,
+    stopCommand,
+    head,
+    lastReviewedSignalFingerprint:
+      (meta.lastReviewedSignalFingerprint ?? "").trim() || undefined,
+    reviewerCount:
+      typeof meta.loop?.iterationCount === "number"
+        ? meta.loop.iterationCount
+        : undefined,
+    fixerCount:
+      typeof meta.reviewFixBudget?.pushCount === "number"
+        ? meta.reviewFixBudget.pushCount
+        : undefined,
+    exhaustedBy: (meta.reviewFixBudget?.exhaustedBy ?? "").trim() || undefined,
+    question,
+    evidence,
+    pauseReason:
+      pauseReason ||
+      (meta.reviewFixBudget?.pauseReason ?? "").trim() ||
+      (meta.reviewScopeHuman?.pauseReason ?? "").trim() ||
+      undefined,
+  };
+}
+
+export function reviewFixHandoffTitle(handoff: ReviewFixHandoff): string {
+  if (handoff.kind === "review_scope_human") {
+    return "Human scope decision required";
+  }
+  return "Review-fix budget exhausted";
+}

--- a/web/dashboard/src/pages/LoopDetail.tsx
+++ b/web/dashboard/src/pages/LoopDetail.tsx
@@ -15,6 +15,7 @@ import { RecoveryCard } from "@/components/RecoveryCard";
 import { StatusChip } from "@/components/StatusChip";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { CopyButton } from "@/components/CopyButton";
 import {
   fetchLoop,
   openLoopLogsStream,
@@ -45,6 +46,10 @@ import {
 } from "@/lib/logsStream";
 import { consumeSSE } from "@/lib/sse";
 import { usePolling } from "@/lib/usePolling";
+import {
+  readReviewFixHandoff,
+  reviewFixHandoffTitle,
+} from "@/lib/reviewFixHandoff";
 
 function seedFromSnapshot(snap: LoopLogsSnapshot): string {
   const agent = snap.agent;
@@ -260,6 +265,68 @@ function HITLDecisionCard({
         </Button>
       </form>
       {error ? <p className="mb-0 text-[12px] text-red-500">{error}</p> : null}
+    </Card>
+  );
+}
+
+function ReviewFixHandoffCard({ loop }: { loop: Loop }) {
+  const handoff = readReviewFixHandoff(loop);
+  if (!handoff) return null;
+  return (
+    <Card title={reviewFixHandoffTitle(handoff)}>
+      <p className="mt-0 text-[13px]">
+        This hold does not approve, resolve, or merge the PR. Continue or
+        Unpause resumes the pair against current evidence
+        {handoff.kind === "review_fix_budget"
+          ? " and refills only exhausted meters"
+          : ""}
+        . Stop terminates both roles.
+      </p>
+      {handoff.question ? (
+        <p className="whitespace-pre-wrap text-[13px]">{handoff.question}</p>
+      ) : null}
+      {handoff.evidence ? (
+        <p className="whitespace-pre-wrap text-[12px] text-[var(--text-muted)]">
+          {handoff.evidence}
+        </p>
+      ) : null}
+      <dl className="m-0 columns-1 gap-x-6 md:columns-2">
+        {handoff.reviewerCount != null ? (
+          <Kv label="Reviewer publications" value={String(handoff.reviewerCount)} />
+        ) : null}
+        {handoff.fixerCount != null ? (
+          <Kv label="Fixer pushes" value={String(handoff.fixerCount)} />
+        ) : null}
+        {handoff.exhaustedBy ? (
+          <Kv label="Exhausted by" value={handoff.exhaustedBy} />
+        ) : null}
+        {handoff.head ? <Kv label="Head" value={handoff.head} /> : null}
+        {handoff.lastReviewedSignalFingerprint ? (
+          <Kv
+            label="Last reviewed signal"
+            value={handoff.lastReviewedSignalFingerprint}
+          />
+        ) : null}
+      </dl>
+      {handoff.hitlEnabled ? (
+        <p className="mb-0 text-[12px] text-[var(--text-muted)]">
+          Answer Continue or Stop on the existing ask. Same pair commands:
+        </p>
+      ) : (
+        <p className="mb-0 text-[12px] text-[var(--text-muted)]">
+          No answer widget. Use these commands:
+        </p>
+      )}
+      <div className="mt-2 flex flex-wrap gap-2">
+        <code className="mono rounded border border-[var(--border)] px-2 py-1 text-[12px]">
+          {handoff.unpauseCommand}
+        </code>
+        <CopyButton text={handoff.unpauseCommand} label="Copy unpause" />
+        <code className="mono rounded border border-[var(--border)] px-2 py-1 text-[12px]">
+          {handoff.stopCommand}
+        </code>
+        <CopyButton text={handoff.stopCommand} label="Copy stop" />
+      </div>
     </Card>
   );
 }
@@ -819,6 +886,7 @@ export function LoopDetailPage() {
       ) : null}
 
       {data ? <HITLDecisionCard loop={data} onMutated={onMutated} /> : null}
+      {data ? <ReviewFixHandoffCard loop={data} /> : null}
 
       {data ? (
         <Card title="Actions">


### PR DESCRIPTION
# Summary

- Make review-fix pairs converge or hand off within independent 3/3 budgets whether HITL is on or off.
- Classify findings as `must_fix` / `follow_up` / `needs_human`; only `must_fix` becomes remote review feedback.
- Later Reviewer passes use the repair frontier instead of rescanning untouched old diff.
- Fixer declines reply with evidence and leave the thread open; Reviewer adjudicates accept/reject/`needs_human`.
- Continuous GitHub Reviewer loops react to trusted `/looper wontfix` and Fixer declines on an unchanged head. `ThreadResolution.Enabled` stays false. Forgejo is exempt from same-head disposition.
- `pull_request_review_comment` and `pull_request_review_thread` `resolved` accelerate both Reviewer and Fixer. Polling remains the correctness fallback.
- Budget/scope holds show an inspect + dashboard handoff brief with exact `looper unpause` / `looper stop` commands. Exhaustion never approves, resolves, or merges.

# Testing

- [x] Targeted packages: `go test ./internal/reviewer/ ./internal/fixer/ ./internal/loops/ ./internal/webhookforward/ ./internal/runtime/ ./internal/cliapp/ ./internal/infra/github/ -count=1` (green during implementation)
- [x] `go vet` + `go build ./...` on this HEAD
- [x] Dashboard `pnpm test` (190 passed, including `reviewFixHandoff`)
- [ ] `go test ./...` — full suite on this machine had unrelated/host flakes: `TestConfigEditRejectsEnabledOsascriptNotificationsWithoutResolvedPath` (osascript present despite LookPath stub), plus one-shot timeouts in `internal/agent`, `internal/agent/modelcatalog`, and `internal/e2e` that passed or were not reproduced on retry
- [x] Additional targeted checks:
  - `go test ./internal/loops/ -run TestHandoffEventIncludes`
  - `go test ./internal/cliapp/ -run 'TestDiagnoseLoopBudgetHold|TestLoopInspectAccepts'`

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [x] Daemon boot / config / runtime path risk
- [x] Worktree / repo isolation / lifecycle risk
- [x] GitHub CLI contract / auth / scope risk
- [x] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

Same-head disposition replies/resolves existing Looper-authored threads. Transient Looper fields are stripped before the existing provider call. No auth/scope/rate-limit contract change, so sandbox E2E was not escalated.

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [x] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- Spec: `specs/2026-08-24-review-fix-convergence/spec.md`
- Follows #641 (HITL-gated budget cap). This change makes caps HITL-independent and adds disposition/same-head convergence.

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied

# Residual risk

Gate 4 Oracle never approved (attempts 1–3 blocked; exceptional review session-errored after remediations). Known leftovers:

- Schedule failure after Complete can still leave the queue item completed (no transactional complete+enqueue).
- Mid-batch accept + resolve failure depends on the classifier returning `accept_wontfix` again on resume.
