### PR TITLE
feat: enforce HITL-independent review-fix budget holds

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -656,8 +656,9 @@ enabledByDefault = true
 # Continuous follow-up debounce after a published review. Inherits defaults.loop when unset.
 quietPeriodSeconds = 60
 minPublishIntervalSeconds = 300
-# Successful reviewer publishes per PR. 0 disables. Exhaustion parks reviewer + sibling fixer via HITL.
-maxPublishesPerPR = 8
+# Successful reviewer publishes per PR. 0 disables. Exhaustion always
+# holds the pair; HITL only chooses ask vs no-ask presentation.
+maxPublishesPerPR = 3
 
 [roles.reviewer.behavior.reviewEvents]
 clean = "APPROVE"
@@ -676,12 +677,19 @@ Unlimited reviewer ⇄ fixer ping-pong is a cost and quality problem: each side 
 
 | Path | Counts | Default |
 | --- | --- | --- |
-| `roles.reviewer.behavior.loop.maxPublishesPerPR` | Successful published reviews on one PR | `8` |
-| `roles.fixer.behavior.loop.maxPushesPerPR` | Successful fixer pushes on one PR | `8` |
+| `roles.reviewer.behavior.loop.maxPublishesPerPR` | Successful published reviews on one PR | `3` |
+| `roles.fixer.behavior.loop.maxPushesPerPR` | Successful fixer pushes on one PR | `3` |
 
-`0` disables that role's cap. Authority is live config plus a durable counter (`iterationCount` for reviewer, `reviewFixBudget.pushCount` for fixer). Exhaustion parks the exhausted loop as `awaiting_human` with a Continue/Stop HITL ask and pauses the sibling loop on the same PR. Continue resets the exhausted counter and unpauses the sibling; Stop terminates both. Product terminals (ready label, identical output, closed PR) still win and do not open a budget ask.
+`0` disables that role's cap. Authority is live config plus a durable counter (`iterationCount` for reviewer, `reviewFixBudget.pushCount` for fixer). Caps enforce whether or not HITL is enabled. Automatic and takeover (`manual` + `followUpdates`) loops participate; one-shot manual loops do not. Either exhausted role holds the same-lane pair:
 
-**Failure prevented:** expanding-scope review/fix that never converges. **Cost:** a new persisted counter and a HITL park that must not fight discovery or the deprecated budget-strip path. **Why not reuse the old knobs:** those were reviewer-only infra counters that stranded long PRs and were explicitly demoted in #209.
+| `hitl.enabled` | Exhausted role | Sibling | Resume |
+| --- | --- | --- | --- |
+| `true` | `awaiting_human` with Continue/Stop | budget-paused | answer the ask |
+| `false` (default) | `paused`, reason `review_fix_budget_exhausted`, no ask | paired budget-paused | `looper unpause <seq>` or `looper stop <seq>` |
+
+Continue / no-HITL `unpause` refills only meters currently at/over their live cap and releases the pair. Stop / no-HITL `looper stop` terminates both roles. Product terminals (ready label, identical output, closed PR) still win and do not open a budget ask. Budget exhaustion never approves, resolves, or merges. Event: `loop.review_fix_budget.exhausted` (`level: action_required`).
+
+**Failure prevented:** expanding-scope review/fix that never converges, including on default HITL-off installs. **Cost:** paired pause/unpause/stop plus an action-required event. **Why not reuse the old knobs:** those were reviewer-only infra counters that stranded long PRs and were explicitly demoted in #209.
 
 ### Quiet-period debounce (shared + per-role)
 
@@ -962,7 +970,7 @@ publishMode = "single_review"
 enabledByDefault = true
 quietPeriodSeconds = 60
 minPublishIntervalSeconds = 300
-maxPublishesPerPR = 8
+maxPublishesPerPR = 3
 
 [roles.reviewer.behavior.reviewEvents]
 clean = "APPROVE"
@@ -982,8 +990,9 @@ scope = "looper-only"
 [roles.fixer.behavior.loop]
 # Opt-in quiet period (default 0 = immediate enqueue). Recommended starter: 60–120.
 quietPeriodSeconds = 0
-# Successful fixer pushes per PR. 0 disables. Exhaustion parks fixer + sibling reviewer via HITL.
-maxPushesPerPR = 8
+# Successful fixer pushes per PR. 0 disables. Exhaustion always holds
+# the pair; HITL only chooses ask vs no-ask presentation.
+maxPushesPerPR = 3
 
 [roles.fixer.discovery]
 autoDiscovery = true

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5588,18 +5588,20 @@ func (h *Handler) mutateLoopStatus(ctx context.Context, loopID string, status do
 			return loopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
 		if preflightLoop != nil {
-			// No-HITL budget hold: looper unpause must paired-Continue, not resume one role.
-			if continued, contErr := h.applyReviewFixBudgetContinueIfHeld(ctx, *preflightLoop); contErr != nil {
-				return loopResponse{}, contErr
-			} else if continued != nil {
-				return *continued, nil
-			}
 			target, targetErr := loopTargetFromRecordCompat(*preflightLoop)
 			if targetErr != nil {
 				return loopResponse{}, targetErr
 			}
 			unlockTarget := h.lockLoopTarget(preflightLoop.ProjectID, domain.LoopType(preflightLoop.Type), target)
 			defer unlockTarget()
+			// No-HITL budget hold: looper unpause must paired-Continue, not resume one role.
+			// Take the same-target lock first so Continue cannot publish claimable
+			// queue rows while a sibling discard+retry resets the shared worktree.
+			if continued, contErr := h.applyReviewFixBudgetContinueIfHeld(ctx, *preflightLoop); contErr != nil {
+				return loopResponse{}, contErr
+			} else if continued != nil {
+				return *continued, nil
+			}
 		}
 	}
 
@@ -6000,11 +6002,47 @@ func (h *Handler) applyReviewFixBudgetContinueIfHeld(ctx context.Context, loop s
 	return &resp, nil
 }
 
+// drainReviewFixBudgetPair stops live agents on both pair members before
+// paired terminalize. A sibling park can leave a run running after the loop
+// record is paused; generic StopLoop is the daemon drain path.
+func (h *Handler) drainReviewFixBudgetPair(ctx context.Context, loop storage.LoopRecord) error {
+	if h.context.StopLoop == nil {
+		return nil
+	}
+	services := h.context.Runtime.Services()
+	if services.Repositories == nil || services.Repositories.Loops == nil {
+		return nil
+	}
+	all, err := services.Repositories.Loops.List(ctx)
+	if err != nil {
+		return apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	members := append(loops.FindSiblingReviewFixLoops(all, loop), loop)
+	seen := make(map[string]struct{}, len(members))
+	for _, member := range members {
+		if _, ok := seen[member.ID]; ok {
+			continue
+		}
+		seen[member.ID] = struct{}{}
+		switch strings.TrimSpace(member.Status) {
+		case "terminated", "stopped", "completed":
+			continue
+		}
+		if _, err := h.context.StopLoop(ctx, member.ID, "Stopped by review-fix budget pair"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // applyReviewFixBudgetStopIfHeld delegates looper stop on a budget-held role to
 // paired Stop (terminate both). Returns nil when not a hold.
 func (h *Handler) applyReviewFixBudgetStopIfHeld(ctx context.Context, loop storage.LoopRecord) (any, error) {
 	if !loops.IsReviewFixBudgetHold(loop) {
 		return nil, nil
+	}
+	if err := h.drainReviewFixBudgetPair(ctx, loop); err != nil {
+		return nil, err
 	}
 	services := h.context.Runtime.Services()
 	if services.Repositories == nil || services.Coordinator == nil {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3115,6 +3115,11 @@ func (h *Handler) buildActiveRunRouteResponse(r *http.Request, path string) (any
 		if err != nil {
 			return nil, err
 		}
+		if stopped, stopErr := h.applyReviewFixBudgetStopIfHeld(r.Context(), loop); stopErr != nil {
+			return nil, stopErr
+		} else if stopped != nil {
+			return stopped, nil
+		}
 		return h.context.StopLoop(r.Context(), loop.ID, fmt.Sprintf("Stopped by user via selector %s", selector))
 	case "close":
 		if r.Method != http.MethodPost {
@@ -5583,6 +5588,12 @@ func (h *Handler) mutateLoopStatus(ctx context.Context, loopID string, status do
 			return loopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 		}
 		if preflightLoop != nil {
+			// No-HITL budget hold: looper unpause must paired-Continue, not resume one role.
+			if continued, contErr := h.applyReviewFixBudgetContinueIfHeld(ctx, *preflightLoop); contErr != nil {
+				return loopResponse{}, contErr
+			} else if continued != nil {
+				return *continued, nil
+			}
 			target, targetErr := loopTargetFromRecordCompat(*preflightLoop)
 			if targetErr != nil {
 				return loopResponse{}, targetErr
@@ -5928,6 +5939,118 @@ func (h *Handler) respondToLoop(ctx context.Context, r *http.Request, loopID str
 	return h.deliverHumanAnswer(ctx, loopID, body.Answer)
 }
 
+func (h *Handler) reviewFixBudgetLiveCaps(projectID string) loops.ReviewFixBudgetLiveCaps {
+	roles := config.ProjectRoleConfigs(h.effectiveConfig(), projectID)
+	return loops.ReviewFixBudgetLiveCaps{
+		ReviewerMaxPublishes: roles.Reviewer.Behavior.Loop.MaxPublishesPerPR,
+		FixerMaxPushes:       roles.Fixer.Behavior.Loop.MaxPushesPerPR,
+	}
+}
+
+// applyReviewFixBudgetContinueIfHeld delegates looper unpause /start on a
+// budget-held role to paired Continue. Returns nil response when not a hold.
+func (h *Handler) applyReviewFixBudgetContinueIfHeld(ctx context.Context, loop storage.LoopRecord) (*loopResponse, error) {
+	if !loops.IsReviewFixBudgetHold(loop) {
+		return nil, nil
+	}
+	services := h.context.Runtime.Services()
+	if services.Repositories == nil || services.Coordinator == nil {
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Storage is not configured"}
+	}
+	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
+	caps := h.reviewFixBudgetLiveCaps(loop.ProjectID)
+	updated, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
+		repos := storage.NewRepositories(tx)
+		fresh, getErr := repos.Loops.GetByID(ctx, loop.ID)
+		if getErr != nil {
+			return storage.LoopRecord{}, getErr
+		}
+		if fresh == nil {
+			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loop.ID)}
+		}
+		if !loops.IsReviewFixBudgetHold(*fresh) {
+			return storage.LoopRecord{}, nil
+		}
+		result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerContinue, nowISO, caps)
+		if applyErr != nil {
+			return storage.LoopRecord{}, applyErr
+		}
+		if !result.Applied {
+			return storage.LoopRecord{}, nil
+		}
+		return result.Loop, nil
+	})
+	if err != nil {
+		var typed apiError
+		if asAPIError(err, &typed) {
+			return nil, typed
+		}
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	if updated.ID == "" {
+		return nil, nil
+	}
+	if h.context.TriggerSchedulerTick != nil {
+		h.context.TriggerSchedulerTick()
+	}
+	resp, serErr := h.serializeLoopWithDiagnostics(ctx, updated)
+	if serErr != nil {
+		return nil, serErr
+	}
+	return &resp, nil
+}
+
+// applyReviewFixBudgetStopIfHeld delegates looper stop on a budget-held role to
+// paired Stop (terminate both). Returns nil when not a hold.
+func (h *Handler) applyReviewFixBudgetStopIfHeld(ctx context.Context, loop storage.LoopRecord) (any, error) {
+	if !loops.IsReviewFixBudgetHold(loop) {
+		return nil, nil
+	}
+	services := h.context.Runtime.Services()
+	if services.Repositories == nil || services.Coordinator == nil {
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: "Storage is not configured"}
+	}
+	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
+	caps := h.reviewFixBudgetLiveCaps(loop.ProjectID)
+	updated, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
+		repos := storage.NewRepositories(tx)
+		fresh, getErr := repos.Loops.GetByID(ctx, loop.ID)
+		if getErr != nil {
+			return storage.LoopRecord{}, getErr
+		}
+		if fresh == nil {
+			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loop.ID)}
+		}
+		if !loops.IsReviewFixBudgetHold(*fresh) {
+			return storage.LoopRecord{}, nil
+		}
+		result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerStop, nowISO, caps)
+		if applyErr != nil {
+			return storage.LoopRecord{}, applyErr
+		}
+		if !result.Applied {
+			return storage.LoopRecord{}, nil
+		}
+		return result.Loop, nil
+	})
+	if err != nil {
+		var typed apiError
+		if asAPIError(err, &typed) {
+			return nil, typed
+		}
+		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
+	}
+	if updated.ID == "" {
+		return nil, nil
+	}
+	return map[string]any{
+		"stopped": true,
+		"loopId":  updated.ID,
+		"status":  updated.Status,
+		"outcome": "review_fix_budget_stop",
+	}, nil
+}
+
 // deliverHumanAnswer is the shared core of the HITL respond path: it validates
 // the loop is awaiting_human, stores the answer on the loop's HITL metadata, and
 // transitions the loop back to running (requeue + scheduler tick). Both the
@@ -5954,7 +6077,7 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 		}
 		ask, _ := loops.ReadHITLAsk(loop.MetadataJSON)
 		if loops.IsReviewFixBudgetAsk(ask) {
-			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO)
+			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO, h.reviewFixBudgetLiveCaps(loop.ProjectID))
 			if applyErr != nil {
 				if errors.Is(applyErr, loops.ErrReviewFixBudgetInvalidAnswer) {
 					return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: applyErr.Error()}
@@ -7025,6 +7148,14 @@ func (h *Handler) assertLoopRetryPreconditions(ctx context.Context, repos *stora
 	if strings.TrimSpace(loop.ProjectID) != "" {
 		if _, err := requireActiveProjectRecord(ctx, repos.Projects, loop.ProjectID); err != nil {
 			return err
+		}
+	}
+	// Budget holds require paired Continue (looper unpause) or Stop — not single-role retry.
+	if loops.IsReviewFixBudgetHold(loop) {
+		return apiError{
+			code:    pkgapi.ErrorCodeValidationFailed,
+			status:  http.StatusBadRequest,
+			message: fmt.Sprintf("Cannot retry review-fix budget hold on loop %s; use looper unpause (Continue) or looper stop", loop.ID),
 		}
 	}
 	if loop.Status == string(domain.LoopStatusStopped) || loop.Status == string(domain.LoopStatusTerminated) || loop.Status == string(domain.LoopStatusCompleted) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -6024,6 +6024,9 @@ func (h *Handler) drainReviewFixBudgetPair(ctx context.Context, loop storage.Loo
 			continue
 		}
 		seen[member.ID] = struct{}{}
+		if member.ID != loop.ID && !loops.IsReviewFixBudgetHold(member) {
+			continue
+		}
 		switch strings.TrimSpace(member.Status) {
 		case "terminated", "stopped", "completed":
 			continue

--- a/internal/api/review_fix_budget_test.go
+++ b/internal/api/review_fix_budget_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/nexu-io/looper/internal/domain"
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 )
@@ -78,18 +80,118 @@ func TestHandlerLoopStartDelegatesNoHITLBudgetHoldToPairedContinue(t *testing.T)
 	}
 }
 
+func TestHandlerBudgetContinueWaitsForSameTargetLock(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = false
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 3
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_budget_unpause_lock"
+	repo := "acme/looper"
+	pr := int64(45)
+	targetID := "pr:acme/looper:45"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_lock_rev", Seq: 4501, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixerMeta := `{"reviewFixBudget":{"pushCount":1}}`
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_lock_fix", Seq: 4502, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &pr,
+		Status: "queued", MetadataJSON: &fixerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if _, err := loops.ParkReviewFixBudget(context.Background(), services.Repositories, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	}); err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+
+	target, err := loopTargetFromRecordCompat(fixer)
+	if err != nil {
+		t.Fatalf("loopTargetFromRecordCompat: %v", err)
+	}
+	unlockTarget := h.lockLoopTarget(projectID, domain.LoopTypeFixer, target)
+
+	started := make(chan struct{})
+	finished := make(chan int, 1)
+	go func() {
+		close(started)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/"+fixer.ID+"/start", nil)
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+		finished <- recorder.Code
+	}()
+	<-started
+	select {
+	case code := <-finished:
+		unlockTarget()
+		t.Fatalf("budget continue completed while target lock held: status=%d", code)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	reviewerHeld, _ := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	fixerHeld, _ := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if reviewerHeld == nil || !loops.IsReviewFixBudgetHold(*reviewerHeld) || fixerHeld == nil || !loops.IsReviewFixBudgetHold(*fixerHeld) {
+		unlockTarget()
+		t.Fatalf("pair released while target lock held: reviewer %#v fixer %#v", reviewerHeld, fixerHeld)
+	}
+
+	unlockTarget()
+	select {
+	case code := <-finished:
+		if code != http.StatusOK {
+			t.Fatalf("start status after lock release = %d, want 200", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("budget continue did not complete after target lock release")
+	}
+	reviewerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	fixerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if reviewerAfter == nil || reviewerAfter.Status != "queued" || fixerAfter == nil || fixerAfter.Status != "queued" {
+		t.Fatalf("pair after locked continue = reviewer %#v fixer %#v, want queued", reviewerAfter, fixerAfter)
+	}
+}
+
 func TestHandlerActiveStopDelegatesBudgetHoldToPairedStop(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	cfg.HITL.Enabled = false
+	services := rt.Services()
+	var drained []string
 	h := NewHandler(Context{
 		Config:  cfg,
 		Runtime: rt,
-		StopLoop: func(context.Context, string, string) (any, error) {
-			t.Fatal("generic StopLoop must not run for budget-held pair")
-			return nil, nil
+		StopLoop: func(ctx context.Context, loopID, _ string) (any, error) {
+			rec, err := services.Repositories.Loops.GetByID(ctx, loopID)
+			if err != nil || rec == nil {
+				t.Fatalf("StopLoop GetByID(%s) = (%v, %v)", loopID, rec, err)
+			}
+			if rec.Status == "terminated" || rec.Status == "stopped" {
+				t.Fatalf("StopLoop(%s) after terminalize: status=%s", loopID, rec.Status)
+			}
+			drained = append(drained, loopID)
+			if services.ActiveExecutions != nil {
+				if _, stopErr := services.ActiveExecutions.BeginLoopStop(loopID, "test drain"); stopErr != nil {
+					return nil, stopErr
+				}
+			}
+			return map[string]any{"stopped": true, "loopId": loopID}, nil
 		},
 	})
-	services := rt.Services()
 	nowISO := "2026-04-11T12:00:00.000Z"
 	projectID := "project_budget_stop"
 	repo := "acme/looper"
@@ -142,6 +244,16 @@ func TestHandlerActiveStopDelegatesBudgetHoldToPairedStop(t *testing.T) {
 	fixerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
 	if reviewerAfter == nil || reviewerAfter.Status != "terminated" || fixerAfter == nil || fixerAfter.Status != "terminated" {
 		t.Fatalf("pair after stop = reviewer %#v fixer %#v, want both terminated", reviewerAfter, fixerAfter)
+	}
+	if len(drained) != 2 {
+		t.Fatalf("StopLoop calls = %v, want both pair members before terminate", drained)
+	}
+	seen := map[string]bool{drained[0]: true, drained[1]: true}
+	if !seen[reviewer.ID] || !seen[fixer.ID] {
+		t.Fatalf("drained = %v, want %s and %s", drained, reviewer.ID, fixer.ID)
+	}
+	if services.ActiveExecutions != nil && (!services.ActiveExecutions.LoopStopActive(reviewer.ID) || !services.ActiveExecutions.LoopStopActive(fixer.ID)) {
+		t.Fatal("pair stop gates not closed after drain")
 	}
 }
 

--- a/internal/api/review_fix_budget_test.go
+++ b/internal/api/review_fix_budget_test.go
@@ -257,6 +257,102 @@ func TestHandlerActiveStopDelegatesBudgetHoldToPairedStop(t *testing.T) {
 	}
 }
 
+func TestHandlerActiveStopDoesNotTerminateHistoricalSibling(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = false
+	services := rt.Services()
+	var drained []string
+	h := NewHandler(Context{
+		Config:  cfg,
+		Runtime: rt,
+		StopLoop: func(ctx context.Context, loopID, _ string) (any, error) {
+			rec, err := services.Repositories.Loops.GetByID(ctx, loopID)
+			if err != nil || rec == nil {
+				t.Fatalf("StopLoop GetByID(%s) = (%v, %v)", loopID, rec, err)
+			}
+			if rec.Status == "terminated" || rec.Status == "stopped" || rec.Status == "completed" {
+				t.Fatalf("StopLoop(%s) after terminalize: status=%s", loopID, rec.Status)
+			}
+			drained = append(drained, loopID)
+			if services.ActiveExecutions != nil {
+				if _, stopErr := services.ActiveExecutions.BeginLoopStop(loopID, "test drain"); stopErr != nil {
+					return nil, stopErr
+				}
+			}
+			return map[string]any{"stopped": true, "loopId": loopID}, nil
+		},
+	})
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_budget_stop_hist"
+	repo := "acme/looper"
+	pr := int64(44)
+	target := "pr:acme/looper:44"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewerMeta := `{"manual":true,"followUpdates":true,"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_stop_hist_rev", Seq: 4401, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixerMeta := `{"manual":true,"followUpdates":true,"reviewFixBudget":{"pushCount":1}}`
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_stop_hist_fix", Seq: 4402, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", MetadataJSON: &fixerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	historicalMeta := `{"manual":true,"followUpdates":true,"reviewFixBudget":{"pushCount":3,"exhaustedBy":"fixer"}}`
+	historical := storage.LoopRecord{
+		ID: "loop_budget_stop_hist_old", Seq: 4400, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "completed", MetadataJSON: &historicalMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), historical); err != nil {
+		t.Fatalf("Upsert historical fixer: %v", err)
+	}
+	if _, err := loops.ParkReviewFixBudget(context.Background(), services.Repositories, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	}); err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/active/"+fixer.ID+"/stop", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("stop status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+
+	reviewerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	fixerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	histAfter, _ := services.Repositories.Loops.GetByID(context.Background(), historical.ID)
+	if reviewerAfter == nil || reviewerAfter.Status != "terminated" || fixerAfter == nil || fixerAfter.Status != "terminated" {
+		t.Fatalf("held pair after stop = reviewer %#v fixer %#v, want both terminated", reviewerAfter, fixerAfter)
+	}
+	if histAfter == nil || histAfter.Status != "completed" || loops.FixerPushCount(histAfter.MetadataJSON) != 3 {
+		t.Fatalf("historical fixer = %#v, want completed with original pushCount 3", histAfter)
+	}
+	if histAfter.MetadataJSON == nil || *histAfter.MetadataJSON != historicalMeta {
+		t.Fatalf("historical metadata = %v, want unchanged", histAfter.MetadataJSON)
+	}
+	if len(drained) != 2 {
+		t.Fatalf("StopLoop calls = %v, want only held pair members", drained)
+	}
+	seen := map[string]bool{drained[0]: true, drained[1]: true}
+	if !seen[reviewer.ID] || !seen[fixer.ID] || seen[historical.ID] {
+		t.Fatalf("drained = %v, want %s and %s only", drained, reviewer.ID, fixer.ID)
+	}
+}
+
 func TestHandlerRetryRejectsReviewFixBudgetHold(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	cfg.HITL.Enabled = false

--- a/internal/api/review_fix_budget_test.go
+++ b/internal/api/review_fix_budget_test.go
@@ -1,0 +1,201 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestHandlerLoopStartDelegatesNoHITLBudgetHoldToPairedContinue(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = false
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 3
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_budget_unpause"
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_unpause_rev", Seq: 4201, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixerMeta := `{"reviewFixBudget":{"pushCount":1}}`
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_unpause_fix", Seq: 4202, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", MetadataJSON: &fixerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	parked, err := loops.ParkReviewFixBudget(context.Background(), services.Repositories, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+	if parked.Status != "paused" {
+		t.Fatalf("parked status = %q, want paused", parked.Status)
+	}
+
+	// Unpause from sibling side.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/"+fixer.ID+"/start", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("start status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+
+	reviewerAfter, err := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || reviewerAfter == nil || reviewerAfter.Status != "queued" || loops.ReviewerPublishCount(reviewerAfter.MetadataJSON) != 0 {
+		t.Fatalf("reviewer after unpause = (%#v, %v), want queued with reset meter", reviewerAfter, err)
+	}
+	fixerAfter, err := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || fixerAfter == nil || fixerAfter.Status != "queued" || loops.FixerPushCount(fixerAfter.MetadataJSON) != 1 {
+		t.Fatalf("fixer after unpause = (%#v, %v), want queued with preserved unused budget", fixerAfter, err)
+	}
+	if loops.IsReviewFixBudgetHold(*reviewerAfter) || loops.IsReviewFixBudgetHold(*fixerAfter) {
+		t.Fatal("pair still budget-held after unpause")
+	}
+}
+
+func TestHandlerActiveStopDelegatesBudgetHoldToPairedStop(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = false
+	h := NewHandler(Context{
+		Config:  cfg,
+		Runtime: rt,
+		StopLoop: func(context.Context, string, string) (any, error) {
+			t.Fatal("generic StopLoop must not run for budget-held pair")
+			return nil, nil
+		},
+	})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_budget_stop"
+	repo := "acme/looper"
+	pr := int64(43)
+	target := "pr:acme/looper:43"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_stop_rev", Seq: 4301, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_stop_fix", Seq: 4302, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if _, err := loops.ParkReviewFixBudget(context.Background(), services.Repositories, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	}); err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/active/"+fixer.ID+"/stop", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("stop status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var envelope struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode: %v body=%s", err, recorder.Body.String())
+	}
+	if envelope.Data["outcome"] != "review_fix_budget_stop" {
+		t.Fatalf("outcome = %#v, want review_fix_budget_stop", envelope.Data)
+	}
+	reviewerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	fixerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if reviewerAfter == nil || reviewerAfter.Status != "terminated" || fixerAfter == nil || fixerAfter.Status != "terminated" {
+		t.Fatalf("pair after stop = reviewer %#v fixer %#v, want both terminated", reviewerAfter, fixerAfter)
+	}
+}
+
+func TestHandlerRetryRejectsReviewFixBudgetHold(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = false
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_budget_retry"
+	repo := "acme/looper"
+	pr := int64(44)
+	target := "pr:acme/looper:44"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_retry_rev", Seq: 4401, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_retry_fix", Seq: 4402, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if _, err := loops.ParkReviewFixBudget(context.Background(), services.Repositories, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	}); err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/4401/retry", strings.NewReader(`{"mode":"auto","resetAttempts":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("retry status = %d body=%s, want 400", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "looper unpause") && !strings.Contains(recorder.Body.String(), "budget") {
+		t.Fatalf("retry body = %s, want budget hold guidance", recorder.Body.String())
+	}
+	// Counters and hold must be unchanged.
+	after, _ := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	if after == nil || !loops.IsReviewFixBudgetHold(*after) || loops.ReviewerPublishCount(after.MetadataJSON) != 3 {
+		t.Fatalf("after rejected retry = %#v, want still held with count 3", after)
+	}
+}

--- a/internal/api/testdata/contracts/daemon-http.responses.compat.json
+++ b/internal/api/testdata/contracts/daemon-http.responses.compat.json
@@ -420,7 +420,7 @@
                   "minPublishIntervalSeconds": 300,
                   "maxIterationsPerPR": 20,
                   "maxIterationsPerHead": 1,
-                  "maxPublishesPerPR": 8,
+                  "maxPublishesPerPR": 3,
                   "maxWallClockSeconds": 0,
                   "maxConsecutiveFailures": 3,
                   "maxAgentExecutionsPerPR": 25,
@@ -482,7 +482,7 @@
               "behavior": {
                 "loop": {
                   "quietPeriodSeconds": 0,
-                  "maxPushesPerPR": 8
+                  "maxPushesPerPR": 3
                 }
               }
             },

--- a/internal/cliapp/review_submit.go
+++ b/internal/cliapp/review_submit.go
@@ -1104,10 +1104,10 @@ func submitReviewWithoutAnchorValidation(cmd *cobra.Command, r *commandRuntime, 
 // maxPublishesPerPR cap or is on a review-fix budget hold. One-shot manual is
 // exempt via ParticipatesInReviewFixBudget. Does not park — daemon owns park.
 //
-// Authority is the submitting loop only (--reviewer-run-id / current running
-// reviewer run). Other lanes and terminal/historical loops are ignored. When no
-// submitting loop can be resolved, skip (same optional-authority posture as a
-// missing DB).
+// Authority is the submitting loop only (--reviewer-run-id / active submit
+// run, including a budget-paused loop whose run is still running). Other lanes
+// and terminal/historical loops are ignored. When no submitting loop can be
+// resolved, skip (same optional-authority posture as a missing DB).
 //
 // Storage probe matches trustedReviewRequestSubmitBypass: only open an already-
 // materialized DB; if DB is absent, skip (optional authority lookup).
@@ -1162,12 +1162,14 @@ func refuseReviewSubmitBudgetAgainstRepos(ctx context.Context, repos *storage.Re
 }
 
 // submittingReviewerLoopForBudgetGate resolves only the submitting reviewer loop.
-// Prefer --reviewer-run-id via trustedCurrentReviewerLoopForRun; otherwise the
-// current running reviewer run's loop. Does not scan all participating loops.
+// Prefer --reviewer-run-id via the active run even when sibling parking has
+// paused the loop; otherwise the newest running reviewer run for the PR,
+// including budget-paused and awaiting-human loops. Does not scan all
+// participating loops.
 func submittingReviewerLoopForBudgetGate(ctx context.Context, repos *storage.Repositories, repo string, prNumber int64, runID string) (*storage.LoopRecord, error) {
 	runID = strings.TrimSpace(runID)
 	if runID != "" {
-		loop, err := trustedCurrentReviewerLoopForRun(ctx, repos, repo, prNumber, runID)
+		loop, err := reviewerLoopForActiveSubmitRun(ctx, repos, repo, prNumber, runID)
 		if err != nil {
 			return nil, fmt.Errorf("check review-fix publish budget: %w", err)
 		}
@@ -1176,28 +1178,91 @@ func submittingReviewerLoopForBudgetGate(ctx context.Context, repos *storage.Rep
 	if repos.Runs == nil {
 		return nil, nil
 	}
-	currentRun, err := currentRunningReviewerRun(ctx, repos, repo, prNumber)
+	currentRun, err := currentSubmittingReviewerRunForBudgetGate(ctx, repos, repo, prNumber)
 	if err != nil {
 		return nil, fmt.Errorf("check review-fix publish budget: %w", err)
 	}
 	if currentRun == nil {
 		return nil, nil
 	}
-	loop, err := repos.Loops.GetByID(ctx, currentRun.LoopID)
-	if err != nil {
-		return nil, fmt.Errorf("check review-fix publish budget: %w", err)
+	return reviewerLoopForBudgetGate(ctx, repos, currentRun.LoopID, repo, prNumber)
+}
+
+// reviewerLoopForActiveSubmitRun returns the reviewer loop for a still-running
+// submit run even when budget parking has paused the loop. Unlike
+// trustedCurrentReviewerLoopForRun, it does not require loop status running.
+func reviewerLoopForActiveSubmitRun(ctx context.Context, repos *storage.Repositories, repo string, prNumber int64, runID string) (*storage.LoopRecord, error) {
+	if repos == nil || repos.Runs == nil || repos.Loops == nil {
+		return nil, fmt.Errorf("storage is not configured")
 	}
-	if loop == nil || loop.Type != string(domain.LoopTypeReviewer) {
+	run, err := repos.Runs.GetByID(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if run == nil || run.Status != string(domain.RunStatusRunning) {
 		return nil, nil
+	}
+	return reviewerLoopForBudgetGate(ctx, repos, run.LoopID, repo, prNumber)
+}
+
+// currentSubmittingReviewerRunForBudgetGate finds the newest running reviewer
+// run for the PR even when sibling parking has moved the loop off running.
+func currentSubmittingReviewerRunForBudgetGate(ctx context.Context, repos *storage.Repositories, repo string, prNumber int64) (*storage.RunRecord, error) {
+	loops, err := repos.Loops.ListByStatuses(ctx, []string{
+		string(domain.LoopStatusRunning),
+		string(domain.LoopStatusPaused),
+		string(domain.LoopStatusAwaitingHuman),
+	})
+	if err != nil {
+		return nil, err
+	}
+	loopIDs := make([]string, 0, len(loops))
+	for _, loop := range loops {
+		if !reviewerLoopMatchesPR(loop, repo, prNumber) {
+			continue
+		}
+		loopIDs = append(loopIDs, loop.ID)
+	}
+	if len(loopIDs) == 0 {
+		return nil, nil
+	}
+	runs, err := repos.Runs.ListLatestByLoopIDs(ctx, loopIDs)
+	if err != nil {
+		return nil, err
+	}
+	var current *storage.RunRecord
+	for i := range runs {
+		if runs[i].Status != string(domain.RunStatusRunning) {
+			continue
+		}
+		if current == nil || reviewerRunNewer(runs[i], *current) {
+			run := runs[i]
+			current = &run
+		}
+	}
+	return current, nil
+}
+
+func reviewerLoopForBudgetGate(ctx context.Context, repos *storage.Repositories, loopID, repo string, prNumber int64) (*storage.LoopRecord, error) {
+	loop, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return nil, err
+	}
+	if loop == nil || !reviewerLoopMatchesPR(*loop, repo, prNumber) {
+		return nil, nil
+	}
+	return loop, nil
+}
+
+func reviewerLoopMatchesPR(loop storage.LoopRecord, repo string, prNumber int64) bool {
+	if loop.Type != string(domain.LoopTypeReviewer) {
+		return false
 	}
 	loopRepo := ""
 	if loop.Repo != nil {
 		loopRepo = *loop.Repo
 	}
-	if !strings.EqualFold(strings.TrimSpace(loopRepo), strings.TrimSpace(repo)) || loop.PRNumber == nil || *loop.PRNumber != prNumber {
-		return nil, nil
-	}
-	return loop, nil
+	return strings.EqualFold(strings.TrimSpace(loopRepo), strings.TrimSpace(repo)) && loop.PRNumber != nil && *loop.PRNumber == prNumber
 }
 
 func writeReviewSubmitDiagnostic(w io.Writer, event string, fields reviewSubmitDiagnosticFields) {

--- a/internal/cliapp/review_submit.go
+++ b/internal/cliapp/review_submit.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nexu-io/looper/internal/forge"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/infra/shell"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/outboundguard"
 	"github.com/nexu-io/looper/internal/projects"
 	"github.com/nexu-io/looper/internal/storage"
@@ -495,7 +496,7 @@ func (r *commandRuntime) reviewSubmit(cmd *cobra.Command, args []string) error {
 			if err := validateForgejoReviewSubmitRequest(cmd.Context(), gateway, prNumber, freshLabels, requestBypass); err != nil {
 				return err
 			}
-			return submitReviewWithoutAnchorValidation(cmd, gateway, repo, prNumber, submissionEvent, payload, commitID, cwd, loaded.Config.Disclosure)
+			return submitReviewWithoutAnchorValidation(cmd, r, loaded.Config, gateway, repo, prNumber, submissionEvent, payload, commitID, cwd, loaded.Config.Disclosure)
 		}
 		// Never reach SubmitReview's content guard on this path: redact paths and
 		// never return path-bearing git/remote errors (path may be secret-shaped).
@@ -518,6 +519,12 @@ func (r *commandRuntime) reviewSubmit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if err := validateForgejoReviewSubmitRequest(cmd.Context(), gateway, prNumber, freshLabels, requestBypass); err != nil {
+		return err
+	}
+	// Budget admission before mutation: agent-native reviews must not publish when
+	// a participating reviewer loop is already at/over live maxPublishesPerPR or
+	// on a review-fix budget hold. Daemon owns park; CLI only refuses.
+	if err := r.refuseReviewSubmitIfBudgetExhausted(cmd, loaded.Config, repo, prNumber); err != nil {
 		return err
 	}
 	if err := gateway.SubmitReview(cmd.Context(), githubinfra.SubmitReviewInput{Repo: repo, PRNumber: prNumber, Event: submissionEvent, Body: payload.Body, CommitID: commitID, Comments: comments, Anchors: anchors, Disclosure: loaded.Config.Disclosure, CWD: cwd}); err != nil {
@@ -1082,11 +1089,115 @@ func canSubmitWithoutAnchorValidation(err error, comments []reviewSubmitComment)
 	return errors.Is(err, githubinfra.ErrDiffTooLarge) || errors.Is(err, githubinfra.ErrLocalCaptureTruncated)
 }
 
-func submitReviewWithoutAnchorValidation(cmd *cobra.Command, gh reviewSubmitGateway, repo string, prNumber int64, event string, payload reviewSubmitPayload, commitID string, cwd string, disclosureCfg config.DisclosureConfig) error {
+func submitReviewWithoutAnchorValidation(cmd *cobra.Command, r *commandRuntime, cfg config.Config, gh reviewSubmitGateway, repo string, prNumber int64, event string, payload reviewSubmitPayload, commitID string, cwd string, disclosureCfg config.DisclosureConfig) error {
+	if err := r.refuseReviewSubmitIfBudgetExhausted(cmd, cfg, repo, prNumber); err != nil {
+		return err
+	}
 	if err := gh.SubmitReview(cmd.Context(), githubinfra.SubmitReviewInput{Repo: repo, PRNumber: prNumber, Event: event, Body: payload.Body, CommitID: commitID, Disclosure: disclosureCfg, CWD: cwd}); err != nil {
 		return wrapReviewSubmitError(cmd, repo, prNumber, event, commitID, payload, "submit PR review without anchor validation", err)
 	}
 	return writeJSON(cmd.OutOrStdout(), map[string]any{"submitted": true})
+}
+
+// refuseReviewSubmitIfBudgetExhausted refuses agent-native review publish when the
+// authoritative submitting reviewer loop is already at/over the live
+// maxPublishesPerPR cap or is on a review-fix budget hold. One-shot manual is
+// exempt via ParticipatesInReviewFixBudget. Does not park — daemon owns park.
+//
+// Authority is the submitting loop only (--reviewer-run-id / current running
+// reviewer run). Other lanes and terminal/historical loops are ignored. When no
+// submitting loop can be resolved, skip (same optional-authority posture as a
+// missing DB).
+//
+// Storage probe matches trustedReviewRequestSubmitBypass: only open an already-
+// materialized DB; if DB is absent, skip (optional authority lookup).
+func (r *commandRuntime) refuseReviewSubmitIfBudgetExhausted(cmd *cobra.Command, cfg config.Config, repo string, prNumber int64) error {
+	dbPath := strings.TrimSpace(cfg.Storage.DBPath)
+	if dbPath == "" {
+		return nil
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("check review-fix publish budget: %w", err)
+	}
+	db, err := storage.OpenSQLiteDB(cmd.Context(), dbPath)
+	if err != nil {
+		return fmt.Errorf("check review-fix publish budget: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	runID := strings.TrimSpace(getStringFlag(cmd, "reviewer-run-id"))
+	return refuseReviewSubmitBudgetAgainstRepos(cmd.Context(), storage.NewRepositories(db), cfg, repo, prNumber, runID)
+}
+
+// refuseReviewSubmitBudgetAgainstRepos is the DB-present budget gate used by
+// refuseReviewSubmitIfBudgetExhausted and unit tests. runID is the optional
+// --reviewer-run-id binding for the submitting loop.
+func refuseReviewSubmitBudgetAgainstRepos(ctx context.Context, repos *storage.Repositories, cfg config.Config, repo string, prNumber int64, runID string) error {
+	if repos == nil || repos.Loops == nil {
+		return nil
+	}
+	loop, err := submittingReviewerLoopForBudgetGate(ctx, repos, repo, prNumber, runID)
+	if err != nil {
+		return err
+	}
+	if loop == nil {
+		// No authoritative submitting loop — optional authority, same as missing DB.
+		return nil
+	}
+	if !loops.ParticipatesInReviewFixBudget(*loop) {
+		// One-shot manual (and any non-participating lane) is exempt.
+		return nil
+	}
+	if loops.IsReviewFixBudgetHold(*loop) {
+		return fmt.Errorf("review submit refused: review-fix budget is held for %s#%d; unpause or stop the loop before publishing", repo, prNumber)
+	}
+	cap := config.ProjectRoleConfigs(cfg, loop.ProjectID).Reviewer.Behavior.Loop.MaxPublishesPerPR
+	count := loops.ReviewerPublishCount(loop.MetadataJSON)
+	if loops.BudgetExhausted(count, cap) {
+		return fmt.Errorf("review submit refused: review-fix publish budget exhausted for %s#%d (%d/%d); unpause or stop the loop before publishing", repo, prNumber, count, cap)
+	}
+	return nil
+}
+
+// submittingReviewerLoopForBudgetGate resolves only the submitting reviewer loop.
+// Prefer --reviewer-run-id via trustedCurrentReviewerLoopForRun; otherwise the
+// current running reviewer run's loop. Does not scan all participating loops.
+func submittingReviewerLoopForBudgetGate(ctx context.Context, repos *storage.Repositories, repo string, prNumber int64, runID string) (*storage.LoopRecord, error) {
+	runID = strings.TrimSpace(runID)
+	if runID != "" {
+		loop, err := trustedCurrentReviewerLoopForRun(ctx, repos, repo, prNumber, runID)
+		if err != nil {
+			return nil, fmt.Errorf("check review-fix publish budget: %w", err)
+		}
+		return loop, nil
+	}
+	if repos.Runs == nil {
+		return nil, nil
+	}
+	currentRun, err := currentRunningReviewerRun(ctx, repos, repo, prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("check review-fix publish budget: %w", err)
+	}
+	if currentRun == nil {
+		return nil, nil
+	}
+	loop, err := repos.Loops.GetByID(ctx, currentRun.LoopID)
+	if err != nil {
+		return nil, fmt.Errorf("check review-fix publish budget: %w", err)
+	}
+	if loop == nil || loop.Type != string(domain.LoopTypeReviewer) {
+		return nil, nil
+	}
+	loopRepo := ""
+	if loop.Repo != nil {
+		loopRepo = *loop.Repo
+	}
+	if !strings.EqualFold(strings.TrimSpace(loopRepo), strings.TrimSpace(repo)) || loop.PRNumber == nil || *loop.PRNumber != prNumber {
+		return nil, nil
+	}
+	return loop, nil
 }
 
 func writeReviewSubmitDiagnostic(w io.Writer, event string, fields reviewSubmitDiagnosticFields) {

--- a/internal/cliapp/review_submit.go
+++ b/internal/cliapp/review_submit.go
@@ -551,9 +551,9 @@ func validateForgejoReviewSubmitRequest(ctx context.Context, gateway reviewSubmi
 //   - the current trusted run is a manual reviewer loop (--reviewer-run-id), or
 //   - the current trusted reviewer loop is an enabled follow-up reviewing a head
 //     that differs from lastPublishedHeadSha (matching requireReviewRequestForLoop
-//     / reviewerFollowUpHasNewHead in the reviewer runner). Automatic follow-up
-//     runs do not pass --reviewer-run-id, so that path resolves the current
-//     running reviewer loop for the PR when the flag is absent.
+//     / reviewerFollowUpHasNewHead in the reviewer runner). Automatic prompts now
+//     pass --reviewer-run-id; the no-flag path still resolves the current running
+//     reviewer loop for the PR when the flag is absent.
 func (r *commandRuntime) trustedReviewRequestSubmitBypass(cmd *cobra.Command, cfg config.Config, repo string, prNumber int64, headSHA string) (bool, error) {
 	dbPath := strings.TrimSpace(cfg.Storage.DBPath)
 	if dbPath == "" {
@@ -928,8 +928,7 @@ func trustedFollowUpNewHeadReviewerRun(ctx context.Context, repos *storage.Repos
 
 // trustedCurrentFollowUpNewHeadReviewerBypass honors the runner's
 // follow_up_new_head requireReviewRequest bypass when agents submit without
-// --reviewer-run-id (automatic reviewer prompts only pass that flag for manual
-// runs). Authority is the current running reviewer loop for the PR.
+// --reviewer-run-id. Authority is the current running reviewer loop for the PR.
 func trustedCurrentFollowUpNewHeadReviewerBypass(ctx context.Context, repos *storage.Repositories, repo string, prNumber int64, headSHA string) (bool, error) {
 	if repos == nil || repos.Runs == nil || repos.Loops == nil {
 		return false, fmt.Errorf("validate follow-up review request bypass: storage is not configured")
@@ -1163,9 +1162,9 @@ func refuseReviewSubmitBudgetAgainstRepos(ctx context.Context, repos *storage.Re
 
 // submittingReviewerLoopForBudgetGate resolves only the submitting reviewer loop.
 // Prefer --reviewer-run-id via the active run even when sibling parking has
-// paused the loop; otherwise the newest running reviewer run for the PR,
-// including budget-paused and awaiting-human loops. Does not scan all
-// participating loops.
+// paused the loop; otherwise the single running reviewer run for the PR,
+// including budget-paused and awaiting-human loops. Multiple running reviewer
+// runs without a run ID are fail-closed so a held lane cannot be masked.
 func submittingReviewerLoopForBudgetGate(ctx context.Context, repos *storage.Repositories, repo string, prNumber int64, runID string) (*storage.LoopRecord, error) {
 	runID = strings.TrimSpace(runID)
 	if runID != "" {
@@ -1205,8 +1204,10 @@ func reviewerLoopForActiveSubmitRun(ctx context.Context, repos *storage.Reposito
 	return reviewerLoopForBudgetGate(ctx, repos, run.LoopID, repo, prNumber)
 }
 
-// currentSubmittingReviewerRunForBudgetGate finds the newest running reviewer
+// currentSubmittingReviewerRunForBudgetGate finds the single running reviewer
 // run for the PR even when sibling parking has moved the loop off running.
+// Two independently budgeted lanes can both have running runs; recency is not
+// authority, so more than one candidate is an error.
 func currentSubmittingReviewerRunForBudgetGate(ctx context.Context, repos *storage.Repositories, repo string, prNumber int64) (*storage.RunRecord, error) {
 	loops, err := repos.Loops.ListByStatuses(ctx, []string{
 		string(domain.LoopStatusRunning),
@@ -1235,10 +1236,11 @@ func currentSubmittingReviewerRunForBudgetGate(ctx context.Context, repos *stora
 		if runs[i].Status != string(domain.RunStatusRunning) {
 			continue
 		}
-		if current == nil || reviewerRunNewer(runs[i], *current) {
-			run := runs[i]
-			current = &run
+		if current != nil {
+			return nil, fmt.Errorf("multiple running reviewer runs for %s#%d; pass --reviewer-run-id", repo, prNumber)
 		}
+		run := runs[i]
+		current = &run
 	}
 	return current, nil
 }

--- a/internal/cliapp/review_submit_test.go
+++ b/internal/cliapp/review_submit_test.go
@@ -644,6 +644,59 @@ func TestRefuseReviewSubmitBudgetAgainstReposPausedSubmittingRun(t *testing.T) {
 	}
 }
 
+func TestRefuseReviewSubmitBudgetFailsClosedOnMultipleRunningRuns(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations, BackupDir: filepath.Join(root, "backups")})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("MigrationRunner.RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Project", RepoPath: "/tmp/project", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert(project_1) error = %v", err)
+	}
+
+	cfg, err := config.DefaultConfig(root)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+
+	heldMeta := `{"loop":{"iterationCount":3},"reviewFixBudget":{"exhaustedBy":"reviewer","pauseReason":"review_fix_budget_exhausted"},"pauseReason":"review_fix_budget_exhausted"}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_auto_held", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &heldMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(auto held) error = %v", err)
+	}
+	cmMeta := `{"manual":true,"followUpdates":true,"loop":{"iterationCount":1}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_cm_live", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &cmMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(continuous manual) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_auto_held", LoopID: "loop_auto_held", Status: "running", StartedAt: now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Runs.Upsert(auto) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{ID: "run_cm_live", LoopID: "loop_cm_live", Status: "running", StartedAt: now, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Runs.Upsert(cm) error = %v", err)
+	}
+
+	err = refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "")
+	if err == nil || !strings.Contains(err.Error(), "pass --reviewer-run-id") {
+		t.Fatalf("multiple running runs without run id error = %v, want fail-closed", err)
+	}
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_auto_held"); err == nil || !strings.Contains(err.Error(), "review-fix budget is held") {
+		t.Fatalf("held automatic via run id error = %v, want held", err)
+	}
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_cm_live"); err != nil {
+		t.Fatalf("continuous_manual via run id error = %v, want nil", err)
+	}
+}
+
 func TestSubmitReviewWithoutAnchorValidationRefusesBudgetBeforeSubmit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/review_submit_test.go
+++ b/internal/cliapp/review_submit_test.go
@@ -459,6 +459,234 @@ func TestTrustedFollowUpNewHeadReviewRequestBypass(t *testing.T) {
 	}
 }
 
+func TestRefuseReviewSubmitBudgetAgainstRepos(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations, BackupDir: filepath.Join(root, "backups")})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("MigrationRunner.RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Project", RepoPath: "/tmp/project", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert(project_1) error = %v", err)
+	}
+
+	cfg, err := config.DefaultConfig(root)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+
+	seedSubmittingRun := func(loopID, runID string) {
+		t.Helper()
+		if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+			ID: runID, LoopID: loopID, Status: "running", StartedAt: now, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("Runs.Upsert(%s) error = %v", runID, err)
+		}
+	}
+
+	// Exhausted submitting loop blocks submit.
+	exhaustedMeta := `{"loop":{"iterationCount":3}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_exhausted", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &exhaustedMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(exhausted) error = %v", err)
+	}
+	seedSubmittingRun("loop_exhausted", "run_exhausted")
+	err = refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_exhausted")
+	if err == nil || !strings.Contains(err.Error(), "publish budget exhausted") {
+		t.Fatalf("exhausted count error = %v, want publish budget exhausted", err)
+	}
+	// Same via current running run (no --reviewer-run-id).
+	err = refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "")
+	if err == nil || !strings.Contains(err.Error(), "publish budget exhausted") {
+		t.Fatalf("exhausted via current run error = %v, want publish budget exhausted", err)
+	}
+
+	// Held loop without a resolvable submitting run skips (optional authority).
+	holdMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"fixer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_exhausted", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &holdMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(hold) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_exhausted", LoopID: "loop_exhausted", Status: "completed", StartedAt: now, EndedAt: &now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(complete exhausted) error = %v", err)
+	}
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, ""); err != nil {
+		t.Fatalf("held without submitting run error = %v, want nil (skip)", err)
+	}
+
+	// Under-cap participating submitting loop allows submit (no error).
+	underMeta := `{"loop":{"iterationCount":1}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_under", Seq: 10, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &underMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(under) error = %v", err)
+	}
+	seedSubmittingRun("loop_under", "run_under")
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_under"); err != nil {
+		t.Fatalf("under-cap error = %v, want nil", err)
+	}
+
+	// One-shot manual submitting loop is exempt even when count is at cap.
+	manualMeta := `{"manual":true,"loop":{"iterationCount":9}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_manual_cap", Seq: 11, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &manualMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(manual) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_under", LoopID: "loop_under", Status: "completed", StartedAt: now, EndedAt: &now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(complete under) error = %v", err)
+	}
+	seedSubmittingRun("loop_manual_cap", "run_manual")
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_manual"); err != nil {
+		t.Fatalf("one-shot manual error = %v, want nil", err)
+	}
+
+	// Exhausted automatic must not block a one-shot manual submitting loop.
+	autoExhausted := `{"loop":{"iterationCount":3}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_auto_exhausted", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &autoExhausted, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(auto exhausted) error = %v", err)
+	}
+	oneShotMeta := `{"manual":true,"loop":{"iterationCount":0}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_oneshot_submit", Seq: 3, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &oneShotMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(oneshot) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_manual", LoopID: "loop_manual_cap", Status: "completed", StartedAt: now, EndedAt: &now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(complete manual) error = %v", err)
+	}
+	seedSubmittingRun("loop_oneshot_submit", "run_oneshot")
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_oneshot"); err != nil {
+		t.Fatalf("oneshot with exhausted automatic error = %v, want nil", err)
+	}
+
+	// Held automatic must not block a different-lane continuous_manual under-cap submit.
+	holdAutoMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"fixer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_auto_held", Seq: 4, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &holdAutoMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(auto held) error = %v", err)
+	}
+	cmMeta := `{"manual":true,"followUpdates":true,"loop":{"iterationCount":1}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_cm_submit", Seq: 5, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &cmMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(continuous manual) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_oneshot", LoopID: "loop_oneshot_submit", Status: "completed", StartedAt: now, EndedAt: &now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(complete oneshot) error = %v", err)
+	}
+	seedSubmittingRun("loop_cm_submit", "run_cm")
+	if err := refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_cm"); err != nil {
+		t.Fatalf("continuous_manual under-cap with held automatic error = %v, want nil", err)
+	}
+
+	// Exhausted continuous_manual submitting loop still blocks.
+	cmExhausted := `{"manual":true,"followUpdates":true,"loop":{"iterationCount":3}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_cm_submit", Seq: 5, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &cmExhausted, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(cm exhausted) error = %v", err)
+	}
+	err = refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_cm")
+	if err == nil || !strings.Contains(err.Error(), "publish budget exhausted") {
+		t.Fatalf("exhausted continuous_manual error = %v, want publish budget exhausted", err)
+	}
+}
+
+func TestSubmitReviewWithoutAnchorValidationRefusesBudgetBeforeSubmit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "looper.sqlite")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), dbPath, storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations, BackupDir: filepath.Join(root, "backups")})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("MigrationRunner.RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Project", RepoPath: "/tmp/project", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert error = %v", err)
+	}
+	exhaustedMeta := `{"loop":{"iterationCount":3}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_budget", Seq: 7, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &exhaustedMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_budget", LoopID: "loop_budget", Status: "running", StartedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert error = %v", err)
+	}
+
+	cfg, err := config.DefaultConfig(root)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Storage.DBPath = dbPath
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+
+	var submitCalls int
+	gateway := &budgetGateSubmitGateway{onSubmit: func() { submitCalls++ }}
+	var stdout, stderr bytes.Buffer
+	cmd := newReviewSubmitTestCommand(&stdout, &stderr)
+	cmd.SetContext(context.Background())
+	if err := cmd.Flags().Set("reviewer-run-id", "run_budget"); err != nil {
+		t.Fatalf("set reviewer-run-id: %v", err)
+	}
+	runtime := &commandRuntime{}
+	payload := reviewSubmitPayload{Body: "ok\n<!-- looper:review id=a head=head outcome=clean -->"}
+	err = submitReviewWithoutAnchorValidation(cmd, runtime, cfg, gateway, repo, prNumber, "COMMENT", payload, "head", root, cfg.Disclosure)
+	if err == nil || !strings.Contains(err.Error(), "publish budget exhausted") {
+		t.Fatalf("submitReviewWithoutAnchorValidation() error = %v, want budget exhausted", err)
+	}
+	if submitCalls != 0 {
+		t.Fatalf("SubmitReview calls = %d, want 0 (refused before mutation)", submitCalls)
+	}
+
+	// Under-cap still reaches mock gateway.
+	underMeta := `{"loop":{"iterationCount":1}}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_budget", Seq: 7, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &underMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(under) error = %v", err)
+	}
+	err = submitReviewWithoutAnchorValidation(cmd, runtime, cfg, gateway, repo, prNumber, "COMMENT", payload, "head", root, cfg.Disclosure)
+	if err != nil {
+		t.Fatalf("under-cap submit error = %v", err)
+	}
+	if submitCalls != 1 {
+		t.Fatalf("SubmitReview calls = %d, want 1", submitCalls)
+	}
+}
+
+type budgetGateSubmitGateway struct {
+	onSubmit func()
+}
+
+func (g *budgetGateSubmitGateway) ViewPullRequest(context.Context, githubinfra.ViewPullRequestInput) (githubinfra.PullRequestDetail, error) {
+	return githubinfra.PullRequestDetail{}, nil
+}
+func (g *budgetGateSubmitGateway) GetCurrentUserLogin(context.Context, string) (string, error) {
+	return "reviewer", nil
+}
+func (g *budgetGateSubmitGateway) GetPullRequestDiff(context.Context, githubinfra.GetPullRequestDiffInput) (string, error) {
+	return "", nil
+}
+func (g *budgetGateSubmitGateway) SubmitReview(context.Context, githubinfra.SubmitReviewInput) error {
+	if g.onSubmit != nil {
+		g.onSubmit()
+	}
+	return nil
+}
+
 func TestValidateReviewSubmitEventAcceptsRequestChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliapp/review_submit_test.go
+++ b/internal/cliapp/review_submit_test.go
@@ -598,6 +598,52 @@ func TestRefuseReviewSubmitBudgetAgainstRepos(t *testing.T) {
 	}
 }
 
+func TestRefuseReviewSubmitBudgetAgainstReposPausedSubmittingRun(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{Migrations: storage.EmbeddedMigrations, BackupDir: filepath.Join(root, "backups")})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background()); err != nil {
+		t.Fatalf("MigrationRunner.RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	now := "2026-04-11T12:00:00.000Z"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Project", RepoPath: "/tmp/project", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Projects.Upsert(project_1) error = %v", err)
+	}
+
+	cfg, err := config.DefaultConfig(root)
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+
+	holdMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"fixer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	if err := repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: "loop_paused_submit", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &holdMeta, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("Loops.Upsert(paused) error = %v", err)
+	}
+	if err := repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_paused_submit", LoopID: "loop_paused_submit", Status: "running", StartedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert(paused submit) error = %v", err)
+	}
+
+	err = refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "run_paused_submit")
+	if err == nil || !strings.Contains(err.Error(), "review-fix budget is held") {
+		t.Fatalf("paused submitting run via run id error = %v, want held", err)
+	}
+	err = refuseReviewSubmitBudgetAgainstRepos(context.Background(), repos, cfg, repo, prNumber, "")
+	if err == nil || !strings.Contains(err.Error(), "review-fix budget is held") {
+		t.Fatalf("paused submitting run via current run error = %v, want held", err)
+	}
+}
+
 func TestSubmitReviewWithoutAnchorValidationRefusesBudgetBeforeSubmit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -319,7 +319,7 @@ func TestRoleDefaultsMirrorCurrentDiscoveryPolicy(t *testing.T) {
 		t.Fatalf("fixer maxPushesPerPR default = %d, want %d", got, DefaultReviewFixBudgetCap)
 	}
 	if cfg.HITL.Enabled {
-		t.Fatal("HITL default must be false so default caps stay inert until HITL is enabled")
+		t.Fatal("HITL default must remain false; caps enforce with a no-ask paired hold when HITL is off")
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -11,7 +11,7 @@ const DefaultServerPort = 17310
 const (
 	DefaultReviewerAutoRecoveryMaxAttempts = 3
 	DefaultReviewerRetryMaxDelayMS         = 300000
-	DefaultReviewFixBudgetCap              = 8
+	DefaultReviewFixBudgetCap              = 3
 )
 
 func DefaultLooperHome() (string, error) {
@@ -245,7 +245,7 @@ func DefaultConfig(cwd string) (Config, error) {
 						StopOnApproved:            false,
 						StopOnReadyLabel:          true,
 						StopOnIdenticalOutput:     true,
-						// Enforced only when HITL is enabled; park needs Continue/Stop.
+						// Always enforced; HITL only selects ask vs no-ask hold presentation.
 						MaxPublishesPerPR: DefaultReviewFixBudgetCap,
 					},
 					Retry:                   DefaultReviewerRetryConfig(),
@@ -285,7 +285,7 @@ func DefaultConfig(cwd string) (Config, error) {
 					Loop: FixerLoopConfig{
 						// Opt-in: keep historical immediate-start behavior until operators enable quiet period.
 						QuietPeriodSeconds: 0,
-						// Enforced only when HITL is enabled; park needs Continue/Stop.
+						// Always enforced; HITL only selects ask vs no-ask hold presentation.
 						MaxPushesPerPR: DefaultReviewFixBudgetCap,
 					},
 				},

--- a/internal/config/testdata/parity/cli-file-env-priority.json
+++ b/internal/config/testdata/parity/cli-file-env-priority.json
@@ -279,7 +279,7 @@
               "minPublishIntervalSeconds": 300,
               "maxIterationsPerPR": 20,
               "maxIterationsPerHead": 1,
-              "maxPublishesPerPR": 8,
+              "maxPublishesPerPR": 3,
               "maxWallClockSeconds": 0,
               "maxConsecutiveFailures": 3,
               "maxAgentExecutionsPerPR": 25,
@@ -341,7 +341,7 @@
           "behavior": {
             "loop": {
               "quietPeriodSeconds": 0,
-              "maxPushesPerPR": 8
+              "maxPushesPerPR": 3
             }
           }
         },

--- a/internal/config/testdata/parity/default-path-missing.json
+++ b/internal/config/testdata/parity/default-path-missing.json
@@ -219,7 +219,7 @@
               "minPublishIntervalSeconds": 300,
               "maxIterationsPerPR": 20,
               "maxIterationsPerHead": 1,
-              "maxPublishesPerPR": 8,
+              "maxPublishesPerPR": 3,
               "maxWallClockSeconds": 0,
               "maxConsecutiveFailures": 3,
               "maxAgentExecutionsPerPR": 25,
@@ -281,7 +281,7 @@
           "behavior": {
             "loop": {
               "quietPeriodSeconds": 0,
-              "maxPushesPerPR": 8
+              "maxPushesPerPR": 3
             }
           }
         },

--- a/internal/config/testdata/parity/env-config-path.json
+++ b/internal/config/testdata/parity/env-config-path.json
@@ -300,7 +300,7 @@
               "minPublishIntervalSeconds": 300,
               "maxIterationsPerPR": 20,
               "maxIterationsPerHead": 1,
-              "maxPublishesPerPR": 8,
+              "maxPublishesPerPR": 3,
               "maxWallClockSeconds": 0,
               "maxConsecutiveFailures": 3,
               "maxAgentExecutionsPerPR": 25,
@@ -362,7 +362,7 @@
           "behavior": {
             "loop": {
               "quietPeriodSeconds": 0,
-              "maxPushesPerPR": 8
+              "maxPushesPerPR": 3
             }
           }
         },

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1793,7 +1793,11 @@ func (r *Runner) notifyHumanAttentionBestEffort(ctx context.Context, loopID stri
 func (r *Runner) refusePushIfBudgetExhausted(ctx context.Context, input stepInput) (bool, error) {
 	loop := input.Loop
 	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
-		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+		fresh, err := r.repos.Loops.GetByID(ctx, loop.ID)
+		if err != nil {
+			return true, err
+		}
+		if fresh != nil {
 			loop = *fresh
 		}
 	}

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -563,6 +563,9 @@ type Options struct {
 	RetryMaxAttempts        int64
 	OnAgentExecutionStarted AgentExecutionStartedFunc
 	OnQueueItemEnqueued     func()
+	// NotifyHumanAttention, when set, observes durable loop state after a new
+	// review-fix budget park (including discovery-time parks before claim).
+	NotifyHumanAttention func(context.Context, string)
 }
 
 type DiscoveryPolicy struct {
@@ -604,6 +607,7 @@ type Runner struct {
 	retryMaxAttempts        int64
 	onAgentExecutionStarted AgentExecutionStartedFunc
 	onQueueItemEnqueued     func()
+	notifyHumanAttention    func(context.Context, string)
 }
 
 type DiscoveryInput struct {
@@ -1336,6 +1340,7 @@ func New(options Options) *Runner {
 		retryMaxAttempts:        retryMax,
 		onAgentExecutionStarted: options.OnAgentExecutionStarted,
 		onQueueItemEnqueued:     options.OnQueueItemEnqueued,
+		notifyHumanAttention:    options.NotifyHumanAttention,
 	}
 }
 
@@ -1657,7 +1662,10 @@ func (r *Runner) shouldCreateFixerBudgetPark(loop storage.LoopRecord) bool {
 	if loop.Status == "terminated" || loop.Status == "stopped" || loop.Status == "awaiting_human" {
 		return false
 	}
-	if !r.hitlEnabled || isManualFixerLoop(loop) {
+	if loop.Status == "paused" && loops.IsReviewFixBudgetHold(loop) {
+		return false
+	}
+	if !loops.ParticipatesInReviewFixBudget(loop) {
 		return false
 	}
 	return loops.BudgetExhausted(loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount, r.maxPushesPerPR(loop.ProjectID))
@@ -1724,15 +1732,18 @@ func (r *Runner) parkFixerBudgetIfExhausted(ctx context.Context, loop storage.Lo
 	if loop.Status == "terminated" || loop.Status == "stopped" {
 		return false, nil
 	}
+	// Sibling pause is already a hold; do not treat "not self-exhausted" as proceed.
+	if loop.Status == "paused" && loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) {
+		return true, nil
+	}
 	if loop.Status == "awaiting_human" {
 		if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
 			return true, nil
 		}
+	} else if loop.Status == "paused" && loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
+		// Re-enter no-ask hold to finish cancel/sibling park / handoff event.
 	} else {
-		if !r.hitlEnabled {
-			return false, nil
-		}
-		if isManualFixerLoop(loop) {
+		if !loops.ParticipatesInReviewFixBudget(loop) {
 			return false, nil
 		}
 		cap := r.maxPushesPerPR(loop.ProjectID)
@@ -1743,16 +1754,72 @@ func (r *Runner) parkFixerBudgetIfExhausted(ctx context.Context, loop storage.Lo
 	}
 	cap := r.maxPushesPerPR(loop.ProjectID)
 	count := loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount
+	reviewerCap := 0
+	if r.projectRoleConfig != nil {
+		reviewerCap = config.ProjectRoleConfigs(*r.projectRoleConfig, loop.ProjectID).Reviewer.Behavior.Loop.MaxPublishesPerPR
+	}
 	_, err := loops.ParkReviewFixBudget(ctx, r.repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: loop,
-		Role:      "fixer",
-		Repo:      derefString(loop.Repo),
-		PRNumber:  derefInt64(loop.PRNumber),
-		Count:     count,
-		Cap:       cap,
-		NowISO:    r.nowISO(),
+		Exhausted:   loop,
+		Role:        "fixer",
+		Repo:        derefString(loop.Repo),
+		PRNumber:    derefInt64(loop.PRNumber),
+		Count:       count,
+		Cap:         cap,
+		NowISO:      r.nowISO(),
+		HITLEnabled: r.hitlEnabled,
+		LiveCaps: loops.ReviewFixBudgetLiveCaps{
+			ReviewerMaxPublishes: reviewerCap,
+			FixerMaxPushes:       cap,
+		},
+		DB: r.db,
 	})
-	return err == nil, err
+	if err != nil {
+		return false, err
+	}
+	// Notify is owned by discovery call sites (and scheduler post-claim), not
+	// shared park — in-run parks must not notify before queue finalization.
+	return true, nil
+}
+
+func (r *Runner) notifyHumanAttentionBestEffort(ctx context.Context, loopID string) {
+	if r.notifyHumanAttention == nil || strings.TrimSpace(loopID) == "" {
+		return
+	}
+	r.notifyHumanAttention(ctx, loopID)
+}
+
+// refusePushIfBudgetExhausted parks and skips when the loop already sits at the
+// live push cap before a counted mutation. Returns refused=true when push must not proceed.
+func (r *Runner) refusePushIfBudgetExhausted(ctx context.Context, input stepInput) (bool, error) {
+	loop := input.Loop
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+			loop = *fresh
+		}
+	}
+	if !loops.ParticipatesInReviewFixBudget(loop) {
+		return false, nil
+	}
+	if loops.IsReviewFixBudgetHold(loop) {
+		if _, err := r.parkFixerBudgetIfExhausted(ctx, loop); err != nil {
+			return true, err
+		}
+		return true, &holdSkipError{summary: "Fixer stopped because review-fix budget is held"}
+	}
+	cap := r.maxPushesPerPR(loop.ProjectID)
+	if !loops.BudgetExhausted(loops.FixerPushCount(loop.MetadataJSON), cap) {
+		return false, nil
+	}
+	if r.livePullRequestClosed(ctx, input.Project, input.Repo, input.PRNumber) {
+		if err := r.terminateLoop(ctx, loop, "pr_closed_or_merged"); err != nil {
+			return true, err
+		}
+		return true, &holdSkipError{summary: "Fixer stopped because pull request is closed"}
+	}
+	if _, err := r.parkFixerBudgetIfExhausted(ctx, loop); err != nil {
+		return true, err
+	}
+	return true, &holdSkipError{summary: "Fixer stopped because review-fix push budget is exhausted"}
 }
 
 func (r *Runner) isForgejoProject(projectID string) bool {
@@ -2465,7 +2532,7 @@ func (r *Runner) schedulePendingRediscoveryAfterRun(ctx context.Context, loop st
 	if current.Status == "paused" || current.Status == "awaiting_human" || current.Status == "human_takeover" || current.Status == "terminated" || current.Status == "stopped" {
 		return false, nil
 	}
-	if r.hitlEnabled && !isManualFixerLoop(*current) {
+	if loops.ParticipatesInReviewFixBudget(*current) {
 		cap := r.maxPushesPerPR(current.ProjectID)
 		count := loops.ReadReviewFixBudgetState(current.MetadataJSON).PushCount
 		if loops.BudgetExhausted(count, cap) {
@@ -2668,9 +2735,15 @@ func (r *Runner) finishHeldFixerQueueItem(ctx context.Context, loop storage.Loop
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil && !errors.Is(err, storage.ErrQueueItemNotActive) {
 		return ProcessResult{}, err
 	}
+	// Do not revive a review-fix budget hold (or other terminal park) that the
+	// step already persisted — only ordinary label/hold skips re-queue.
 	if _, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
-		updated.Status = "queued"
 		updated.LastRunAt = stringPtr(r.nowISO())
+		if loops.IsReviewFixBudgetHold(*updated) || updated.Status == "terminated" || updated.Status == "stopped" || updated.Status == "awaiting_human" || updated.Status == "human_takeover" {
+			updated.NextRunAt = nil
+			return
+		}
+		updated.Status = "queued"
 		updated.NextRunAt = nil
 	}); err != nil {
 		return ProcessResult{}, err
@@ -3338,6 +3411,11 @@ func (r *Runner) runPushStep(ctx context.Context, input stepInput) (fixerCheckpo
 	if checkpoint.Push != nil && checkpoint.Push.Pushed {
 		return r.ensureFixerPushBudgetCounted(ctx, input, checkpoint)
 	}
+	// Admission at the mutation seam: refuse a counted push when already at the
+	// live cap (observe mid-run cap lowers). PR-closed still wins later.
+	if refused, err := r.refusePushIfBudgetExhausted(ctx, input); refused || err != nil {
+		return checkpoint, err
+	}
 	worktree, err := requireWorktree(checkpoint)
 	if err != nil {
 		return checkpoint, err
@@ -3550,14 +3628,52 @@ func (r *Runner) ensureFixerPushBudgetCounted(ctx context.Context, input stepInp
 	if checkpoint.Push == nil || !checkpoint.Push.Pushed || checkpoint.Push.BudgetCounted {
 		return checkpoint, nil
 	}
-	if _, err := r.incrementFixerPushCount(ctx, input.Loop); err != nil {
+	updated, err := r.incrementFixerPushCount(ctx, input.Loop)
+	if err != nil {
 		return checkpoint, err
 	}
 	checkpoint.Push.BudgetCounted = true
 	if err := r.persistCheckpoint(ctx, input.Run.ID, stepPush, checkpoint); err != nil {
 		return checkpoint, err
 	}
+	// Persist just-pushed head before park so handoff / lastFixHeadSha sees the
+	// current head (runPushStep still merges full evidence metadata afterward).
+	if head := fixerPushBudgetHeadSHA(checkpoint); head != "" {
+		merged, mergeErr := r.mergeLoopMetadata(ctx, updated, map[string]any{"lastFixHeadSha": head})
+		if mergeErr != nil {
+			return checkpoint, mergeErr
+		}
+		updated = merged
+	}
+	// After a successful counted increment, park immediately when now exhausted
+	// and do not continue into resolve-comments / further counted work.
+	// PR-closed still wins over budget park.
+	if r.shouldCreateFixerBudgetPark(updated) {
+		if r.livePullRequestClosed(ctx, input.Project, input.Repo, input.PRNumber) {
+			if termErr := r.terminateLoop(ctx, updated, "pr_closed_or_merged"); termErr != nil {
+				return checkpoint, termErr
+			}
+			return checkpoint, &holdSkipError{summary: "Fixer stopped because pull request is closed"}
+		}
+		if _, parkErr := r.parkFixerBudgetIfExhausted(ctx, updated); parkErr != nil {
+			return checkpoint, parkErr
+		}
+		return checkpoint, &holdSkipError{summary: "Fixer stopped because review-fix push budget is exhausted"}
+	}
 	return checkpoint, nil
+}
+
+func fixerPushBudgetHeadSHA(checkpoint fixerCheckpoint) string {
+	if checkpoint.Push == nil {
+		return ""
+	}
+	if head := strings.TrimSpace(checkpoint.Push.HeadSHA); head != "" {
+		return head
+	}
+	if checkpoint.Push.Evidence != nil {
+		return strings.TrimSpace(checkpoint.Push.Evidence.HeadSHA)
+	}
+	return ""
 }
 
 func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (fixerCheckpoint, error) {
@@ -5222,9 +5338,20 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 		if updatedLoop.Status == "awaiting_human" || updatedLoop.Status == "human_takeover" || updatedLoop.Status == "terminated" || updatedLoop.Status == "stopped" {
 			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
 		}
+		// Sibling pause / exhausted hold must not be revived by discovery enqueue.
+		// Notify only from discovery after a successful park (not from shared park).
+		if loops.IsReviewFixBudgetHold(updatedLoop) {
+			if parked, err := r.parkFixerBudgetIfExhausted(ctx, updatedLoop); err != nil {
+				return loopUpsertResult{}, err
+			} else if parked {
+				r.notifyHumanAttentionBestEffort(ctx, updatedLoop.ID)
+			}
+			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
+		}
 		if parked, err := r.parkFixerBudgetIfExhausted(ctx, updatedLoop); err != nil {
 			return loopUpsertResult{}, err
 		} else if parked {
+			r.notifyHumanAttentionBestEffort(ctx, updatedLoop.ID)
 			updated, getErr := r.repos.Loops.GetByID(ctx, updatedLoop.ID)
 			if getErr != nil {
 				return loopUpsertResult{}, getErr

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -79,6 +79,100 @@ func TestBackoffDelayCapsInfiniteRetryOverflow(t *testing.T) {
 	}
 }
 
+func TestRefusePushIfBudgetExhaustedDoesNotResolveComments(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	// Already at cap before push.
+	meta := `{"reviewFixBudget":{"pushCount":1}}`
+	fixer := storage.LoopRecord{ID: "loop_push_refuse", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &meta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	cfg.HITL.Enabled = false
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: false, GitHub: &fakeGitHubGateway{}})
+	refused, err := runner.refusePushIfBudgetExhausted(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:    fixer, Repo: repo, PRNumber: prNumber,
+	})
+	if !refused {
+		t.Fatalf("refused=%v err=%v, want refused at live cap", refused, err)
+	}
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if after == nil || !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatalf("after refuse = %#v, want budget hold", after)
+	}
+}
+
+func TestEnsureFixerPushBudgetCountedParksWhenCapReached(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	// Cap 1, count 0 — after increment should park and return hold skip.
+	// Prior head must not win over the just-pushed head on handoff.
+	meta := `{"reviewFixBudget":{"pushCount":0},"lastFixHeadSha":"previous-head"}`
+	fixer := storage.LoopRecord{ID: "loop_push_count_park", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &meta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	run := storage.RunRecord{ID: "run_push_count_park", LoopID: fixer.ID, Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	cfg.HITL.Enabled = false
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: false, GitHub: &fakeGitHubGateway{}})
+	pushedHead := "cap-reach-head-sha"
+	checkpoint := fixerCheckpoint{Push: &checkpointPush{Pushed: true, BudgetCounted: false, HeadSHA: pushedHead, Evidence: &fixEvidence{HeadSHA: pushedHead}}}
+	_, err = runner.ensureFixerPushBudgetCounted(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:    fixer, Run: run, Repo: repo, PRNumber: prNumber,
+	}, checkpoint)
+	var hold *holdSkipError
+	if err == nil || !errors.As(err, &hold) {
+		t.Fatalf("err = %v, want holdSkipError after cap-reaching push", err)
+	}
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if after == nil || !loops.IsReviewFixBudgetHold(*after) || loops.FixerPushCount(after.MetadataJSON) != 1 {
+		t.Fatalf("after count+park = %#v, want held with pushCount 1", after)
+	}
+	if after.MetadataJSON == nil || !strings.Contains(*after.MetadataJSON, `"lastFixHeadSha":"`+pushedHead+`"`) {
+		t.Fatalf("lastFixHeadSha missing/stale after cap park: %v", after.MetadataJSON)
+	}
+	events, err := fixture.repos.Events.ListByEntity(context.Background(), "loop", fixer.ID)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	var handoffPayload string
+	for i := range events {
+		if events[i].EventType == "loop.review_fix_budget.exhausted" {
+			handoffPayload = events[i].PayloadJSON
+			break
+		}
+	}
+	if handoffPayload == "" {
+		t.Fatal("missing review-fix budget handoff event")
+	}
+	if !strings.Contains(handoffPayload, `"head":"`+pushedHead+`"`) {
+		t.Fatalf("handoff payload = %s, want head %q", handoffPayload, pushedHead)
+	}
+}
+
 func TestIncrementAndParkFixerBudgetParksSibling(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -289,7 +383,7 @@ func TestParkFixerBudgetBeforePendingRediscoveryDoesNotEnqueue(t *testing.T) {
 	}
 }
 
-func TestParkFixerBudgetIfExhaustedSkipsWhenHITLDisabled(t *testing.T) {
+func TestParkFixerBudgetIfExhaustedParksWhenHITLDisabled(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repo := "acme/looper"
@@ -317,16 +411,19 @@ func TestParkFixerBudgetIfExhaustedSkipsWhenHITLDisabled(t *testing.T) {
 		t.Fatalf("incrementFixerPushCount() error = %v", err)
 	}
 	parked, err := runner.parkFixerBudgetIfExhausted(context.Background(), fixer)
-	if err != nil || parked {
-		t.Fatalf("parkFixerBudgetIfExhausted() = (%v, %v), want skipped under default HITL-off config", parked, err)
+	if err != nil || !parked {
+		t.Fatalf("parkFixerBudgetIfExhausted() = (%v, %v), want no-HITL paired park", parked, err)
 	}
 	updated, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
-	if err != nil || updated == nil || updated.Status != "running" {
-		t.Fatalf("fixer = (%#v, %v), want still running", updated, err)
+	if err != nil || updated == nil || updated.Status != "paused" || !loops.IsReviewFixBudgetExhaustedPause(updated.MetadataJSON) {
+		t.Fatalf("fixer = (%#v, %v), want paused review_fix_budget_exhausted", updated, err)
+	}
+	if _, ok := loops.ReadHITLAsk(updated.MetadataJSON); ok {
+		t.Fatal("no-HITL park must not write a HITL ask")
 	}
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
-	if err != nil || sibling == nil || sibling.Status != "waiting" {
-		t.Fatalf("reviewer sibling = (%#v, %v), want still waiting", sibling, err)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("reviewer sibling = (%#v, %v), want paired budget pause", sibling, err)
 	}
 }
 
@@ -1741,20 +1838,20 @@ func TestProcessClaimedItemCompletesSuccessfulFlow(t *testing.T) {
 	}
 }
 
-func TestProcessClaimedItemDoesNotParkBudgetWhenPushClosesPR(t *testing.T) {
+func TestProcessClaimedItemParksBudgetAfterCapReachingPushWithoutResolve(t *testing.T) {
+	// Cap-reaching push must park immediately and must not continue into resolve-comments.
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
 	target := buildPullRequestTargetID(repo, prNumber)
-	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_closed_pr", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_cap_push", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
 		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
 	}
 	github := &fakeGitHubGateway{
-		closeAfterResolve: true,
-		listOpen:          []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
+		listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1"}},
 		viewResponses: []PullRequestDetail{
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
 			{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix-42", BaseRefName: "main", BaseSHA: "base-1", Comments: []map[string]any{{"id": "c1", "threadId": "t1", "body": "please fix"}}, Checks: []map[string]any{{"name": "ci", "conclusion": "FAILURE"}}},
@@ -1789,60 +1886,70 @@ func TestProcessClaimedItemDoesNotParkBudgetWhenPushClosesPR(t *testing.T) {
 	if err != nil || claim == nil {
 		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed item", claim, err)
 	}
-	claimedLoop, err := fixture.repos.Loops.GetByID(context.Background(), *claim.LoopID)
-	if err != nil || claimedLoop == nil {
-		t.Fatalf("Loops.GetByID(claimed) = (%#v, %v), want discovered fixer loop", claimedLoop, err)
-	}
-	pendingMeta := mustMarshalJSON(map[string]any{"pendingFixerRediscovery": map[string]any{"headSha": "head-followup", "fixItemsStateHash": "state-followup", "unresolvedThreadIds": []string{"t2"}, "recordedAt": nowISO}})
-	claimedLoop.MetadataJSON = &pendingMeta
-	if err := fixture.repos.Loops.Upsert(context.Background(), *claimedLoop); err != nil {
-		t.Fatalf("Loops.Upsert(pending rediscovery) error = %v", err)
-	}
 	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
 	if err != nil {
 		t.Fatalf("ProcessClaimedItem() error = %v", err)
 	}
-	if result.Status != "success" {
-		t.Fatalf("result = %#v, want success after pushed fix", result)
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped after cap-reaching push park", result)
+	}
+	if len(github.resolveCalls) != 0 {
+		t.Fatalf("resolve calls = %d, want 0 (no resolve-comments after budget park)", len(github.resolveCalls))
 	}
 	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
-	if err != nil || loop == nil || loop.Status != "terminated" {
-		t.Fatalf("fixer = (%#v, %v), want terminated product terminal after closed PR", loop, err)
-	}
-	reason := ""
-	if loopMeta, ok := parseJSONObject(loop.MetadataJSON)["loop"].(map[string]any); ok {
-		reason, _ = stringFromAny(loopMeta["terminationReason"])
-	}
-	if reason != "pr_closed_or_merged" {
-		t.Fatalf("terminationReason = %q, want pr_closed_or_merged", reason)
+	if err != nil || loop == nil || loop.Status != "awaiting_human" {
+		t.Fatalf("fixer = (%#v, %v), want awaiting_human budget hold", loop, err)
 	}
 	if loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount < 1 {
-		t.Fatalf("push count = %d, want cap-reaching push before closed-PR terminal", loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount)
+		t.Fatalf("push count = %d, want cap-reaching push counted", loops.ReadReviewFixBudgetState(loop.MetadataJSON).PushCount)
 	}
-	if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
-		t.Fatalf("HITL ask = %#v, want no budget ask on a closed PR", ask)
+	if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("HITL ask = %#v, want budget ask", ask)
 	}
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
-	if err != nil || sibling == nil || sibling.Status != "waiting" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
-		t.Fatalf("reviewer sibling = (%#v, %v), want still waiting without budget pause", sibling, err)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("reviewer sibling = (%#v, %v), want paused sibling hold", sibling, err)
 	}
-	active, err := fixture.repos.Queue.FindActiveByLoopID(context.Background(), loop.ID)
+}
+
+func TestEnsureFixerPushBudgetCountedTerminatesWhenPRClosed(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	meta := `{"reviewFixBudget":{"pushCount":0}}`
+	fixer := storage.LoopRecord{ID: "loop_push_closed_pr", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &meta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	run := storage.RunRecord{ID: "run_push_closed_pr", LoopID: fixer.ID, Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Runs.Upsert(context.Background(), run); err != nil {
+		t.Fatalf("Runs.Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
 	if err != nil {
-		t.Fatalf("Queue.FindActiveByLoopID() error = %v", err)
+		t.Fatalf("DefaultConfig: %v", err)
 	}
-	if active != nil {
-		t.Fatalf("activeQueue = %#v, want no follow-up after closed-PR terminal", active)
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "MERGED", HeadSHA: "new-head"}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: true, GitHub: github})
+	checkpoint := fixerCheckpoint{Push: &checkpointPush{Pushed: true, BudgetCounted: false}}
+	_, err = runner.ensureFixerPushBudgetCounted(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:    fixer, Run: run, Repo: repo, PRNumber: prNumber,
+	}, checkpoint)
+	var hold *holdSkipError
+	if err == nil || !errors.As(err, &hold) {
+		t.Fatalf("err = %v, want holdSkipError for closed PR", err)
 	}
-	parked, err := runner.parkFixerBudgetIfExhausted(context.Background(), *loop)
-	if err != nil || parked {
-		t.Fatalf("parkFixerBudgetIfExhausted() = (%v, %v), want skipped on terminated closed PR", parked, err)
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if after == nil || after.Status != "terminated" {
+		t.Fatalf("after = %#v, want terminated (PR-closed wins over budget park)", after)
 	}
-	scheduled, err := runner.schedulePendingRediscoveryAfterRun(context.Background(), *loop, repo, prNumber)
-	if err != nil {
-		t.Fatalf("schedulePendingRediscoveryAfterRun() error = %v", err)
-	}
-	if scheduled {
-		t.Fatal("schedulePendingRediscoveryAfterRun() = true, want no enqueue after closed-PR terminal")
+	if ask, ok := loops.ReadHITLAsk(after.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("budget ask = %#v, want none when PR closed", ask)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -112,6 +112,40 @@ func TestRefusePushIfBudgetExhaustedDoesNotResolveComments(t *testing.T) {
 	}
 }
 
+func TestRefusePushIfBudgetExhaustedFailsClosedOnLedgerRead(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	// Under the live cap: swallowing GetByID would admit the stale snapshot.
+	meta := `{"reviewFixBudget":{"pushCount":0}}`
+	fixer := storage.LoopRecord{ID: "loop_push_ledger_fail", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &meta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg, HITLEnabled: false, GitHub: &fakeGitHubGateway{}})
+	if err := fixture.coordinator.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	refused, err := runner.refusePushIfBudgetExhausted(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:    fixer, Repo: repo, PRNumber: prNumber,
+	})
+	if err == nil {
+		t.Fatalf("refused=%v err=%v, want fail closed on ledger read", refused, err)
+	}
+	if !refused {
+		t.Fatalf("refused=%v, want true when ledger refresh fails", refused)
+	}
+}
+
 func TestEnsureFixerPushBudgetCountedParksWhenCapReached(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/forge/trusted_review_proxy.go
+++ b/internal/forge/trusted_review_proxy.go
@@ -734,7 +734,10 @@ func applyTrustedReviewProxyPolicy(argv []string, policy TrustedReviewProxyPolic
 		"--commit-id", policy.ExpectedCommitID,
 	)
 	if policy.ReviewerManual {
-		bound = append(bound, "--reviewer-manual", "--reviewer-run-id", policy.ReviewerRunID)
+		bound = append(bound, "--reviewer-manual")
+	}
+	if policy.ReviewerRunID != "" {
+		bound = append(bound, "--reviewer-run-id", policy.ReviewerRunID)
 	}
 	return bound
 }

--- a/internal/forge/trusted_review_proxy_test.go
+++ b/internal/forge/trusted_review_proxy_test.go
@@ -98,6 +98,13 @@ func TestApplyTrustedReviewProxyPolicyRewritesAgentFlags(t *testing.T) {
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("applyTrustedReviewProxyPolicy(automatic) = %#v, want %#v", got, want)
 	}
+	// Daemon-authored automatic run identity is still bound.
+	automaticBound := TrustedReviewProxyPolicy{Clean: "COMMENT", Blocking: "COMMENT", ExpectedCommitID: "automatic-head", ReviewerRunID: "run_auto"}
+	got = applyTrustedReviewProxyPolicy([]string{"review", "submit", "acme/looper#1", "--reviewer-run-id=run_agent"}, automaticBound)
+	want = []string{"review", "submit", "acme/looper#1", "--clean-review-event", "COMMENT", "--blocking-review-event", "COMMENT", "--commit-id", "automatic-head", "--reviewer-run-id", "run_auto"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("applyTrustedReviewProxyPolicy(automatic bound) = %#v, want %#v", got, want)
+	}
 }
 
 func testTrustedReviewPolicy() TrustedReviewProxyPolicy {

--- a/internal/infra/notify/human_attention.go
+++ b/internal/infra/notify/human_attention.go
@@ -21,6 +21,9 @@ const (
 	HumanAttentionAwaitingHuman HumanAttentionReason = "awaiting_human"
 	// HumanAttentionManualIntervention is a durable manual_intervention hard hold.
 	HumanAttentionManualIntervention HumanAttentionReason = "manual_intervention"
+	// HumanAttentionReviewFixBudget is a no-HITL review-fix budget exhausted hold
+	// (paused + review_fix_budget_exhausted). Sibling-only pause does not notify.
+	HumanAttentionReviewFixBudget HumanAttentionReason = "review_fix_budget"
 )
 
 // HumanAttentionInput describes one durable entry into a state that requires an operator.
@@ -76,7 +79,7 @@ func (g *Gateway) NotifyHumanAttention(ctx context.Context, input HumanAttention
 		return nil
 	}
 	reason := HumanAttentionReason(strings.TrimSpace(string(input.Reason)))
-	if reason != HumanAttentionAwaitingHuman && reason != HumanAttentionManualIntervention {
+	if reason != HumanAttentionAwaitingHuman && reason != HumanAttentionManualIntervention && reason != HumanAttentionReviewFixBudget {
 		return nil
 	}
 	entryKey := strings.TrimSpace(input.EntryKey)
@@ -291,6 +294,8 @@ func humanAttentionReasonLabel(reason HumanAttentionReason) string {
 		return "awaiting human decision"
 	case HumanAttentionManualIntervention:
 		return "manual intervention"
+	case HumanAttentionReviewFixBudget:
+		return "review-fix budget exhausted"
 	default:
 		return string(reason)
 	}

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -335,7 +335,9 @@ func ParkReviewFixBudget(ctx context.Context, repos *storage.Repositories, input
 
 func parkReviewFixBudgetBody(ctx context.Context, repos *storage.Repositories, input ParkReviewFixBudgetInput) (storage.LoopRecord, error) {
 	exhausted := input.Exhausted
-	if fresh, err := repos.Loops.GetByID(ctx, exhausted.ID); err == nil && fresh != nil {
+	if fresh, err := repos.Loops.GetByID(ctx, exhausted.ID); err != nil {
+		return input.Exhausted, err
+	} else if fresh != nil {
 		exhausted = *fresh
 	}
 	if isReviewFixBudgetExhaustedHold(exhausted) {
@@ -748,16 +750,6 @@ func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, l
 		if encoded == nil {
 			continue
 		}
-		// Clear handoff marker on refill so a later park emits a fresh event.
-		state := ReadReviewFixBudgetState(encoded)
-		if state.HandoffEventAt != "" {
-			state.HandoffEventAt = ""
-			cleared, writeErr := WriteReviewFixBudgetState(encoded, state)
-			if writeErr != nil {
-				return loop, writeErr
-			}
-			encoded = &cleared
-		}
 		updated := *fresh
 		updated.MetadataJSON = encoded
 		updated.UpdatedAt = nowISO
@@ -853,6 +845,7 @@ func releaseOneReviewFixBudgetHold(ctx context.Context, repos *storage.Repositor
 	if state.PauseReason == ReviewFixBudgetPauseReason || state.PauseReason == ReviewFixBudgetTerminationReason {
 		state.PauseReason = ""
 	}
+	state.HandoffEventAt = ""
 	state.ExhaustedBy = ""
 	encoded, err := WriteReviewFixBudgetState(metadata, state)
 	if err != nil {

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -925,13 +925,17 @@ func requeueReviewFixBudgetLoop(ctx context.Context, repos *storage.Repositories
 }
 
 func terminateReviewFixPair(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
-	// Keep the answered/held loop until every same-lane sibling is terminated so
-	// a later poll can retry the same Stop.
+	// Keep the answered/held loop until every currently held same-lane sibling
+	// is terminated so a later poll can retry the same Stop. Historical
+	// completed or independently finished siblings stay untouched.
 	all, err := repos.Loops.List(ctx)
 	if err != nil {
 		return loop, err
 	}
 	for _, sibling := range FindSiblingReviewFixLoops(all, loop) {
+		if !IsReviewFixBudgetHold(sibling) {
+			continue
+		}
 		if _, err := terminateReviewFixLoop(ctx, repos, sibling, nowISO); err != nil {
 			return loop, err
 		}

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -737,14 +737,9 @@ func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, l
 		if fresh == nil {
 			continue
 		}
-		if !IsReviewFixBudgetHold(*fresh) && fresh.ID != loop.ID {
-			// Independently paused / failed siblings are not budget-held.
-			if fresh.Status == "paused" && !IsSiblingReviewFixBudgetPause(fresh.MetadataJSON) && !IsReviewFixBudgetExhaustedPause(fresh.MetadataJSON) {
-				continue
-			}
-			if fresh.Status == "failed" || fresh.Status == "interrupted" {
-				continue
-			}
+		if fresh.ID != loop.ID && !IsReviewFixBudgetHold(*fresh) {
+			// Reset only the answered loop and siblings currently carrying this hold.
+			continue
 		}
 		encoded, resetErr := resetReviewFixBudgetMetersIfNeeded(fresh.MetadataJSON, fresh.Type, caps)
 		if resetErr != nil {

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -2,6 +2,7 @@ package loops
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -24,7 +25,10 @@ const (
 	reviewFixBudgetMetadataKey = "reviewFixBudget"
 	reviewerLoopMetadataKey    = "loop"
 	reviewerIterationCountKey  = "iterationCount"
-	fixerPushCountKey          = "pushCount"
+
+	reviewFixBudgetLaneAutomatic        = "automatic"
+	reviewFixBudgetLaneContinuousManual = "continuous_manual"
+	reviewFixBudgetHandoffEventType     = "loop.review_fix_budget.exhausted"
 )
 
 // ErrReviewFixBudgetInvalidAnswer is the only ApplyReviewFixBudgetAnswer
@@ -35,10 +39,18 @@ var ErrReviewFixBudgetInvalidAnswer = fmt.Errorf("review-fix budget answer must 
 // Authority for the cap is live config; this record only stores counts and
 // which role exhausted.
 type ReviewFixBudgetState struct {
-	PushCount   int    `json:"pushCount,omitempty"`
-	ExhaustedBy string `json:"exhaustedBy,omitempty"`
-	SiblingOf   string `json:"siblingOf,omitempty"`
-	PauseReason string `json:"pauseReason,omitempty"`
+	PushCount      int    `json:"pushCount,omitempty"`
+	ExhaustedBy    string `json:"exhaustedBy,omitempty"`
+	SiblingOf      string `json:"siblingOf,omitempty"`
+	PauseReason    string `json:"pauseReason,omitempty"`
+	HandoffEventAt string `json:"handoffEventAt,omitempty"`
+}
+
+// ReviewFixBudgetLiveCaps carries live role caps for Continue meter refill.
+// Authority is current project/role config, not stored hold state.
+type ReviewFixBudgetLiveCaps struct {
+	ReviewerMaxPublishes int
+	FixerMaxPushes       int
 }
 
 func BudgetExhausted(count, cap int) bool {
@@ -170,6 +182,10 @@ func ResetFixerPushCount(metadataJSON *string) (string, error) {
 	return WriteReviewFixBudgetState(metadataJSON, state)
 }
 
+func FixerPushCount(metadataJSON *string) int {
+	return ReadReviewFixBudgetState(metadataJSON).PushCount
+}
+
 func IsSiblingReviewFixBudgetPause(metadataJSON *string) bool {
 	if reason, _ := stringFromAny(parseMetadataObject(metadataJSON)["pauseReason"]); reason == ReviewFixBudgetPauseReason {
 		return true
@@ -177,9 +193,49 @@ func IsSiblingReviewFixBudgetPause(metadataJSON *string) bool {
 	return ReadReviewFixBudgetState(metadataJSON).PauseReason == ReviewFixBudgetPauseReason
 }
 
-func isManualReviewFixLoop(loop storage.LoopRecord) bool {
-	manual, _ := parseMetadataObject(loop.MetadataJSON)["manual"].(bool)
-	return manual
+// IsReviewFixBudgetExhaustedPause reports a no-HITL exhausted-role hold.
+func IsReviewFixBudgetExhaustedPause(metadataJSON *string) bool {
+	if reason, _ := stringFromAny(parseMetadataObject(metadataJSON)["pauseReason"]); reason == ReviewFixBudgetTerminationReason {
+		return true
+	}
+	state := ReadReviewFixBudgetState(metadataJSON)
+	return state.PauseReason == ReviewFixBudgetTerminationReason
+}
+
+// IsReviewFixBudgetHold reports whether a loop is part of a review-fix budget
+// hold (HITL ask, exhausted no-ask pause, or sibling paired pause).
+func IsReviewFixBudgetHold(loop storage.LoopRecord) bool {
+	switch strings.TrimSpace(loop.Status) {
+	case "awaiting_human":
+		ask, ok := ReadHITLAsk(loop.MetadataJSON)
+		return ok && IsReviewFixBudgetAsk(ask)
+	case "paused":
+		if IsSiblingReviewFixBudgetPause(loop.MetadataJSON) || IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
+			return true
+		}
+		return strings.TrimSpace(ReadReviewFixBudgetState(loop.MetadataJSON).ExhaustedBy) != ""
+	default:
+		return false
+	}
+}
+
+// ParticipatesInReviewFixBudget is true for automatic loops and continuous
+// manual/takeover loops (manual + followUpdates). One-shot manual is exempt.
+func ParticipatesInReviewFixBudget(loop storage.LoopRecord) bool {
+	return reviewFixBudgetLane(loop) != ""
+}
+
+func reviewFixBudgetLane(loop storage.LoopRecord) string {
+	meta := parseMetadataObject(loop.MetadataJSON)
+	manual, _ := meta["manual"].(bool)
+	followUpdates, _ := meta["followUpdates"].(bool)
+	if !manual {
+		return reviewFixBudgetLaneAutomatic
+	}
+	if followUpdates {
+		return reviewFixBudgetLaneContinuousManual
+	}
+	return ""
 }
 
 func isTerminalReviewFixSiblingStatus(status string) bool {
@@ -200,9 +256,14 @@ func isReviewFixBudgetPauseApplicable(status string) bool {
 	}
 }
 
-// FindSiblingReviewFixLoops returns automatic opposite-role loops on the same
-// project/repo/PR. Manual loops are not part of the review-fix budget pair.
+// FindSiblingReviewFixLoops returns opposite-role loops on the same
+// project/repo/PR in the same derived lane (automatic or continuous_manual).
+// One-shot manual loops are excluded. Automatic never pairs with continuous_manual.
 func FindSiblingReviewFixLoops(all []storage.LoopRecord, loop storage.LoopRecord) []storage.LoopRecord {
+	lane := reviewFixBudgetLane(loop)
+	if lane == "" {
+		return nil
+	}
 	wantType := ""
 	switch strings.TrimSpace(loop.Type) {
 	case "reviewer":
@@ -225,7 +286,7 @@ func FindSiblingReviewFixLoops(all []storage.LoopRecord, loop storage.LoopRecord
 		if derefLoopString(candidate.Repo) != repo || derefLoopInt64(candidate.PRNumber) != pr {
 			continue
 		}
-		if isManualReviewFixLoop(candidate) {
+		if reviewFixBudgetLane(candidate) != lane {
 			continue
 		}
 		siblings = append(siblings, candidate)
@@ -233,79 +294,172 @@ func FindSiblingReviewFixLoops(all []storage.LoopRecord, loop storage.LoopRecord
 	return siblings
 }
 
-// FindSiblingReviewFixLoop returns the preferred automatic sibling: a
-// non-terminal match when one exists, otherwise the first automatic match.
-func FindSiblingReviewFixLoop(all []storage.LoopRecord, loop storage.LoopRecord) *storage.LoopRecord {
-	siblings := FindSiblingReviewFixLoops(all, loop)
-	for i := range siblings {
-		if !isTerminalReviewFixSiblingStatus(siblings[i].Status) {
-			return &siblings[i]
-		}
-	}
-	if len(siblings) > 0 {
-		return &siblings[0]
-	}
-	return nil
-}
-
 type ParkReviewFixBudgetInput struct {
-	Exhausted storage.LoopRecord
-	Role      string
-	Repo      string
-	PRNumber  int64
-	Count     int
-	Cap       int
-	NowISO    string
+	Exhausted   storage.LoopRecord
+	Role        string
+	Repo        string
+	PRNumber    int64
+	Count       int
+	Cap         int
+	NowISO      string
+	HITLEnabled bool
+	// LiveCaps optional; used with pair metadata to snapshot both role meters
+	// on the handoff event. Zero caps mean unknown for that role.
+	LiveCaps ReviewFixBudgetLiveCaps
+	// DB optional. When set, exhausted persist + sibling park + queue cancel
+	// run in one transaction so a partial park cannot leave one role runnable.
+	DB *sql.DB
 }
 
-// ParkReviewFixBudget parks the exhausted loop as awaiting_human with a budget
-// HITL ask and pauses the sibling loop on the same PR. Queue items on both
-// sides are cancelled so discovery cannot immediately restart the ping-pong.
-// Re-entry on an already-awaiting budget loop finishes cancel/sibling park
-// without rewriting a delivered ask.
+// ParkReviewFixBudget parks the exhausted loop and pauses same-lane siblings.
+// When HITLEnabled is true the exhausted role is awaiting_human with a Continue/Stop
+// ask; when false it is paused with reason review_fix_budget_exhausted and no ask.
+// Queue items on both sides are cancelled so discovery cannot immediately restart.
+// Re-entry on an already-held budget loop finishes cancel/sibling park and retries
+// a missing handoff event without rewriting a delivered ask or no-ask hold metadata.
 func ParkReviewFixBudget(ctx context.Context, repos *storage.Repositories, input ParkReviewFixBudgetInput) (storage.LoopRecord, error) {
 	if repos == nil || repos.Loops == nil {
 		return input.Exhausted, fmt.Errorf("review-fix budget park requires loop storage")
 	}
+	if input.DB != nil {
+		var parked storage.LoopRecord
+		err := storage.WithTransaction(ctx, input.DB, nil, func(tx *sql.Tx) error {
+			var parkErr error
+			parked, parkErr = parkReviewFixBudgetBody(ctx, storage.NewRepositories(tx), input)
+			return parkErr
+		})
+		return parked, err
+	}
+	return parkReviewFixBudgetBody(ctx, repos, input)
+}
+
+func parkReviewFixBudgetBody(ctx context.Context, repos *storage.Repositories, input ParkReviewFixBudgetInput) (storage.LoopRecord, error) {
 	exhausted := input.Exhausted
-	if ask, ok := ReadHITLAsk(exhausted.MetadataJSON); ok && IsReviewFixBudgetAsk(ask) && exhausted.Status == "awaiting_human" {
+	if fresh, err := repos.Loops.GetByID(ctx, exhausted.ID); err == nil && fresh != nil {
+		exhausted = *fresh
+	}
+	if isReviewFixBudgetExhaustedHold(exhausted) {
 		if err := finishReviewFixBudgetPark(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
+			return exhausted, err
+		}
+		// Re-entry: retry a missing handoff event after the pair is non-runnable.
+		if err := ensureReviewFixBudgetHandoffEvent(ctx, repos, exhausted, input); err != nil {
 			return exhausted, err
 		}
 		return exhausted, nil
 	}
-	ask := NewReviewFixBudgetAsk(input.Role, input.Repo, input.PRNumber, input.Count, input.Cap, input.NowISO)
-	metadata, err := WriteHITLAsk(exhausted.MetadataJSON, ask)
+
+	// Fail-closed order without relying on outer TX alone: cancel queues and
+	// park siblings before persisting the exhausted hold so a sibling failure
+	// never leaves the sibling runnable while the exhausted side is already held.
+	if err := cancelReviewFixBudgetQueues(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
+		return input.Exhausted, err
+	}
+	if err := parkSiblingReviewFixLoop(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
+		return input.Exhausted, err
+	}
+
+	role := strings.TrimSpace(input.Role)
+	state := ReadReviewFixBudgetState(exhausted.MetadataJSON)
+	state.ExhaustedBy = role
+	state.PauseReason = ""
+	if !input.HITLEnabled {
+		state.PauseReason = ReviewFixBudgetTerminationReason
+	}
+	metadata, err := WriteReviewFixBudgetState(exhausted.MetadataJSON, state)
 	if err != nil {
 		return input.Exhausted, err
 	}
-	state := ReadReviewFixBudgetState(&metadata)
-	state.ExhaustedBy = strings.TrimSpace(input.Role)
-	metadata, err = WriteReviewFixBudgetState(&metadata, state)
-	if err != nil {
-		return input.Exhausted, err
+	if input.HITLEnabled {
+		ask := NewReviewFixBudgetAsk(input.Role, input.Repo, input.PRNumber, input.Count, input.Cap, input.NowISO)
+		metadata, err = WriteHITLAsk(&metadata, ask)
+		if err != nil {
+			return input.Exhausted, err
+		}
+		exhausted.Status = "awaiting_human"
+	} else {
+		if ask, ok := ReadHITLAsk(&metadata); ok && IsReviewFixBudgetAsk(ask) {
+			cleared, clearErr := ClearHITLAsk(&metadata)
+			if clearErr != nil {
+				return input.Exhausted, clearErr
+			}
+			metadata = cleared
+		}
+		meta := parseMetadataObject(&metadata)
+		meta["pauseReason"] = ReviewFixBudgetTerminationReason
+		encoded, marshalErr := json.Marshal(meta)
+		if marshalErr != nil {
+			return input.Exhausted, marshalErr
+		}
+		metadata = string(encoded)
+		exhausted.Status = "paused"
 	}
 	exhausted.MetadataJSON = &metadata
-	exhausted.Status = "awaiting_human"
 	exhausted.NextRunAt = nil
 	exhausted.UpdatedAt = input.NowISO
 	if err := repos.Loops.Upsert(ctx, exhausted); err != nil {
 		return input.Exhausted, err
 	}
-	if err := finishReviewFixBudgetPark(ctx, repos, exhausted, input.Role, input.NowISO); err != nil {
+	// Cancel exhausted queue again after status flip (idempotent).
+	if repos.Queue != nil {
+		reason := ReviewFixBudgetTerminationReason
+		if _, err := repos.Queue.CancelByLoop(ctx, exhausted.ID, input.NowISO, &reason); err != nil {
+			return exhausted, err
+		}
+	}
+	if err := ensureReviewFixBudgetHandoffEvent(ctx, repos, exhausted, input); err != nil {
+		// Pair is already non-runnable; surface the error so re-entry retries.
 		return exhausted, err
 	}
 	return exhausted, nil
 }
 
+func isReviewFixBudgetExhaustedHold(loop storage.LoopRecord) bool {
+	switch strings.TrimSpace(loop.Status) {
+	case "awaiting_human":
+		ask, ok := ReadHITLAsk(loop.MetadataJSON)
+		return ok && IsReviewFixBudgetAsk(ask)
+	case "paused":
+		return IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) ||
+			(strings.TrimSpace(ReadReviewFixBudgetState(loop.MetadataJSON).ExhaustedBy) != "" && !IsSiblingReviewFixBudgetPause(loop.MetadataJSON))
+	default:
+		return false
+	}
+}
+
 func finishReviewFixBudgetPark(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, exhaustedBy, nowISO string) error {
-	if repos.Queue != nil {
-		reason := ReviewFixBudgetTerminationReason
-		if _, err := repos.Queue.CancelByLoop(ctx, exhausted.ID, nowISO, &reason); err != nil {
+	if err := cancelReviewFixBudgetQueues(ctx, repos, exhausted, exhaustedBy, nowISO); err != nil {
+		return err
+	}
+	return parkSiblingReviewFixLoop(ctx, repos, exhausted, exhaustedBy, nowISO)
+}
+
+func cancelReviewFixBudgetQueues(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, exhaustedBy, nowISO string) error {
+	if repos.Queue == nil {
+		return nil
+	}
+	reason := ReviewFixBudgetTerminationReason
+	if _, err := repos.Queue.CancelByLoop(ctx, exhausted.ID, nowISO, &reason); err != nil {
+		return err
+	}
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	siblingReason := ReviewFixBudgetPauseReason
+	for _, sibling := range FindSiblingReviewFixLoops(all, exhausted) {
+		if !isReviewFixBudgetPauseApplicable(sibling.Status) {
+			continue
+		}
+		if sibling.Status == "paused" && !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) && !IsReviewFixBudgetExhaustedPause(sibling.MetadataJSON) {
+			continue
+		}
+		if _, err := repos.Queue.CancelByLoop(ctx, sibling.ID, nowISO, &siblingReason); err != nil {
 			return err
 		}
 	}
-	return parkSiblingReviewFixLoop(ctx, repos, exhausted, exhaustedBy, nowISO)
+	_ = exhaustedBy
+	return nil
 }
 
 func parkSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, exhaustedBy, nowISO string) error {
@@ -321,11 +475,34 @@ func parkSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, 
 	return nil
 }
 
+// reviewFixBudgetSiblingParkHook, when set (tests only), runs before sibling
+// persist so failure-path coverage can inject list/upsert errors.
+var reviewFixBudgetSiblingParkHook func(sibling storage.LoopRecord) error
+
+// reviewFixBudgetReleaseHook, when set (tests only), runs after a successful
+// release of one hold so Continue failure after partial release can be injected.
+var reviewFixBudgetReleaseHook func(loopID string) error
+
 func parkOneSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, sibling storage.LoopRecord, exhaustedBy, nowISO string) error {
+	if reviewFixBudgetSiblingParkHook != nil {
+		if err := reviewFixBudgetSiblingParkHook(sibling); err != nil {
+			return err
+		}
+	}
 	if !isReviewFixBudgetPauseApplicable(sibling.Status) {
 		return nil
 	}
-	if sibling.Status == "paused" && !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+	if sibling.Status == "paused" && !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) && !IsReviewFixBudgetExhaustedPause(sibling.MetadataJSON) {
+		return nil
+	}
+	// Already sibling-paused: still cancel queue on re-entry.
+	if sibling.Status == "paused" && IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		if repos.Queue != nil {
+			reason := ReviewFixBudgetPauseReason
+			if _, err := repos.Queue.CancelByLoop(ctx, sibling.ID, nowISO, &reason); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 	state := ReadReviewFixBudgetState(sibling.MetadataJSON)
@@ -359,19 +536,165 @@ func parkOneSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositorie
 	return nil
 }
 
+func ensureReviewFixBudgetHandoffEvent(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, input ParkReviewFixBudgetInput) error {
+	if repos == nil || repos.Events == nil {
+		return nil
+	}
+	state := ReadReviewFixBudgetState(exhausted.MetadataJSON)
+	if strings.TrimSpace(state.HandoffEventAt) != "" {
+		return nil
+	}
+	if err := appendReviewFixBudgetHandoffEvent(ctx, repos, exhausted, input); err != nil {
+		return err
+	}
+	state = ReadReviewFixBudgetState(exhausted.MetadataJSON)
+	state.HandoffEventAt = input.NowISO
+	encoded, err := WriteReviewFixBudgetState(exhausted.MetadataJSON, state)
+	if err != nil {
+		return err
+	}
+	updated := exhausted
+	updated.MetadataJSON = &encoded
+	updated.UpdatedAt = input.NowISO
+	return repos.Loops.Upsert(ctx, updated)
+}
+
+func appendReviewFixBudgetHandoffEvent(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, input ParkReviewFixBudgetInput) error {
+	if repos == nil || repos.Events == nil {
+		return nil
+	}
+	lane := reviewFixBudgetLane(exhausted)
+	resume := reviewFixBudgetHandoffResume(exhausted, input.HITLEnabled)
+	head := reviewFixBudgetHandoffHead(exhausted)
+	reviewerCount, reviewerCap, fixerCount, fixerCap, exhaustedRoles := reviewFixBudgetHandoffMeters(ctx, repos, exhausted, input)
+	projectID := strings.TrimSpace(exhausted.ProjectID)
+	loopID := strings.TrimSpace(exhausted.ID)
+	exhaustedBy := strings.TrimSpace(input.Role)
+	if len(exhaustedRoles) > 1 {
+		exhaustedBy = strings.Join(exhaustedRoles, ",")
+	}
+	payload := map[string]any{
+		"level":          "action_required",
+		"kind":           HITLKindReviewFixBudget,
+		"repo":           strings.TrimSpace(input.Repo),
+		"prNumber":       input.PRNumber,
+		"lane":           lane,
+		"exhaustedBy":    exhaustedBy,
+		"exhaustedRoles": exhaustedRoles,
+		"hitlEnabled":    input.HITLEnabled,
+		"resume":         resume,
+		"reviewer":       map[string]any{"count": reviewerCount, "cap": reviewerCap},
+		"fixer":          map[string]any{"count": fixerCount, "cap": fixerCap},
+	}
+	if head != "" {
+		payload["head"] = head
+	}
+	return eventlog.Append(ctx, repos, eventlog.AppendInput{
+		EventType:  reviewFixBudgetHandoffEventType,
+		ProjectID:  optionalBudgetString(projectID),
+		LoopID:     optionalBudgetString(loopID),
+		EntityType: optionalBudgetString("loop"),
+		EntityID:   optionalBudgetString(loopID),
+		ActorType:  optionalBudgetString("system"),
+		ActorID:    optionalBudgetString("review-fix-budget"),
+		Payload:    payload,
+	})
+}
+
+// reviewFixBudgetHandoffResume returns concrete CLI commands including loop seq
+// (fallback to id when seq is 0). HITL-on keeps Continue/Stop plus the same CLI.
+func reviewFixBudgetHandoffResume(exhausted storage.LoopRecord, hitlEnabled bool) string {
+	selector := strings.TrimSpace(exhausted.ID)
+	if exhausted.Seq > 0 {
+		selector = fmt.Sprintf("%d", exhausted.Seq)
+	}
+	cli := fmt.Sprintf("looper unpause %s / looper stop %s", selector, selector)
+	if hitlEnabled {
+		return ReviewFixBudgetAnswerContinue + " / " + ReviewFixBudgetAnswerStop + "; " + cli
+	}
+	return cli
+}
+
+// reviewFixBudgetHandoffHead prefers lastPublishedHeadSha (reviewer) then
+// lastFixHeadSha (fixer) from exhausted-loop metadata.
+func reviewFixBudgetHandoffHead(exhausted storage.LoopRecord) string {
+	meta := parseMetadataObject(exhausted.MetadataJSON)
+	if head, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && strings.TrimSpace(head) != "" {
+		return strings.TrimSpace(head)
+	}
+	if head, ok := stringFromAny(meta["lastFixHeadSha"]); ok && strings.TrimSpace(head) != "" {
+		return strings.TrimSpace(head)
+	}
+	return ""
+}
+
+func reviewFixBudgetHandoffMeters(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, input ParkReviewFixBudgetInput) (reviewerCount, reviewerCap, fixerCount, fixerCap int, exhaustedRoles []string) {
+	reviewerCap = input.LiveCaps.ReviewerMaxPublishes
+	fixerCap = input.LiveCaps.FixerMaxPushes
+	if reviewerCap == 0 && strings.TrimSpace(exhausted.Type) == "reviewer" {
+		reviewerCap = input.Cap
+	}
+	if fixerCap == 0 && strings.TrimSpace(exhausted.Type) == "fixer" {
+		fixerCap = input.Cap
+	}
+	// Prefer live pair metadata over the single-role Count/Cap snapshot.
+	members := []storage.LoopRecord{exhausted}
+	if repos != nil && repos.Loops != nil {
+		if all, err := repos.Loops.List(ctx); err == nil {
+			members = reviewFixBudgetPairMembers(all, exhausted)
+		}
+	}
+	for _, member := range members {
+		switch strings.TrimSpace(member.Type) {
+		case "reviewer":
+			reviewerCount = ReviewerPublishCount(member.MetadataJSON)
+		case "fixer":
+			fixerCount = FixerPushCount(member.MetadataJSON)
+		}
+	}
+	// Fall back to the triggering role's admission snapshot when pair read is empty.
+	if strings.TrimSpace(exhausted.Type) == "reviewer" && reviewerCount == 0 && input.Count > 0 {
+		reviewerCount = input.Count
+	}
+	if strings.TrimSpace(exhausted.Type) == "fixer" && fixerCount == 0 && input.Count > 0 {
+		fixerCount = input.Count
+	}
+	if BudgetExhausted(reviewerCount, reviewerCap) {
+		exhaustedRoles = append(exhaustedRoles, "reviewer")
+	}
+	if BudgetExhausted(fixerCount, fixerCap) {
+		exhaustedRoles = append(exhaustedRoles, "fixer")
+	}
+	if len(exhaustedRoles) == 0 && strings.TrimSpace(input.Role) != "" {
+		exhaustedRoles = []string{strings.TrimSpace(input.Role)}
+	}
+	return reviewerCount, reviewerCap, fixerCount, fixerCap, exhaustedRoles
+}
+
+func optionalBudgetString(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
 type ReviewFixBudgetAnswerResult struct {
 	Applied bool
 	Action  string
 	Loop    storage.LoopRecord
 }
 
-// ApplyReviewFixBudgetAnswer handles Continue (reset counter, queue, unpause
-// sibling) or Stop (terminate both). Returns Applied=false for mid-run HITL asks.
-func ApplyReviewFixBudgetAnswer(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string) (ReviewFixBudgetAnswerResult, error) {
-	ask, ok := ReadHITLAsk(loop.MetadataJSON)
-	if !ok || !IsReviewFixBudgetAsk(ask) {
+// ApplyReviewFixBudgetAnswer handles Continue (reset at/over-cap meters, queue,
+// release pair) or Stop (terminate both). Works for HITL asks and no-ask holds.
+// Caps must be live config values used to decide which meters to refill.
+// Returns Applied=false when the loop is not a review-fix budget hold.
+func ApplyReviewFixBudgetAnswer(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string, caps ReviewFixBudgetLiveCaps) (ReviewFixBudgetAnswerResult, error) {
+	if !IsReviewFixBudgetHold(loop) {
 		return ReviewFixBudgetAnswerResult{}, nil
 	}
+	// Mid-run agent asks share awaiting_human but are not budget holds; the
+	// IsReviewFixBudgetHold check above already requires a budget ask kind.
 	if repos == nil || repos.Loops == nil {
 		return ReviewFixBudgetAnswerResult{}, fmt.Errorf("review-fix budget answer requires loop storage")
 	}
@@ -385,56 +708,187 @@ func ApplyReviewFixBudgetAnswer(ctx context.Context, repos *storage.Repositories
 	if !IsReviewFixBudgetContinue(answer) {
 		return ReviewFixBudgetAnswerResult{}, ErrReviewFixBudgetInvalidAnswer
 	}
-	updated, err := continueReviewFixBudget(ctx, repos, loop, nowISO)
+	updated, err := continueReviewFixBudget(ctx, repos, loop, nowISO, caps)
 	if err != nil {
 		return ReviewFixBudgetAnswerResult{}, err
 	}
 	return ReviewFixBudgetAnswerResult{Applied: true, Action: "continue", Loop: updated}, nil
 }
 
-func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
-	// Keep awaiting_human + the budget ask until sibling unpause and requeue
-	// succeed so a later GitHub/Feishu poll can retry the same answer.
-	if err := unpauseSiblingReviewFixLoop(ctx, repos, loop, nowISO); err != nil {
+func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string, caps ReviewFixBudgetLiveCaps) (storage.LoopRecord, error) {
+	// Keep holds until every required meter reset succeeds, then release the pair.
+	// Fail-closed: never unpause a sibling until meters are reset and the
+	// exhausted/answered side can complete its transition. Callers that have a
+	// DB should wrap ApplyReviewFixBudgetAnswer in storage.WithTransaction so
+	// release is atomic; without a TX we still release the answered side first
+	// so a later sibling failure cannot leave a sibling queued while the
+	// exhausted side remains held.
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
 		return loop, err
 	}
-	if err := requeueReviewFixBudgetLoop(ctx, repos, loop.ID, nowISO); err != nil {
+	members := reviewFixBudgetPairMembers(all, loop)
+
+	for _, member := range members {
+		fresh, getErr := repos.Loops.GetByID(ctx, member.ID)
+		if getErr != nil {
+			return loop, getErr
+		}
+		if fresh == nil {
+			continue
+		}
+		if !IsReviewFixBudgetHold(*fresh) && fresh.ID != loop.ID {
+			// Independently paused / failed siblings are not budget-held.
+			if fresh.Status == "paused" && !IsSiblingReviewFixBudgetPause(fresh.MetadataJSON) && !IsReviewFixBudgetExhaustedPause(fresh.MetadataJSON) {
+				continue
+			}
+			if fresh.Status == "failed" || fresh.Status == "interrupted" {
+				continue
+			}
+		}
+		encoded, resetErr := resetReviewFixBudgetMetersIfNeeded(fresh.MetadataJSON, fresh.Type, caps)
+		if resetErr != nil {
+			return loop, resetErr
+		}
+		if encoded == nil {
+			continue
+		}
+		// Clear handoff marker on refill so a later park emits a fresh event.
+		state := ReadReviewFixBudgetState(encoded)
+		if state.HandoffEventAt != "" {
+			state.HandoffEventAt = ""
+			cleared, writeErr := WriteReviewFixBudgetState(encoded, state)
+			if writeErr != nil {
+				return loop, writeErr
+			}
+			encoded = &cleared
+		}
+		updated := *fresh
+		updated.MetadataJSON = encoded
+		updated.UpdatedAt = nowISO
+		if err := repos.Loops.Upsert(ctx, updated); err != nil {
+			return loop, err
+		}
+	}
+
+	// Release answered/exhausted side first while siblings stay held.
+	if err := releaseOneReviewFixBudgetHold(ctx, repos, loop.ID, nowISO); err != nil {
 		return loop, err
 	}
-	metadata := loop.MetadataJSON
-	switch loop.Type {
+	for _, member := range members {
+		if member.ID == loop.ID {
+			continue
+		}
+		if err := releaseOneReviewFixBudgetHold(ctx, repos, member.ID, nowISO); err != nil {
+			return loop, err
+		}
+	}
+	fresh, err := repos.Loops.GetByID(ctx, loop.ID)
+	if err != nil {
+		return loop, err
+	}
+	if fresh == nil {
+		return loop, fmt.Errorf("review-fix budget continue lost loop %s", loop.ID)
+	}
+	return *fresh, nil
+}
+
+func reviewFixBudgetPairMembers(all []storage.LoopRecord, loop storage.LoopRecord) []storage.LoopRecord {
+	members := FindSiblingReviewFixLoops(all, loop)
+	members = append(members, loop)
+	return members
+}
+
+func resetReviewFixBudgetMetersIfNeeded(metadataJSON *string, loopType string, caps ReviewFixBudgetLiveCaps) (*string, error) {
+	switch strings.TrimSpace(loopType) {
 	case "reviewer":
-		encoded, resetErr := ResetReviewerPublishCount(metadata)
-		if resetErr != nil {
-			return loop, resetErr
+		if !BudgetExhausted(ReviewerPublishCount(metadataJSON), caps.ReviewerMaxPublishes) {
+			return nil, nil
 		}
-		metadata = &encoded
+		encoded, err := ResetReviewerPublishCount(metadataJSON)
+		if err != nil {
+			return nil, err
+		}
+		// Clear exhausted markers on the meter owner when refilling.
+		state := ReadReviewFixBudgetState(&encoded)
+		state.ExhaustedBy = ""
+		if state.PauseReason == ReviewFixBudgetTerminationReason {
+			state.PauseReason = ""
+		}
+		encoded, err = WriteReviewFixBudgetState(&encoded, state)
+		if err != nil {
+			return nil, err
+		}
+		return &encoded, nil
 	case "fixer":
-		encoded, resetErr := ResetFixerPushCount(metadata)
-		if resetErr != nil {
-			return loop, resetErr
+		if !BudgetExhausted(FixerPushCount(metadataJSON), caps.FixerMaxPushes) {
+			return nil, nil
 		}
-		metadata = &encoded
+		encoded, err := ResetFixerPushCount(metadataJSON)
+		if err != nil {
+			return nil, err
+		}
+		return &encoded, nil
+	default:
+		return nil, nil
 	}
-	cleared, err := ClearHITLAsk(metadata)
+}
+
+func releaseOneReviewFixBudgetHold(ctx context.Context, repos *storage.Repositories, loopID, nowISO string) error {
+	fresh, err := repos.Loops.GetByID(ctx, loopID)
 	if err != nil {
-		return loop, err
+		return err
 	}
-	state := ReadReviewFixBudgetState(&cleared)
+	if fresh == nil {
+		return nil
+	}
+	if !IsReviewFixBudgetHold(*fresh) {
+		return nil
+	}
+	metadata := fresh.MetadataJSON
+	if ask, ok := ReadHITLAsk(metadata); ok && IsReviewFixBudgetAsk(ask) {
+		cleared, clearErr := ClearHITLAsk(metadata)
+		if clearErr != nil {
+			return clearErr
+		}
+		metadata = &cleared
+	}
+	state := ReadReviewFixBudgetState(metadata)
+	state.SiblingOf = ""
+	if state.PauseReason == ReviewFixBudgetPauseReason || state.PauseReason == ReviewFixBudgetTerminationReason {
+		state.PauseReason = ""
+	}
 	state.ExhaustedBy = ""
-	cleared, err = WriteReviewFixBudgetState(&cleared, state)
+	encoded, err := WriteReviewFixBudgetState(metadata, state)
 	if err != nil {
-		return loop, err
+		return err
 	}
-	updated := loop
-	updated.MetadataJSON = &cleared
+	meta := parseMetadataObject(&encoded)
+	if reason, _ := stringFromAny(meta["pauseReason"]); reason == ReviewFixBudgetPauseReason || reason == ReviewFixBudgetTerminationReason {
+		delete(meta, "pauseReason")
+	}
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	text := string(out)
+	updated := *fresh
+	updated.MetadataJSON = &text
 	updated.Status = "queued"
 	updated.NextRunAt = &nowISO
 	updated.UpdatedAt = nowISO
 	if err := repos.Loops.Upsert(ctx, updated); err != nil {
-		return loop, err
+		return err
 	}
-	return updated, nil
+	if err := requeueReviewFixBudgetLoop(ctx, repos, updated.ID, nowISO); err != nil {
+		return err
+	}
+	if reviewFixBudgetReleaseHook != nil {
+		if err := reviewFixBudgetReleaseHook(updated.ID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func requeueReviewFixBudgetLoop(ctx context.Context, repos *storage.Repositories, loopID, nowISO string) error {
@@ -482,51 +936,9 @@ func requeueReviewFixBudgetLoop(ctx context.Context, repos *storage.Repositories
 	return err
 }
 
-func unpauseSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, exhausted storage.LoopRecord, nowISO string) error {
-	all, err := repos.Loops.List(ctx)
-	if err != nil {
-		return err
-	}
-	for _, sibling := range FindSiblingReviewFixLoops(all, exhausted) {
-		if sibling.Status != "paused" || !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
-			continue
-		}
-		if err := unpauseOneSiblingReviewFixLoop(ctx, repos, sibling, nowISO); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func unpauseOneSiblingReviewFixLoop(ctx context.Context, repos *storage.Repositories, sibling storage.LoopRecord, nowISO string) error {
-	state := ReadReviewFixBudgetState(sibling.MetadataJSON)
-	state.SiblingOf = ""
-	state.PauseReason = ""
-	metadata, err := WriteReviewFixBudgetState(sibling.MetadataJSON, state)
-	if err != nil {
-		return err
-	}
-	meta := parseMetadataObject(&metadata)
-	delete(meta, "pauseReason")
-	encoded, err := json.Marshal(meta)
-	if err != nil {
-		return err
-	}
-	text := string(encoded)
-	updated := sibling
-	updated.MetadataJSON = &text
-	updated.Status = "queued"
-	updated.NextRunAt = &nowISO
-	updated.UpdatedAt = nowISO
-	if err := repos.Loops.Upsert(ctx, updated); err != nil {
-		return err
-	}
-	return requeueReviewFixBudgetLoop(ctx, repos, updated.ID, nowISO)
-}
-
 func terminateReviewFixPair(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
-	// Keep awaiting_human + the budget ask until every automatic sibling is
-	// terminated so a later GitHub/Feishu poll can retry the same Stop.
+	// Keep the answered/held loop until every same-lane sibling is terminated so
+	// a later poll can retry the same Stop.
 	all, err := repos.Loops.List(ctx)
 	if err != nil {
 		return loop, err
@@ -554,12 +966,25 @@ func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, lo
 		loopMeta["terminationReason"] = ReviewFixBudgetTerminationReason
 		meta[reviewerLoopMetadataKey] = loopMeta
 	}
+	if reason, _ := stringFromAny(meta["pauseReason"]); reason == ReviewFixBudgetPauseReason || reason == ReviewFixBudgetTerminationReason {
+		delete(meta, "pauseReason")
+	}
 	encoded, err := json.Marshal(meta)
 	if err != nil {
 		return loop, err
 	}
 	encodedText := string(encoded)
 	cleared, err := ClearHITLAsk(&encodedText)
+	if err != nil {
+		return loop, err
+	}
+	state := ReadReviewFixBudgetState(&cleared)
+	state.SiblingOf = ""
+	state.ExhaustedBy = ""
+	if state.PauseReason == ReviewFixBudgetPauseReason || state.PauseReason == ReviewFixBudgetTerminationReason {
+		state.PauseReason = ""
+	}
+	cleared, err = WriteReviewFixBudgetState(&cleared, state)
 	if err != nil {
 		return loop, err
 	}

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -2,6 +2,9 @@ package loops
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,7 +53,7 @@ func TestParkAndContinueReviewFixBudget(t *testing.T) {
 	seedBudgetQueue(t, repos, nowISO, "queue_fixer", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -77,7 +80,7 @@ func TestParkAndContinueReviewFixBudget(t *testing.T) {
 		}
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "continue" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -108,7 +111,7 @@ func TestContinueReviewFixBudgetEnqueuesFreshWorkAfterCompletedClaim(t *testing.
 	}
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -122,7 +125,7 @@ func TestContinueReviewFixBudgetEnqueuesFreshWorkAfterCompletedClaim(t *testing.
 		t.Fatalf("sibling queue after park = (%#v, %v), want cancelled", siblingQueue, err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "continue" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -154,7 +157,7 @@ func TestApplyReviewFixBudgetAnswerStopTerminatesPair(t *testing.T) {
 		t.Fatalf("Loops.Upsert() error = %v", err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, reviewer, "Stop", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, reviewer, "Stop", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "stop" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -167,7 +170,7 @@ func TestApplyReviewFixBudgetAnswerStopTerminatesPair(t *testing.T) {
 	}
 }
 
-func TestFindSiblingReviewFixLoopPrefersActiveAutomatic(t *testing.T) {
+func TestFindSiblingReviewFixLoopsPrefersAutomaticLane(t *testing.T) {
 	t.Parallel()
 	repo := "acme/looper"
 	pr := int64(42)
@@ -177,10 +180,6 @@ func TestFindSiblingReviewFixLoopPrefersActiveAutomatic(t *testing.T) {
 	terminalFixer := storage.LoopRecord{ID: "loop_terminal_fixer", ProjectID: "project_1", Type: "fixer", Status: "terminated", Repo: &repo, PRNumber: &pr}
 	automaticFixer := storage.LoopRecord{ID: "loop_auto_fixer", ProjectID: "project_1", Type: "fixer", Status: "queued", Repo: &repo, PRNumber: &pr}
 
-	got := FindSiblingReviewFixLoop([]storage.LoopRecord{manualFixer, terminalFixer, automaticFixer}, reviewer)
-	if got == nil || got.ID != automaticFixer.ID {
-		t.Fatalf("FindSiblingReviewFixLoop() = %#v, want automatic fixer", got)
-	}
 	siblings := FindSiblingReviewFixLoops([]storage.LoopRecord{manualFixer, terminalFixer, automaticFixer}, reviewer)
 	if len(siblings) != 2 || siblings[0].ID != terminalFixer.ID || siblings[1].ID != automaticFixer.ID {
 		t.Fatalf("FindSiblingReviewFixLoops() = %#v, want automatic siblings only", siblings)
@@ -202,7 +201,7 @@ func TestParkAndStopReviewFixBudgetSkipsManualSibling(t *testing.T) {
 	seedBudgetQueue(t, repos, nowISO, "queue_fixer_auto", automatic.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -216,7 +215,7 @@ func TestParkAndStopReviewFixBudgetSkipsManualSibling(t *testing.T) {
 		t.Fatalf("automatic sibling = (%#v, %v), want paused", automaticAfter, err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "stop" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -259,7 +258,7 @@ func TestParkReviewFixBudgetCompletesSiblingAfterPartialPark(t *testing.T) {
 	}
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -289,16 +288,16 @@ func TestContinueReviewFixBudgetRetriesAfterSiblingAlreadyUnpaused(t *testing.T)
 	seedBudgetQueue(t, repos, nowISO, "queue_fixer_retry", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
 	}
-	if err := unpauseSiblingReviewFixLoop(context.Background(), repos, parked, nowISO); err != nil {
-		t.Fatalf("unpauseSiblingReviewFixLoop() error = %v", err)
+	if err := releaseOneReviewFixBudgetHold(context.Background(), repos, fixer.ID, nowISO); err != nil {
+		t.Fatalf("releaseOneReviewFixBudgetHold(sibling) error = %v", err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "continue" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -328,7 +327,7 @@ func TestParkAndContinueReviewFixBudgetSkipsPreexistingPausedSibling(t *testing.
 	seedBudgetQueue(t, repos, nowISO, "queue_fixer_pre_paused", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -345,7 +344,7 @@ func TestParkAndContinueReviewFixBudgetSkipsPreexistingPausedSibling(t *testing.
 		t.Fatalf("sibling queue after park = (%#v, %v), want still queued", siblingQueue, err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "continue" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -375,7 +374,7 @@ func TestParkAndContinueReviewFixBudgetSkipsFailedSibling(t *testing.T) {
 			seedBudgetQueue(t, repos, nowISO, "queue_fixer_"+status, fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 			parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-				Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+				Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 			})
 			if err != nil {
 				t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -389,7 +388,7 @@ func TestParkAndContinueReviewFixBudgetSkipsFailedSibling(t *testing.T) {
 				t.Fatalf("sibling queue after park = (%#v, %v), want still queued", siblingQueue, err)
 			}
 
-			result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO)
+			result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(8, 8))
 			if err != nil || !result.Applied || result.Action != "continue" {
 				t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 			}
@@ -414,7 +413,7 @@ func TestStopReviewFixBudgetRetriesAfterSiblingAlreadyTerminated(t *testing.T) {
 	seedBudgetQueue(t, repos, nowISO, "queue_fixer_stop_retry", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -423,7 +422,7 @@ func TestStopReviewFixBudgetRetriesAfterSiblingAlreadyTerminated(t *testing.T) {
 		t.Fatalf("terminateReviewFixLoop(sibling) error = %v", err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "stop" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
@@ -448,10 +447,481 @@ func TestApplyReviewFixBudgetAnswerIgnoresAgentAsk(t *testing.T) {
 		t.Fatalf("WriteHITLAsk() error = %v", err)
 	}
 	loop.MetadataJSON = &metadata
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, loop, "Continue", nowISO)
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, loop, "Continue", nowISO, testBudgetCaps(8, 8))
 	if err != nil || result.Applied {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v), want not applied", result, err)
 	}
+}
+
+func TestBudgetExhaustedIndependentCapsAndZeroDisablesRole(t *testing.T) {
+	t.Parallel()
+	if BudgetExhausted(3, 0) {
+		t.Fatal("cap 0 must disable only that role")
+	}
+	if !BudgetExhausted(3, 3) {
+		t.Fatal("3/3 must be exhausted")
+	}
+	if BudgetExhausted(2, 3) {
+		t.Fatal("2/3 must not be exhausted")
+	}
+	// Live cap lowered below current count halts on next admission.
+	if !BudgetExhausted(5, 3) {
+		t.Fatal("count above lowered live cap must be exhausted")
+	}
+}
+
+func TestParkNoHITLPausesPairWithoutAsk(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_nohitl", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_nohitl", "fixer", "queued")
+	seedBudgetQueue(t, repos, nowISO, "queue_reviewer_nohitl", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer_nohitl", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	if parked.Status != "paused" || !IsReviewFixBudgetExhaustedPause(parked.MetadataJSON) {
+		t.Fatalf("exhausted = %#v, want paused with review_fix_budget_exhausted", parked)
+	}
+	if _, ok := ReadHITLAsk(parked.MetadataJSON); ok {
+		t.Fatal("no-HITL park must not write a HITL ask")
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling = (%#v, %v), want paired budget pause", sibling, err)
+	}
+	for _, queueID := range []string{"queue_reviewer_nohitl", "queue_fixer_nohitl"} {
+		queue, err := repos.Queue.GetByID(context.Background(), queueID)
+		if err != nil || queue == nil || queue.Status != "cancelled" {
+			t.Fatalf("%s = (%#v, %v), want cancelled", queueID, queue, err)
+		}
+	}
+}
+
+func TestContinueNoHITLFromEitherRoleResetsOnlyExhaustedMeters(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	fixerMeta := `{"reviewFixBudget":{"pushCount":1}}`
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_cont_nohitl", "reviewer", "running")
+	reviewer.MetadataJSON = &reviewerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_cont_nohitl", "fixer", "queued")
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	seedBudgetQueue(t, repos, nowISO, "queue_reviewer_cont_nohitl", reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+	seedBudgetQueue(t, repos, nowISO, "queue_fixer_cont_nohitl", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	// Unpause from sibling side.
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil {
+		t.Fatalf("sibling get: %v", err)
+	}
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, *sibling, "Continue", nowISO, testBudgetCaps(3, 3))
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("Continue from sibling = (%#v, %v)", result, err)
+	}
+	reviewerAfter, err := repos.Loops.GetByID(context.Background(), parked.ID)
+	if err != nil || reviewerAfter == nil || reviewerAfter.Status != "queued" || ReviewerPublishCount(reviewerAfter.MetadataJSON) != 0 {
+		t.Fatalf("reviewer after continue = (%#v, %v), want queued with reset count", reviewerAfter, err)
+	}
+	fixerAfter, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || fixerAfter == nil || fixerAfter.Status != "queued" || FixerPushCount(fixerAfter.MetadataJSON) != 1 {
+		t.Fatalf("fixer after continue = (%#v, %v), want queued with preserved unused push budget", fixerAfter, err)
+	}
+}
+
+func TestContinueResetsBothMetersWhenBothExhausted(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	fixerMeta := `{"reviewFixBudget":{"pushCount":3}}`
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_both", "reviewer", "running")
+	reviewer.MetadataJSON = &reviewerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_both", "fixer", "queued")
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: true,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(3, 3))
+	if err != nil || !result.Applied {
+		t.Fatalf("Continue = (%#v, %v)", result, err)
+	}
+	if ReviewerPublishCount(result.Loop.MetadataJSON) != 0 {
+		t.Fatalf("reviewer count = %d, want 0", ReviewerPublishCount(result.Loop.MetadataJSON))
+	}
+	fixerAfter, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if fixerAfter == nil || FixerPushCount(fixerAfter.MetadataJSON) != 0 {
+		t.Fatalf("fixer count = %#v, want reset to 0", fixerAfter)
+	}
+}
+
+func TestStopNoHITLFromEitherRoleTerminatesPair(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_stop_nohitl", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_stop_nohitl", "fixer", "queued")
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil {
+		t.Fatalf("sibling get: %v", err)
+	}
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, *sibling, "Stop", nowISO, testBudgetCaps(3, 3))
+	if err != nil || !result.Applied || result.Action != "stop" {
+		t.Fatalf("Stop from sibling = (%#v, %v)", result, err)
+	}
+	reviewerAfter, _ := repos.Loops.GetByID(context.Background(), parked.ID)
+	fixerAfter, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if reviewerAfter == nil || reviewerAfter.Status != "terminated" || fixerAfter == nil || fixerAfter.Status != "terminated" {
+		t.Fatalf("pair after stop = reviewer %#v fixer %#v, want both terminated", reviewerAfter, fixerAfter)
+	}
+}
+
+func TestFindSiblingSameLanePairing(t *testing.T) {
+	t.Parallel()
+	repo := "acme/looper"
+	pr := int64(42)
+	reviewer := storage.LoopRecord{ID: "loop_reviewer", ProjectID: "project_1", Type: "reviewer", Repo: &repo, PRNumber: &pr}
+	oneShot := `{"manual":true,"followUpdates":false}`
+	continuous := `{"manual":true,"followUpdates":true}`
+	oneShotFixer := storage.LoopRecord{ID: "loop_oneshot", ProjectID: "project_1", Type: "fixer", Status: "queued", Repo: &repo, PRNumber: &pr, MetadataJSON: &oneShot}
+	continuousFixer := storage.LoopRecord{ID: "loop_continuous", ProjectID: "project_1", Type: "fixer", Status: "queued", Repo: &repo, PRNumber: &pr, MetadataJSON: &continuous}
+	autoFixer := storage.LoopRecord{ID: "loop_auto", ProjectID: "project_1", Type: "fixer", Status: "queued", Repo: &repo, PRNumber: &pr}
+
+	// Automatic reviewer pairs only with automatic fixer.
+	got := FindSiblingReviewFixLoops([]storage.LoopRecord{oneShotFixer, continuousFixer, autoFixer}, reviewer)
+	if len(got) != 1 || got[0].ID != autoFixer.ID {
+		t.Fatalf("automatic siblings = %#v, want only auto fixer", got)
+	}
+	if ParticipatesInReviewFixBudget(oneShotFixer) {
+		t.Fatal("one-shot manual must not participate")
+	}
+	if !ParticipatesInReviewFixBudget(continuousFixer) {
+		t.Fatal("continuous manual must participate")
+	}
+
+	// Continuous manual reviewer pairs only with continuous manual fixer.
+	contReviewerMeta := continuous
+	contReviewer := storage.LoopRecord{ID: "loop_cont_reviewer", ProjectID: "project_1", Type: "reviewer", Repo: &repo, PRNumber: &pr, MetadataJSON: &contReviewerMeta}
+	got = FindSiblingReviewFixLoops([]storage.LoopRecord{oneShotFixer, continuousFixer, autoFixer}, contReviewer)
+	if len(got) != 1 || got[0].ID != continuousFixer.ID {
+		t.Fatalf("continuous_manual siblings = %#v, want only continuous fixer", got)
+	}
+}
+
+func TestParkContinuousManualPairsWithSameLaneOnly(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	contMeta := `{"manual":true,"followUpdates":true,"loop":{"iterationCount":3}}`
+	autoMeta := `{"loop":{"iterationCount":0}}`
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_cont_rev_park", "reviewer", "running")
+	reviewer.MetadataJSON = &contMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	autoFixer := seedBudgetLoop(t, repos, nowISO, "loop_auto_fix_park", "fixer", "queued")
+	autoFixer.MetadataJSON = &autoMeta
+	if err := repos.Loops.Upsert(context.Background(), autoFixer); err != nil {
+		t.Fatalf("Upsert auto fixer: %v", err)
+	}
+	contFixer := seedBudgetLoop(t, repos, nowISO, "loop_cont_fix_park", "fixer", "queued")
+	contFixerMeta := `{"manual":true,"followUpdates":true}`
+	contFixer.MetadataJSON = &contFixerMeta
+	if err := repos.Loops.Upsert(context.Background(), contFixer); err != nil {
+		t.Fatalf("Upsert cont fixer: %v", err)
+	}
+
+	_, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
+	}
+	autoAfter, _ := repos.Loops.GetByID(context.Background(), autoFixer.ID)
+	contAfter, _ := repos.Loops.GetByID(context.Background(), contFixer.ID)
+	if autoAfter == nil || autoAfter.Status != "queued" || IsSiblingReviewFixBudgetPause(autoAfter.MetadataJSON) {
+		t.Fatalf("automatic fixer = %#v, want untouched", autoAfter)
+	}
+	if contAfter == nil || contAfter.Status != "paused" || !IsSiblingReviewFixBudgetPause(contAfter.MetadataJSON) {
+		t.Fatalf("continuous fixer = %#v, want paired pause", contAfter)
+	}
+}
+
+func TestIsReviewFixBudgetHoldCoversExhaustedAndSibling(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_hold_rev", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_hold_fix", "fixer", "queued")
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	if !IsReviewFixBudgetHold(parked) {
+		t.Fatal("exhausted no-HITL hold must be detected")
+	}
+	sibling, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if sibling == nil || !IsReviewFixBudgetHold(*sibling) {
+		t.Fatalf("sibling hold = %#v", sibling)
+	}
+}
+
+func TestParkSiblingFailureDoesNotLeaveSiblingRunnableWhileExhaustedHeld(t *testing.T) {
+	// Serial: uses package-level inject hook.
+	coordinator := openCoordinator(t)
+	db := coordinator.DB()
+	repos := storage.NewRepositories(db)
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	seedProject(t, repos, now)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_sib_fail_rev", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_sib_fail_fix", "fixer", "queued")
+	seedBudgetQueue(t, repos, nowISO, "queue_sib_fail_fix", fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+	reviewFixBudgetSiblingParkHook = func(sibling storage.LoopRecord) error {
+		if sibling.ID == fixer.ID {
+			return fmt.Errorf("injected sibling park failure")
+		}
+		return nil
+	}
+	t.Cleanup(func() { reviewFixBudgetSiblingParkHook = nil })
+
+	_, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: false, DB: db,
+		LiveCaps: testBudgetCaps(3, 3),
+	})
+	if err == nil {
+		t.Fatal("ParkReviewFixBudget() error = nil, want injected sibling failure")
+	}
+
+	exhausted, _ := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	sibling, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	// TX rollback: exhausted must not be held while sibling remains runnable.
+	if exhausted != nil && IsReviewFixBudgetHold(*exhausted) && sibling != nil && (sibling.Status == "queued" || sibling.Status == "running") {
+		t.Fatalf("partial park left exhausted held and sibling runnable: exhausted=%#v sibling=%#v", exhausted, sibling)
+	}
+	if sibling != nil && sibling.Status == "queued" && exhausted != nil && exhausted.Status == "paused" {
+		t.Fatalf("sibling still queued while exhausted paused: exhausted=%#v sibling=%#v", exhausted, sibling)
+	}
+}
+
+func TestContinueFailureDoesNotLeaveSiblingQueuedWhileExhaustedHeld(t *testing.T) {
+	// Serial: uses package-level inject hook.
+	coordinator := openCoordinator(t)
+	db := coordinator.DB()
+	repos := storage.NewRepositories(db)
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	seedProject(t, repos, now)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_cont_fail_rev", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_cont_fail_fix", "fixer", "queued")
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: true, DB: db, LiveCaps: testBudgetCaps(3, 3),
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+
+	// Fail after exhausted side is released (first release). With TX, both roll back.
+	released := 0
+	reviewFixBudgetReleaseHook = func(loopID string) error {
+		released++
+		if released == 1 {
+			return fmt.Errorf("injected continue failure after first release")
+		}
+		return nil
+	}
+	t.Cleanup(func() { reviewFixBudgetReleaseHook = nil })
+
+	_, err = storage.WithTransactionValue(context.Background(), db, nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
+		txRepos := storage.NewRepositories(tx)
+		fresh, getErr := txRepos.Loops.GetByID(context.Background(), parked.ID)
+		if getErr != nil || fresh == nil {
+			return storage.LoopRecord{}, fmt.Errorf("fresh: %v", getErr)
+		}
+		result, applyErr := ApplyReviewFixBudgetAnswer(context.Background(), txRepos, *fresh, "Continue", nowISO, testBudgetCaps(3, 3))
+		if applyErr != nil {
+			return storage.LoopRecord{}, applyErr
+		}
+		return result.Loop, nil
+	})
+	if err == nil {
+		t.Fatal("Continue TX error = nil, want injected failure")
+	}
+
+	exhausted, _ := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	sibling, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if sibling != nil && sibling.Status == "queued" && exhausted != nil && IsReviewFixBudgetHold(*exhausted) {
+		t.Fatalf("sibling queued while exhausted still held after failed Continue: exhausted=%#v sibling=%#v", exhausted, sibling)
+	}
+	// TX rollback: pair should still be held.
+	if exhausted == nil || !IsReviewFixBudgetHold(*exhausted) {
+		t.Fatalf("exhausted after failed Continue = %#v, want still held (TX rollback)", exhausted)
+	}
+	if sibling == nil || !IsReviewFixBudgetHold(*sibling) {
+		t.Fatalf("sibling after failed Continue = %#v, want still held (TX rollback)", sibling)
+	}
+}
+
+func TestHandoffEventIncludesHeadAndConcreteResumeCommands(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewerMeta := `{"lastPublishedHeadSha":"abc123def","loop":{"iterationCount":3}}`
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_handoff_head", "reviewer", "running")
+	reviewer.MetadataJSON = &reviewerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("upsert reviewer: %v", err)
+	}
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: true, LiveCaps: testBudgetCaps(3, 3),
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	events, err := repos.Events.ListByEntity(context.Background(), "loop", parked.ID)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	var handoff *storage.EventLogRecord
+	for i := range events {
+		if events[i].EventType == reviewFixBudgetHandoffEventType {
+			handoff = &events[i]
+			break
+		}
+	}
+	if handoff == nil {
+		t.Fatal("missing handoff event")
+	}
+	payloadJSON := handoff.PayloadJSON
+	payload := parseMetadataObject(&payloadJSON)
+	if head, _ := payload["head"].(string); head != "abc123def" {
+		t.Fatalf("head = %q, want abc123def", head)
+	}
+	resume, _ := payload["resume"].(string)
+	wantCLI := fmt.Sprintf("looper unpause %d / looper stop %d", parked.Seq, parked.Seq)
+	if !strings.Contains(resume, "Continue / Stop") || !strings.Contains(resume, wantCLI) {
+		t.Fatalf("resume = %q, want Continue/Stop plus %q", resume, wantCLI)
+	}
+	if lane, _ := payload["lane"].(string); lane != reviewFixBudgetLaneAutomatic {
+		t.Fatalf("lane = %q, want %q", lane, reviewFixBudgetLaneAutomatic)
+	}
+}
+
+func TestHandoffEventIncludesBothRoleMetersAndRetriesOnReentry(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_handoff_rev", "reviewer", "running")
+	reviewer.MetadataJSON = &reviewerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("upsert reviewer: %v", err)
+	}
+	fixerMeta := `{"reviewFixBudget":{"pushCount":2}}`
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_handoff_fix", "fixer", "queued")
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("upsert fixer: %v", err)
+	}
+
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: false, LiveCaps: testBudgetCaps(3, 5),
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	events, err := repos.Events.ListByEntity(context.Background(), "loop", parked.ID)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	var handoff *storage.EventLogRecord
+	for i := range events {
+		if events[i].EventType == reviewFixBudgetHandoffEventType {
+			handoff = &events[i]
+			break
+		}
+	}
+	if handoff == nil {
+		t.Fatal("missing handoff event")
+	}
+	payloadJSON := handoff.PayloadJSON
+	payload := parseMetadataObject(&payloadJSON)
+	reviewerPayload, _ := payload["reviewer"].(map[string]any)
+	fixerPayload, _ := payload["fixer"].(map[string]any)
+	if intFromMetadata(reviewerPayload["count"]) != 3 || intFromMetadata(reviewerPayload["cap"]) != 3 {
+		t.Fatalf("reviewer meters = %#v, want 3/3", reviewerPayload)
+	}
+	if intFromMetadata(fixerPayload["count"]) != 2 || intFromMetadata(fixerPayload["cap"]) != 5 {
+		t.Fatalf("fixer meters = %#v, want 2/5", fixerPayload)
+	}
+	resume, _ := payload["resume"].(string)
+	wantResume := fmt.Sprintf("looper unpause %d / looper stop %d", parked.Seq, parked.Seq)
+	if resume != wantResume {
+		t.Fatalf("resume = %q, want %q", resume, wantResume)
+	}
+	if _, ok := payload["head"]; ok {
+		t.Fatalf("head = %#v, want omitted when metadata has no head sha", payload["head"])
+	}
+
+	// Clear handoff marker and delete event to force re-entry retry.
+	state := ReadReviewFixBudgetState(parked.MetadataJSON)
+	state.HandoffEventAt = ""
+	encoded, err := WriteReviewFixBudgetState(parked.MetadataJSON, state)
+	if err != nil {
+		t.Fatalf("clear handoff marker: %v", err)
+	}
+	parked.MetadataJSON = &encoded
+	if err := repos.Loops.Upsert(context.Background(), parked); err != nil {
+		t.Fatalf("upsert cleared: %v", err)
+	}
+	// Re-entry should rewrite HandoffEventAt (event append is idempotent enough via marker).
+	if _, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: parked, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: false, LiveCaps: testBudgetCaps(3, 5),
+	}); err != nil {
+		t.Fatalf("re-entry park: %v", err)
+	}
+	fresh, _ := repos.Loops.GetByID(context.Background(), parked.ID)
+	if fresh == nil || strings.TrimSpace(ReadReviewFixBudgetState(fresh.MetadataJSON).HandoffEventAt) == "" {
+		t.Fatalf("re-entry did not restore handoff marker: %#v", fresh)
+	}
+}
+
+func testBudgetCaps(reviewerCap, fixerCap int) ReviewFixBudgetLiveCaps {
+	return ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: reviewerCap, FixerMaxPushes: fixerCap}
 }
 
 func newBudgetFixture(t *testing.T) (*storage.Repositories, string) {
@@ -469,8 +939,16 @@ func seedBudgetLoop(t *testing.T, repos *storage.Repositories, nowISO, id, loopT
 	pr := int64(42)
 	target := "pr:acme/looper:42"
 	metadata := `{"loop":{"iterationCount":8}}`
+	// Stable unique seq from id bytes so parallel tests and multi-loop fixtures do not collide.
+	var seq int64
+	for _, b := range id {
+		seq = seq*33 + int64(b)
+	}
+	if seq < 0 {
+		seq = -seq
+	}
 	loop := storage.LoopRecord{
-		ID: id, Seq: int64(len(id)), ProjectID: "project_1", Type: loopType, TargetType: "pull_request",
+		ID: id, Seq: seq, ProjectID: "project_1", Type: loopType, TargetType: "pull_request",
 		TargetID: &target, Repo: &repo, PRNumber: &pr, Status: status, CreatedAt: nowISO, UpdatedAt: nowISO,
 		MetadataJSON: &metadata,
 	}

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -147,25 +147,23 @@ func TestContinueReviewFixBudgetEnqueuesFreshWorkAfterCompletedClaim(t *testing.
 func TestApplyReviewFixBudgetAnswerStopTerminatesPair(t *testing.T) {
 	t.Parallel()
 	repos, nowISO := newBudgetFixture(t)
-	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_stop", "reviewer", "awaiting_human")
-	_ = seedBudgetLoop(t, repos, nowISO, "loop_fixer_stop", "fixer", "paused")
-	metadata, err := WriteHITLAsk(reviewer.MetadataJSON, NewReviewFixBudgetAsk("reviewer", "acme/looper", 42, 8, 8, nowISO))
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_stop", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_stop", "fixer", "queued")
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
+	})
 	if err != nil {
-		t.Fatalf("WriteHITLAsk() error = %v", err)
-	}
-	reviewer.MetadataJSON = &metadata
-	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
-		t.Fatalf("Loops.Upsert() error = %v", err)
+		t.Fatalf("ParkReviewFixBudget() error = %v", err)
 	}
 
-	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, reviewer, "Stop", nowISO, testBudgetCaps(8, 8))
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO, testBudgetCaps(8, 8))
 	if err != nil || !result.Applied || result.Action != "stop" {
 		t.Fatalf("ApplyReviewFixBudgetAnswer() = (%#v, %v)", result, err)
 	}
 	if result.Loop.Status != "terminated" {
 		t.Fatalf("exhausted after stop = %q, want terminated", result.Loop.Status)
 	}
-	sibling, err := repos.Loops.GetByID(context.Background(), "loop_fixer_stop")
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
 	if err != nil || sibling == nil || sibling.Status != "terminated" {
 		t.Fatalf("sibling after stop = (%#v, %v), want terminated", sibling, err)
 	}
@@ -626,6 +624,60 @@ func TestContinueReviewFixBudgetDoesNotResetHistoricalSiblingMeters(t *testing.T
 			histAfter, err := repos.Loops.GetByID(context.Background(), historical.ID)
 			if err != nil || histAfter == nil || histAfter.Status != status || FixerPushCount(histAfter.MetadataJSON) != 3 {
 				t.Fatalf("historical fixer = (%#v, %v), want %s with original pushCount 3", histAfter, err, status)
+			}
+		})
+	}
+}
+
+func TestStopReviewFixBudgetDoesNotTerminateHistoricalSibling(t *testing.T) {
+	t.Parallel()
+	for _, status := range []string{"terminated", "completed"} {
+		status := status
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			repos, nowISO := newBudgetFixture(t)
+			contMeta := `{"manual":true,"followUpdates":true,"loop":{"iterationCount":3}}`
+			liveFixerMeta := `{"manual":true,"followUpdates":true,"reviewFixBudget":{"pushCount":1}}`
+			historicalMeta := `{"manual":true,"followUpdates":true,"reviewFixBudget":{"pushCount":3,"exhaustedBy":"fixer"}}`
+			reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_stop_hist_"+status, "reviewer", "running")
+			reviewer.MetadataJSON = &contMeta
+			if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+				t.Fatalf("Upsert reviewer: %v", err)
+			}
+			liveFixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_stop_hist_live_"+status, "fixer", "queued")
+			liveFixer.MetadataJSON = &liveFixerMeta
+			if err := repos.Loops.Upsert(context.Background(), liveFixer); err != nil {
+				t.Fatalf("Upsert live fixer: %v", err)
+			}
+			historical := seedBudgetLoop(t, repos, nowISO, "loop_fixer_stop_hist_"+status, "fixer", status)
+			historical.MetadataJSON = &historicalMeta
+			if err := repos.Loops.Upsert(context.Background(), historical); err != nil {
+				t.Fatalf("Upsert historical fixer: %v", err)
+			}
+
+			parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+				Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: true,
+			})
+			if err != nil {
+				t.Fatalf("ParkReviewFixBudget() error = %v", err)
+			}
+			result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Stop", nowISO, testBudgetCaps(3, 3))
+			if err != nil || !result.Applied || result.Action != "stop" {
+				t.Fatalf("Stop = (%#v, %v)", result, err)
+			}
+			if result.Loop.Status != "terminated" {
+				t.Fatalf("exhausted after stop = %q, want terminated", result.Loop.Status)
+			}
+			liveAfter, err := repos.Loops.GetByID(context.Background(), liveFixer.ID)
+			if err != nil || liveAfter == nil || liveAfter.Status != "terminated" {
+				t.Fatalf("live fixer = (%#v, %v), want terminated", liveAfter, err)
+			}
+			histAfter, err := repos.Loops.GetByID(context.Background(), historical.ID)
+			if err != nil || histAfter == nil || histAfter.Status != status || FixerPushCount(histAfter.MetadataJSON) != 3 {
+				t.Fatalf("historical fixer = (%#v, %v), want %s with original pushCount 3", histAfter, err, status)
+			}
+			if histAfter.MetadataJSON == nil || *histAfter.MetadataJSON != historicalMeta {
+				t.Fatalf("historical metadata = %v, want unchanged", histAfter.MetadataJSON)
 			}
 		})
 	}

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -579,6 +579,57 @@ func TestContinueResetsBothMetersWhenBothExhausted(t *testing.T) {
 	}
 }
 
+func TestContinueReviewFixBudgetDoesNotResetHistoricalSiblingMeters(t *testing.T) {
+	t.Parallel()
+	for _, status := range []string{"terminated", "completed"} {
+		status := status
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			repos, nowISO := newBudgetFixture(t)
+			reviewerMeta := `{"loop":{"iterationCount":3}}`
+			liveFixerMeta := `{"reviewFixBudget":{"pushCount":1}}`
+			historicalMeta := `{"reviewFixBudget":{"pushCount":3}}`
+			reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_hist_"+status, "reviewer", "running")
+			reviewer.MetadataJSON = &reviewerMeta
+			if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+				t.Fatalf("Upsert reviewer: %v", err)
+			}
+			liveFixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_hist_live_"+status, "fixer", "queued")
+			liveFixer.MetadataJSON = &liveFixerMeta
+			if err := repos.Loops.Upsert(context.Background(), liveFixer); err != nil {
+				t.Fatalf("Upsert live fixer: %v", err)
+			}
+			historical := seedBudgetLoop(t, repos, nowISO, "loop_fixer_hist_"+status, "fixer", status)
+			historical.MetadataJSON = &historicalMeta
+			if err := repos.Loops.Upsert(context.Background(), historical); err != nil {
+				t.Fatalf("Upsert historical fixer: %v", err)
+			}
+
+			parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+				Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: true,
+			})
+			if err != nil {
+				t.Fatalf("ParkReviewFixBudget() error = %v", err)
+			}
+			result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(3, 3))
+			if err != nil || !result.Applied {
+				t.Fatalf("Continue = (%#v, %v)", result, err)
+			}
+			if ReviewerPublishCount(result.Loop.MetadataJSON) != 0 {
+				t.Fatalf("reviewer count = %d, want 0", ReviewerPublishCount(result.Loop.MetadataJSON))
+			}
+			liveAfter, err := repos.Loops.GetByID(context.Background(), liveFixer.ID)
+			if err != nil || liveAfter == nil || liveAfter.Status != "queued" || FixerPushCount(liveAfter.MetadataJSON) != 1 {
+				t.Fatalf("live fixer = (%#v, %v), want queued with preserved unused push budget", liveAfter, err)
+			}
+			histAfter, err := repos.Loops.GetByID(context.Background(), historical.ID)
+			if err != nil || histAfter == nil || histAfter.Status != status || FixerPushCount(histAfter.MetadataJSON) != 3 {
+				t.Fatalf("historical fixer = (%#v, %v), want %s with original pushCount 3", histAfter, err, status)
+			}
+		})
+	}
+}
+
 func TestStopNoHITLFromEitherRoleTerminatesPair(t *testing.T) {
 	t.Parallel()
 	repos, nowISO := newBudgetFixture(t)

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -3,6 +3,7 @@ package loops
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -968,6 +969,107 @@ func TestHandoffEventIncludesBothRoleMetersAndRetriesOnReentry(t *testing.T) {
 	fresh, _ := repos.Loops.GetByID(context.Background(), parked.ID)
 	if fresh == nil || strings.TrimSpace(ReadReviewFixBudgetState(fresh.MetadataJSON).HandoffEventAt) == "" {
 		t.Fatalf("re-entry did not restore handoff marker: %#v", fresh)
+	}
+}
+
+func TestContinueClearsHandoffMarkerWithoutMeterReset(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_cap_raise", "reviewer", "running")
+	reviewer.MetadataJSON = &reviewerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("upsert reviewer: %v", err)
+	}
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_fixer_cap_raise", "fixer", "queued")
+	parked, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: false, LiveCaps: testBudgetCaps(3, 3),
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	freshParked, err := repos.Loops.GetByID(context.Background(), parked.ID)
+	if err != nil || freshParked == nil {
+		t.Fatalf("GetByID parked = (%v, %v)", freshParked, err)
+	}
+	parked = *freshParked
+	if strings.TrimSpace(ReadReviewFixBudgetState(parked.MetadataJSON).HandoffEventAt) == "" {
+		t.Fatal("expected handoff marker after first park")
+	}
+
+	result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, parked, "Continue", nowISO, testBudgetCaps(8, 8))
+	if err != nil || !result.Applied {
+		t.Fatalf("Continue after cap raise = (%#v, %v)", result, err)
+	}
+	if ReviewerPublishCount(result.Loop.MetadataJSON) != 3 {
+		t.Fatalf("reviewer count = %d, want 3 (no reset under raised cap)", ReviewerPublishCount(result.Loop.MetadataJSON))
+	}
+	if strings.TrimSpace(ReadReviewFixBudgetState(result.Loop.MetadataJSON).HandoffEventAt) != "" {
+		t.Fatalf("HandoffEventAt survived Continue without meter reset: %#v", result.Loop.MetadataJSON)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || strings.TrimSpace(ReadReviewFixBudgetState(sibling.MetadataJSON).HandoffEventAt) != "" {
+		t.Fatalf("sibling marker after Continue = (%#v, %v), want cleared", sibling, err)
+	}
+
+	continued := result.Loop
+	meta := parseMetadataObject(continued.MetadataJSON)
+	loopMeta, _ := meta[reviewerLoopMetadataKey].(map[string]any)
+	if loopMeta == nil {
+		loopMeta = map[string]any{}
+	}
+	loopMeta[reviewerIterationCountKey] = 8
+	meta[reviewerLoopMetadataKey] = loopMeta
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal raised count: %v", err)
+	}
+	raised := string(encoded)
+	continued.MetadataJSON = &raised
+	if err := repos.Loops.Upsert(context.Background(), continued); err != nil {
+		t.Fatalf("upsert raised count: %v", err)
+	}
+	if _, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: continued, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 8, Cap: 8,
+		NowISO: nowISO, HITLEnabled: false, LiveCaps: testBudgetCaps(8, 8),
+	}); err != nil {
+		t.Fatalf("re-park after cap raise: %v", err)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), continued.ID)
+	if err != nil || fresh == nil || strings.TrimSpace(ReadReviewFixBudgetState(fresh.MetadataJSON).HandoffEventAt) == "" {
+		t.Fatalf("new hold episode did not emit a handoff marker: (%#v, %v)", fresh, err)
+	}
+	events, err := repos.Events.ListByEntity(context.Background(), "loop", continued.ID)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	handoffs := 0
+	for i := range events {
+		if events[i].EventType == reviewFixBudgetHandoffEventType {
+			handoffs++
+		}
+	}
+	if handoffs < 2 {
+		t.Fatalf("handoff events = %d, want a fresh event for the new hold episode", handoffs)
+	}
+}
+
+func TestParkReviewFixBudgetFailsClosedWhenRefreshErrors(t *testing.T) {
+	coordinator := openCoordinator(t)
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	seedProject(t, repos, now)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_reviewer_refresh_err", "reviewer", "running")
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("close coordinator: %v", err)
+	}
+	if _, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: false, LiveCaps: testBudgetCaps(3, 3),
+	}); err == nil {
+		t.Fatal("ParkReviewFixBudget error = nil, want refresh error")
 	}
 }
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4691,7 +4691,11 @@ func (r *Runner) recordPublishedReviewProgress(ctx context.Context, input stepIn
 func (r *Runner) refusePublishIfBudgetExhausted(ctx context.Context, input stepInput) (bool, error) {
 	loop := input.Loop
 	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
-		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+		fresh, err := r.repos.Loops.GetByID(ctx, loop.ID)
+		if err != nil {
+			return true, err
+		}
+		if fresh != nil {
 			loop = *fresh
 		}
 	}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -6901,8 +6901,11 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	specLabelInstruction := "Do not transition spec-review labels yourself. Looper may transition spec-review labels only after it validates a matching APPROVED clean review marker for the current head."
 	policyFlags := fmt.Sprintf("--clean-review-event %s --blocking-review-event %s", reviewEvents.Clean, reviewEvents.Blocking)
 	reviewerModeFlag := ""
+	if strings.TrimSpace(runID) != "" {
+		reviewerModeFlag = fmt.Sprintf(" --reviewer-run-id %s", runID)
+	}
 	if manual {
-		reviewerModeFlag = fmt.Sprintf(" --reviewer-manual --reviewer-run-id %s", runID)
+		reviewerModeFlag = " --reviewer-manual" + reviewerModeFlag
 	}
 	actionableReviewSubmitCommand := fmt.Sprintf("`%s review submit %s#%d --event COMMENT --commit-id %s%s %s`", looperCLICommand, repo, prNumber, snapshotHeadSHA(checkpoint), reviewerModeFlag, policyFlags)
 	if reviewEvents.Clean == config.ReviewerReviewEventApprove && looperCLIPath != "" && !(autoMergeEnabled && phase != "spec") {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3383,8 +3383,14 @@ func (r *Runner) finishHeldReviewerQueueItem(ctx context.Context, loop storage.L
 		return ProcessResult{}, err
 	}
 	if _, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
-		updated.Status = "queued"
 		updated.LastRunAt = stringPtr(r.nowISO())
+		// Do not revive a review-fix budget hold (or other terminal park) that
+		// the step already persisted — only ordinary label/hold skips re-queue.
+		if loops.IsReviewFixBudgetHold(*updated) || updated.Status == "terminated" || updated.Status == "stopped" || updated.Status == "awaiting_human" || updated.Status == "human_takeover" {
+			updated.NextRunAt = nil
+			return
+		}
+		updated.Status = "queued"
 		updated.NextRunAt = nil
 	}); err != nil {
 		return ProcessResult{}, err

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -487,6 +487,9 @@ type Options struct {
 	CommentOnlyPublish      bool
 	OnAgentExecutionStarted AgentExecutionStartedFunc
 	OnQueueItemEnqueued     func()
+	// NotifyHumanAttention, when set, observes durable loop state after a new
+	// review-fix budget park (including discovery-time parks before claim).
+	NotifyHumanAttention func(context.Context, string)
 }
 
 type DiscoveryPolicy struct {
@@ -537,6 +540,7 @@ type Runner struct {
 	commentOnlyPublish      bool
 	onAgentExecutionStarted AgentExecutionStartedFunc
 	onQueueItemEnqueued     func()
+	notifyHumanAttention    func(context.Context, string)
 }
 
 type DiscoveryInput struct {
@@ -777,6 +781,7 @@ func New(options Options) *Runner {
 		commentOnlyPublish:      options.CommentOnlyPublish,
 		onAgentExecutionStarted: options.OnAgentExecutionStarted,
 		onQueueItemEnqueued:     options.OnQueueItemEnqueued,
+		notifyHumanAttention:    options.NotifyHumanAttention,
 	}
 }
 
@@ -1072,9 +1077,21 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		result.Skipped++
 		return nil
 	}
+	// Sibling pause / exhausted hold must not be revived by discovery enqueue.
+	// Notify only from discovery after a successful park (not from shared park).
+	if loops.IsReviewFixBudgetHold(loopResult.record) {
+		if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
+			return err
+		} else if parked {
+			r.notifyHumanAttentionBestEffort(ctx, loopResult.record.ID)
+		}
+		result.Skipped++
+		return nil
+	}
 	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
 		return err
 	} else if parked {
+		r.notifyHumanAttentionBestEffort(ctx, loopResult.record.ID)
 		result.Skipped++
 		return nil
 	}
@@ -3132,6 +3149,11 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		checkpoint.SkipReason = fmt.Sprintf("Skipped already-published review for head %s", pending.HeadSHA)
 		return checkpoint, nil
 	}
+	// Admission at the mutation seam: refuse a counted publish when already at
+	// the live cap (observe mid-run cap lowers). PR-closed still wins later.
+	if refused, err := r.refusePublishIfBudgetExhausted(ctx, input); refused || err != nil {
+		return checkpoint, err
+	}
 	if pending.CleanNoop {
 		detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 		if err != nil {
@@ -4632,7 +4654,7 @@ func isValidBlockingReviewEvent(value string) bool {
 }
 
 func (r *Runner) recordPublishedReviewProgress(ctx context.Context, input stepInput, pending pendingReviewCheckpoint, reviewEvent ReviewEvent) error {
-	if _, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) {
+	updated, err := r.updateLoop(ctx, input.Loop, func(updated *storage.LoopRecord) {
 		previous, _ := stringFromAny(parseJSONObject(updated.MetadataJSON)["lastPublishedHeadSha"])
 		metadataJSON, err := mergeLoopMetadataJSON(updated.MetadataJSON, map[string]any{"lastPublishedHeadSha": pending.HeadSHA, "lastReviewEvent": string(reviewEvent), "lastReviewSummary": pending.Summary, "lastPublishedAt": r.nowISO()})
 		if err != nil {
@@ -4646,11 +4668,56 @@ func (r *Runner) recordPublishedReviewProgress(ctx context.Context, input stepIn
 			metadataJSON = counted
 		}
 		updated.MetadataJSON = stringPtr(metadataJSON)
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
 	r.appendEvent(ctx, eventInput{eventType: "pr.review.posted", projectID: input.Project.ID, loopID: input.Loop.ID, runID: input.Run.ID, entityType: "pull_request", entityID: fmt.Sprintf("%s#%d", input.Repo, input.PRNumber), payload: map[string]any{"repo": input.Repo, "prNumber": input.PRNumber, "event": string(reviewEvent), "headSha": pending.HeadSHA}})
+	// After a successful counted increment, park immediately when now exhausted.
+	if r.shouldCreateReviewerBudgetPark(updated) {
+		if r.livePullRequestClosed(ctx, input.Project, input.Repo, input.PRNumber) {
+			return nil
+		}
+		if _, parkErr := r.parkReviewerBudgetIfExhausted(ctx, updated); parkErr != nil {
+			return parkErr
+		}
+	}
 	return nil
+}
+
+// refusePublishIfBudgetExhausted parks and skips when the loop already sits at
+// the live publish cap before a counted mutation. Returns refused=true when the
+// publish must not proceed.
+func (r *Runner) refusePublishIfBudgetExhausted(ctx context.Context, input stepInput) (bool, error) {
+	loop := input.Loop
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+			loop = *fresh
+		}
+	}
+	if !loops.ParticipatesInReviewFixBudget(loop) {
+		return false, nil
+	}
+	if loops.IsReviewFixBudgetHold(loop) {
+		if _, err := r.parkReviewerBudgetIfExhausted(ctx, loop); err != nil {
+			return true, err
+		}
+		return true, &holdSkipError{summary: "Reviewer stopped because review-fix budget is held"}
+	}
+	cap := r.maxPublishesPerPR(loop.ProjectID)
+	if !loops.BudgetExhausted(loops.ReviewerPublishCount(loop.MetadataJSON), cap) {
+		return false, nil
+	}
+	if r.livePullRequestClosed(ctx, input.Project, input.Repo, input.PRNumber) {
+		if err := r.terminateLoop(ctx, loop, "pr_closed_or_merged"); err != nil {
+			return true, err
+		}
+		return true, &holdSkipError{summary: "Reviewer stopped because pull request is closed"}
+	}
+	if _, err := r.parkReviewerBudgetIfExhausted(ctx, loop); err != nil {
+		return true, err
+	}
+	return true, &holdSkipError{summary: "Reviewer stopped because review-fix publish budget is exhausted"}
 }
 
 type eventInput struct {
@@ -5122,6 +5189,10 @@ func (r *Runner) markLoopQueuedForReview(ctx context.Context, loop storage.LoopR
 		return nil
 	}
 	_, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
+		// Never flip a budget hold (exhausted or sibling pause) back to queued.
+		if loops.IsReviewFixBudgetHold(*updated) {
+			return
+		}
 		if active, activeErr := r.hasActiveRunningRun(ctx, updated.ID); activeErr == nil && active {
 			updated.Status = "running"
 			updated.NextRunAt = nil
@@ -6253,7 +6324,7 @@ func (r *Runner) reviewFixHITLEnabled() bool {
 }
 
 func (r *Runner) shouldParkReviewerBudget(loop storage.LoopRecord, checkpoint reviewerCheckpoint) bool {
-	if !r.reviewFixHITLEnabled() || isManualReviewerLoop(loop) || checkpoint.SkipReason != "" || checkpoint.PendingReview == nil {
+	if !loops.ParticipatesInReviewFixBudget(loop) || checkpoint.SkipReason != "" || checkpoint.PendingReview == nil {
 		return false
 	}
 	if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
@@ -6277,7 +6348,10 @@ func (r *Runner) shouldCreateReviewerBudgetPark(loop storage.LoopRecord) bool {
 	if loop.Status == "terminated" || loop.Status == "stopped" || loop.Status == "awaiting_human" {
 		return false
 	}
-	if !r.reviewFixHITLEnabled() || isManualReviewerLoop(loop) {
+	if loop.Status == "paused" && loops.IsReviewFixBudgetHold(loop) {
+		return false
+	}
+	if !loops.ParticipatesInReviewFixBudget(loop) {
 		return false
 	}
 	if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
@@ -6300,15 +6374,19 @@ func (r *Runner) parkReviewerBudgetIfExhausted(ctx context.Context, loop storage
 	if loop.Status == "terminated" || loop.Status == "stopped" {
 		return false, nil
 	}
+	// Sibling pause is already a hold; finish cancel/sibling work on re-entry
+	// but do not treat "not self-exhausted" as permission to proceed.
+	if loop.Status == "paused" && loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) {
+		return true, nil
+	}
 	if loop.Status == "awaiting_human" {
 		if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
 			return true, nil
 		}
+	} else if loop.Status == "paused" && loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
+		// Re-enter no-ask hold to finish cancel/sibling park / handoff event.
 	} else {
-		if !r.reviewFixHITLEnabled() {
-			return false, nil
-		}
-		if isManualReviewerLoop(loop) {
+		if !loops.ParticipatesInReviewFixBudget(loop) {
 			return false, nil
 		}
 		if reason, _ := stringFromAny(reviewerLoopMetadata(parseJSONObject(loop.MetadataJSON))["terminationReason"]); reason != "" && !isDeprecatedReviewerLoopBudgetReason(reason) {
@@ -6320,16 +6398,39 @@ func (r *Runner) parkReviewerBudgetIfExhausted(ctx context.Context, loop storage
 		}
 	}
 	cap := r.maxPublishesPerPR(loop.ProjectID)
+	count := loops.ReviewerPublishCount(loop.MetadataJSON)
+	fixerCap := 0
+	if r.projectRoleConfig != nil {
+		fixerCap = config.ProjectRoleConfigs(*r.projectRoleConfig, loop.ProjectID).Fixer.Behavior.Loop.MaxPushesPerPR
+	}
 	_, err := loops.ParkReviewFixBudget(ctx, r.repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: loop,
-		Role:      "reviewer",
-		Repo:      derefString(loop.Repo),
-		PRNumber:  derefInt64(loop.PRNumber),
-		Count:     loops.ReviewerPublishCount(loop.MetadataJSON),
-		Cap:       cap,
-		NowISO:    r.nowISO(),
+		Exhausted:   loop,
+		Role:        "reviewer",
+		Repo:        derefString(loop.Repo),
+		PRNumber:    derefInt64(loop.PRNumber),
+		Count:       count,
+		Cap:         cap,
+		NowISO:      r.nowISO(),
+		HITLEnabled: r.reviewFixHITLEnabled(),
+		LiveCaps: loops.ReviewFixBudgetLiveCaps{
+			ReviewerMaxPublishes: cap,
+			FixerMaxPushes:       fixerCap,
+		},
+		DB: r.db,
 	})
-	return err == nil, err
+	if err != nil {
+		return false, err
+	}
+	// Notify is owned by discovery call sites (and scheduler post-claim), not
+	// shared park — in-run parks must not notify before queue finalization.
+	return true, nil
+}
+
+func (r *Runner) notifyHumanAttentionBestEffort(ctx context.Context, loopID string) {
+	if r.notifyHumanAttention == nil || strings.TrimSpace(loopID) == "" {
+		return
+	}
+	r.notifyHumanAttention(ctx, loopID)
 }
 
 func terminalReviewerLoopReason(loop storage.LoopRecord) string {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2428,6 +2428,37 @@ func TestRefusePublishIfBudgetExhaustedFailsClosedOnLedgerRead(t *testing.T) {
 	}
 }
 
+func TestFinishHeldReviewerQueueItemPreservesBudgetHold(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	projectID := "project_1"
+	holdMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"fixer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	loop := storage.LoopRecord{ID: "loop_held_finish", Seq: 1, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &holdMeta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	queue := storage.QueueItemRecord{ID: "queue_held_finish", ProjectID: &projectID, LoopID: &loop.ID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:held-finish", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, MaxAttempts: 3, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Queue.Upsert(context.Background(), queue); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now})
+	result, err := runner.finishHeldReviewerQueueItem(context.Background(), loop, nil, queue, reviewerCheckpoint{}, "Reviewer stopped because review-fix budget is held")
+	if err != nil {
+		t.Fatalf("finishHeldReviewerQueueItem() error = %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped", result)
+	}
+	after, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || after == nil || after.Status != "paused" || !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatalf("reviewer after finish = (%#v, %v), want still sibling-paused hold", after, err)
+	}
+}
+
 func TestRecordPublishedReviewProgressCountsBeforeClaimComplete(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -8484,7 +8484,7 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"do not write or publish a bare LGTM review body",
 		"Group related findings by file, subsystem, function, or rule",
 		"fixture-matrix tests",
-		"'/opt/looper/bin/looper' review submit acme/looper#42 --event COMMENT --commit-id abc123 --clean-review-event APPROVE --blocking-review-event COMMENT`",
+		"'/opt/looper/bin/looper' review submit acme/looper#42 --event COMMENT --commit-id abc123 --reviewer-run-id run_1 --clean-review-event APPROVE --blocking-review-event COMMENT`",
 		"wrapper validates inline anchors against the live PR diff before it calls GitHub",
 		"Review pass contract",
 		"Do not stop after the first issue",
@@ -8520,7 +8520,7 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"ANSI escape sequences",
 		"file-read traces",
 		"submit exactly one APPROVE review through the trusted Looper CLI wrapper with `outcome=clean`, no inline `comments`, and no extra PR conversation comment",
-		"'/opt/looper/bin/looper' review submit acme/looper#42 --event APPROVE --commit-id abc123 --clean-review-event APPROVE --blocking-review-event COMMENT`",
+		"'/opt/looper/bin/looper' review submit acme/looper#42 --event APPROVE --commit-id abc123 --reviewer-run-id run_1 --clean-review-event APPROVE --blocking-review-event COMMENT`",
 		"never use an LGTM, empty, or disclosure-only clean body as a fallback",
 		"visible body must start with `@<PR-author-login>`",
 		"briefly summarize what changed or what you verified",
@@ -8699,7 +8699,7 @@ func TestBuildReviewPromptRestrictsExistingMarkerSkipWhenApprovalsDisallowed(t *
 	for _, want := range []string{
 		"only treat an existing `outcome=clean` marker as satisfied when it is on a COMMENTED review if clean policy is COMMENT",
 		"Treat `outcome=non_blocking` or legacy `outcome=actionable` markers as satisfied only when they are on a COMMENTED review",
-		"'/opt/looper/bin/looper' review submit acme/looper#42 --event COMMENT --commit-id abc123 --clean-review-event COMMENT --blocking-review-event COMMENT",
+		"'/opt/looper/bin/looper' review submit acme/looper#42 --event COMMENT --commit-id abc123 --reviewer-run-id run_1 --clean-review-event COMMENT --blocking-review-event COMMENT",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
@@ -9541,6 +9541,18 @@ func TestBuildReviewPromptOmitsReviewRequestGuardrailWhenDisabled(t *testing.T) 
 	}
 	if !strings.Contains(prompt, "does not require a current-user review request") {
 		t.Fatalf("prompt missing disabled review-request instruction:\n%s", prompt)
+	}
+}
+
+func TestBuildReviewPromptBindsAutomaticReviewerRunID(t *testing.T) {
+	t.Parallel()
+
+	prompt, _ := buildReviewPromptWithInstructions("", config.Config{}, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_auto", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventComment}, false, true, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, false)
+	if !strings.Contains(prompt, "--reviewer-run-id run_auto") {
+		t.Fatalf("automatic prompt missing --reviewer-run-id:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "--reviewer-manual") {
+		t.Fatalf("automatic prompt included --reviewer-manual:\n%s", prompt)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2394,6 +2394,40 @@ func TestRefusePublishIfBudgetExhaustedAtLiveCap(t *testing.T) {
 	}
 }
 
+func TestRefusePublishIfBudgetExhaustedFailsClosedOnLedgerRead(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	// Under the live cap: swallowing GetByID would admit the stale snapshot.
+	metadata := `{"loop":{"iterationCount":0}}`
+	loop := storage.LoopRecord{ID: "loop_pub_ledger_fail", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 2
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg, GitHub: &fakeGitHubGateway{viewState: "OPEN"}})
+	if err := fixture.coordinator.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	refused, err := runner.refusePublishIfBudgetExhausted(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:    loop, Repo: repo, PRNumber: prNumber,
+	})
+	if err == nil {
+		t.Fatalf("refused=%v err=%v, want fail closed on ledger read", refused, err)
+	}
+	if !refused {
+		t.Fatalf("refused=%v, want true when ledger refresh fails", refused)
+	}
+}
+
 func TestRecordPublishedReviewProgressCountsBeforeClaimComplete(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2152,14 +2152,101 @@ func TestParkReviewerBudgetIfExhaustedParksSibling(t *testing.T) {
 	}
 }
 
-func TestParkReviewerBudgetIfExhaustedSkipsWhenHITLDisabled(t *testing.T) {
+func TestParkReviewerBudgetIfExhaustedDoesNotNotifyHumanAttention(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repo := "acme/looper"
 	prNumber := int64(42)
 	nowISO := fixture.nowISO()
 	reviewerTarget := "pr:acme/looper:42"
-	metadata := `{"loop":{"iterationCount":8}}`
+	metadata := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_notify", Seq: 11, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	var notified []string
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		NotifyHumanAttention: func(_ context.Context, loopID string) {
+			notified = append(notified, loopID)
+		},
+	})
+	parked, err := runner.parkReviewerBudgetIfExhausted(context.Background(), reviewer)
+	if err != nil || !parked {
+		t.Fatalf("parkReviewerBudgetIfExhausted() = (%v, %v), want parked", parked, err)
+	}
+	if len(notified) != 0 {
+		t.Fatalf("NotifyHumanAttention = %#v, want none from shared park", notified)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || updated == nil || !loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("reviewer after park = (%#v, %v), want still held", updated, err)
+	}
+}
+
+func TestReviewerDiscoveryParkNotifiesHumanAttention(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	reviewerTarget := "pr:acme/looper:42"
+	// Exhausted automatic loop — discovery enqueue should park and notify.
+	metadata := `{"loop":{"iterationCount":3,"enabled":true}}`
+	reviewer := storage.LoopRecord{ID: "loop_reviewer_disc_notify", Seq: 12, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "waiting", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID = (%v, %v)", project, err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	var notified []string
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		NotifyHumanAttention: func(_ context.Context, loopID string) {
+			notified = append(notified, loopID)
+		},
+	})
+	result := &DiscoveryResult{}
+	login := ""
+	err = runner.enqueueReviewerDiscoveryCandidate(context.Background(), *project, repo, DiscoveryPolicy{AutoDiscovery: true, RequireReviewRequest: false, EnableSelfReview: true}, &login, PullRequestSummary{Number: prNumber, HeadSHA: "new-head-for-discovery", State: "OPEN"}, &reviewer, false, result)
+	if err != nil {
+		t.Fatalf("enqueueReviewerDiscoveryCandidate() error = %v", err)
+	}
+	if result.Skipped == 0 {
+		t.Fatalf("discovery result = %#v, want skipped after budget park", result)
+	}
+	if len(notified) != 1 || notified[0] != reviewer.ID {
+		t.Fatalf("NotifyHumanAttention = %#v, want [%q] from discovery park", notified, reviewer.ID)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || updated == nil || !loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("reviewer after discovery = (%#v, %v), want held", updated, err)
+	}
+}
+
+func TestParkReviewerBudgetIfExhaustedParksWhenHITLDisabled(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	reviewerTarget := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":3}}`
 	reviewer := storage.LoopRecord{ID: "loop_reviewer_budget_no_hitl", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
 	fixer := storage.LoopRecord{ID: "loop_fixer_budget_no_hitl", Seq: 2, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &reviewerTarget, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
 	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
@@ -2175,18 +2262,22 @@ func TestParkReviewerBudgetIfExhaustedSkipsWhenHITLDisabled(t *testing.T) {
 	if cfg.HITL.Enabled {
 		t.Fatal("DefaultConfig HITL.Enabled = true, want false")
 	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg})
 	parked, err := runner.parkReviewerBudgetIfExhausted(context.Background(), reviewer)
-	if err != nil || parked {
-		t.Fatalf("parkReviewerBudgetIfExhausted() = (%v, %v), want skipped under default HITL-off config", parked, err)
+	if err != nil || !parked {
+		t.Fatalf("parkReviewerBudgetIfExhausted() = (%v, %v), want no-HITL paired park", parked, err)
 	}
 	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
-	if err != nil || updated == nil || updated.Status != "running" {
-		t.Fatalf("reviewer = (%#v, %v), want still running", updated, err)
+	if err != nil || updated == nil || updated.Status != "paused" || !loops.IsReviewFixBudgetExhaustedPause(updated.MetadataJSON) {
+		t.Fatalf("reviewer = (%#v, %v), want paused review_fix_budget_exhausted", updated, err)
+	}
+	if _, ok := loops.ReadHITLAsk(updated.MetadataJSON); ok {
+		t.Fatal("no-HITL park must not write a HITL ask")
 	}
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
-	if err != nil || sibling == nil || sibling.Status != "queued" {
-		t.Fatalf("fixer sibling = (%#v, %v), want still queued", sibling, err)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer sibling = (%#v, %v), want paired budget pause", sibling, err)
 	}
 }
 
@@ -2219,6 +2310,87 @@ func TestParkReviewerBudgetIfExhaustedCompletesSiblingAfterPartialPark(t *testin
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
 	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		t.Fatalf("fixer sibling = (%#v, %v), want paused after reconcile", sibling, err)
+	}
+}
+
+func TestReviewerDiscoveryDoesNotReviveSiblingPausedReviewer(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	// Fixer exhausted; Reviewer sibling-paused with unused budget.
+	fixerMeta := `{"reviewFixBudget":{"pushCount":1,"exhaustedBy":"fixer","pauseReason":"review_fix_budget_exhausted"},"pauseReason":"review_fix_budget_exhausted"}`
+	reviewerMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"fixer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	fixer := storage.LoopRecord{ID: "loop_fix_exh_disc", Seq: 1, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &fixerMeta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	reviewer := storage.LoopRecord{ID: "loop_rev_sib_disc", Seq: 2, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "paused", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 1
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg})
+
+	if err := runner.markLoopQueuedForReview(context.Background(), reviewer, nowISO); err != nil {
+		t.Fatalf("markLoopQueuedForReview: %v", err)
+	}
+	after, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || after == nil || after.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(after.MetadataJSON) {
+		t.Fatalf("reviewer after mark = (%#v, %v), want still sibling-paused", after, err)
+	}
+	// Discovery hold check must also skip.
+	if !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatal("sibling-paused reviewer must be a budget hold")
+	}
+	parked, err := runner.parkReviewerBudgetIfExhausted(context.Background(), *after)
+	if err != nil || !parked {
+		t.Fatalf("parkReviewerBudgetIfExhausted sibling = (%v, %v), want held", parked, err)
+	}
+}
+
+func TestRefusePublishIfBudgetExhaustedAtLiveCap(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":2}}`
+	loop := storage.LoopRecord{ID: "loop_pub_refuse", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 2
+	cfg.HITL.Enabled = false
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg, GitHub: &fakeGitHubGateway{viewState: "OPEN"}})
+	refused, err := runner.refusePublishIfBudgetExhausted(context.Background(), stepInput{
+		Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()},
+		Loop:    loop, Repo: repo, PRNumber: prNumber,
+	})
+	if !refused {
+		t.Fatalf("refused=%v err=%v, want refused at live cap", refused, err)
+	}
+	if err != nil {
+		var hold *holdSkipError
+		if !errors.As(err, &hold) {
+			t.Fatalf("error = %v, want holdSkipError", err)
+		}
+	}
+	after, _ := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if after == nil || !loops.IsReviewFixBudgetHold(*after) {
+		t.Fatalf("after refuse = %#v, want budget hold", after)
 	}
 }
 

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/eventlog"
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
@@ -170,16 +172,22 @@ func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopR
 // an explicit budget Continue/Stop, invokes onAnswered so the live ask card is
 // marked resolved. Card-action delivery already does this; typed decisions must
 // too, or the cached loop-seq buttons can answer a later budget cycle.
-func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, nowISO, loopID, text string, onAnswered func(context.Context, string, string)) error {
+func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, db *sql.DB, cfg *config.Config, nowISO, loopID, text string, onAnswered func(context.Context, string, string)) error {
 	shouldResolve := false
-	if repos != nil && repos.Loops != nil && (loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text)) {
+	caps := reviewFixBudgetLiveCaps(cfg, "")
+	if repos != nil && repos.Loops != nil {
 		if loop, err := repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
-			if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
-				shouldResolve = true
+			caps = reviewFixBudgetLiveCaps(cfg, loop.ProjectID)
+			if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
+				if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+					shouldResolve = true
+				} else if loops.IsReviewFixBudgetHold(*loop) {
+					shouldResolve = true
+				}
 			}
 		}
 	}
-	if err := enqueueHumanMessageToLoop(ctx, repos, nowISO, loopID, text); err != nil {
+	if err := enqueueHumanMessageToLoopWithCaps(ctx, repos, db, nowISO, loopID, text, caps); err != nil {
 		return err
 	}
 	if shouldResolve && onAnswered != nil {
@@ -277,7 +285,11 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 			return loop.ID
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			if err := deliverHITLAnswerToLoop(ctx, input.Repos, nowISO, loopID, answer); err != nil {
+			caps := reviewFixBudgetLiveCaps(input.Config, "")
+			if loop, err := input.Repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
+				caps = reviewFixBudgetLiveCaps(input.Config, loop.ProjectID)
+			}
+			if err := deliverHITLAnswerToLoopWithCaps(ctx, input.Repos, input.DB, nowISO, loopID, answer, caps); err != nil {
 				return err
 			}
 			// Mark the ask card resolved ("✅ 已选:X", brief preserved).
@@ -287,7 +299,7 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 			return nil
 		},
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
-			return enqueueFeishuHITLMessage(ctx, input.Repos, nowISO, loopID, text, input.OnHITLAnswerDelivered)
+			return enqueueFeishuHITLMessage(ctx, input.Repos, input.DB, input.Config, nowISO, loopID, text, input.OnHITLAnswerDelivered)
 		},
 	}
 	if input.Logger != nil {

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/worker"
@@ -101,7 +102,7 @@ func TestFeishuHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 	}
 
 	parked, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -152,7 +153,7 @@ func TestFeishuHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 			return ""
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
 		},
 	})
 	if n != 1 || maxID != 20 {
@@ -219,7 +220,7 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 	}
 
 	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	}); err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
 	}
@@ -244,12 +245,12 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 			return ""
 		},
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
-			return enqueueFeishuHITLMessage(ctx, repos, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
+			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
 				resolved = append(resolved, answeredLoopID+"="+answer)
 			})
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
 		},
 	}
 
@@ -293,6 +294,127 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 	}
 	if len(resolved) != 1 || resolved[0] != reviewer.ID+"=Continue" {
 		t.Fatalf("card resolution after typed Continue = %#v, want reviewer Continue", resolved)
+	}
+}
+
+func TestFeishuContinueUsesLiveProjectCaps(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_budget_feishu_caps"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Budget", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	// Reviewer at 2/2 (exhausted); fixer at 1/5 (under cap).
+	reviewerMeta := `{"loop":{"iterationCount":2}}`
+	fixerMeta := `{"reviewFixBudget":{"pushCount":1}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_feishu_caps_rev", Seq: 91, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &reviewerMeta,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_feishu_caps_fix", Seq: 92, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &fixerMeta,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 2, Cap: 2, NowISO: nowISO, HITLEnabled: true,
+		LiveCaps: loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 2, FixerMaxPushes: 5},
+	}); err != nil {
+		t.Fatalf("Park: %v", err)
+	}
+
+	cfg, err := config.DefaultConfig(root)
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 2
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 5
+
+	if err := deliverHITLAnswerToLoopWithCaps(context.Background(), repos, coordinator.DB(), nowISO, reviewer.ID, "Continue", reviewFixBudgetLiveCaps(&cfg, projectID)); err != nil {
+		t.Fatalf("Continue: %v", err)
+	}
+	fresh, _ := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if fresh == nil || fresh.Status != "queued" || loops.ReviewerPublishCount(fresh.MetadataJSON) != 0 {
+		t.Fatalf("reviewer after Continue = %#v, want queued with reset meter", fresh)
+	}
+	sibling, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if sibling == nil || sibling.Status != "queued" || loops.FixerPushCount(sibling.MetadataJSON) != 1 {
+		t.Fatalf("fixer after Continue = %#v, want queued with preserved pushCount 1", sibling)
+	}
+}
+
+func TestGenericMessageDoesNotQueueNoAskBudgetHold(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_budget_noask_msg"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Budget", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_noask_msg_rev", Seq: 101, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &reviewerMeta,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	}); err != nil {
+		t.Fatalf("Park: %v", err)
+	}
+	// Generic message must not queue a no-ask hold.
+	if err := enqueueHumanMessageToLoop(context.Background(), repos, nowISO, reviewer.ID, "please look at this"); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	fresh, _ := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if fresh == nil || fresh.Status != "paused" || !loops.IsReviewFixBudgetExhaustedPause(fresh.MetadataJSON) {
+		t.Fatalf("after generic message = %#v, want still paused exhausted hold", fresh)
+	}
+	if loops.ReviewerPublishCount(fresh.MetadataJSON) != 3 {
+		t.Fatalf("publish count = %d, want unchanged 3", loops.ReviewerPublishCount(fresh.MetadataJSON))
 	}
 }
 

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -2,9 +2,11 @@ package runtime
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 
+	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/disclosure"
 	"github.com/nexu-io/looper/internal/eventlog"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
@@ -356,6 +358,10 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 // is the exception: only Continue/Stop may unpark, and they apply the budget
 // decision instead of enqueueing conversational text.
 func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, text string) error {
+	return enqueueHumanMessageToLoopWithCaps(ctx, repos, nil, nowISO, loopID, text, reviewFixBudgetLiveCaps(nil, ""))
+}
+
+func enqueueHumanMessageToLoopWithCaps(ctx context.Context, repos *storage.Repositories, db *sql.DB, nowISO, loopID, text string, caps loops.ReviewFixBudgetLiveCaps) error {
 	// Share process-wide requeue exclusion with API discard+retry so free-text
 	// inbox delivery cannot requeue paused/waiting/manual_intervention loops
 	// between discard preflight and git reset (see LockLoopRequeue).
@@ -377,13 +383,11 @@ func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories,
 	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*loop))
 	defer unlockTarget()
 
-	if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
-		// Budget holds are Continue/Stop decisions, not conversational inbox
-		// turns. A typed Feishu reply must not flip awaiting_human to queued
-		// without resetting the counter or unpausing the sibling.
+	// Budget holds (HITL ask or no-ask exhausted/sibling pause) are never
+	// conversational inbox turns. Only explicit Continue/Stop may unpark.
+	if loops.IsReviewFixBudgetHold(*loop) {
 		if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
-			_, err = loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, text, nowISO)
-			return err
+			return applyReviewFixBudgetAnswerTX(ctx, db, repos, *loop, text, nowISO, caps)
 		}
 		return nil
 	}
@@ -411,7 +415,44 @@ func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories,
 	return err
 }
 
+func reviewFixBudgetLiveCaps(cfg *config.Config, projectID string) loops.ReviewFixBudgetLiveCaps {
+	if cfg == nil {
+		return loops.ReviewFixBudgetLiveCaps{
+			ReviewerMaxPublishes: config.DefaultReviewFixBudgetCap,
+			FixerMaxPushes:       config.DefaultReviewFixBudgetCap,
+		}
+	}
+	roles := config.ProjectRoleConfigs(*cfg, projectID)
+	return loops.ReviewFixBudgetLiveCaps{
+		ReviewerMaxPublishes: roles.Reviewer.Behavior.Loop.MaxPublishesPerPR,
+		FixerMaxPushes:       roles.Fixer.Behavior.Loop.MaxPushesPerPR,
+	}
+}
+
+func applyReviewFixBudgetAnswerTX(ctx context.Context, db *sql.DB, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string, caps loops.ReviewFixBudgetLiveCaps) error {
+	if db != nil {
+		return storage.WithTransaction(ctx, db, nil, func(tx *sql.Tx) error {
+			txRepos := storage.NewRepositories(tx)
+			fresh, err := txRepos.Loops.GetByID(ctx, loop.ID)
+			if err != nil {
+				return err
+			}
+			if fresh == nil {
+				return nil
+			}
+			_, err = loops.ApplyReviewFixBudgetAnswer(ctx, txRepos, *fresh, answer, nowISO, caps)
+			return err
+		})
+	}
+	_, err := loops.ApplyReviewFixBudgetAnswer(ctx, repos, loop, answer, nowISO, caps)
+	return err
+}
+
 func deliverHITLAnswerToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, answer string) error {
+	return deliverHITLAnswerToLoopWithCaps(ctx, repos, nil, nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
+}
+
+func deliverHITLAnswerToLoopWithCaps(ctx context.Context, repos *storage.Repositories, db *sql.DB, nowISO, loopID, answer string, caps loops.ReviewFixBudgetLiveCaps) error {
 	// Same requeue + target exclusion as free-text enqueue / API discard+retry.
 	unlock := LockLoopRequeue(loopID)
 	defer unlock()
@@ -420,18 +461,21 @@ func deliverHITLAnswerToLoop(ctx context.Context, repos *storage.Repositories, n
 	if err != nil || loop == nil {
 		return err
 	}
-	if loop.Status != "awaiting_human" {
+	if loop.Status != "awaiting_human" && !loops.IsReviewFixBudgetHold(*loop) {
 		return nil
 	}
 	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*loop))
 	defer unlockTarget()
+	if loops.IsReviewFixBudgetHold(*loop) {
+		// Budget Continue/Stop (HITL ask or no-ask hold) — fail-closed TX when DB set.
+		return applyReviewFixBudgetAnswerTX(ctx, db, repos, *loop, answer, nowISO, caps)
+	}
+	if loop.Status != "awaiting_human" {
+		return nil
+	}
 	ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
 	if !ok {
 		return nil
-	}
-	if loops.IsReviewFixBudgetAsk(ask) {
-		_, err = loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO)
-		return err
 	}
 	ask.Answer = answer
 	ask.Status = "answered"
@@ -556,7 +600,7 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 			return out, nil
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			return deliverHITLAnswerToLoop(ctx, input.Repos, nowISO, loopID, answer)
+			return deliverHITLAnswerToLoopWithCaps(ctx, input.Repos, input.DB, nowISO, loopID, answer, reviewFixBudgetLiveCaps(input.Config, project.ID))
 		},
 		clearAwaiting: func(ctx contextType, repo string, pr int64, cwd string) {
 			_ = gw.RemovePullRequestLabels(ctx, githubinfra.PullRequestLabelsInput{Repo: repo, PRNumber: pr, Labels: []string{awaitingLabel}, CWD: cwd})

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -136,7 +136,7 @@ func TestGitHubHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 	seedPollBudgetQueue(t, repos, nowISO, "project_budget_github", "queue_budget_fixer", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -301,7 +301,7 @@ func TestGitHubHITLPollRecoversBudgetAskAfterPersistFailure(t *testing.T) {
 	seedPollBudgetQueue(t, repos, nowISO, projectID, "queue_budget_fixer_recover", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	parked, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	})
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
@@ -409,7 +409,7 @@ func TestGitHubHITLPollPostsNewAskAfterAPIAnsweredPriorCycle(t *testing.T) {
 	seedPollBudgetQueue(t, repos, firstISO, projectID, "queue_budget_fixer_generation", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: firstISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: firstISO, HITLEnabled: true,
 	}); err != nil {
 		t.Fatalf("ParkReviewFixBudget(first) error = %v", err)
 	}
@@ -435,7 +435,7 @@ func TestGitHubHITLPollPostsNewAskAfterAPIAnsweredPriorCycle(t *testing.T) {
 	if err != nil || fresh == nil {
 		t.Fatalf("Loops.GetByID(reviewer) = (%#v, %v)", fresh, err)
 	}
-	if _, err := loops.ApplyReviewFixBudgetAnswer(context.Background(), repos, *fresh, loops.ReviewFixBudgetAnswerContinue, firstISO); err != nil {
+	if _, err := loops.ApplyReviewFixBudgetAnswer(context.Background(), repos, *fresh, loops.ReviewFixBudgetAnswerContinue, firstISO, loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 8, FixerMaxPushes: 8}); err != nil {
 		t.Fatalf("ApplyReviewFixBudgetAnswer(API Continue) error = %v", err)
 	}
 
@@ -451,7 +451,7 @@ func TestGitHubHITLPollPostsNewAskAfterAPIAnsweredPriorCycle(t *testing.T) {
 		t.Fatalf("Loops.Upsert(re-exhaust) error = %v", err)
 	}
 	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: *fresh, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: secondISO,
+		Exhausted: *fresh, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: secondISO, HITLEnabled: true,
 	}); err != nil {
 		t.Fatalf("ParkReviewFixBudget(second) error = %v", err)
 	}
@@ -536,7 +536,7 @@ func TestGitHubHITLPollDeliversAndStopsReviewFixBudget(t *testing.T) {
 	seedPollBudgetQueue(t, repos, nowISO, projectID, "queue_budget_fixer_stop", fixer.ID, "fixer", storage.QueuePriorityFixer)
 
 	if _, err := loops.ParkReviewFixBudget(context.Background(), repos, loops.ParkReviewFixBudgetInput{
-		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO,
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: true,
 	}); err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
 	}

--- a/internal/runtime/human_attention.go
+++ b/internal/runtime/human_attention.go
@@ -277,9 +277,10 @@ func (r *Runtime) isStopped() bool {
 }
 
 // collectHumanAttentionLoopIDs returns loop IDs that may need human-attention
-// observation after recovery: durable awaiting_human loop status, and latest
-// queue rows parked as manual_intervention. notifyDurableHumanAttention applies
-// the hard-condition filter and permanent entry dedupe.
+// observation after recovery: durable awaiting_human loop status, no-HITL
+// review-fix budget exhausted pauses, and latest queue rows parked as
+// manual_intervention. notifyDurableHumanAttention applies the hard-condition
+// filter and permanent entry dedupe.
 func collectHumanAttentionLoopIDs(ctx context.Context, repos *storage.Repositories) []string {
 	if repos == nil {
 		return nil
@@ -298,10 +299,19 @@ func collectHumanAttentionLoopIDs(ctx context.Context, repos *storage.Repositori
 		ids = append(ids, id)
 	}
 	if repos.Loops != nil {
-		loops, err := repos.Loops.ListByStatuses(ctx, []string{string(domain.LoopStatusAwaitingHuman)})
+		awaiting, err := repos.Loops.ListByStatuses(ctx, []string{string(domain.LoopStatusAwaitingHuman)})
 		if err == nil {
-			for _, loop := range loops {
+			for _, loop := range awaiting {
 				add(loop.ID)
+			}
+		}
+		// No-HITL budget exhausted holds are paused (not awaiting_human).
+		paused, err := repos.Loops.ListByStatuses(ctx, []string{string(domain.LoopStatusPaused)})
+		if err == nil {
+			for _, loop := range paused {
+				if loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
+					add(loop.ID)
+				}
 			}
 		}
 	}
@@ -346,6 +356,28 @@ func notifyDurableHumanAttention(ctx context.Context, gateway *notify.Gateway, r
 			RunID:      latestRunID(ctx, repos, loop.ID),
 			LoopType:   loop.Type,
 			Reason:     notify.HumanAttentionAwaitingHuman,
+			EntryKey:   entryKey,
+			Subtitle:   humanAttentionSubtitle(*loop),
+			EntityType: "loop",
+			EntityID:   loop.ID,
+		})
+		return
+	}
+
+	// No-HITL review-fix budget exhausted: paused + review_fix_budget_exhausted.
+	// Sibling-only pause does not notify separately (exhausted role notifies).
+	if loop.Status == string(domain.LoopStatusPaused) && loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
+		entryKey := humanAttentionEntryKeyForReviewFixBudget(*loop)
+		if entryKey == "" {
+			return
+		}
+		gateway.NotifyHumanAttention(ctx, notify.HumanAttentionInput{
+			ProjectID:  loop.ProjectID,
+			LoopID:     loop.ID,
+			LoopSeq:    loop.Seq,
+			RunID:      latestRunID(ctx, repos, loop.ID),
+			LoopType:   loop.Type,
+			Reason:     notify.HumanAttentionReviewFixBudget,
 			EntryKey:   entryKey,
 			Subtitle:   humanAttentionSubtitle(*loop),
 			EntityType: "loop",
@@ -417,6 +449,17 @@ func humanAttentionEntryKeyForAwaitingHuman(ctx context.Context, repos *storage.
 		return "loop:" + loop.ID + ":" + updated
 	}
 	return "loop:" + loop.ID
+}
+
+func humanAttentionEntryKeyForReviewFixBudget(loop storage.LoopRecord) string {
+	state := loops.ReadReviewFixBudgetState(loop.MetadataJSON)
+	if at := strings.TrimSpace(state.HandoffEventAt); at != "" {
+		return "budget:" + loop.ID + ":" + at
+	}
+	if updated := strings.TrimSpace(loop.UpdatedAt); updated != "" {
+		return "budget:" + loop.ID + ":" + updated
+	}
+	return "budget:" + loop.ID
 }
 
 func humanAttentionEntryKeyForManualIntervention(queue storage.QueueItemRecord) string {

--- a/internal/runtime/human_attention_budget_contract_test.go
+++ b/internal/runtime/human_attention_budget_contract_test.go
@@ -1,0 +1,95 @@
+package runtime
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/infra/notify"
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// No-HITL review-fix budget exhausted hold must produce action-required human attention.
+func TestHumanAttentionContract_ReviewFixBudgetExhausted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	capturePath := filepath.Join(root, "osascript.log")
+	scriptPath := filepath.Join(root, "osascript")
+	writeHumanAttentionOsascript(t, scriptPath, capturePath, false)
+
+	coordinator := openMigratedCoordinator(t, filepath.Join(root, "budget-attention.sqlite"), filepath.Join(root, "backups"))
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 29, 12, 0, 0, 0, time.UTC)
+	nowISO := eventlog.FormatJavaScriptISOString(now)
+
+	projectID := "project_budget_attention"
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{
+		ID: projectID, Name: "Budget Attention", RepoPath: filepath.Join(root, "repo"),
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_attention", Seq: 717, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(ctx, reviewer); err != nil {
+		t.Fatalf("Loops.Upsert: %v", err)
+	}
+	parked, err := loops.ParkReviewFixBudget(ctx, repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3,
+		NowISO: nowISO, HITLEnabled: false, LiveCaps: loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 3, FixerMaxPushes: 3},
+	})
+	if err != nil {
+		t.Fatalf("Park: %v", err)
+	}
+	if parked.Status != "paused" || !loops.IsReviewFixBudgetExhaustedPause(parked.MetadataJSON) {
+		t.Fatalf("parked = %#v, want no-HITL exhausted pause", parked)
+	}
+
+	ids := collectHumanAttentionLoopIDs(ctx, repos)
+	found := false
+	for _, id := range ids {
+		if id == reviewer.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("collectHumanAttentionLoopIDs() = %v, want exhausted hold %s", ids, reviewer.ID)
+	}
+
+	gateway := notify.NewGateway(notify.Options{
+		Config: config.NotificationConfig{
+			InApp: true,
+			Osascript: config.OsascriptNotificationConfig{
+				Enabled:               true,
+				SoundForLevels:        []config.NotificationSoundLevel{config.NotificationSoundLevelActionRequired},
+				ThrottleWindowSeconds: 1,
+			},
+		},
+		OsascriptPath: scriptPath,
+		Repositories:  repos,
+		Now:           func() time.Time { return now },
+	})
+
+	notifyDurableHumanAttention(ctx, gateway, repos, reviewer.ID)
+	assertHumanAttentionInAppCount(t, repos, reviewer.ID, 1)
+	assertOsascriptContains(t, capturePath, "display notification")
+
+	// Re-observe must not resend.
+	notifyDurableHumanAttention(ctx, gateway, repos, reviewer.ID)
+	assertHumanAttentionInAppCount(t, repos, reviewer.ID, 1)
+}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1980,7 +1980,7 @@ func (a reviewerAgentExecutorAdapter) Start(ctx context.Context, input reviewer.
 		allowedPR := reviewerAllowedPRRef(input.Metadata)
 		allowedCwd := strings.TrimSpace(input.WorkingDirectory)
 		policy := reviewerAllowedReviewPolicy(input.Metadata)
-		if policy.ReviewerManual && policy.ReviewerRunID != strings.TrimSpace(input.RunID) {
+		if policy.ReviewerRunID != "" && policy.ReviewerRunID != strings.TrimSpace(input.RunID) {
 			return nil, fmt.Errorf("install run-bound trusted review proxy: reviewer run id does not match agent run")
 		}
 		vendor, model := reviewerTrustedReviewAgentIdentity(input, a.agentVendor, a.agentModel)

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -84,6 +85,7 @@ type schedulerAsyncRunner interface {
 
 type defaultSchedulerTickInput struct {
 	Repos             *storage.Repositories
+	DB                *sql.DB
 	GitHubGateway     *githubinfra.Gateway
 	Logger            bootstrap.Logger
 	Now               func() time.Time
@@ -3490,6 +3492,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 			RetryMaxAttempts:        int64(cfg.Scheduler.RetryMaxAttempts),
 			RetryPolicy:             cfg.Roles.Reviewer.Behavior.Retry,
 			OnQueueItemEnqueued:     requestWake,
+			NotifyHumanAttention:    notifyHumanAttention,
 			OnAgentExecutionStarted: func(ctx context.Context, input reviewer.AgentExecutionStartedInput) error {
 				return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Reviewer", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})
 			},
@@ -3531,16 +3534,17 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 				Labels:        append([]string(nil), cfg.Roles.Fixer.Triggers.Labels...),
 				LabelMode:     cfg.Roles.Fixer.Triggers.LabelMode,
 			},
-			Disclosure:          &cfg.Disclosure,
-			AgentRuntime:        string(resolved.Vendor),
-			AgentProfileID:      resolved.ProfileID,
-			CustomInstructions:  &cfg,
-			AgentModel:          agentModel,
-			AgentTimeout:        time.Duration(cfg.Agent.Timeouts.FixerMaxRuntimeSeconds) * time.Second,
-			AgentIdleTimeout:    time.Duration(cfg.Agent.Timeouts.FixerIdleTimeoutSeconds) * time.Second,
-			RetryBaseDelay:      retryBaseDelay,
-			RetryMaxAttempts:    int64(cfg.Scheduler.RetryMaxAttempts),
-			OnQueueItemEnqueued: requestWake,
+			Disclosure:           &cfg.Disclosure,
+			AgentRuntime:         string(resolved.Vendor),
+			AgentProfileID:       resolved.ProfileID,
+			CustomInstructions:   &cfg,
+			AgentModel:           agentModel,
+			AgentTimeout:         time.Duration(cfg.Agent.Timeouts.FixerMaxRuntimeSeconds) * time.Second,
+			AgentIdleTimeout:     time.Duration(cfg.Agent.Timeouts.FixerIdleTimeoutSeconds) * time.Second,
+			RetryBaseDelay:       retryBaseDelay,
+			RetryMaxAttempts:     int64(cfg.Scheduler.RetryMaxAttempts),
+			OnQueueItemEnqueued:  requestWake,
+			NotifyHumanAttention: notifyHumanAttention,
 			OnAgentExecutionStarted: func(ctx context.Context, input fixer.AgentExecutionStartedInput) error {
 				return notifyAgentExecutionStarted(ctx, agentExecutionNotificationInput{ExecutionID: input.ExecutionID, ProjectID: input.ProjectID, LoopID: input.LoopID, RunID: input.RunID, Title: "Looper Fixer", Subtitle: input.Subtitle, Body: input.Body, DedupeKey: input.DedupeKey})
 			},
@@ -3629,8 +3633,13 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 		if githubGateway != nil {
 			snapshotter = githubGateway
 		}
+		var tickDB *sql.DB
+		if services.Coordinator != nil {
+			tickDB = services.Coordinator.DB()
+		}
 		return defaultSchedulerTickInput{
 			Repos:                services.Repositories,
+			DB:                   tickDB,
 			GitHubGateway:        githubGateway,
 			Logger:               logger,
 			Now:                  now,

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -371,7 +371,7 @@ scope = "changed_ranges"
 publishMode = "single_review"
 
 [roles.reviewer.behavior.loop]
-maxPublishesPerPR = 8
+maxPublishesPerPR = 3
 
 [roles.reviewer.behavior.reviewEvents]
 clean = "APPROVE"
@@ -379,7 +379,7 @@ blocking = "REQUEST_CHANGES"
 
 [roles.fixer.behavior.loop]
 quietPeriodSeconds = 0
-maxPushesPerPR = 8
+maxPushesPerPR = 3
 
 [roles.fixer.discovery]
 autoDiscovery = true

--- a/specs/2026-08-24-review-fix-convergence/spec.md
+++ b/specs/2026-08-24-review-fix-convergence/spec.md
@@ -1,0 +1,988 @@
+# Review-fix convergence: scope-aware review, reactive dispositions, and bounded automation
+
+## 1. Background
+
+Looper already has several useful pieces:
+
+- Reviewer prompts require a complete pass and finding accumulation.
+- Reviewer and Fixer have independent live caps:
+  `maxPublishesPerPR` and `maxPushesPerPR`.
+- Fixer treats repository instructions and documented PR intent as scope
+  authority, and can decline an out-of-scope review item.
+- Native review data carries thread id/resolution state plus comment-level
+  `updatedAt`, replies, and author association. GitHub's ReviewThread node does
+  not itself expose `updatedAt`.
+- Reviewer has a thread-resolution phase, while Fixer already fingerprints
+  observed thread comments before mutating a thread.
+
+Those pieces do not yet form a convergence protocol.
+
+Two relevant features are disabled by default today. `HITL.Enabled` is `false`,
+and both role budgets are skipped entirely when HITL is off. Reviewer
+`ThreadResolution.Enabled` is also `false`; its default mode is report-only,
+`RequireNewHeadSinceThread` is `true`, and `MaxThreadsPerRun` is `10`. A bounded
+default cannot depend on operators discovering and enabling either feature.
+
+[powerformer/nexus#56](https://github.com/powerformer/nexus/pull/56) is a useful
+failure case: the PR received 17 Codex review passes, 29 inline comments, and 16
+manual `@codex review` triggers over roughly 5 hours 22 minutes. The PR was also
+large (83 files and about 9.9k added lines), so this spec does not claim every
+comment was invalid. The relevant signal is the shape of the interaction:
+independent findings arrived in small batches, later passes expanded into edge
+hardening, and the system had no bounded clean-or-handoff outcome.
+
+There is a second same-head failure mode. A human or Fixer can edit/reply to an
+unresolved thread with a `wontfix`/decline decision, but Reviewer discovery
+currently skips a PR when `lastPublishedHeadSha == currentHeadSha`. Existing
+thread-resolution audit is also keyed primarily by head, not by the current
+thread content. In addition, Fixer currently replies to a validated `declined`
+decision, resolves the thread itself, and suppresses the same decline by a
+head-bound fingerprint. Reviewer candidate selection then ignores the resolved
+thread. Therefore an updated comment can be invisible until another commit, or
+can disappear before Reviewer adjudicates it at all. The review-fix pair can
+wait, repeat, or converge on the wrong authority even though the relevant input
+has changed.
+
+## 2. Product outcome
+
+For each continuously followed PR with finite role caps, Looper must reach one
+of these outcomes within the configured independent role budgets, whether HITL
+is enabled or disabled. Setting a cap to `0` explicitly waives the finite-bound
+guarantee for that role:
+
+1. **Clean convergence:** every in-scope finding is fixed, explicitly disposed,
+   or resolved, and Reviewer publishes the configured clean outcome.
+2. **Human handoff:** the pair is non-runnable—parked with a Continue/Stop ask
+   when HITL is enabled, or paused in a manual hold without an ask when it is
+   disabled—with both meters, every remaining actionable thread, every pending
+   scope dispute, and the exact next action.
+
+Budget exhaustion is operational convergence, not code approval. Looper must
+never publish a clean review, resolve a blocker, or enable auto-merge merely
+because a budget was exhausted.
+
+The full same-head thread-disposition guarantee applies to GitHub projects with
+native review-thread capabilities. Providers without those capabilities still
+receive bounded review-publication/Fixer-push behavior, but cannot claim the
+same-head `wontfix` convergence path. In particular, Forgejo remains explicitly
+exempt until its provider capabilities can supply the required thread identity,
+authorship, edit timestamp, reply, and resolve operations.
+
+## 3. Goals
+
+1. Make the first Reviewer publication contain every independent, concrete,
+   in-scope finding visible in the configured review scope.
+2. Prevent follow-up passes from reopening untouched old diff for ordinary
+   P2/P3 improvements after the first complete pass.
+3. Prevent out-of-scope suggestions from becoming automatic Fixer work or
+   resolvable PR threads by default.
+4. Keep Reviewer and Fixer caps independently configurable and independently
+   counted, while pausing/stopping the pair together when either cap trips.
+5. React to review-thread edits/replies on an unchanged PR head, especially
+   explicit human `wontfix` decisions and structured Fixer declines.
+6. Make same-head disposition handling idempotent across polling, webhooks,
+   retries, and daemon restarts.
+7. Reuse existing loop metadata, event log, HITL, review markers, and thread
+   resolution instead of adding a review-round ledger or workflow engine.
+8. Enforce finite caps in the default `HITL.Enabled=false` configuration without
+   silently dropping a finding that needs human judgment.
+
+## 4. Non-goals (kill list)
+
+1. A total comment-count cap that hides independent blockers
+2. A single opaque `maxReviewFixRounds` replacing the two role caps
+3. Automatic approval, merge, or thread resolution on budget exhaustion
+4. Treating every issue found near changed code as required PR scope
+5. Inferring product scope from changed ranges, test failures, labels, or GitHub
+   state when documented intent says otherwise
+6. Automatically creating GitHub issues for every suppressed follow-up
+7. A new SQL table, epoch id, finding ledger, or persisted scope-status machine
+8. Full rescans of the original PR diff after every Fixer push
+9. Trusting arbitrary commenters or bot text as a `wontfix` authority
+10. Forgejo same-head thread-disposition parity before Forgejo supports the
+    required native thread identity, authorship, edit timestamp, reply, and
+    resolve capabilities; Forgejo is exempt only from that part of §2, not from
+    role-budget enforcement
+11. Solving oversized-PR policy; PR size may be reported in handoff evidence but
+    is not a new admission gate in this change
+
+## 5. Authority
+
+> The authority for whether a finding must be fixed in this PR is repository
+> instructions, the PR's documented intent and linked issue/specification, and
+> correctness or safety invariants directly affected by the PR—not the
+> Reviewer's structured output.
+
+The authority order is:
+
+1. Repository instructions, including `AGENTS.md`
+2. PR title/body, explicit goals and non-goals, and linked issue/specification
+3. A regression introduced by the PR or an invariant directly affected by its
+   changed behavior
+4. Existing intentional PR decisions that predate the current review/fix dispute
+
+Reviewer output is a structured claim with evidence. Fixer must still verify it.
+Changed ranges are location scope, not product scope.
+
+For an explicit human disposition, the authority is the PR author or a provider
+identity whose author association is `OWNER`, `MEMBER`, or `COLLABORATOR`.
+GitHub exposes `authorAssociation` and `updatedAt` on
+[PullRequestReviewComment](https://docs.github.com/en/graphql/reference/pulls#pullrequestreviewcomment).
+Arbitrary external users and bots are not disposition authorities. A Looper
+Fixer reply with a validated `declined` marker is a scope-dispute signal, not
+human authority; Reviewer must adjudicate it.
+
+## 6. Decisions (locked)
+
+| Topic | Decision |
+| --- | --- |
+| Reviewer/Fixer meters | Remain separate: publications vs pushes |
+| Default caps | Lower both defaults from `8` to `3`; explicit config is unchanged |
+| Disabled cap | `0` still disables only that role's cap |
+| Pair behavior | Either exhausted role halts both roles in the same lane: park with a HITL ask or pause in a no-ask manual hold |
+| Continue | Replenish only meters currently at/over their live cap; preserve unused sibling budget |
+| Stop | Terminate both roles in the lane |
+| Budget enforcement | Independent of `HITL.Enabled`; HITL selects answer delivery, not whether the pair halts |
+| HITL disabled at cap | Pause both roles in a paired manual hold, cancel queues, persist counters/reason + handoff event, and notify action-required; no ask or automatic resume |
+| No-HITL resume | `looper unpause` on either budget-held role delegates to paired Continue; `looper stop` delegates to paired Stop |
+| `needs_human` with HITL disabled | Pause the pair with reason `review_scope_human_required` and the same handoff evidence; never suppress and continue |
+| First pass | Full configured PR scope; accumulate before publishing |
+| Later code pass | Prior findings + new head delta + affected invariants |
+| Later thread pass | Changed thread feedback only; no full code rescan by default |
+| Finding disposition | `must_fix`, `follow_up`, or `needs_human` |
+| Remote comments | Only `must_fix` becomes actionable PR feedback by default |
+| `follow_up` | Retained in the run result/event; no remote comment or Fixer item by default |
+| Scope ambiguity | `needs_human`; no code or thread mutation until answered |
+| Human command | Canonical `/looper wontfix <reason>`; exact standalone `wontfix`, `won't fix`, and `won’t fix` are compatibility aliases |
+| Fixer decline | Reply with evidence and leave unresolved; Reviewer owns accept/reject/resolve |
+| Disposition feature gate | Always on for continuous Looper-authored GitHub threads; legacy ThreadResolution config continues to govern objective-fix reconciliation only |
+| Same-head gate | `RequireNewHeadSinceThread` never blocks a human/Fixer disposition change |
+| Same-head reactivity | Review signal includes current thread feedback, not only head SHA |
+| Budget at human reply | Either hold may run disposition-only reconciliation, but it cannot release the hold, refill a meter, publish a review, or push code |
+| Persistence | One review-signal fingerprint in existing loop metadata; no new table/ledger |
+| Queue dedupe | Keep the stable per-loop/PR dedupe key; coalesce the latest signal into one active item |
+
+## 7. Reviewer convergence protocol
+
+### 7.1 First pass: exhaustive within authority scope
+
+A pass is an initial pass when no validated prior Looper review marker exists for
+the PR lane.
+
+Before publication, Reviewer must:
+
+1. Read repository instructions, PR intent, linked specification when available,
+   complete configured diff scope, prior review history, and necessary context.
+2. Accumulate candidate findings without publishing.
+3. Classify every candidate by disposition, severity, scope basis, and concrete
+   evidence.
+4. Deduplicate only the same root cause or a genuinely repeated pattern.
+5. Keep unrelated concerns separate even when there are many of them.
+6. Submit one review containing every independent `must_fix` finding found in
+   that pass.
+
+Remove prompt language that says to “prefer fewer” comments and remove numeric
+comment-flood thresholds as completeness signals. Grouping is valid only for a
+shared root cause with representative locations; it must not hide unrelated
+findings. The budget limits review publications, not findings per publication.
+
+The Reviewer is not required to find unknowable issues. It is required not to
+intentionally defer an already observed in-scope issue to a later publication.
+
+### 7.2 Follow-up code pass: review the repair frontier
+
+When a validated prior Looper review exists and the head changed, Reviewer must
+inspect:
+
+- every unresolved prior `must_fix` thread;
+- the diff from the last reviewed head to the current head;
+- directly affected call sites, contracts, tests, and lifecycle invariants;
+- evidence that the Fixer actually addressed each prior finding.
+
+Reviewer must not rescan untouched original diff merely to invent ordinary new
+hardening work. A newly discovered issue in untouched old diff is handled as:
+
+| Late finding | Disposition |
+| --- | --- |
+| Clear security, data corruption/loss, broken public contract, or P0/P1 correctness blocker | Publish as `must_fix`, mark as late discovery, and include it in convergence evidence |
+| Ordinary P2/P3 robustness, cleanup, style, or independent improvement | `follow_up`; do not feed the current Fixer loop |
+| Scope or severity is genuinely ambiguous | `needs_human` |
+
+Continue/reset of a budget meter does not reset this review frontier.
+
+### 7.3 Finding disposition contract
+
+Every candidate uses this logical shape:
+
+```json
+{
+  "disposition": "must_fix | follow_up | needs_human",
+  "severity": "blocking | non_blocking | nit",
+  "scopeBasis": "stated_intent | introduced_regression | required_invariant | independent_improvement | ambiguous_intent",
+  "scopeEvidence": "specific repository rule, PR goal/non-goal, linked spec section, or regression evidence",
+  "path": "internal/example.go",
+  "line": 42,
+  "problem": "concrete problem",
+  "why": "observable consequence",
+  "suggestedChange": "smallest complete repair"
+}
+```
+
+Publication rules:
+
+- `must_fix`: publish as inline feedback when anchorable; it becomes Fixer input.
+- `follow_up`: retain in the structured completion/event record. Do not create a
+  GitHub review thread or top-level action item unless repository instructions
+  explicitly require all such observations to be published.
+- `needs_human`: do not publish it as a change request and do not let Fixer edit.
+  With HITL enabled, park the pair with the conflicting evidence and exact
+  question. With HITL disabled, pause the pair in a manual hold with reason
+  `review_scope_human_required`, the same structured handoff evidence, and an
+  action-required event/notification. The handoff must say which authority
+  input must change before `looper unpause`; never suppress the finding and
+  continue.
+
+For native review submission, each actionable comment must carry transient
+`disposition`, `scopeBasis`, and `scopeEvidence` fields. The trusted review-submit
+Seam rejects missing fields and rejects `follow_up`/`needs_human` in an
+actionable comment payload. The provider Adapter removes Looper-only fields
+before calling GitHub/Forgejo. The fields are a declaration and validation
+surface, not the authority itself.
+
+The actionable review body may summarize published `must_fix` findings but must
+not smuggle suppressed findings into unstructured top-level prose. Comment-only
+publish mode must apply the same dispositions before it posts remote content.
+
+### 7.4 Fixer remains a second scope check
+
+Fixer keeps its current scope authority and may return `declined` or
+`needs_human` even when Reviewer emitted `must_fix`.
+
+When Fixer declines with concrete scope evidence:
+
+- it makes no code change for that item;
+- it replies on the existing thread through the structured response path;
+- it does **not** resolve the thread or treat its own output as dismissal
+  authority;
+- it records the existing decline marker as pending Reviewer adjudication, not
+  as a terminal suppression for the current head;
+- Reviewer treats the reply as a changed disposition signal;
+- Reviewer must not open a duplicate thread for the same fingerprint;
+- Reviewer either accepts the decline, rejects it with new authority evidence,
+  or requests HITL.
+
+Only Reviewer `accept_wontfix` (or an already-resolved human action) makes the
+decline terminal. Reviewer `reject_wontfix` invalidates Fixer's pending decline
+suppression for that exact feedback fingerprint and returns the existing thread
+to Fixer; it does not create a new thread.
+
+A second attempted fix to the same subsystem or a reviewer/fixer scope conflict
+that repeats without new evidence is `needs_human`, not another automatic round.
+
+## 8. Same-head `wontfix` and decline reactivity
+
+### 8.1 Feature ownership and existing ThreadResolution config
+
+Same-head scope disposition is a narrow convergence path, not an implicit
+enablement of the broader optional ThreadResolution feature.
+
+It runs only when all are true:
+
+- the Reviewer loop is continuous;
+- the provider exposes the required native thread capabilities;
+- the thread is Looper-authored; and
+- there is a changed trusted-human disposition or validated Fixer decline.
+
+Existing settings retain these meanings:
+
+| Existing setting | Locked meaning after this change |
+| --- | --- |
+| `ThreadResolution.Enabled` | Gates general objective-fix reconciliation only; it does not disable the narrow disposition path |
+| `Mode`, `AutoResolve`, `RequireAuditComment` | Govern objective-fix report/reply/resolve behavior only |
+| `RequireNewHeadSinceThread` | Applies to objective code-fix detection only; a changed disposition signal bypasses it |
+| `RequireCurrentReviewRequest` | Applies to general objective reconciliation/full review; an explicit Looper-thread disposition is targeted work intent and may receive the narrow adjudication without a fresh review request |
+| `MaxThreadsPerRun` | Shared batch-size ceiling for classifier work; default remains `10` |
+
+Therefore the defaults remain `Enabled=false`, report-only,
+`RequireNewHeadSinceThread=true`, and `MaxThreadsPerRun=10`. The new path does
+not start scanning or resolving arbitrary stale threads. Its only remote
+mutations are an audited accept/reject reply and, for `accept_wontfix`, resolution
+of that same Looper-authored thread.
+
+### 8.2 Review signal identity
+
+`lastPublishedHeadSha` remains publication/audit metadata, but it is no longer
+the sole discovery identity for a continuous Reviewer loop.
+
+Define:
+
+```text
+threadFeedbackFingerprint = sha256(canonical Looper-authored review threads)
+reviewSignalFingerprint   = sha256(headSha + threadFeedbackFingerprint)
+```
+
+The canonical thread input includes, in stable thread/comment order:
+
+- thread id and `isResolved`;
+- each comment id, author, author association, `createdAt`, `updatedAt`, and a
+  hash of normalized body content;
+- original/current commit ids when available.
+
+Every Reviewer thread-resolution or disposition reply must carry the extended
+`looper:thread-resolution` audit marker. Exclude all such Reviewer audit replies
+from the fingerprint, otherwise accept/reject replies trigger themselves.
+Include the original Looper review comment, trusted human edits/replies, and
+validated Fixer fixed/declined replies. Keep `isResolved` in the input because a
+human resolve/reopen is real state change.
+
+Store only `lastReviewedSignalFingerprint` in existing Reviewer loop metadata;
+do not persist comment bodies or a per-thread ledger. The queue dedupe key stays
+stable at the existing per-loop/PR identity and does **not** include the
+fingerprint. The signal fingerprint travels in queue payload/checkpoint data and
+in remote idempotency/audit markers.
+
+For a single-batch disposition, after Reviewer performs its own reply/resolve
+mutation, it must:
+
+1. refetch the authoritative, fully paginated relevant thread set;
+2. recompute the post-mutation fingerprint, including the new `isResolved`;
+3. persist the checkpoint and promote the post-mutation fingerprint to
+   `lastReviewedSignalFingerprint` in one fail-closed local commit before
+   completing the run.
+
+If the refetch or local persistence fails, do not run the classifier again just
+because Reviewer's own mutation changed the signal. Retry observes the existing
+remote audit marker, completes the missing post-mutation fingerprint commit,
+and remains idempotent.
+
+A webhook caused by Reviewer's own mutation may race that local commit. It may
+coalesce discovery work, but after the commit the Reviewer admission check must
+recognize the already-recorded post-mutation signal and exit before starting an
+agent execution.
+
+When more than `MaxThreadsPerRun` candidates exist, process stable batches. Each
+partial batch stores its refetched post-mutation fingerprint and completed
+thread ids in the active run checkpoint, but does **not** promote it to loop
+`lastReviewedSignalFingerprint`. Requeue a continuation through the same stable
+queue item. Promote only after every candidate from the captured signal is
+adjudicated or has a terminal per-thread outcome and a final full refetch is
+stable. A partial batch must not make the remaining threads invisible.
+
+The active checkpoint is a crash-recovery cursor, not decision authority.
+Current provider thread state plus Looper's remote audit markers remain the
+authority for whether a thread mutation already happened; any freshness drift
+invalidates the cursor before another mutation.
+
+If external feedback arrives between batches, freshness detection invalidates
+the captured set, retains already idempotent remote decisions, and coalesces the
+latest complete signal. It must not promote either the stale captured signal or
+an intermediate post-mutation signal.
+
+### 8.3 Disposition directives
+
+The canonical command is:
+
+```text
+/looper wontfix <reason>
+```
+
+Directive parsing applies only inside Looper-authored review threads. For
+compatibility, a trusted human comment whose entire non-quoted content is
+`wontfix`, `won't fix`, `won’t fix` (Unicode apostrophe), or any of those
+followed by `: <reason>` is equivalent. Do not interpret incidental prose
+containing the word as a command.
+
+`/looper reconsider <reason>` cancels the latest accepted disposition for an
+unresolved/reopened thread. The latest valid trusted-human directive after the
+last Reviewer audit is the input to adjudicate.
+
+### 8.4 Reviewer decisions
+
+Extend thread reconciliation beyond objective code resolution:
+
+| Decision | Required evidence | Remote action |
+| --- | --- | --- |
+| `objectively_fixed` | Requested behavior is verifiably present at current head | Existing audit/resolve policy |
+| `accept_wontfix` | Finding is outside documented PR scope, optional, incorrect, or superseded by trusted intent | Reply with scope evidence and resolve thread |
+| `reject_wontfix` | Finding is required by repository rule/PR intent or is a directly introduced correctness/safety regression | Reply on same thread with concrete authority; keep unresolved |
+| `needs_human` | Authority conflicts, reason is missing, or evidence is ambiguous | Halt pair; ask if HITL is enabled, no-ask manual hold otherwise; no later mutation |
+| `not_fixed` | No disposition applies and requested behavior is still absent | Keep unresolved; Fixer remains eligible |
+
+The classifier prompt must receive PR title/body, relevant linked intent when
+available, repository instructions, current head, and full candidate thread
+history. An author reply like “fixed” remains insufficient objective evidence;
+an explicit trusted `wontfix` is a request for scope adjudication, not automatic
+acceptance.
+
+The existing `looper:thread-resolution` audit identity becomes keyed by
+`threadId + headSha + threadFeedbackFingerprint + decision`. Every remote
+Reviewer adjudication reply (`accept_wontfix`, `reject_wontfix`,
+`objectively_fixed`, or `not_fixed`) carries the extended marker and is excluded
+from the next fingerprint. A `needs_human` outcome writes the same identity to
+the local checkpoint/handoff but posts no remote adjudication reply. A prior
+audit for the same head but older comment fingerprint must not suppress a new
+decision.
+
+The automatic dispute quota is one Reviewer rejection per unchanged adjudicated
+input. If Fixer emits `declined` again after `reject_wontfix`, and the head plus
+canonical human/original-finding feedback are unchanged after excluding Looper
+Fixer-decline and Reviewer-audit coordination replies, force `needs_human`.
+Another Reviewer/Fixer argument is forbidden. A changed head or changed trusted
+human directive creates a new adjudicated input.
+
+### 8.5 Discovery, coalescing, and responsiveness
+
+Correctness must not depend on webhooks:
+
+1. Polling discovery checks thread feedback for active continuous Reviewer
+   loops, even when the code head is unchanged.
+2. GitHub `pull_request_review_comment` create/edit/delete and
+   `pull_request_review_thread` resolve events trigger targeted discovery as an
+   acceleration path; these are documented
+   [GitHub webhook events](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request_review_comment).
+3. A changed review signal queues a thread-disposition pass after the configured
+   **Reviewer** quiet period (default `60s`); it does not use the Fixer quiet
+   period (default `0`) and does not wait for another commit.
+4. The thread-disposition pass does not perform a full code rescan unless the
+   decision itself exposes a code-scope conflict requiring one.
+5. `minPublishIntervalSeconds` applies to a new PR review publication, not to a
+   disposition-only classifier run.
+
+Responsiveness target: absent provider/rate-limit failure, a same-head trusted
+directive should start adjudication within one discovery interval plus the
+configured quiet period. Webhook mode should normally be faster.
+
+Keep exactly one active Reviewer queue item for a PR/lane:
+
+- Keep the existing stable dedupe key
+  `reviewer:{project}:{loop}:{repo}:{pr}`.
+- If the item is queued/retry-wait, update it in place to the latest head/signal
+  and extend its eligibility with
+  `DebounceSchedule(now, reviewerQuietPeriod, existingAvailableAt)`.
+- If the item is running, retain only the latest pending signal. The running
+  pass must freshness-check before mutation; on completion/drift it schedules
+  one continuation for the latest signal.
+- Never create old-signal and new-signal active items side by side. Because the
+  fingerprint represents complete current state, coalescing intermediate
+  signals cannot lose work.
+
+Polling may use PR `updatedAt` and a short-lived thread-list cache as a
+non-authoritative negative-cache hint. An unchanged hint may skip a thread list
+only until the cache TTL; a forced periodic full refresh remains required.
+`updatedAt` never advances `lastReviewedSignalFingerprint` and never proves that
+thread state is unchanged.
+
+Webhook implementation is not a one-case addition:
+
+- route `pull_request_review_comment` to both Reviewer and Fixer lanes instead
+  of the current Fixer-only route;
+- add `pull_request_review_thread` to `routeDelivery` and route `resolved` to
+  both lanes;
+- add the event to every runtime forwarding/subscription list, including
+  `internal/runtime/webhook.go`, `internal/runtime/webhook_forwarder.go`, and
+  the CLI/netadmin hook event lists;
+- update advertised event lists and forwarder contract tests together so a
+  managed hook and an external forwarder subscribe to the same events.
+
+### 8.6 Fixer race and same-head clean outcome
+
+An unresolved thread with a new, unaudited trusted disposition directive or a
+validated Fixer decline is temporarily withheld from further Fixer edits.
+Reviewer has first right to adjudicate it.
+
+- Accepted `wontfix` removes the thread from Fixer input by resolving it.
+- Rejected `wontfix` restores it as actionable without opening a new thread.
+- A Fixer decline follows the same accept/reject path; Fixer never resolves its
+  own scope dispute.
+- `needs_human` parks the pair in both modes: with an ask when HITL is enabled,
+  or with a structured no-ask manual hold when it is disabled.
+- If all blockers disappear without a code-head change, Reviewer may run a
+  same-head convergence pass and publish the configured clean outcome. Review
+  admission is keyed by the new review signal, so head-only idempotency must not
+  suppress it.
+
+Fixer's existing pre-mutation thread snapshot/drift check remains mandatory. If
+a comment changes after Fixer starts, Fixer must make no thread mutation from
+the stale decision and must return to discovery.
+
+### 8.7 Interaction with budget hold
+
+A budget-held pair may run a disposition-only reconciliation in response to a
+new trusted human directive or validated Fixer decline, whether or not HITL is
+enabled. This is allowed because it cannot push code or publish a new PR review
+and can only reduce or clarify the outstanding set.
+
+It does not reset either meter, release the pair, or imply `Continue`. A new
+clean/finding review publication and every Fixer push remain held until an
+explicit Continue. The handoff brief must refresh when disposition state
+changes.
+
+When HITL is disabled, no background disposition run may revive the pair. A
+trusted human edit can resolve a scope dispute and update the handoff, but
+continuing counted automation still requires `looper unpause` on the held pair.
+Polling, webhooks, daemon restart, and enabling HITL are never interpreted as an
+implicit Continue.
+
+## 9. Independent budgets with a paired circuit breaker
+
+### 9.1 Configuration and counting
+
+| Path | Unit | New default |
+| --- | --- | --- |
+| `roles.reviewer.behavior.loop.maxPublishesPerPR` | Successful native/top-level review publications | `3` |
+| `roles.fixer.behavior.loop.maxPushesPerPR` | Successful head-changing Fixer pushes | `3` |
+
+These are independent meters because the work units and risk differ. A project
+may configure Reviewer `2` / Fixer `5`, Reviewer `5` / Fixer `2`, or disable one
+cap with `0`.
+
+Do not introduce a “round” counter. Reviewer and Fixer are asynchronous: a
+review may produce no Fixer push, one push may address many reviews, and a human
+thread disposition may change convergence without a commit. “Round” has no
+stable authority.
+
+Thread-disposition audit replies are not Reviewer review publications. Failed
+agent executions, rejected outbound payloads, no-op Fixer runs, and failed
+pushes do not consume these meters; their existing retry/terminal policies still
+apply.
+
+### 9.2 Which loops participate
+
+Budget participation is based on continuity, not only `manual`:
+
+```text
+participates = automatic || followUpdates == true
+```
+
+- Automatic Reviewer/Fixer loops participate.
+- `looper takeover` loops (`manual=true`, `followUpdates=true`) participate.
+- One-shot manual loops (`manual=true`, `followUpdates=false`) remain exempt.
+
+Pair only loops in the same derived lane:
+
+- `automatic`
+- `continuous_manual`
+
+Do not cross-pair a takeover loop with an automatic loop. Preserve the invariant
+of at most one non-terminal loop per role per PR/lane; discovery coalesces
+duplicates. No persisted pair id is added unless implementation evidence proves
+that invariant cannot be maintained.
+
+### 9.3 Exhaustion
+
+Before any counted mutation and after every successful counted mutation, read
+live caps and current counters. Product terminal states (closed/merged PR,
+accepted clean outcome, explicit stop) win over opening a budget ask.
+
+Budget admission does not check `HITL.Enabled`; caps are always enforced. When
+either role is at its live cap and more counted work is required:
+
+1. Cancel pending queue entries for both roles in the lane.
+2. Persist counters/reason and append the handoff event described below.
+3. Emit an event and action-required notification.
+4. Do not allow discovery or daemon restart to revive either side.
+
+The hold presentation depends only on whether HITL answer delivery is enabled:
+
+| `HITL.Enabled` | Exhausted role | Sibling | Resume path |
+| --- | --- | --- | --- |
+| `true` | `awaiting_human` with one Continue/Stop budget ask | budget-paused | Answer the existing ask |
+| `false` | `paused`, reason `review_fix_budget_exhausted`, no ask | paired budget-paused | `looper unpause <either-seq>` for Continue or `looper stop <either-seq>` for Stop |
+
+Do not use `human_takeover` for the HITL-disabled case. That status means a real
+interactive agent session is pinned and can be handed back; a budget hold has
+no such session. Do not use `terminated` for the initial no-HITL handoff
+either: it is irreversible and would force the operator to reconstruct the
+continuous lane even though the existing paired pause is sufficient.
+
+### 9.4 Continue and Stop
+
+`Continue` is a role-specific refill with pair-wide release. It comes from the
+HITL answer when enabled; when disabled, `looper unpause` on either member of a
+budget-held pair must delegate to the same budget Continue operation instead of
+the generic single-loop resume:
+
+- Reset every meter that is currently at/over its live cap.
+- Preserve a sibling meter that still has unused budget.
+- Clear the budget ask and pair pause only after all required resets succeed.
+- Requeue both eligible sides against current PR/thread state.
+
+This avoids wasting unused Fixer budget when Reviewer alone exhausts, while also
+avoiding an immediate second HITL when both meters are already exhausted.
+
+`Stop` terminates both roles in the lane and cancels their queue work. It does
+not resolve threads, approve, merge, or delete worktrees outside existing
+terminal cleanup policy. For a no-HITL budget hold, `looper stop` on either role
+must delegate to the paired Stop operation.
+
+For a no-HITL `review_scope_human_required` hold, the handoff names the
+repository/PR/thread authority evidence that must be clarified. `looper
+unpause` resumes the pair against current evidence without resetting a meter
+unless one is also exhausted. If the authority input is unchanged, admission
+returns to the same manual hold without a counted mutation.
+
+Pair transitions must be idempotent and fail closed. A partial storage/queue
+failure must leave both roles non-runnable until reconciliation completes. Do
+not unpause a sibling before the exhausted counters and pair transition are in
+a safe state. In HITL-disabled mode, a partial paired hold likewise cannot leave
+one role runnable.
+
+### 9.5 Handoff brief
+
+The budget ask (when enabled), event/notification, and CLI/dashboard detail must
+show:
+
+- PR, lane, current head, and last reviewed signal;
+- Reviewer publications: `count / live cap`;
+- Fixer pushes: `count / live cap`;
+- which role(s) are exhausted;
+- unresolved `must_fix` thread links/titles;
+- pending `wontfix`/decline decisions and their latest trusted reason;
+- late-discovery blockers;
+- last Reviewer/Fixer outcome and whether progress decreased the outstanding
+  set;
+- exact semantics: Continue refills exhausted meter(s); Stop terminates both.
+
+When HITL is enabled, the only required ask choices remain `Continue` and
+`Stop`. When HITL is disabled, the handoff has no answer widget; it shows the
+exact `looper unpause` and `looper stop` commands instead. Better evidence is
+more valuable than another configurable answer matrix.
+
+Do not add a persisted handoff record. The action-required event payload
+captures the decision-time snapshot; loop metadata remains authority for
+counters/reason; CLI/dashboard may refresh thread links and PR state from the
+provider. This keeps historical evidence without another state copy to
+reconcile.
+
+## 10. Module design
+
+### 10.1 Reviewer convergence Module
+
+Deepen the existing Reviewer Module instead of adding a workflow layer.
+
+- **Interface:** phase-specific review instructions, structured finding
+  validation, review-signal calculation, and thread-disposition decisions.
+- **Implementation:** full-pass accumulator, repair frontier, scope evidence,
+  same-head signal discovery, and audit idempotency stay local to Reviewer.
+- **Seam:** trusted review-submit accepts only validated actionable
+  findings.
+- **Adapter:** existing GitHub/Forgejo publishers map accepted fields to provider
+  payloads; no new provider interface is justified.
+- **Depth:** callers see one review signal and one disposition result, while the
+  Module hides prompt, fingerprint, frontier, and provider-publication details.
+- **Leverage:** the same finding rules serve native review and comment-only
+  modes; the same signal drives polling and webhook-targeted discovery.
+- **Locality:** scope and convergence changes should not require edits across
+  Reviewer, Fixer, scheduler, and every provider Adapter.
+
+The deletion test is positive: delete head-only discovery authority, numeric
+comment batching language, and direct publication of unclassified findings.
+
+### 10.2 Review-fix budget Module
+
+Deepen `internal/loops/review_fix_budget.go`.
+
+- **Interface:** check admission, halt a lane, apply Continue/Stop when
+  available, and build the handoff brief.
+- **Implementation:** lane matching, independent meter reads/resets, queue
+  cancellation, HITL ask vs no-ask paired pause, pair status
+  transitions, handoff evidence, and idempotent recovery live together.
+- Reviewer and Fixer runners report successful counted mutations; they do not
+  implement their own sibling/pause/reset ordering.
+
+Do not add a Go interface with one implementation. Exported functions on the
+existing Module are sufficient until a second implementation exists.
+
+## 11. New-concept trade-offs
+
+### 11.1 Structured finding disposition
+
+**Failure prevented:** Reviewer publishes a plausible but independent
+improvement; Fixer treats the remote thread as mandatory; both roles spend
+rounds arguing about work the PR never promised.
+
+**Cost:** new transient result fields, validator branches, prompt fixtures, and
+provider payload stripping must remain compatible across native and
+comment-only publication. The model may still provide bad evidence, so Fixer
+must retain its independent check.
+
+**Why simpler alternatives are insufficient:** prompt-only wording is already
+present and is not an enforceable outbound Seam. Inferring scope from diff
+or GitHub state would make infrastructure pretend to be product authority.
+Structured agent output plus explicit documented evidence is the smaller path.
+
+### 11.2 Review-signal fingerprint
+
+**Failure prevented:** a human edits/replies `wontfix` or Fixer posts a decline
+on an unchanged head; Reviewer keeps skipping by head SHA; unresolved state and
+the review-fix loop never converge.
+
+**Cost:** polling active thread lists consumes provider quota; canonicalization
+must handle edits, deletes, pagination, bot/audit exclusions, Reviewer
+self-mutations, partial `MaxThreadsPerRun` batches, and provider timestamp
+quirks; one new loop-metadata field plus queue payload/coalescing state must
+remain consistent across restart and webhook/poll races. Existing active-run
+checkpoint storage also carries a partial batch's completed thread ids and
+post-mutation fingerprint until final promotion; this is another retry path to
+test, but not a new per-thread history ledger.
+
+**Why simpler alternatives are insufficient:** head SHA cannot represent thread
+state. PR `updatedAt` is too broad and is not a reliable per-thread authority.
+Webhook-only detection loses events during daemon/network downtime. Persisting a
+full thread ledger would add much more state and recovery surface than one
+content fingerprint. A bounded cache and PR `updatedAt` are useful negative
+cache hints, but a periodic full refresh is still required.
+
+### 11.3 Always-on narrow disposition path
+
+**Failure prevented:** the same-head protocol is implemented inside the
+existing ThreadResolution feature, which remains disabled by default, so the
+documented convergence behavior never runs for default users.
+
+**Cost:** continuous GitHub Reviewer loops gain a narrow default thread query,
+classifier, reply, and accepted-disposition resolve path. It must coexist with
+legacy ThreadResolution modes without making arbitrary stale threads eligible.
+
+**Why simpler alternatives are insufficient:** enabling all ThreadResolution by
+default would broaden behavior far beyond `wontfix`/decline convergence and
+would change report/resolve policy for existing users. Leaving the new behavior
+behind `Enabled=false` makes §2 false. A capability-checked, Looper-authored,
+changed-disposition-only path is the smaller Interface.
+
+### 11.4 Fixer-decline handshake
+
+**Failure prevented:** Fixer decides a Reviewer request is out of scope, then
+uses its own structured output as authority to resolve and suppress the thread.
+Reviewer cannot accept or reject that scope dispute, and the PR can become
+stuck or falsely clean.
+
+**Cost:** a declined thread stays unresolved for one additional adjudication
+pass; Fixer suppression must distinguish pending, accepted, and rejected audit
+evidence; retry tests must cover a crash between reply and Reviewer action.
+
+**Why simpler alternatives are insufficient:** allowing Fixer to reply and
+resolve is fast but assigns authority to the party disputing the request.
+Leaving the thread unresolved forever just moves the deadlock. Reusing the
+existing decline reply and thread-resolution audit markers creates a two-phase
+handshake without a new persisted status field or table.
+
+### 11.5 Paired circuit breaker over independent meters
+
+**Failure prevented:** one role exhausts but the sibling continues publishing or
+pushing, or two nearly simultaneous exhaustions produce contradictory HITL
+asks.
+
+**Cost:** pair-wide queue/status transitions and partial-failure recovery are
+cross-loop lifecycle behavior and require integration coverage. Default
+HITL-disabled users now enter a paired manual hold at a finite cap instead of
+silently ignoring it, so migration, pair-aware `unpause`/`stop`, and
+action-required observability are product-visible.
+
+**Why simpler alternatives are insufficient:** fully independent pauses permit
+the other role to mutate stale state. One shared counter loses the flexible
+Reviewer/Fixer risk budgets requested by operators. Keeping enforcement behind
+HITL would preserve compatibility by making the default cap fictional. A
+notification without halting would still allow unbounded mutation. Independent
+meters with one paired halt keep flexibility and the finite guarantee.
+Terminating a no-HITL pair would discard an otherwise resumable lane; a generic
+single-loop unpause would either trip the same exhausted cap immediately or
+revive only one side. Reusing the paired budget pause and routing unpause/stop
+through the existing budget Module avoids both failures. No epoch id or ledger
+is needed; existing counters plus event history are sufficient.
+
+## 12. Failure modes and required behavior
+
+| Failure | Required behavior |
+| --- | --- |
+| Reviewer omits disposition/scope evidence | Trusted Seam rejects before remote publication; retry same signal |
+| Comment changes while Reviewer/Fixer runs | Freshness check detects fingerprint drift; no stale reply/resolve; rediscover |
+| Same-head directive arrives after prior audit | New fingerprint invalidates old audit and queues adjudication |
+| Reviewer reply/resolve changes its own thread | Refetch and commit post-mutation fingerprint; do not spend another classifier run |
+| More than `MaxThreadsPerRun` candidates | Continue stable batches; do not advance stored signal until all captured candidates terminate |
+| Several signals arrive while one item is queued/running | Coalesce latest signal into the one stable-dedupe work item; never run stale items side by side |
+| Untrusted user/bot says `wontfix` | Treat as context, not authority; do not auto-resolve |
+| Trusted `wontfix` conflicts with repository safety rule | `reject_wontfix` or `needs_human`; never silently accept |
+| Fixer emits `declined` | Reply with evidence, leave unresolved, and queue Reviewer adjudication |
+| Fixer declines again after one unchanged-input rejection | Force `needs_human`; no third automatic argument |
+| Thread is manually resolved before mutation | Treat as idempotent success; do not recreate it |
+| Thread is reopened or accepted directive edited/deleted | Fingerprint changes; adjudicate current state |
+| Provider thread listing is partial/rate-limited | Fail retryably; do not advance stored review signal |
+| Budget config lowers below current count | Halt on next admission check: ask-backed park with HITL, no-ask paired pause without it |
+| HITL-disabled budget exhausts | Pause pair, persist handoff/event, notify, and require pair-aware unpause/stop; never continue silently |
+| HITL-disabled `needs_human` occurs | Pause pair with unresolved evidence; never discard the finding or auto-resume |
+| Handoff notification delivery fails | Pair remains non-runnable; CLI/dashboard/event evidence remains retryable/visible |
+| Continue partially fails | Keep pair non-runnable and original ask retryable |
+| Generic `looper unpause` targets a budget-held role | Delegate to paired Continue; never resume only one role or preserve an exhausted counter |
+| Daemon restarts after a halt | Discovery cannot revive either held side; ask/handoff remains authoritative |
+| No sibling exists | Halt the existing role idempotently using the configured HITL mode; do not invent a phantom loop |
+| `ThreadResolution.Enabled=false` | Narrow changed-disposition path still runs; objective stale-thread reconciliation remains off |
+| Provider lacks native thread capabilities | Enforce budgets but do not claim same-head disposition convergence |
+| Legacy Looper comment has no new disposition fields | Fixer applies existing scope classification; no comment is lost |
+
+## 13. Migration and compatibility
+
+1. Existing explicit numeric cap values are preserved. Their enforcement is no
+   longer conditional on HITL, which is an intentional behavior change for
+   HITL-disabled installations.
+2. The normalized defaults change from `8/8` to `3/3`. A running loop already
+   over the live cap halts on its next admission check: `awaiting_human`/paused
+   with HITL enabled, or a no-ask paired pause with HITL disabled. Neither path
+   approves, resolves, or merges.
+3. Existing Reviewer `iterationCount` and Fixer
+   `reviewFixBudget.pushCount` remain the meter storage.
+4. `HITL.Enabled` remains `false` by default. The change does not silently turn
+   on GitHub/Feishu asks; it adds an action-required event/notification/dashboard
+   handoff and pair-aware `looper unpause`/`looper stop` path when no answer
+   transport is enabled.
+5. Continue resets only exhausted meters. A no-HITL budget `unpause` delegates
+   to this same operation. Existing event history remains the audit trail; no
+   epoch history is added.
+6. Existing automatic loops retain pairing. Continuous manual/takeover loops
+   become budget participants based on `followUpdates=true`.
+7. Existing ThreadResolution defaults remain unchanged. `Enabled`, mode,
+   auto-resolve, new-head, current-review-request, and max-thread settings keep
+   governing objective reconciliation as defined in §8.1. Only the narrow
+   Looper-authored changed-disposition path becomes default behavior on capable
+   providers.
+8. `lastReviewedSignalFingerprint` is absent on upgrade. For a same-head loop:
+   if it has unresolved Looper-authored threads, run one bounded reconciliation
+   pass; otherwise store the baseline without publishing a new review.
+   Upgrade backfill must use the normal stable-dedupe queue, Reviewer quiet
+   period, scheduler concurrency limit, and discovery limits; it must not launch
+   all legacy PR reconciliations outside normal admission.
+9. The Reviewer queue dedupe key remains unchanged. New signal data is added to
+   payload/checkpoint/coalescing state, so no old/new fingerprint queue pair can
+   coexist.
+10. Managed webhook reconciliation adds `pull_request_review_thread` to existing
+    GitHub hooks and advertised forwarder event lists; review-comment events are
+    re-routed to Reviewer as well as Fixer. Polling remains the correctness
+    fallback during rollout.
+11. `lastPublishedHeadSha` remains for provider publication history and backwards
+   compatibility but no longer suppresses a changed thread signal.
+12. Existing `looper:thread-resolution` markers without a feedback fingerprint
+   are valid historical audits only; they do not suppress newer comment state.
+13. Legacy Fixer declines that are already remotely resolved remain resolved;
+   migration does not reopen historical threads. New declines use the Reviewer
+   handshake.
+14. Forgejo keeps its existing ThreadResolution/provider limitations and is
+    explicitly exempt from same-head disposition convergence; its Reviewer and
+    Fixer budgets are still enforced independently of HITL.
+15. Unmarked third-party review comments retain current Fixer behavior and scope
+   checks.
+
+## 14. Verification
+
+Minimum credible evidence:
+
+| Level | Required case |
+| --- | --- |
+| Unit | Finding disposition/schema validation and provider-field stripping |
+| Unit | Same-root grouping does not merge independent findings |
+| Unit | Initial vs changed-head vs same-head-thread prompt/frontier selection |
+| Unit | Review-signal canonicalization: edit, reply, delete, resolve, reopen, audit exclusion |
+| Unit | Reviewer post-mutation refetch commits the new signal; self-webhook starts no agent |
+| Unit | Trusted directive parser, aliases, incidental-word rejection, and author authority |
+| Unit | Directive parser is limited to Looper-authored threads and accepts ASCII/Unicode apostrophes |
+| Unit | Thread decision matrix for fixed/accept/reject/needs-human/not-fixed |
+| Unit | ThreadResolution gate matrix: legacy disabled/report-only/new-head settings do not disable narrow disposition |
+| Unit | `MaxThreadsPerRun+1` candidates require continuation and do not advance the signal early |
+| Unit | Independent cap matrix, `0`, live cap changes, and “reset exhausted only” |
+| Unit | HITL-disabled cap/needs-human produces a no-ask paired hold; HITL-enabled produces a resumable ask |
+| Unit | No-HITL scope hold with unchanged evidence re-holds without consuming a meter |
+| Unit | Stable queue dedupe coalesces queued/retry-wait signals with Reviewer debounce |
+| Integration | First pass publishes all independent in-scope findings in one review |
+| Integration | `follow_up` never becomes a remote thread or Fixer item by default |
+| Integration | Fixer decline triggers same-head Reviewer adjudication and no duplicate thread |
+| Integration | Fixer decline reply does not resolve; accept resolves; reject re-enables the existing Fixer item |
+| Integration | Edited `wontfix` comment queues within one polling cycle on unchanged head |
+| Integration | Accepted `wontfix` resolves, rejected remains actionable, ambiguous halts pair according to HITL mode |
+| Integration | Same-head accepted disposition can lead to a clean convergence review |
+| Integration | Comment drift between classification and mutation performs no stale mutation |
+| Integration | Running old signal plus two new signals yields one latest-signal continuation, not parallel/back-to-back stale work |
+| Integration | Second unchanged-input Fixer decline after Reviewer reject goes directly to `needs_human` |
+| Integration | HITL-off default enforces `3/3`, pauses pair, preserves handoff, and cannot be rediscovered |
+| Lifecycle integration | Reviewer cap halts Fixer; Fixer cap halts Reviewer; ask/no-ask hold follows HITL mode and restart cannot revive pair |
+| Lifecycle integration | Continue refills only exhausted meter(s) and releases pair fail-closed |
+| Lifecycle integration | No-HITL `looper unpause` delegates to paired Continue; `looper stop` delegates to paired Stop |
+| Lifecycle integration | `manual=true,followUpdates=true` participates; one-shot manual remains exempt |
+| Lifecycle integration | Upgrade baseline reconciliation respects queue dedupe, Reviewer quiet period, scheduler concurrency, and discovery limits |
+| GitHub contract | Review-comment create/edit/delete routes Reviewer+Fixer; thread resolved routes both; polling remains fallback |
+| GitHub contract | Runtime, forwarder, CLI, and netadmin managed-hook event lists remain identical |
+| GitHub contract | Paginated thread timestamps/body hashes and audit markers preserve idempotency |
+| GitHub contract | `updatedAt` negative cache expires into forced full refresh and never advances authority state |
+| Provider contract | Forgejo enforces role budgets but advertises no same-head disposition guarantee |
+
+Because this changes cross-Module lifecycle, GitHub command, worktree review,
+and resolve-comments behavior, unit-only coverage is insufficient. Prefer the
+existing fake-`gh` contract and invariant integration harness. Escalate to real
+GitHub sandbox E2E only if implementation changes auth, scopes, provider thread
+mutation shape, or rate-limit behavior; adding transient Looper fields that are
+stripped before the existing provider call does not by itself require sandbox
+E2E.
+
+Repository verification for implementation PRs:
+
+```sh
+gofmt -l .
+go vet ./...
+go test ./...
+go build ./...
+```
+
+## 15. Ship slices
+
+1. **Budget semantics:** HITL-independent enforcement, default `3/3`,
+   continuous-manual participation, ask/no-ask paired holds, independent
+   refill, and lifecycle integration tests.
+2. **Reviewer finding contract:** scope authority, dispositions, complete first
+   pass, trusted outbound validation, prompt/contract tests.
+3. **Repair frontier:** changed-head delta rules, late-discovery handling, and
+   duplicate decline protection.
+4. **Thread signal:** narrow feature gate, fingerprint, stable queue coalescing,
+   same-head polling/webhook trigger, extended decisions, post-mutation signal
+   commit, and stale-mutation guard tests.
+5. **Docs/observability:** configuration guide, user guide, dashboard/CLI handoff
+   detail, metrics/events for disposition and budget outcomes.
+
+Each slice must leave existing authority and lifecycle invariants intact. Do not
+merge a prompt-only partial that publishes new disposition words without the
+trusted outbound gate, or a thread fingerprint that can enqueue but cannot
+dedupe across restart.
+
+## 16. Done bar
+
+- [ ] Reviewer and Fixer retain separately configurable caps and counters
+- [ ] Defaults are `3` Reviewer publications and `3` Fixer pushes
+- [ ] Caps enforce with HITL on or off; default HITL-off produces a no-ask paired hold
+- [ ] HITL-on exhaustion parks the pair; Continue refills exhausted meters only
+- [ ] HITL-off budget hold resumes only through pair-aware unpause; stop terminates both
+- [ ] HITL-off `needs_human` pauses with evidence instead of dropping the finding
+- [ ] Takeover continuous loops participate; one-shot manual loops do not
+- [ ] First Reviewer pass reports every independent in-scope finding observed
+- [ ] Later passes use repair/thread frontiers instead of full old-diff rescans
+- [ ] Out-of-scope follow-ups do not become remote actionable comments by default
+- [ ] Fixer still independently verifies scope and may decline/ask for human
+- [ ] Fixer cannot resolve its own decline; Reviewer adjudicates the existing thread
+- [ ] Same-head thread edits/replies change Reviewer discovery identity
+- [ ] Legacy ThreadResolution defaults remain unchanged; narrow disposition works anyway
+- [ ] Reviewer adjudication replies cannot self-trigger another agent execution
+- [ ] More than ten changed threads complete in bounded batches without signal loss
+- [ ] Stable queue dedupe coalesces latest signal; fingerprint is not part of the key
+- [ ] Trusted `wontfix` is accepted, rejected, or escalated with evidence
+- [ ] One unchanged-input reject/decline recurrence forces `needs_human`
+- [ ] Fixer cannot race an unaudited disposition or mutate a stale thread
+- [ ] Accepted same-head dispositions can reach a clean review without a new commit
+- [ ] Budget exhaustion never implies approve/resolve/merge
+- [ ] No new SQL table, epoch id, pair id, or finding ledger is introduced
+- [ ] Forgejo budget guarantee and same-head disposition exemption are explicit
+- [ ] Contract/invariant integration coverage passes with Go CI commands
+
+## 17. Open implementation choices (not product locks)
+
+- Exact metadata key spelling for `lastReviewedSignalFingerprint`
+- Whether polling computes the aggregate hash directly or through a small cache
+- Exact event names and dashboard presentation of the handoff brief
+- Whether `/looper reconsider` ships in the same PR as `wontfix` or immediately
+  after, provided edit/delete/reopen still invalidates prior audit
+- Exact default quiet-period interaction for webhook-triggered thread changes,
+  provided the responsiveness target and burst dedupe hold


### PR DESCRIPTION
# Summary

- Stack 1/4 of review-fix convergence (replaces the monolithic #642).
- Lower default Reviewer/Fixer caps to 3/3 and enforce them whether HITL is on or off.
- Either exhausted role holds the same-lane pair: Continue/Stop ask when HITL is on; no-ask `paused` when it is off.
- `looper unpause` / `looper stop` on a held role delegate to paired Continue/Stop. Continue refills only meters at/over the live cap.
- Discovery, retry, and review-submit cannot revive or publish past a held lane.
- Docs now match the 3/3 HITL-independent behavior.

Next: dispositions (`needs_human` / outbound `must_fix` gate).

# Testing

- [x] Targeted: `go test ./internal/loops/ ./internal/api/ ./internal/reviewer/ ./internal/fixer/ ./internal/runtime/ -count=1`
- [ ] `go test ./...` (full suite not re-run on this slice tip)
- [x] Additional targeted checks: package tests above

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [x] Daemon boot / config / runtime path risk
- [ ] Worktree / repo isolation / lifecycle risk
- [ ] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [x] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- Spec slice 1: `specs/2026-08-24-review-fix-convergence/spec.md`
- Follows #641

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied
