### PR TITLE
feat: add review finding dispositions and scope pair holds

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -145,6 +145,10 @@ type Context struct {
 	TakeoverLoop         func(context.Context, string, string) (TakeoverResult, error)
 	RepairReviewer       func(context.Context, reviewer.RepairInput) (reviewer.RepairResult, error)
 	TriggerSchedulerTick func()
+	// NotifyHumanAttention observes a durable human-attention park after a
+	// non-claim path (budget Continue → scope promotion). Optional; Runtime
+	// NotifyHumanAttention is used when unset.
+	NotifyHumanAttention func(context.Context, string)
 }
 
 // TakeoverResult is what a takeover yields: the native session id + worktree +
@@ -6008,11 +6012,62 @@ func (h *Handler) applyReviewFixBudgetContinueIfHeld(ctx context.Context, loop s
 	if h.context.TriggerSchedulerTick != nil {
 		h.context.TriggerSchedulerTick()
 	}
+	h.observePromotedScopeHolds(ctx, updated)
 	resp, serErr := h.serializeLoopWithDiagnostics(ctx, updated)
 	if serErr != nil {
 		return nil, serErr
 	}
 	return &resp, nil
+}
+
+func (h *Handler) humanAttentionObserver() func(context.Context, string) {
+	if h.context.NotifyHumanAttention != nil {
+		return h.context.NotifyHumanAttention
+	}
+	if rt, ok := h.context.Runtime.(*looperdruntime.Runtime); ok {
+		return rt.NotifyHumanAttention
+	}
+	return nil
+}
+
+// observePromotedScopeHolds notifies after budget Continue may have created a
+// fresh no-HITL scope park. That path never finishes a claim, so the scheduler
+// observer would otherwise miss it until daemon restart.
+func (h *Handler) observePromotedScopeHolds(ctx context.Context, loop storage.LoopRecord) {
+	notify := h.humanAttentionObserver()
+	if notify == nil {
+		return
+	}
+	if h.context.Runtime == nil {
+		if loops.IsReviewScopeHumanHold(loop) {
+			notify(ctx, loop.ID)
+		}
+		return
+	}
+	services := h.context.Runtime.Services()
+	if services.Repositories == nil || services.Repositories.Loops == nil {
+		if loops.IsReviewScopeHumanHold(loop) {
+			notify(ctx, loop.ID)
+		}
+		return
+	}
+	all, err := services.Repositories.Loops.List(ctx)
+	if err != nil {
+		if loops.IsReviewScopeHumanHold(loop) {
+			notify(ctx, loop.ID)
+		}
+		return
+	}
+	seen := make(map[string]struct{})
+	for _, member := range append(loops.FindSiblingReviewFixLoops(all, loop), loop) {
+		if _, ok := seen[member.ID]; ok {
+			continue
+		}
+		seen[member.ID] = struct{}{}
+		if loops.IsReviewScopeHumanHold(member) {
+			notify(ctx, member.ID)
+		}
+	}
 }
 
 // drainReviewFixBudgetPair stops live agents on both pair members before
@@ -6037,7 +6092,7 @@ func (h *Handler) drainReviewFixBudgetPair(ctx context.Context, loop storage.Loo
 			continue
 		}
 		seen[member.ID] = struct{}{}
-		if member.ID != loop.ID && !loops.IsReviewFixBudgetHold(member) {
+		if member.ID != loop.ID && !loops.IsReviewFixPairHold(member) {
 			continue
 		}
 		switch strings.TrimSpace(member.Status) {
@@ -6131,6 +6186,17 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 
 	services := h.context.Runtime.Services()
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
+	if services.Repositories != nil && services.Repositories.Loops != nil {
+		if peek, peekErr := services.Repositories.Loops.GetByID(ctx, loopID); peekErr == nil && peek != nil {
+			ask, _ := loops.ReadHITLAsk(peek.MetadataJSON)
+			if (loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewScopeHumanHold(*peek)) && loops.IsReviewFixBudgetStop(answer) {
+				if drainErr := h.drainReviewFixBudgetPair(ctx, *peek); drainErr != nil {
+					return loopResponse{}, drainErr
+				}
+			}
+		}
+	}
+
 	updated, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
 		repos := storage.NewRepositories(tx)
 		loop, err := repos.Loops.GetByID(ctx, loopID)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5950,9 +5950,11 @@ func (h *Handler) reviewFixBudgetLiveCaps(projectID string) loops.ReviewFixBudge
 }
 
 // applyReviewFixBudgetContinueIfHeld delegates looper unpause /start on a
-// budget-held role to paired Continue. Returns nil response when not a hold.
+// budget-held or scope-held role to paired Continue. Scope-only holds release
+// without resetting meters; budget holds keep existing refill semantics.
+// Returns nil response when not a pair hold.
 func (h *Handler) applyReviewFixBudgetContinueIfHeld(ctx context.Context, loop storage.LoopRecord) (*loopResponse, error) {
-	if !loops.IsReviewFixBudgetHold(loop) {
+	if !loops.IsReviewFixPairHold(loop) {
 		return nil, nil
 	}
 	services := h.context.Runtime.Services()
@@ -5970,17 +5972,28 @@ func (h *Handler) applyReviewFixBudgetContinueIfHeld(ctx context.Context, loop s
 		if fresh == nil {
 			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loop.ID)}
 		}
-		if !loops.IsReviewFixBudgetHold(*fresh) {
-			return storage.LoopRecord{}, nil
+		// Budget hold (including combined with scope) uses meter-aware Continue.
+		if loops.IsReviewFixBudgetHold(*fresh) {
+			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerContinue, nowISO, caps)
+			if applyErr != nil {
+				return storage.LoopRecord{}, applyErr
+			}
+			if !result.Applied {
+				return storage.LoopRecord{}, nil
+			}
+			return result.Loop, nil
 		}
-		result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerContinue, nowISO, caps)
-		if applyErr != nil {
-			return storage.LoopRecord{}, applyErr
+		if loops.IsReviewScopeHumanHold(*fresh) {
+			result, applyErr := loops.ApplyReviewScopeHumanAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerContinue, nowISO)
+			if applyErr != nil {
+				return storage.LoopRecord{}, applyErr
+			}
+			if !result.Applied {
+				return storage.LoopRecord{}, nil
+			}
+			return result.Loop, nil
 		}
-		if !result.Applied {
-			return storage.LoopRecord{}, nil
-		}
-		return result.Loop, nil
+		return storage.LoopRecord{}, nil
 	})
 	if err != nil {
 		var typed apiError
@@ -6038,10 +6051,10 @@ func (h *Handler) drainReviewFixBudgetPair(ctx context.Context, loop storage.Loo
 	return nil
 }
 
-// applyReviewFixBudgetStopIfHeld delegates looper stop on a budget-held role to
-// paired Stop (terminate both). Returns nil when not a hold.
+// applyReviewFixBudgetStopIfHeld delegates looper stop on a budget-held or
+// scope-held role to paired Stop (terminate both). Returns nil when not a hold.
 func (h *Handler) applyReviewFixBudgetStopIfHeld(ctx context.Context, loop storage.LoopRecord) (any, error) {
-	if !loops.IsReviewFixBudgetHold(loop) {
+	if !loops.IsReviewFixPairHold(loop) {
 		return nil, nil
 	}
 	if err := h.drainReviewFixBudgetPair(ctx, loop); err != nil {
@@ -6062,17 +6075,27 @@ func (h *Handler) applyReviewFixBudgetStopIfHeld(ctx context.Context, loop stora
 		if fresh == nil {
 			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loop.ID)}
 		}
-		if !loops.IsReviewFixBudgetHold(*fresh) {
-			return storage.LoopRecord{}, nil
+		if loops.IsReviewFixBudgetHold(*fresh) {
+			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerStop, nowISO, caps)
+			if applyErr != nil {
+				return storage.LoopRecord{}, applyErr
+			}
+			if !result.Applied {
+				return storage.LoopRecord{}, nil
+			}
+			return result.Loop, nil
 		}
-		result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerStop, nowISO, caps)
-		if applyErr != nil {
-			return storage.LoopRecord{}, applyErr
+		if loops.IsReviewScopeHumanHold(*fresh) {
+			result, applyErr := loops.ApplyReviewScopeHumanAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerStop, nowISO)
+			if applyErr != nil {
+				return storage.LoopRecord{}, applyErr
+			}
+			if !result.Applied {
+				return storage.LoopRecord{}, nil
+			}
+			return result.Loop, nil
 		}
-		if !result.Applied {
-			return storage.LoopRecord{}, nil
-		}
-		return result.Loop, nil
+		return storage.LoopRecord{}, nil
 	})
 	if err != nil {
 		var typed apiError
@@ -6084,11 +6107,15 @@ func (h *Handler) applyReviewFixBudgetStopIfHeld(ctx context.Context, loop stora
 	if updated.ID == "" {
 		return nil, nil
 	}
+	outcome := "review_fix_budget_stop"
+	if loops.IsReviewScopeHumanHold(loop) && !loops.IsReviewFixBudgetHold(loop) {
+		outcome = "review_scope_human_stop"
+	}
 	return map[string]any{
 		"stopped": true,
 		"loopId":  updated.ID,
 		"status":  updated.Status,
-		"outcome": "review_fix_budget_stop",
+		"outcome": outcome,
 	}, nil
 }
 
@@ -6121,6 +6148,18 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO, h.reviewFixBudgetLiveCaps(loop.ProjectID))
 			if applyErr != nil {
 				if errors.Is(applyErr, loops.ErrReviewFixBudgetInvalidAnswer) {
+					return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: applyErr.Error()}
+				}
+				return storage.LoopRecord{}, applyErr
+			}
+			if result.Applied {
+				return result.Loop, nil
+			}
+		}
+		if loops.IsReviewScopeHumanAsk(ask) {
+			result, applyErr := loops.ApplyReviewScopeHumanAnswer(ctx, repos, *loop, answer, nowISO)
+			if applyErr != nil {
+				if errors.Is(applyErr, loops.ErrReviewScopeHumanInvalidAnswer) {
 					return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: applyErr.Error()}
 				}
 				return storage.LoopRecord{}, applyErr
@@ -7191,12 +7230,16 @@ func (h *Handler) assertLoopRetryPreconditions(ctx context.Context, repos *stora
 			return err
 		}
 	}
-	// Budget holds require paired Continue (looper unpause) or Stop — not single-role retry.
-	if loops.IsReviewFixBudgetHold(loop) {
+	// Budget/scope pair holds require paired Continue (looper unpause) or Stop — not single-role retry.
+	if loops.IsReviewFixPairHold(loop) {
+		kind := "budget"
+		if loops.IsReviewScopeHumanHold(loop) && !loops.IsReviewFixBudgetHold(loop) {
+			kind = "scope"
+		}
 		return apiError{
 			code:    pkgapi.ErrorCodeValidationFailed,
 			status:  http.StatusBadRequest,
-			message: fmt.Sprintf("Cannot retry review-fix budget hold on loop %s; use looper unpause (Continue) or looper stop", loop.ID),
+			message: fmt.Sprintf("Cannot retry review-fix %s hold on loop %s; use looper unpause (Continue) or looper stop", kind, loop.ID),
 		}
 	}
 	if loop.Status == string(domain.LoopStatusStopped) || loop.Status == string(domain.LoopStatusTerminated) || loop.Status == string(domain.LoopStatusCompleted) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -6144,25 +6144,28 @@ func (h *Handler) drainReviewFixBudgetPair(ctx context.Context, loop storage.Loo
 // drainScopeHoldBeforeRespond looks up the loop before a HITL Stop mutation.
 // A lookup error must fail closed so ApplyReviewScopeHumanAnswer cannot
 // terminalize the pair without draining a live sibling.
-func drainScopeHoldBeforeRespond(ctx context.Context, repos *storage.Repositories, loopID, answer string, drain func(context.Context, storage.LoopRecord) error) error {
+func drainScopeHoldBeforeRespond(ctx context.Context, repos *storage.Repositories, loopID, answer string, drain func(context.Context, storage.LoopRecord) error) (bool, error) {
 	if repos == nil || repos.Loops == nil || !loops.IsReviewFixBudgetStop(answer) {
-		return nil
+		return false, nil
 	}
 	peek, err := repos.Loops.GetByID(ctx, loopID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if peek == nil {
-		return nil
+		return false, nil
 	}
 	ask, _ := loops.ReadHITLAsk(peek.MetadataJSON)
 	if !(loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewScopeHumanHold(*peek)) {
-		return nil
+		return false, nil
 	}
 	if drain == nil {
-		return nil
+		return false, nil
 	}
-	return drain(ctx, *peek)
+	if err := drain(ctx, *peek); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // applyReviewFixBudgetStopIfHeld delegates looper stop on a budget-held or
@@ -6245,7 +6248,8 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 
 	services := h.context.Runtime.Services()
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
-	if err := drainScopeHoldBeforeRespond(ctx, services.Repositories, loopID, answer, h.drainReviewFixBudgetPair); err != nil {
+	drained, err := drainScopeHoldBeforeRespond(ctx, services.Repositories, loopID, answer, h.drainReviewFixBudgetPair)
+	if err != nil {
 		var typed apiError
 		if asAPIError(err, &typed) {
 			return loopResponse{}, typed
@@ -6267,6 +6271,12 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 			// Production StopLoop pauses awaiting_human during drain.
 			// Scope Stop must still terminalize a still-held paused record.
 			if loop.Status != string(domain.LoopStatusPaused) || !loops.IsReviewFixBudgetStop(answer) || !(loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewScopeHumanHold(*loop)) {
+				if drained && loops.IsReviewFixBudgetStop(answer) && !loops.IsReviewScopeHumanHold(*loop) && !loops.IsReviewFixBudgetHold(*loop) {
+					switch strings.TrimSpace(loop.Status) {
+					case "queued", "running":
+						return *loop, nil
+					}
+				}
 				return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Loop %s is not awaiting a human (status: %s)", loopID, loop.Status)}
 			}
 		}
@@ -6309,6 +6319,9 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 		}
 		return updated, nil
 	})
+	if drained {
+		looperdruntime.ReopenUnappliedScopeStopGates(ctx, services.Repositories, services.ActiveExecutions, loopID)
+	}
 	if err != nil {
 		var typed apiError
 		if asAPIError(err, &typed) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -6156,7 +6156,7 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 				return result.Loop, nil
 			}
 		}
-		if loops.IsReviewScopeHumanAsk(ask) {
+		if loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewScopeHumanHold(*loop) {
 			result, applyErr := loops.ApplyReviewScopeHumanAnswer(ctx, repos, *loop, answer, nowISO)
 			if applyErr != nil {
 				if errors.Is(applyErr, loops.ErrReviewScopeHumanInvalidAnswer) {
@@ -6191,7 +6191,10 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 		return loopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
 
-	if updated.Status != string(domain.LoopStatusAwaitingHuman) {
+	// Budget Continue may promote deferred needs_human into a fresh scope hold
+	// that is still awaiting_human. Return that park; do not treat it as the
+	// just-answered ask and implicitly Continue via mutateLoopStatus.
+	if updated.Status != string(domain.LoopStatusAwaitingHuman) || loops.IsReviewFixPairHold(updated) {
 		if h.context.TriggerSchedulerTick != nil {
 			h.context.TriggerSchedulerTick()
 		}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -6222,6 +6222,9 @@ func (h *Handler) applyReviewFixBudgetStopIfHeld(ctx context.Context, loop stora
 		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
 	if updated.ID == "" {
+		// Continue already released the hold after drain. Reopen sibling
+		// gates before the route falls through to single-loop StopLoop.
+		looperdruntime.ReopenUnappliedScopeStopGates(ctx, services.Repositories, services.ActiveExecutions, loop.ID)
 		return nil, nil
 	}
 	outcome := "review_fix_budget_stop"

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -6318,9 +6318,13 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 	}
 
 	// Budget Continue may promote deferred needs_human into a fresh scope hold
-	// that is still awaiting_human. Return that park; do not treat it as the
-	// just-answered ask and implicitly Continue via mutateLoopStatus.
-	if updated.Status != string(domain.LoopStatusAwaitingHuman) || loops.IsReviewFixPairHold(updated) {
+	// that is still awaiting_human. Overlay Continue can also release the pair
+	// hold while a residual ordinary agent ask remains awaiting. Return that
+	// park; do not treat it as the just-answered ask and implicitly Continue
+	// via mutateLoopStatus.
+	residualAsk, hasResidualAsk := loops.ReadHITLAsk(updated.MetadataJSON)
+	residualAwaiting := hasResidualAsk && strings.EqualFold(strings.TrimSpace(residualAsk.Status), "awaiting")
+	if updated.Status != string(domain.LoopStatusAwaitingHuman) || loops.IsReviewFixPairHold(updated) || residualAwaiting {
 		if h.context.TriggerSchedulerTick != nil {
 			h.context.TriggerSchedulerTick()
 		}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -6206,10 +6206,14 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 		if loop == nil {
 			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loopID)}
 		}
-		if loop.Status != string(domain.LoopStatusAwaitingHuman) {
-			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Loop %s is not awaiting a human (status: %s)", loopID, loop.Status)}
-		}
 		ask, _ := loops.ReadHITLAsk(loop.MetadataJSON)
+		if loop.Status != string(domain.LoopStatusAwaitingHuman) {
+			// Production StopLoop pauses awaiting_human during drain.
+			// Scope Stop must still terminalize a still-held paused record.
+			if loop.Status != string(domain.LoopStatusPaused) || !loops.IsReviewFixBudgetStop(answer) || !(loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewScopeHumanHold(*loop)) {
+				return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("Loop %s is not awaiting a human (status: %s)", loopID, loop.Status)}
+			}
+		}
 		if loops.IsReviewFixBudgetAsk(ask) {
 			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *loop, answer, nowISO, h.reviewFixBudgetLiveCaps(loop.ProjectID))
 			if applyErr != nil {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5967,37 +5967,37 @@ func (h *Handler) applyReviewFixBudgetContinueIfHeld(ctx context.Context, loop s
 	}
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
 	caps := h.reviewFixBudgetLiveCaps(loop.ProjectID)
-	updated, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {
+	updated, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (reviewFixContinueOutcome, error) {
 		repos := storage.NewRepositories(tx)
 		fresh, getErr := repos.Loops.GetByID(ctx, loop.ID)
 		if getErr != nil {
-			return storage.LoopRecord{}, getErr
+			return reviewFixContinueOutcome{}, getErr
 		}
 		if fresh == nil {
-			return storage.LoopRecord{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loop.ID)}
+			return reviewFixContinueOutcome{}, apiError{code: pkgapi.ErrorCodeLoopNotFound, status: http.StatusNotFound, message: fmt.Sprintf("Loop not found: %s", loop.ID)}
 		}
 		// Budget hold (including combined with scope) uses meter-aware Continue.
 		if loops.IsReviewFixBudgetHold(*fresh) {
 			result, applyErr := loops.ApplyReviewFixBudgetAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerContinue, nowISO, caps)
 			if applyErr != nil {
-				return storage.LoopRecord{}, applyErr
+				return reviewFixContinueOutcome{}, applyErr
 			}
 			if !result.Applied {
-				return storage.LoopRecord{}, nil
+				return reviewFixContinueOutcome{}, nil
 			}
-			return result.Loop, nil
+			return reviewFixContinueOutcome{loop: result.Loop, fallbackID: promotedScopeHoldFallbackID(ctx, repos, result.Loop)}, nil
 		}
 		if loops.IsReviewScopeHumanHold(*fresh) {
 			result, applyErr := loops.ApplyReviewScopeHumanAnswer(ctx, repos, *fresh, loops.ReviewFixBudgetAnswerContinue, nowISO)
 			if applyErr != nil {
-				return storage.LoopRecord{}, applyErr
+				return reviewFixContinueOutcome{}, applyErr
 			}
 			if !result.Applied {
-				return storage.LoopRecord{}, nil
+				return reviewFixContinueOutcome{}, nil
 			}
-			return result.Loop, nil
+			return reviewFixContinueOutcome{loop: result.Loop, fallbackID: promotedScopeHoldFallbackID(ctx, repos, result.Loop)}, nil
 		}
-		return storage.LoopRecord{}, nil
+		return reviewFixContinueOutcome{}, nil
 	})
 	if err != nil {
 		var typed apiError
@@ -6006,14 +6006,14 @@ func (h *Handler) applyReviewFixBudgetContinueIfHeld(ctx context.Context, loop s
 		}
 		return nil, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
-	if updated.ID == "" {
+	if updated.loop.ID == "" {
 		return nil, nil
 	}
 	if h.context.TriggerSchedulerTick != nil {
 		h.context.TriggerSchedulerTick()
 	}
-	h.observePromotedScopeHolds(ctx, updated)
-	resp, serErr := h.serializeLoopWithDiagnostics(ctx, updated)
+	h.observePromotedScopeHolds(ctx, updated.loop, updated.fallbackID)
+	resp, serErr := h.serializeLoopWithDiagnostics(ctx, updated.loop)
 	if serErr != nil {
 		return nil, serErr
 	}
@@ -6033,29 +6033,35 @@ func (h *Handler) humanAttentionObserver() func(context.Context, string) {
 // observePromotedScopeHolds notifies after budget Continue may have created a
 // fresh no-HITL scope park. That path never finishes a claim, so the scheduler
 // observer would otherwise miss it until daemon restart.
-func (h *Handler) observePromotedScopeHolds(ctx context.Context, loop storage.LoopRecord) {
+// fallbackID is the notification-owning primary captured inside the Continue
+// transaction. Durable attention ignores sibling-only pauses, so a later List
+// failure must not fall back to the answered sibling.
+func (h *Handler) observePromotedScopeHolds(ctx context.Context, loop storage.LoopRecord, fallbackID string) {
 	notify := h.humanAttentionObserver()
 	if notify == nil {
 		return
 	}
-	if h.context.Runtime == nil {
-		if loops.IsReviewScopeHumanHold(loop) {
-			notify(ctx, loop.ID)
+	fallback := func() {
+		if id := strings.TrimSpace(fallbackID); id != "" {
+			notify(ctx, id)
+			return
 		}
+		if id := reviewScopeHumanNotifyLoopID(loop); id != "" {
+			notify(ctx, id)
+		}
+	}
+	if h.context.Runtime == nil {
+		fallback()
 		return
 	}
 	services := h.context.Runtime.Services()
 	if services.Repositories == nil || services.Repositories.Loops == nil {
-		if loops.IsReviewScopeHumanHold(loop) {
-			notify(ctx, loop.ID)
-		}
+		fallback()
 		return
 	}
 	all, err := services.Repositories.Loops.List(ctx)
 	if err != nil {
-		if loops.IsReviewScopeHumanHold(loop) {
-			notify(ctx, loop.ID)
-		}
+		fallback()
 		return
 	}
 	seen := make(map[string]struct{})
@@ -6068,6 +6074,35 @@ func (h *Handler) observePromotedScopeHolds(ctx context.Context, loop storage.Lo
 			notify(ctx, member.ID)
 		}
 	}
+}
+
+type reviewFixContinueOutcome struct {
+	loop       storage.LoopRecord
+	fallbackID string
+}
+
+func promotedScopeHoldFallbackID(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord) string {
+	if repos != nil && repos.Loops != nil {
+		if all, err := repos.Loops.List(ctx); err == nil {
+			for _, member := range append(loops.FindSiblingReviewFixLoops(all, loop), loop) {
+				if id := reviewScopeHumanNotifyLoopID(member); id != "" {
+					return id
+				}
+			}
+		}
+	}
+	return reviewScopeHumanNotifyLoopID(loop)
+}
+
+func reviewScopeHumanNotifyLoopID(loop storage.LoopRecord) string {
+	if loops.IsReviewScopeHumanRequiredPause(loop.MetadataJSON) && !loops.IsSiblingReviewScopeHumanPause(loop.MetadataJSON) {
+		return loop.ID
+	}
+	ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
+	if ok && loops.IsReviewScopeHumanAsk(ask) && strings.TrimSpace(loop.Status) == "awaiting_human" {
+		return loop.ID
+	}
+	return ""
 }
 
 // drainReviewFixBudgetPair stops live agents on both pair members before

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -6141,6 +6141,30 @@ func (h *Handler) drainReviewFixBudgetPair(ctx context.Context, loop storage.Loo
 	return nil
 }
 
+// drainScopeHoldBeforeRespond looks up the loop before a HITL Stop mutation.
+// A lookup error must fail closed so ApplyReviewScopeHumanAnswer cannot
+// terminalize the pair without draining a live sibling.
+func drainScopeHoldBeforeRespond(ctx context.Context, repos *storage.Repositories, loopID, answer string, drain func(context.Context, storage.LoopRecord) error) error {
+	if repos == nil || repos.Loops == nil || !loops.IsReviewFixBudgetStop(answer) {
+		return nil
+	}
+	peek, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return err
+	}
+	if peek == nil {
+		return nil
+	}
+	ask, _ := loops.ReadHITLAsk(peek.MetadataJSON)
+	if !(loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewScopeHumanHold(*peek)) {
+		return nil
+	}
+	if drain == nil {
+		return nil
+	}
+	return drain(ctx, *peek)
+}
+
 // applyReviewFixBudgetStopIfHeld delegates looper stop on a budget-held or
 // scope-held role to paired Stop (terminate both). Returns nil when not a hold.
 func (h *Handler) applyReviewFixBudgetStopIfHeld(ctx context.Context, loop storage.LoopRecord) (any, error) {
@@ -6221,15 +6245,12 @@ func (h *Handler) deliverHumanAnswer(ctx context.Context, loopID string, rawAnsw
 
 	services := h.context.Runtime.Services()
 	nowISO := eventlog.FormatJavaScriptISOString(h.now().UTC())
-	if services.Repositories != nil && services.Repositories.Loops != nil {
-		if peek, peekErr := services.Repositories.Loops.GetByID(ctx, loopID); peekErr == nil && peek != nil {
-			ask, _ := loops.ReadHITLAsk(peek.MetadataJSON)
-			if (loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewScopeHumanHold(*peek)) && loops.IsReviewFixBudgetStop(answer) {
-				if drainErr := h.drainReviewFixBudgetPair(ctx, *peek); drainErr != nil {
-					return loopResponse{}, drainErr
-				}
-			}
+	if err := drainScopeHoldBeforeRespond(ctx, services.Repositories, loopID, answer, h.drainReviewFixBudgetPair); err != nil {
+		var typed apiError
+		if asAPIError(err, &typed) {
+			return loopResponse{}, typed
 		}
+		return loopResponse{}, apiError{code: pkgapi.ErrorCodeInternalError, status: http.StatusInternalServerError, message: err.Error()}
 	}
 
 	updated, err := storage.WithTransactionValue(ctx, services.Coordinator.DB(), nil, func(tx *sql.Tx) (storage.LoopRecord, error) {

--- a/internal/api/handler_hitl_test.go
+++ b/internal/api/handler_hitl_test.go
@@ -623,6 +623,75 @@ func TestHandlerRespondOrdinaryAskDoesNotReleaseScopeOverlay(t *testing.T) {
 	}
 }
 
+func TestHandlerRespondScopeContinueOnOverlayKeepsResidualAsk(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_scope_overlay_continue"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewer := storage.LoopRecord{
+		ID: "loop_scope_overlay_continue_reviewer", Seq: 649, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer): %v", err)
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_scope_overlay_continue_fixer", Seq: 650, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	midAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO, PRNumber: prNumber,
+	}
+	meta, err := loops.WriteHITLAsk(fixer.MetadataJSON, midAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk: %v", err)
+	}
+	fixer.MetadataJSON = &meta
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer): %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), services.Repositories, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: prNumber,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/650/respond", strings.NewReader(`{"answer":"Continue"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+
+	freshFixer, err := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || freshFixer == nil || freshFixer.Status != "awaiting_human" {
+		t.Fatalf("fixer after overlay Continue = (%#v, %v), want awaiting_human residual ask", freshFixer, err)
+	}
+	if loops.IsReviewScopeHumanHold(*freshFixer) || loops.IsReviewFixPairHold(*freshFixer) {
+		t.Fatalf("fixer still pair-held after overlay Continue: %#v", freshFixer)
+	}
+	ask, ok := loops.ReadHITLAsk(freshFixer.MetadataJSON)
+	if !ok || ask.Question != midAsk.Question || ask.Status != "awaiting" || ask.Answer != "" {
+		t.Fatalf("residual ask = (%#v, %v), want unanswered agent question", ask, ok)
+	}
+	freshReviewer, err := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || freshReviewer == nil || freshReviewer.Status == "running" || loops.IsReviewScopeHumanHold(*freshReviewer) {
+		t.Fatalf("reviewer after overlay Continue = (%#v, %v), want released and not running", freshReviewer, err)
+	}
+}
+
 func TestHandlerRespondScopeStopDrainsLiveSibling(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	services := rt.Services()

--- a/internal/api/handler_hitl_test.go
+++ b/internal/api/handler_hitl_test.go
@@ -637,6 +637,11 @@ func TestHandlerRespondScopeStopDrainsLiveSibling(t *testing.T) {
 			if rec.Status == "terminated" || rec.Status == "stopped" {
 				t.Fatalf("StopLoop(%s) after terminalize: status=%s", loopID, rec.Status)
 			}
+			paused := *rec
+			paused.Status = "paused"
+			if err := services.Repositories.Loops.Upsert(ctx, paused); err != nil {
+				return nil, err
+			}
 			drained = append(drained, loopID)
 			if services.ActiveExecutions != nil {
 				if _, stopErr := services.ActiveExecutions.BeginLoopStop(loopID, "test drain"); stopErr != nil {

--- a/internal/api/handler_hitl_test.go
+++ b/internal/api/handler_hitl_test.go
@@ -822,7 +822,7 @@ func TestHandlerRespondScopeStopFailsClosedWhenPeekErrors(t *testing.T) {
 	}
 
 	failingRepos := storage.NewRepositories(&failFirstLoopGetByIDQuerier{db: services.Coordinator.DB(), fails: 1})
-	if err := drainScopeHoldBeforeRespond(context.Background(), failingRepos, reviewer.ID, "Stop", func(context.Context, storage.LoopRecord) error {
+	if _, err := drainScopeHoldBeforeRespond(context.Background(), failingRepos, reviewer.ID, "Stop", func(context.Context, storage.LoopRecord) error {
 		t.Fatal("drain must not run when pre-drain GetByID fails")
 		return nil
 	}); err == nil {

--- a/internal/api/handler_hitl_test.go
+++ b/internal/api/handler_hitl_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -703,6 +704,109 @@ func TestHandlerRespondScopeStopDrainsLiveSibling(t *testing.T) {
 	if !seen[reviewer.ID] || !seen[fixer.ID] {
 		t.Fatalf("drained = %v, want %s and %s", drained, reviewer.ID, fixer.ID)
 	}
+}
+
+func TestHandlerRespondScopeStopFailsClosedWhenPeekErrors(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	services := rt.Services()
+	drained := 0
+	h := NewHandler(Context{
+		Config:  cfg,
+		Runtime: rt,
+		StopLoop: func(ctx context.Context, loopID, _ string) (any, error) {
+			drained++
+			return map[string]any{"stopped": true, "loopId": loopID}, nil
+		},
+	})
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_scope_respond_stop_peek"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewer := storage.LoopRecord{
+		ID: "loop_scope_respond_stop_peek_rev", Seq: 649, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_scope_respond_stop_peek_fix", Seq: 650, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer): %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer): %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), services.Repositories, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: prNumber,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	failingRepos := storage.NewRepositories(&failFirstLoopGetByIDQuerier{db: services.Coordinator.DB(), fails: 1})
+	if err := drainScopeHoldBeforeRespond(context.Background(), failingRepos, reviewer.ID, "Stop", func(context.Context, storage.LoopRecord) error {
+		t.Fatal("drain must not run when pre-drain GetByID fails")
+		return nil
+	}); err == nil {
+		t.Fatal("drainScopeHoldBeforeRespond error = nil, want peek failure")
+	}
+	if drained != 0 {
+		t.Fatalf("StopLoop called %d times, want 0 before peek failure", drained)
+	}
+
+	fresh, err := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || !loops.IsReviewScopeHumanHold(*fresh) {
+		t.Fatalf("reviewer after peek failure = (%#v, %v), want still held", fresh, err)
+	}
+	sibling, err := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status == "terminated" {
+		t.Fatalf("fixer after peek failure = (%#v, %v), want live sibling", sibling, err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/649/respond", strings.NewReader(`{"answer":"Stop"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("later /respond status = %d, want 200 after lookup recovers; body=%s", recorder.Code, recorder.Body.String())
+	}
+	reviewerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	fixerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if reviewerAfter == nil || reviewerAfter.Status != "terminated" || fixerAfter == nil || fixerAfter.Status != "terminated" {
+		t.Fatalf("pair after recovered Stop = reviewer %#v fixer %#v, want both terminated", reviewerAfter, fixerAfter)
+	}
+	if drained == 0 {
+		t.Fatal("recovered /respond Stop must drain after a successful peek")
+	}
+}
+
+type failFirstLoopGetByIDQuerier struct {
+	db    *sql.DB
+	fails int
+}
+
+func (q *failFirstLoopGetByIDQuerier) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return q.db.ExecContext(ctx, query, args...)
+}
+
+func (q *failFirstLoopGetByIDQuerier) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return q.db.QueryContext(ctx, query, args...)
+}
+
+func (q *failFirstLoopGetByIDQuerier) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	if q.fails > 0 && strings.Contains(query, "FROM loops") && strings.Contains(query, "WHERE id") {
+		q.fails--
+		return q.db.QueryRowContext(ctx, "SELECT * FROM loops WHERE this_column_does_not_exist = ?", "x")
+	}
+	return q.db.QueryRowContext(ctx, query, args...)
 }
 
 func seedReviewFixBudgetAwaitingLoop(t *testing.T, rt *looperdruntime.Runtime, projectID, loopID string, seq int64) {

--- a/internal/api/handler_hitl_test.go
+++ b/internal/api/handler_hitl_test.go
@@ -507,6 +507,121 @@ func TestHandlerRespondReviewFixBudgetStorageFailureIsInternalError(t *testing.T
 	}
 }
 
+func TestHandlerRespondBudgetContinueReturnsPromotedScopeHold(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	triggered := 0
+	h := NewHandler(Context{Config: cfg, Runtime: rt, TriggerSchedulerTick: func() { triggered++ }})
+	seedReviewFixBudgetAwaitingLoop(t, rt, "project_budget_promote_scope", "loop_budget_promote_scope", 644)
+
+	services := rt.Services()
+	loop, err := services.Repositories.Loops.GetByID(context.Background(), "loop_budget_promote_scope")
+	if err != nil || loop == nil {
+		t.Fatalf("GetByID() = (%#v, %v)", loop, err)
+	}
+	encoded, err := loops.PersistPendingReviewScopeHumanEvidence(loop.MetadataJSON, "Clarify AGENTS.md rule X before unpause", "PR non-goals exclude API expansion", true)
+	if err != nil {
+		t.Fatalf("PersistPendingReviewScopeHumanEvidence: %v", err)
+	}
+	loop.MetadataJSON = &encoded
+	if err := services.Repositories.Loops.Upsert(context.Background(), *loop); err != nil {
+		t.Fatalf("Loops.Upsert pending: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/644/respond", strings.NewReader(`{"answer":"Continue"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if triggered != 1 {
+		t.Fatalf("TriggerSchedulerTick called %d times, want 1 after budget Continue promote", triggered)
+	}
+
+	updated, err := services.Repositories.Loops.GetByID(context.Background(), "loop_budget_promote_scope")
+	if err != nil || updated == nil {
+		t.Fatalf("loop after promote = (%#v, %v)", updated, err)
+	}
+	if updated.Status != "awaiting_human" {
+		t.Fatalf("status = %q, want awaiting_human promoted scope hold (not running/queued)", updated.Status)
+	}
+	if !loops.IsReviewScopeHumanHold(*updated) || loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("hold = scope=%v budget=%v, want scope-only", loops.IsReviewScopeHumanHold(*updated), loops.IsReviewFixBudgetHold(*updated))
+	}
+	ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+	if !ok || !loops.IsReviewScopeHumanAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want promoted scope ask", ask, ok)
+	}
+}
+
+func TestHandlerRespondOrdinaryAskDoesNotReleaseScopeOverlay(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_scope_overlay"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewer := storage.LoopRecord{
+		ID: "loop_scope_overlay_reviewer", Seq: 645, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer): %v", err)
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_scope_overlay_fixer", Seq: 646, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	midAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO, PRNumber: prNumber,
+	}
+	meta, err := loops.WriteHITLAsk(fixer.MetadataJSON, midAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk: %v", err)
+	}
+	fixer.MetadataJSON = &meta
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer): %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), services.Repositories, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: prNumber,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/646/respond", strings.NewReader(`{"answer":"A"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for ordinary overlay answer; body=%s", recorder.Code, recorder.Body.String())
+	}
+
+	freshFixer, err := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || freshFixer == nil || freshFixer.Status != "awaiting_human" {
+		t.Fatalf("fixer after ordinary answer = (%#v, %v), want awaiting_human", freshFixer, err)
+	}
+	ask, ok := loops.ReadHITLAsk(freshFixer.MetadataJSON)
+	if !ok || ask.Question != midAsk.Question || ask.Status != "awaiting" {
+		t.Fatalf("mid-run ask mutated: ok=%v ask=%#v", ok, ask)
+	}
+	if !loops.IsReviewScopeHumanHold(*freshFixer) {
+		t.Fatalf("fixer overlay released by ordinary answer: %#v", freshFixer)
+	}
+	freshReviewer, err := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || freshReviewer == nil || !loops.IsReviewScopeHumanHold(*freshReviewer) {
+		t.Fatalf("reviewer hold released by sibling ordinary answer: (%#v, %v)", freshReviewer, err)
+	}
+}
+
 func seedReviewFixBudgetAwaitingLoop(t *testing.T, rt *looperdruntime.Runtime, projectID, loopID string, seq int64) {
 	t.Helper()
 	services := rt.Services()

--- a/internal/api/handler_hitl_test.go
+++ b/internal/api/handler_hitl_test.go
@@ -622,6 +622,84 @@ func TestHandlerRespondOrdinaryAskDoesNotReleaseScopeOverlay(t *testing.T) {
 	}
 }
 
+func TestHandlerRespondScopeStopDrainsLiveSibling(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	services := rt.Services()
+	var drained []string
+	h := NewHandler(Context{
+		Config:  cfg,
+		Runtime: rt,
+		StopLoop: func(ctx context.Context, loopID, _ string) (any, error) {
+			rec, err := services.Repositories.Loops.GetByID(ctx, loopID)
+			if err != nil || rec == nil {
+				t.Fatalf("StopLoop GetByID(%s) = (%v, %v)", loopID, rec, err)
+			}
+			if rec.Status == "terminated" || rec.Status == "stopped" {
+				t.Fatalf("StopLoop(%s) after terminalize: status=%s", loopID, rec.Status)
+			}
+			drained = append(drained, loopID)
+			if services.ActiveExecutions != nil {
+				if _, stopErr := services.ActiveExecutions.BeginLoopStop(loopID, "test drain"); stopErr != nil {
+					return nil, stopErr
+				}
+			}
+			return map[string]any{"stopped": true, "loopId": loopID}, nil
+		},
+	})
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_scope_respond_stop"
+	repo := "acme/looper"
+	prNumber := int64(42)
+	targetID := "pr:acme/looper:42"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: "/tmp/repos/looper", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewer := storage.LoopRecord{
+		ID: "loop_scope_respond_stop_rev", Seq: 647, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_scope_respond_stop_fix", Seq: 648, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &targetID, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer): %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer): %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), services.Repositories, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: prNumber,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/647/respond", strings.NewReader(`{"answer":"Stop"}`))
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	reviewerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	fixerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if reviewerAfter == nil || reviewerAfter.Status != "terminated" || fixerAfter == nil || fixerAfter.Status != "terminated" {
+		t.Fatalf("pair after Stop = reviewer %#v fixer %#v, want both terminated", reviewerAfter, fixerAfter)
+	}
+	if len(drained) != 2 {
+		t.Fatalf("StopLoop calls = %v, want both pair members before terminalize", drained)
+	}
+	seen := map[string]bool{drained[0]: true, drained[1]: true}
+	if !seen[reviewer.ID] || !seen[fixer.ID] {
+		t.Fatalf("drained = %v, want %s and %s", drained, reviewer.ID, fixer.ID)
+	}
+}
+
 func seedReviewFixBudgetAwaitingLoop(t *testing.T, rt *looperdruntime.Runtime, projectID, loopID string, seq int64) {
 	t.Helper()
 	services := rt.Services()

--- a/internal/api/review_fix_budget_test.go
+++ b/internal/api/review_fix_budget_test.go
@@ -257,6 +257,171 @@ func TestHandlerActiveStopDelegatesBudgetHoldToPairedStop(t *testing.T) {
 	}
 }
 
+func TestHandlerActiveStopDrainsScopeHeldSibling(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = false
+	services := rt.Services()
+	var drained []string
+	h := NewHandler(Context{
+		Config:  cfg,
+		Runtime: rt,
+		StopLoop: func(ctx context.Context, loopID, _ string) (any, error) {
+			rec, err := services.Repositories.Loops.GetByID(ctx, loopID)
+			if err != nil || rec == nil {
+				t.Fatalf("StopLoop GetByID(%s) = (%v, %v)", loopID, rec, err)
+			}
+			if rec.Status == "terminated" || rec.Status == "stopped" {
+				t.Fatalf("StopLoop(%s) after terminalize: status=%s", loopID, rec.Status)
+			}
+			drained = append(drained, loopID)
+			if services.ActiveExecutions != nil {
+				if _, stopErr := services.ActiveExecutions.BeginLoopStop(loopID, "test drain"); stopErr != nil {
+					return nil, stopErr
+				}
+			}
+			return map[string]any{"stopped": true, "loopId": loopID}, nil
+		},
+	})
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_scope_stop"
+	repo := "acme/looper"
+	pr := int64(46)
+	target := "pr:acme/looper:46"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewer := storage.LoopRecord{
+		ID: "loop_scope_stop_rev", Seq: 4601, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_scope_stop_fix", Seq: 4602, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), services.Repositories, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: false,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/active/"+reviewer.ID+"/stop", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("stop status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var envelope struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode: %v body=%s", err, recorder.Body.String())
+	}
+	if envelope.Data["outcome"] != "review_scope_human_stop" {
+		t.Fatalf("outcome = %#v, want review_scope_human_stop", envelope.Data)
+	}
+	reviewerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	fixerAfter, _ := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if reviewerAfter == nil || reviewerAfter.Status != "terminated" || fixerAfter == nil || fixerAfter.Status != "terminated" {
+		t.Fatalf("pair after stop = reviewer %#v fixer %#v, want both terminated", reviewerAfter, fixerAfter)
+	}
+	if len(drained) != 2 {
+		t.Fatalf("StopLoop calls = %v, want both scope-held pair members before terminate", drained)
+	}
+	seen := map[string]bool{drained[0]: true, drained[1]: true}
+	if !seen[reviewer.ID] || !seen[fixer.ID] {
+		t.Fatalf("drained = %v, want %s and %s", drained, reviewer.ID, fixer.ID)
+	}
+}
+
+func TestHandlerNoHITLBudgetContinueNotifiesPromotedScopeHold(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = false
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 3
+	var notified []string
+	h := NewHandler(Context{
+		Config:  cfg,
+		Runtime: rt,
+		NotifyHumanAttention: func(_ context.Context, loopID string) {
+			notified = append(notified, loopID)
+		},
+	})
+	services := rt.Services()
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_budget_promote_notify"
+	repo := "acme/looper"
+	pr := int64(47)
+	target := "pr:acme/looper:47"
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_promote_notify_rev", Seq: 4701, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_promote_notify_fix", Seq: 4702, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	parked, err := loops.ParkReviewFixBudget(context.Background(), services.Repositories, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+	encoded, err := loops.PersistPendingReviewScopeHumanEvidence(parked.MetadataJSON, "Clarify AGENTS.md rule X before unpause", "PR non-goals exclude API expansion", false)
+	if err != nil {
+		t.Fatalf("PersistPendingReviewScopeHumanEvidence: %v", err)
+	}
+	parked.MetadataJSON = &encoded
+	if err := services.Repositories.Loops.Upsert(context.Background(), parked); err != nil {
+		t.Fatalf("Loops.Upsert pending: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/"+fixer.ID+"/start", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("start status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	reviewerAfter, err := services.Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || reviewerAfter == nil || !loops.IsReviewScopeHumanHold(*reviewerAfter) || loops.IsReviewFixBudgetHold(*reviewerAfter) {
+		t.Fatalf("reviewer after promote = (%#v, %v), want no-HITL scope hold", reviewerAfter, err)
+	}
+	if reviewerAfter.Status != "paused" {
+		t.Fatalf("reviewer status = %q, want paused", reviewerAfter.Status)
+	}
+	seen := map[string]bool{}
+	for _, id := range notified {
+		seen[id] = true
+	}
+	if !seen[reviewer.ID] {
+		t.Fatalf("NotifyHumanAttention = %v, want promoted scope hold %s", notified, reviewer.ID)
+	}
+}
+
 func TestHandlerActiveStopDoesNotTerminateHistoricalSibling(t *testing.T) {
 	rt, cfg := startTestRuntime(t)
 	cfg.HITL.Enabled = false

--- a/internal/api/review_fix_budget_test.go
+++ b/internal/api/review_fix_budget_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -419,6 +420,90 @@ func TestHandlerNoHITLBudgetContinueNotifiesPromotedScopeHold(t *testing.T) {
 	}
 	if !seen[reviewer.ID] {
 		t.Fatalf("NotifyHumanAttention = %v, want promoted scope hold %s", notified, reviewer.ID)
+	}
+}
+
+func TestHandlerNoHITLBudgetContinueNotifiesPrimaryWhenSiblingListFails(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = false
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 3
+	var notified []string
+	services := rt.Services()
+	services.Repositories = storage.NewRepositories(errorInjectingQuerier{
+		db: services.Coordinator.DB(),
+		queryError: func(query string) error {
+			if strings.Contains(query, "SELECT * FROM loops") && !strings.Contains(query, "WHERE") {
+				return errors.New("database is locked")
+			}
+			return nil
+		},
+	})
+	h := NewHandler(Context{
+		Config:  cfg,
+		Runtime: fixedRuntimeState{services: services},
+		NotifyHumanAttention: func(_ context.Context, loopID string) {
+			notified = append(notified, loopID)
+		},
+	})
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_budget_promote_list_fail"
+	repo := "acme/looper"
+	pr := int64(48)
+	target := "pr:acme/looper:48"
+	if err := rt.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewerMeta := `{"loop":{"iterationCount":3}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_budget_promote_list_fail_rev", Seq: 4801, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_budget_promote_list_fail_fix", Seq: 4802, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := rt.Services().Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := rt.Services().Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	parked, err := loops.ParkReviewFixBudget(context.Background(), rt.Services().Repositories, loops.ParkReviewFixBudgetInput{
+		Exhausted: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, Count: 3, Cap: 3, NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+	encoded, err := loops.PersistPendingReviewScopeHumanEvidence(parked.MetadataJSON, "Clarify AGENTS.md rule X before unpause", "PR non-goals exclude API expansion", false)
+	if err != nil {
+		t.Fatalf("PersistPendingReviewScopeHumanEvidence: %v", err)
+	}
+	parked.MetadataJSON = &encoded
+	if err := rt.Services().Repositories.Loops.Upsert(context.Background(), parked); err != nil {
+		t.Fatalf("Loops.Upsert pending: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/loops/"+fixer.ID+"/start", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("start status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	reviewerAfter, err := rt.Services().Repositories.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || reviewerAfter == nil || !loops.IsReviewScopeHumanHold(*reviewerAfter) || loops.IsReviewFixBudgetHold(*reviewerAfter) {
+		t.Fatalf("reviewer after promote = (%#v, %v), want no-HITL scope hold", reviewerAfter, err)
+	}
+	fixerAfter, err := rt.Services().Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || fixerAfter == nil || !loops.IsSiblingReviewScopeHumanPause(fixerAfter.MetadataJSON) {
+		t.Fatalf("fixer after promote = (%#v, %v), want sibling-only pause", fixerAfter, err)
+	}
+	if len(notified) != 1 || notified[0] != reviewer.ID {
+		t.Fatalf("NotifyHumanAttention = %v, want primary scope hold %s after sibling List failure", notified, reviewer.ID)
 	}
 }
 

--- a/internal/api/review_fix_budget_test.go
+++ b/internal/api/review_fix_budget_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/domain"
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
@@ -342,6 +343,95 @@ func TestHandlerActiveStopDrainsScopeHeldSibling(t *testing.T) {
 	seen := map[string]bool{drained[0]: true, drained[1]: true}
 	if !seen[reviewer.ID] || !seen[fixer.ID] {
 		t.Fatalf("drained = %v, want %s and %s", drained, reviewer.ID, fixer.ID)
+	}
+}
+
+func TestHandlerActiveStopReopensGatesWhenContinueWinsAfterDrain(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	cfg.HITL.Enabled = true
+	services := rt.Services()
+	var drained []string
+	nowISO := "2026-04-11T12:00:00.000Z"
+	projectID := "project_scope_stop_continue_race"
+	repo := "acme/looper"
+	pr := int64(48)
+	target := "pr:acme/looper:48"
+	reviewerID := "loop_scope_stop_race_rev"
+	fixerID := "loop_scope_stop_race_fix"
+	h := NewHandler(Context{
+		Config:  cfg,
+		Runtime: rt,
+		StopLoop: func(ctx context.Context, loopID, _ string) (any, error) {
+			rec, err := services.Repositories.Loops.GetByID(ctx, loopID)
+			if err != nil || rec == nil {
+				t.Fatalf("StopLoop GetByID(%s) = (%v, %v)", loopID, rec, err)
+			}
+			drained = append(drained, loopID)
+			if services.ActiveExecutions != nil {
+				if _, stopErr := services.ActiveExecutions.BeginLoopStop(loopID, "test drain"); stopErr != nil {
+					return nil, stopErr
+				}
+			}
+			if len(drained) == 2 {
+				fresh, getErr := services.Repositories.Loops.GetByID(ctx, reviewerID)
+				if getErr != nil || fresh == nil {
+					t.Fatalf("racing Continue GetByID = (%v, %v)", fresh, getErr)
+				}
+				if _, applyErr := loops.ApplyReviewScopeHumanAnswer(ctx, services.Repositories, *fresh, loops.ReviewFixBudgetAnswerContinue, nowISO); applyErr != nil {
+					t.Fatalf("racing Continue: %v", applyErr)
+				}
+			}
+			return map[string]any{"stopped": true, "loopId": loopID}, nil
+		},
+	})
+	if err := services.Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Looper", RepoPath: t.TempDir(), CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	reviewer := storage.LoopRecord{
+		ID: reviewerID, Seq: 4801, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: fixerID, Seq: 4802, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Upsert reviewer: %v", err)
+	}
+	if err := services.Repositories.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Upsert fixer: %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), services.Repositories, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs/active/"+reviewer.ID+"/stop", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("stop status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if services.ActiveExecutions == nil {
+		t.Fatal("ActiveExecutions is nil")
+	}
+	if services.ActiveExecutions.LoopStopActive(fixer.ID) {
+		t.Fatal("sibling stop gate still closed after unapplied active Stop")
+	}
+	if _, err := services.ActiveExecutions.AdmitSpawn(context.Background(), agent.SpawnMeta{
+		LoopID: fixer.ID, RunID: "run_scope_continue_fix", ExecutionID: "exec_scope_continue_fix",
+	}); err != nil {
+		t.Fatalf("AdmitSpawn fixer after unapplied active Stop: %v", err)
+	}
+	fixerAfter, err := services.Repositories.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || fixerAfter == nil || fixerAfter.Status == "terminated" || loops.IsReviewScopeHumanHold(*fixerAfter) {
+		t.Fatalf("fixer after Continue-wins active Stop = (%#v, %v), want released pair member", fixerAfter, err)
 	}
 }
 

--- a/internal/cliapp/review_submit.go
+++ b/internal/cliapp/review_submit.go
@@ -744,6 +744,7 @@ func validateReviewSubmitEventAllowed(event string, policy config.ReviewerReview
 var reviewSubmitMarkerRE = regexp.MustCompile(`<!--\s*looper:review\s+([^>]*)-->`)
 var markdownHTMLCommentRE = regexp.MustCompile(`(?s)<!--.*?-->`)
 var markdownReferenceDefinitionRE = regexp.MustCompile(`(?m)^\s{0,3}\[[^\]\n]+\]:[^\n]*(?:\n[ \t]+[^\n]*)*`)
+var reviewSubmitSuppressedFindingRE = regexp.MustCompile(`(?i)\b(?:follow_up|needs_human)\b`)
 
 func validateReviewSubmitBody(body string, comments []reviewSubmitComment, commitID string, event string, policy config.ReviewerReviewEventsConfig, authorLogin string) error {
 	matches := reviewSubmitMarkerRE.FindAllStringSubmatch(body, -1)
@@ -793,7 +794,17 @@ func validateReviewSubmitBody(body string, comments []reviewSubmitComment, commi
 			return fmt.Errorf("actionable COMMENT reviews require at least one inline comment; body-only reviews may only be clean COMMENT/APPROVE")
 		}
 	}
-	return nil
+	return validateReviewSubmitBodyHasNoSuppressedFindings(body)
+}
+
+// validateReviewSubmitBodyHasNoSuppressedFindings fail-closes when visible
+// review prose smuggles follow_up/needs_human findings. Spec 7.3 allows a
+// must_fix summary in the body; it does not allow suppressed dispositions.
+func validateReviewSubmitBodyHasNoSuppressedFindings(body string) error {
+	if reviewSubmitSuppressedFindingRE.FindString(cleanReviewHumanBody(body)) == "" {
+		return nil
+	}
+	return fmt.Errorf("review body must not include follow_up or needs_human findings; only must_fix may be published remotely")
 }
 
 // validateReviewSubmitCommentDispositions enforces the trusted finding contract on

--- a/internal/cliapp/review_submit.go
+++ b/internal/cliapp/review_submit.go
@@ -47,7 +47,19 @@ type reviewSubmitComment struct {
 	Side      string `json:"side"`
 	StartLine int64  `json:"start_line"`
 	StartSide string `json:"start_side"`
+	// Looper-only finding contract fields. Validated on actionable comments and
+	// stripped before provider SubmitReview (GitHub/Forgejo receive body/path/line/side only).
+	Disposition   string `json:"disposition,omitempty"`
+	Severity      string `json:"severity,omitempty"`
+	ScopeBasis    string `json:"scopeBasis,omitempty"`
+	ScopeEvidence string `json:"scopeEvidence,omitempty"`
 }
+
+const (
+	reviewFindingDispositionMustFix    = "must_fix"
+	reviewFindingDispositionFollowUp   = "follow_up"
+	reviewFindingDispositionNeedsHuman = "needs_human"
+)
 
 type reviewSubmitDiagnosticFields struct {
 	Repo        string
@@ -476,6 +488,12 @@ func (r *commandRuntime) reviewSubmit(cmd *cobra.Command, args []string) error {
 		})
 		return err
 	}
+	if err := validateReviewSubmitCommentDispositions(payload.Comments); err != nil {
+		writeReviewSubmitDiagnostic(cmd.ErrOrStderr(), "github_review_submit_validation_failed", reviewSubmitDiagnosticFields{
+			Repo: repo, PRNumber: prNumber, Event: event, CommitID: commitID, Payload: payload, Error: err.Error(), RedactPaths: true,
+		})
+		return err
+	}
 	submissionEvent, err := r.effectiveReviewSubmitEvent(cmd, gateway, repo, prNumber, event, detail.Author, cwd)
 	if err != nil {
 		return err
@@ -511,6 +529,7 @@ func (r *commandRuntime) reviewSubmit(cmd *cobra.Command, args []string) error {
 
 	comments := make([]githubinfra.ReviewComment, 0, len(payload.Comments))
 	for _, comment := range payload.Comments {
+		// Strip Looper-only disposition/scope fields before the provider Adapter.
 		comments = append(comments, githubinfra.ReviewComment{Body: comment.Body, Path: comment.Path, Line: comment.Line, Side: comment.Side, StartLine: comment.StartLine, StartSide: comment.StartSide})
 	}
 	// Fail closed on base/head drift between anchor resolution and mutation.
@@ -754,12 +773,49 @@ func validateReviewSubmitBody(body string, comments []reviewSubmitComment, commi
 		if outcome != "blocking" {
 			return fmt.Errorf("review marker outcome=%s does not match REQUEST_CHANGES event", outcome)
 		}
+		// Body-only must not be the sole carrier of a blocking finding.
+		if len(comments) == 0 {
+			return fmt.Errorf("REQUEST_CHANGES requires at least one inline comment; body-only reviews may only be clean COMMENT/APPROVE")
+		}
 	case "COMMENT":
 		if outcome == "clean" && policy.Clean == config.ReviewerReviewEventApprove {
 			return fmt.Errorf("review marker outcome=clean requires APPROVE under effective policy")
 		}
 		if outcome == "blocking" && policy.Blocking == config.ReviewerReviewEventRequestChanges {
 			return fmt.Errorf("review marker outcome=blocking requires REQUEST_CHANGES under effective policy")
+		}
+		// Clean COMMENT is body-only (same as APPROVE); inline comments imply must_fix.
+		if outcome == "clean" && len(comments) > 0 {
+			return fmt.Errorf("COMMENT reviews require clean outcome without inline comments")
+		}
+		// Actionable/blocking COMMENT with zero comments smuggles findings in body only.
+		if outcome != "clean" && len(comments) == 0 {
+			return fmt.Errorf("actionable COMMENT reviews require at least one inline comment; body-only reviews may only be clean COMMENT/APPROVE")
+		}
+	}
+	return nil
+}
+
+// validateReviewSubmitCommentDispositions enforces the trusted finding contract on
+// actionable inline comments. Clean body-only APPROVE/COMMENT needs no dispositions.
+func validateReviewSubmitCommentDispositions(comments []reviewSubmitComment) error {
+	if len(comments) == 0 {
+		return nil
+	}
+	for i, comment := range comments {
+		disposition := strings.TrimSpace(comment.Disposition)
+		scopeBasis := strings.TrimSpace(comment.ScopeBasis)
+		scopeEvidence := strings.TrimSpace(comment.ScopeEvidence)
+		if disposition == "" || scopeBasis == "" || scopeEvidence == "" {
+			return fmt.Errorf("actionable review comment %d requires disposition=must_fix, non-empty scopeBasis, and non-empty scopeEvidence", i)
+		}
+		switch disposition {
+		case reviewFindingDispositionMustFix:
+			// ok
+		case reviewFindingDispositionFollowUp, reviewFindingDispositionNeedsHuman:
+			return fmt.Errorf("actionable review comment %d rejects disposition=%s; only must_fix may be submitted as remote feedback", i, disposition)
+		default:
+			return fmt.Errorf("actionable review comment %d has invalid disposition %q (want must_fix)", i, disposition)
 		}
 	}
 	return nil
@@ -1149,7 +1205,10 @@ func refuseReviewSubmitBudgetAgainstRepos(ctx context.Context, repos *storage.Re
 		// One-shot manual (and any non-participating lane) is exempt.
 		return nil
 	}
-	if loops.IsReviewFixBudgetHold(*loop) {
+	if loops.IsReviewFixPairHold(*loop) {
+		if loops.IsReviewScopeHumanHold(*loop) && !loops.IsReviewFixBudgetHold(*loop) {
+			return fmt.Errorf("review submit refused: review scope requires human judgment for %s#%d; unpause or stop the loop before publishing", repo, prNumber)
+		}
 		return fmt.Errorf("review submit refused: review-fix budget is held for %s#%d; unpause or stop the loop before publishing", repo, prNumber)
 	}
 	cap := config.ProjectRoleConfigs(cfg, loop.ProjectID).Reviewer.Behavior.Loop.MaxPublishesPerPR

--- a/internal/cliapp/review_submit.go
+++ b/internal/cliapp/review_submit.go
@@ -798,6 +798,12 @@ func validateReviewSubmitBody(body string, comments []reviewSubmitComment, commi
 
 // validateReviewSubmitCommentDispositions enforces the trusted finding contract on
 // actionable inline comments. Clean body-only APPROVE/COMMENT needs no dispositions.
+//
+// Authority for publishing a finding as remote review feedback is repository
+// instructions, PR intent, and spec 7.3 — not this gate. The gate fail-closes on
+// the agent's own structured disposition/scope fields so a prompt-only subset
+// cannot publish follow_up/needs_human or omit the declaration; it does not infer
+// disposition from GitHub or other infra state.
 func validateReviewSubmitCommentDispositions(comments []reviewSubmitComment) error {
 	if len(comments) == 0 {
 		return nil

--- a/internal/cliapp/review_submit.go
+++ b/internal/cliapp/review_submit.go
@@ -59,6 +59,12 @@ const (
 	reviewFindingDispositionMustFix    = "must_fix"
 	reviewFindingDispositionFollowUp   = "follow_up"
 	reviewFindingDispositionNeedsHuman = "needs_human"
+
+	reviewFindingScopeStatedIntent           = "stated_intent"
+	reviewFindingScopeIntroducedRegression   = "introduced_regression"
+	reviewFindingScopeRequiredInvariant      = "required_invariant"
+	reviewFindingScopeIndependentImprovement = "independent_improvement"
+	reviewFindingScopeAmbiguousIntent        = "ambiguous_intent"
 )
 
 type reviewSubmitDiagnosticFields struct {
@@ -833,6 +839,12 @@ func validateReviewSubmitCommentDispositions(comments []reviewSubmitComment) err
 			return fmt.Errorf("actionable review comment %d rejects disposition=%s; only must_fix may be submitted as remote feedback", i, disposition)
 		default:
 			return fmt.Errorf("actionable review comment %d has invalid disposition %q (want must_fix)", i, disposition)
+		}
+		switch scopeBasis {
+		case reviewFindingScopeStatedIntent, reviewFindingScopeIntroducedRegression, reviewFindingScopeRequiredInvariant, reviewFindingScopeIndependentImprovement, reviewFindingScopeAmbiguousIntent:
+			// ok
+		default:
+			return fmt.Errorf("actionable review comment %d has invalid scopeBasis %q", i, scopeBasis)
 		}
 	}
 	return nil

--- a/internal/cliapp/review_submit_contract_failclosed_test.go
+++ b/internal/cliapp/review_submit_contract_failclosed_test.go
@@ -175,3 +175,54 @@ func TestReviewSubmitOrchestrationRetryDoesNotDuplicateAfterAuthorityRecovery(t 
 		t.Fatalf("submit log lines = %d (%q), want exactly one publish after recovery", len(lines), string(data))
 	}
 }
+
+func TestReviewSubmitOrchestrationRejectsSuppressedFindingsInBody(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	baseSHA, headSHA, targetLine := seedReviewSubmitLargeRepo(t, repo)
+	payloadPath, configPath, submitLog, _ := writeReviewSubmitHarness(t, repo, baseSHA, headSHA, "truncated")
+
+	payload := map[string]any{
+		"body": "Valid must_fix inline, plus a follow_up rename in the body.\n<!-- looper:review id=review-body-smuggle head=" + headSHA + " outcome=actionable -->",
+		"comments": []map[string]any{
+			reviewSubmitMustFixComment("late change", "target/late.go", targetLine, "RIGHT"),
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := os.WriteFile(payloadPath, raw, 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	runtime := newCommandRuntime(New(Deps{Stdout: stdout, Stderr: stderr, Getwd: func() (string, error) { return repo, nil }}), []string{"--config", configPath})
+	cmd := newReviewSubmitTestCommand(stdout, stderr)
+	cmd.SetContext(context.Background())
+	f, err := os.Open(payloadPath)
+	if err != nil {
+		t.Fatalf("open payload: %v", err)
+	}
+	defer f.Close()
+	cmd.SetIn(f)
+	if err := cmd.Flags().Set("event", "COMMENT"); err != nil {
+		t.Fatalf("set event: %v", err)
+	}
+	if err := cmd.Flags().Set("commit-id", headSHA); err != nil {
+		t.Fatalf("set commit-id: %v", err)
+	}
+
+	err = runtime.reviewSubmit(cmd, []string{"acme/looper#42"})
+	if err == nil || !strings.Contains(err.Error(), "follow_up or needs_human") {
+		t.Fatalf("reviewSubmit() error = %v, want body disposition rejection", err)
+	}
+	if _, statErr := os.Stat(submitLog); !os.IsNotExist(statErr) {
+		data, _ := os.ReadFile(submitLog)
+		if len(bytes.TrimSpace(data)) > 0 {
+			t.Fatalf("provider SubmitReview received payload despite suppressed body finding: %s", data)
+		}
+	}
+}

--- a/internal/cliapp/review_submit_contract_failclosed_test.go
+++ b/internal/cliapp/review_submit_contract_failclosed_test.go
@@ -20,7 +20,7 @@ func TestReviewSubmitOrchestrationFailsClosedOnBaseHeadMismatch(t *testing.T) {
 	payload := map[string]any{
 		"body": "Actionable review\n<!-- looper:review id=review-mismatch head=" + strings.Repeat("a", 40) + " outcome=actionable -->",
 		"comments": []map[string]any{
-			{"body": "late change", "path": "target/late.go", "line": targetLine, "side": "RIGHT"},
+			reviewSubmitMustFixComment("late change", "target/late.go", targetLine, "RIGHT"),
 		},
 	}
 	raw, _ := json.Marshal(payload)
@@ -67,7 +67,7 @@ func TestReviewSubmitOrchestrationFailsClosedWhenRemoteOversizedAndLocalUnavaila
 	payload := map[string]any{
 		"body": "Actionable review\n<!-- looper:review id=review-oversized head=" + headSHA + " outcome=actionable -->",
 		"comments": []map[string]any{
-			{"body": "needs fix", "path": secretPath, "line": 1, "side": "RIGHT"},
+			reviewSubmitMustFixComment("needs fix", secretPath, 1, "RIGHT"),
 		},
 	}
 	raw, _ := json.Marshal(payload)
@@ -123,7 +123,7 @@ func TestReviewSubmitOrchestrationRetryDoesNotDuplicateAfterAuthorityRecovery(t 
 	payload := map[string]any{
 		"body": "Actionable review\n<!-- looper:review id=review-retry head=" + headSHA + " outcome=actionable -->",
 		"comments": []map[string]any{
-			{"body": "late change needs attention", "path": "target/late.go", "line": targetLine, "side": "RIGHT"},
+			reviewSubmitMustFixComment("late change needs attention", "target/late.go", targetLine, "RIGHT"),
 		},
 	}
 	raw, _ := json.Marshal(payload)

--- a/internal/cliapp/review_submit_contract_helpers_test.go
+++ b/internal/cliapp/review_submit_contract_helpers_test.go
@@ -13,6 +13,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// reviewSubmitMustFixComment returns a contract-test comment with required
+// Looper disposition fields. Provider payloads must strip these before GitHub.
+func reviewSubmitMustFixComment(body, path string, line int64, side string) map[string]any {
+	return map[string]any{
+		"body":          body,
+		"path":          path,
+		"line":          line,
+		"side":          side,
+		"disposition":   "must_fix",
+		"severity":      "blocking",
+		"scopeBasis":    "introduced_regression",
+		"scopeEvidence": "contract test finding in PR scope",
+	}
+}
+
 func newReviewSubmitTestCommand(stdout, stderr *bytes.Buffer) *cobra.Command {
 	cmd := &cobra.Command{Use: "submit"}
 	cmd.SetOut(stdout)

--- a/internal/cliapp/review_submit_contract_test.go
+++ b/internal/cliapp/review_submit_contract_test.go
@@ -22,12 +22,7 @@ func TestReviewSubmitOrchestrationPreservesInlineCommentsWhenFullDiffExceedsCapt
 	payload := map[string]any{
 		"body": "Actionable review\n<!-- looper:review id=review-large head=" + headSHA + " outcome=actionable -->",
 		"comments": []map[string]any{
-			{
-				"body": "late change needs attention",
-				"path": "target/late.go",
-				"line": targetLine,
-				"side": "RIGHT",
-			},
+			reviewSubmitMustFixComment("late change needs attention", "target/late.go", targetLine, "RIGHT"),
 		},
 	}
 	raw, err := json.Marshal(payload)
@@ -77,6 +72,11 @@ func TestReviewSubmitOrchestrationPreservesInlineCommentsWhenFullDiffExceedsCapt
 	if comment["path"] != "target/late.go" || int64(comment["line"].(float64)) != targetLine || comment["side"] != "RIGHT" {
 		t.Fatalf("comment = %#v, want resolvable target/late.go RIGHT %d", comment, targetLine)
 	}
+	for _, forbidden := range []string{"disposition", "scopeBasis", "scopeEvidence", "severity"} {
+		if _, ok := comment[forbidden]; ok {
+			t.Fatalf("provider comment retained Looper-only field %q: %#v", forbidden, comment)
+		}
+	}
 	// A non-empty comments[] entry is the GitHub contract for a resolvable review thread.
 	if submitted["commit_id"] != headSHA {
 		t.Fatalf("commit_id = %#v, want %s", submitted["commit_id"], headSHA)
@@ -94,7 +94,7 @@ func TestReviewSubmitOrchestrationPreservesLeftDeletedInlineComment(t *testing.T
 	payload := map[string]any{
 		"body": "Actionable review\n<!-- looper:review id=review-left head=" + headSHA + " outcome=actionable -->",
 		"comments": []map[string]any{
-			{"body": "deleted line issue", "path": "removed.go", "line": deletedLine, "side": "LEFT"},
+			reviewSubmitMustFixComment("deleted line issue", "removed.go", deletedLine, "LEFT"),
 		},
 	}
 	raw, _ := json.Marshal(payload)

--- a/internal/cliapp/review_submit_test.go
+++ b/internal/cliapp/review_submit_test.go
@@ -1604,6 +1604,14 @@ func TestValidateReviewSubmitCommentDispositionsRequiresMustFixEvidence(t *testi
 			}},
 			want: "needs_human",
 		},
+		{
+			name: "invalid scopeBasis rejected",
+			comments: []reviewSubmitComment{{
+				Body: "x", Path: "app.go", Line: 1, Side: "RIGHT",
+				Disposition: "must_fix", ScopeBasis: "whatever", ScopeEvidence: "nil deref",
+			}},
+			want: "invalid scopeBasis",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := validateReviewSubmitCommentDispositions(tc.comments)

--- a/internal/cliapp/review_submit_test.go
+++ b/internal/cliapp/review_submit_test.go
@@ -898,6 +898,37 @@ func TestValidateReviewSubmitBodyRejectsCleanCommentWithInlineComments(t *testin
 	}
 }
 
+func TestValidateReviewSubmitBodyRejectsSuppressedFindings(t *testing.T) {
+	t.Parallel()
+
+	comments := []reviewSubmitComment{{
+		Body: "must_fix", Path: "main.go", Line: 1, Side: "RIGHT",
+		Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "nil deref",
+	}}
+	ok := "Must-fix only: guard the nil pointer.\n<!-- looper:review id=abc head=def outcome=actionable -->"
+	if err := validateReviewSubmitBody(ok, comments, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err != nil {
+		t.Fatalf("must_fix summary body error = %v", err)
+	}
+	hidden := "<!-- follow_up: rename helper -->\nMust-fix only.\n<!-- looper:review id=abc head=def outcome=actionable -->"
+	if err := validateReviewSubmitBody(hidden, comments, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err != nil {
+		t.Fatalf("suppressed token only in HTML comment error = %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "follow_up prose", body: "Also a follow_up rename later.\n<!-- looper:review id=abc head=def outcome=actionable -->"},
+		{name: "needs_human prose", body: "This needs_human because scope is unclear.\n<!-- looper:review id=abc head=def outcome=actionable -->"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateReviewSubmitBody(tc.body, comments, "def", "COMMENT", commentOnlyReviewPolicy, "octocat")
+			if err == nil || !strings.Contains(err.Error(), "follow_up or needs_human") {
+				t.Fatalf("error = %v, want suppressed-finding rejection", err)
+			}
+		})
+	}
+}
+
 func TestValidateReviewSubmitBodyRequiresHumanCleanApproveBody(t *testing.T) {
 	t.Parallel()
 	marker := "<!-- looper:review id=abc head=def outcome=clean -->"

--- a/internal/cliapp/review_submit_test.go
+++ b/internal/cliapp/review_submit_test.go
@@ -803,7 +803,8 @@ func TestValidateReviewSubmitEventAcceptsRequestChanges(t *testing.T) {
 func TestValidateReviewSubmitBodyRequiresSingleMatchingMarker(t *testing.T) {
 	t.Parallel()
 	body := "Review body\n<!-- looper:review id=abc head=def outcome=actionable -->"
-	if err := validateReviewSubmitBody(body, nil, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err != nil {
+	// Actionable COMMENT requires inline comments (no body-only smuggling).
+	if err := validateReviewSubmitBody(body, []reviewSubmitComment{{Body: "fix", Path: "main.go", Line: 1, Side: "RIGHT"}}, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err != nil {
 		t.Fatalf("validateReviewSubmitBody() error = %v", err)
 	}
 	for _, tc := range []struct {
@@ -849,12 +850,51 @@ func TestValidateReviewSubmitBodyAllowsRequestChangesOnlyForBlocking(t *testing.
 	}
 }
 
+func TestValidateReviewSubmitBodyRejectsActionableBodyOnly(t *testing.T) {
+	t.Parallel()
+	blocking := "<!-- looper:review id=abc head=def outcome=blocking -->"
+	if err := validateReviewSubmitBody(blocking, nil, "def", "REQUEST_CHANGES", decisionReviewPolicy, "octocat"); err == nil || !strings.Contains(err.Error(), "at least one inline comment") {
+		t.Fatalf("REQUEST_CHANGES body-only error = %v, want inline comment requirement", err)
+	}
+	actionable := "<!-- looper:review id=abc head=def outcome=non_blocking -->"
+	if err := validateReviewSubmitBody(actionable, nil, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err == nil || !strings.Contains(err.Error(), "at least one inline comment") {
+		t.Fatalf("actionable COMMENT body-only error = %v, want inline comment requirement", err)
+	}
+	// Clean body-only COMMENT remains allowed.
+	clean := "<!-- looper:review id=abc head=def outcome=clean -->"
+	if err := validateReviewSubmitBody(clean, nil, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err != nil {
+		t.Fatalf("clean COMMENT body-only error = %v", err)
+	}
+}
+
 func TestValidateReviewSubmitBodyRejectsCleanApproveWithInlineComments(t *testing.T) {
 	t.Parallel()
 	body := "<!-- looper:review id=abc head=def outcome=clean -->"
 	err := validateReviewSubmitBody(body, []reviewSubmitComment{{Body: "inline", Path: "main.go", Line: 10, Side: "RIGHT"}}, "def", "APPROVE", decisionReviewPolicy, "octocat")
 	if err == nil || !strings.Contains(err.Error(), "without inline comments") {
 		t.Fatalf("validateReviewSubmitBody(APPROVE with comments) error = %v, want inline rejection", err)
+	}
+}
+
+func TestValidateReviewSubmitBodyRejectsCleanCommentWithInlineComments(t *testing.T) {
+	t.Parallel()
+	body := "<!-- looper:review id=abc head=def outcome=clean -->"
+	// Clean COMMENT must reject any inline comments (same as APPROVE).
+	err := validateReviewSubmitBody(body, []reviewSubmitComment{{
+		Body: "must_fix smuggled", Path: "main.go", Line: 10, Side: "RIGHT",
+		Disposition: "must_fix", ScopeBasis: "required_invariant", ScopeEvidence: "rule",
+	}}, "def", "COMMENT", commentOnlyReviewPolicy, "octocat")
+	if err == nil || !strings.Contains(err.Error(), "without inline comments") {
+		t.Fatalf("validateReviewSubmitBody(clean COMMENT with comments) error = %v, want inline rejection", err)
+	}
+	// Clean body-only COMMENT remains allowed.
+	if err := validateReviewSubmitBody(body, nil, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err != nil {
+		t.Fatalf("validateReviewSubmitBody(clean COMMENT body-only) error = %v", err)
+	}
+	// Actionable COMMENT still requires ≥1 inline comment (must_fix enforced separately).
+	actionable := "<!-- looper:review id=abc head=def outcome=non_blocking -->"
+	if err := validateReviewSubmitBody(actionable, nil, "def", "COMMENT", commentOnlyReviewPolicy, "octocat"); err == nil || !strings.Contains(err.Error(), "at least one inline comment") {
+		t.Fatalf("actionable COMMENT body-only error = %v, want inline comment requirement", err)
 	}
 }
 
@@ -1488,5 +1528,110 @@ func TestReviewSubmitGatewayUsesStorageProjectRoles(t *testing.T) {
 	}
 	if got := strings.Join(forgeGateway.labels, ","); got != "looper:review" {
 		t.Fatalf("labels = %q, want looper:review from storage project roles", got)
+	}
+}
+
+func TestValidateReviewSubmitCommentDispositionsRequiresMustFixEvidence(t *testing.T) {
+	t.Parallel()
+
+	mustFix := []reviewSubmitComment{{
+		Body: "Null check missing", Path: "app.go", Line: 10, Side: "RIGHT",
+		Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "PR adds nil deref on happy path",
+	}}
+	if err := validateReviewSubmitCommentDispositions(mustFix); err != nil {
+		t.Fatalf("must_fix+evidence error = %v", err)
+	}
+	if err := validateReviewSubmitCommentDispositions(nil); err != nil {
+		t.Fatalf("empty comments error = %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		comments []reviewSubmitComment
+		want     string
+	}{
+		{
+			name: "missing fields",
+			comments: []reviewSubmitComment{{
+				Body: "x", Path: "app.go", Line: 1, Side: "RIGHT",
+			}},
+			want: "requires disposition=must_fix",
+		},
+		{
+			name: "follow_up rejected",
+			comments: []reviewSubmitComment{{
+				Body: "x", Path: "app.go", Line: 1, Side: "RIGHT",
+				Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "nice to have",
+			}},
+			want: "follow_up",
+		},
+		{
+			name: "needs_human rejected",
+			comments: []reviewSubmitComment{{
+				Body: "x", Path: "app.go", Line: 1, Side: "RIGHT",
+				Disposition: "needs_human", ScopeBasis: "ambiguous_intent", ScopeEvidence: "unclear",
+			}},
+			want: "needs_human",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateReviewSubmitCommentDispositions(tc.comments)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestReviewSubmitStripsLooperOnlyFieldsAndRejectsBeforeSubmit(t *testing.T) {
+	t.Parallel()
+
+	// Unknown extra JSON keys are ignored by encoding/json into the struct.
+	raw := []byte(`{
+		"body": "Blocking\n\n<!-- looper:review id=abc head=deadbeef outcome=blocking -->",
+		"comments": [{
+			"body": "fix it",
+			"path": "app.go",
+			"line": 10,
+			"side": "RIGHT",
+			"disposition": "must_fix",
+			"severity": "blocking",
+			"scopeBasis": "introduced_regression",
+			"scopeEvidence": "nil deref",
+			"unknownExtra": true
+		}]
+	}`)
+	var payload reviewSubmitPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if err := validateReviewSubmitCommentDispositions(payload.Comments); err != nil {
+		t.Fatalf("validate dispositions: %v", err)
+	}
+	if payload.Comments[0].Disposition != "must_fix" || payload.Comments[0].ScopeBasis == "" {
+		t.Fatalf("payload comments = %#v", payload.Comments[0])
+	}
+	// Provider mapping strips Looper-only fields (same as reviewSubmit path).
+	mapped := githubinfra.ReviewComment{
+		Body: payload.Comments[0].Body, Path: payload.Comments[0].Path,
+		Line: payload.Comments[0].Line, Side: payload.Comments[0].Side,
+	}
+	if mapped.Body != "fix it" || mapped.Path != "app.go" {
+		t.Fatalf("mapped = %#v", mapped)
+	}
+
+	// Reject path: follow_up never reaches SubmitReview.
+	submitCalls := 0
+	gateway := &budgetGateSubmitGateway{onSubmit: func() { submitCalls++ }}
+	_ = gateway
+	bad := []reviewSubmitComment{{
+		Body: "x", Path: "app.go", Line: 1, Side: "RIGHT",
+		Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "later",
+	}}
+	if err := validateReviewSubmitCommentDispositions(bad); err == nil {
+		t.Fatal("expected follow_up rejection")
+	}
+	if submitCalls != 0 {
+		t.Fatalf("SubmitReview calls = %d, want 0", submitCalls)
 	}
 }

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1662,7 +1662,7 @@ func (r *Runner) shouldCreateFixerBudgetPark(loop storage.LoopRecord) bool {
 	if loop.Status == "terminated" || loop.Status == "stopped" || loop.Status == "awaiting_human" {
 		return false
 	}
-	if loop.Status == "paused" && loops.IsReviewFixBudgetHold(loop) {
+	if loop.Status == "paused" && loops.IsReviewFixPairHold(loop) {
 		return false
 	}
 	if !loops.ParticipatesInReviewFixBudget(loop) {
@@ -1732,12 +1732,16 @@ func (r *Runner) parkFixerBudgetIfExhausted(ctx context.Context, loop storage.Lo
 	if loop.Status == "terminated" || loop.Status == "stopped" {
 		return false, nil
 	}
-	// Sibling pause is already a hold; do not treat "not self-exhausted" as proceed.
-	if loop.Status == "paused" && loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) {
+	// Sibling pause / scope hold is already a hold; do not treat "not self-exhausted" as proceed.
+	if loop.Status == "paused" && (loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) || loops.IsSiblingReviewScopeHumanPause(loop.MetadataJSON)) {
+		return true, nil
+	}
+	if loops.IsReviewScopeHumanHold(loop) && !loops.IsReviewFixBudgetHold(loop) {
 		return true, nil
 	}
 	if loop.Status == "awaiting_human" {
 		if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
+			// Agent ask or scope ask: not a budget park target.
 			return true, nil
 		}
 	} else if loop.Status == "paused" && loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
@@ -1804,11 +1808,14 @@ func (r *Runner) refusePushIfBudgetExhausted(ctx context.Context, input stepInpu
 	if !loops.ParticipatesInReviewFixBudget(loop) {
 		return false, nil
 	}
-	if loops.IsReviewFixBudgetHold(loop) {
-		if _, err := r.parkFixerBudgetIfExhausted(ctx, loop); err != nil {
-			return true, err
+	if loops.IsReviewFixPairHold(loop) {
+		if loops.IsReviewFixBudgetHold(loop) {
+			if _, err := r.parkFixerBudgetIfExhausted(ctx, loop); err != nil {
+				return true, err
+			}
+			return true, &holdSkipError{summary: "Fixer stopped because review-fix budget is held"}
 		}
-		return true, &holdSkipError{summary: "Fixer stopped because review-fix budget is held"}
+		return true, &holdSkipError{summary: "Fixer stopped because review scope requires human judgment"}
 	}
 	cap := r.maxPushesPerPR(loop.ProjectID)
 	if !loops.BudgetExhausted(loops.FixerPushCount(loop.MetadataJSON), cap) {
@@ -2743,7 +2750,7 @@ func (r *Runner) finishHeldFixerQueueItem(ctx context.Context, loop storage.Loop
 	// step already persisted — only ordinary label/hold skips re-queue.
 	if _, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
 		updated.LastRunAt = stringPtr(r.nowISO())
-		if loops.IsReviewFixBudgetHold(*updated) || updated.Status == "terminated" || updated.Status == "stopped" || updated.Status == "awaiting_human" || updated.Status == "human_takeover" {
+		if loops.IsReviewFixPairHold(*updated) || updated.Status == "terminated" || updated.Status == "stopped" || updated.Status == "awaiting_human" || updated.Status == "human_takeover" {
 			updated.NextRunAt = nil
 			return
 		}
@@ -5342,13 +5349,15 @@ func (r *Runner) ensureLoopForPullRequest(ctx context.Context, project storage.P
 		if updatedLoop.Status == "awaiting_human" || updatedLoop.Status == "human_takeover" || updatedLoop.Status == "terminated" || updatedLoop.Status == "stopped" {
 			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
 		}
-		// Sibling pause / exhausted hold must not be revived by discovery enqueue.
+		// Sibling pause / exhausted / scope hold must not be revived by discovery enqueue.
 		// Notify only from discovery after a successful park (not from shared park).
-		if loops.IsReviewFixBudgetHold(updatedLoop) {
-			if parked, err := r.parkFixerBudgetIfExhausted(ctx, updatedLoop); err != nil {
-				return loopUpsertResult{}, err
-			} else if parked {
-				r.notifyHumanAttentionBestEffort(ctx, updatedLoop.ID)
+		if loops.IsReviewFixPairHold(updatedLoop) {
+			if loops.IsReviewFixBudgetHold(updatedLoop) {
+				if parked, err := r.parkFixerBudgetIfExhausted(ctx, updatedLoop); err != nil {
+					return loopUpsertResult{}, err
+				} else if parked {
+					r.notifyHumanAttentionBestEffort(ctx, updatedLoop.ID)
+				}
 			}
 			return loopUpsertResult{record: updatedLoop, created: false, skipped: true}, nil
 		}

--- a/internal/infra/notify/human_attention.go
+++ b/internal/infra/notify/human_attention.go
@@ -70,6 +70,8 @@ type HumanAttentionInput struct {
 	Reason     HumanAttentionReason
 	EntryKey   string
 	Subtitle   string
+	Question   string
+	Evidence   string
 	EntityType string
 	EntityID   string
 }
@@ -95,6 +97,12 @@ func (g *Gateway) NotifyHumanAttention(ctx context.Context, input HumanAttention
 	body := fmt.Sprintf("%s requires operator attention (%s).", loopLabel, humanAttentionReasonLabel(reason))
 	if loopType := strings.TrimSpace(input.LoopType); loopType != "" {
 		body = fmt.Sprintf("%s (%s) requires operator attention (%s).", loopLabel, loopType, humanAttentionReasonLabel(reason))
+	}
+	if q := strings.TrimSpace(input.Question); q != "" {
+		body += " " + q
+	}
+	if e := strings.TrimSpace(input.Evidence); e != "" {
+		body += " " + e
 	}
 
 	entityType := strings.TrimSpace(input.EntityType)

--- a/internal/infra/notify/human_attention.go
+++ b/internal/infra/notify/human_attention.go
@@ -24,6 +24,9 @@ const (
 	// HumanAttentionReviewFixBudget is a no-HITL review-fix budget exhausted hold
 	// (paused + review_fix_budget_exhausted). Sibling-only pause does not notify.
 	HumanAttentionReviewFixBudget HumanAttentionReason = "review_fix_budget"
+	// HumanAttentionReviewScopeHuman is a no-HITL needs_human scope hold
+	// (paused + review_scope_human_required). Sibling-only pause does not notify.
+	HumanAttentionReviewScopeHuman HumanAttentionReason = "review_scope_human"
 )
 
 // HumanAttentionInput describes one durable entry into a state that requires an operator.
@@ -79,7 +82,7 @@ func (g *Gateway) NotifyHumanAttention(ctx context.Context, input HumanAttention
 		return nil
 	}
 	reason := HumanAttentionReason(strings.TrimSpace(string(input.Reason)))
-	if reason != HumanAttentionAwaitingHuman && reason != HumanAttentionManualIntervention && reason != HumanAttentionReviewFixBudget {
+	if reason != HumanAttentionAwaitingHuman && reason != HumanAttentionManualIntervention && reason != HumanAttentionReviewFixBudget && reason != HumanAttentionReviewScopeHuman {
 		return nil
 	}
 	entryKey := strings.TrimSpace(input.EntryKey)
@@ -296,6 +299,8 @@ func humanAttentionReasonLabel(reason HumanAttentionReason) string {
 		return "manual intervention"
 	case HumanAttentionReviewFixBudget:
 		return "review-fix budget exhausted"
+	case HumanAttentionReviewScopeHuman:
+		return "review scope requires human judgment"
 	default:
 		return string(reason)
 	}

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -225,6 +225,12 @@ func ParticipatesInReviewFixBudget(loop storage.LoopRecord) bool {
 	return reviewFixBudgetLane(loop) != ""
 }
 
+// ReviewFixBudgetLane is the pairing lane used by FindSiblingReviewFixLoops:
+// automatic, continuous_manual, or empty for one-shot manual loops.
+func ReviewFixBudgetLane(loop storage.LoopRecord) string {
+	return reviewFixBudgetLane(loop)
+}
+
 func reviewFixBudgetLane(loop storage.LoopRecord) string {
 	meta := parseMetadataObject(loop.MetadataJSON)
 	manual, _ := meta["manual"].(bool)

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -701,7 +701,7 @@ func ApplyReviewFixBudgetAnswer(ctx context.Context, repos *storage.Repositories
 		return ReviewFixBudgetAnswerResult{}, fmt.Errorf("review-fix budget answer requires loop storage")
 	}
 	if IsReviewFixBudgetStop(answer) {
-		updated, err := terminateReviewFixPair(ctx, repos, loop, nowISO)
+		updated, err := terminateReviewFixPair(ctx, repos, loop, nowISO, ReviewFixBudgetTerminationReason)
 		if err != nil {
 			return ReviewFixBudgetAnswerResult{}, err
 		}
@@ -770,6 +770,11 @@ func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, l
 			return loop, err
 		}
 	}
+	// If needs_human was deferred under the budget hold, promote to a real
+	// scope park now that budget is no longer the primary hold.
+	if err := promotePendingReviewScopeHumanAfterBudgetRelease(ctx, repos, members, nowISO); err != nil {
+		return loop, err
+	}
 	fresh, err := repos.Loops.GetByID(ctx, loop.ID)
 	if err != nil {
 		return loop, err
@@ -778,6 +783,40 @@ func continueReviewFixBudget(ctx context.Context, repos *storage.Repositories, l
 		return loop, fmt.Errorf("review-fix budget continue lost loop %s", loop.ID)
 	}
 	return *fresh, nil
+}
+
+// promotePendingReviewScopeHumanAfterBudgetRelease parks scope when a member
+// still carries deferred needs_human evidence from a publish that hit the cap.
+func promotePendingReviewScopeHumanAfterBudgetRelease(ctx context.Context, repos *storage.Repositories, members []storage.LoopRecord, nowISO string) error {
+	for _, member := range members {
+		fresh, err := repos.Loops.GetByID(ctx, member.ID)
+		if err != nil {
+			return err
+		}
+		if fresh == nil || !HasPendingReviewScopeHuman(*fresh) {
+			continue
+		}
+		state := ReadReviewScopeHumanState(fresh.MetadataJSON)
+		role := strings.TrimSpace(fresh.Type)
+		if role == "" {
+			role = "reviewer"
+		}
+		if _, err := ParkReviewScopeHuman(ctx, repos, ParkReviewScopeHumanInput{
+			Held:        *fresh,
+			Role:        role,
+			Repo:        strings.TrimSpace(derefLoopString(fresh.Repo)),
+			PRNumber:    derefLoopInt64(fresh.PRNumber),
+			NowISO:      nowISO,
+			HITLEnabled: state.PendingHITL,
+			Question:    state.Question,
+			Evidence:    state.Evidence,
+		}); err != nil {
+			return err
+		}
+		// One primary scope park is enough for the pair.
+		return nil
+	}
+	return nil
 }
 
 func reviewFixBudgetPairMembers(all []storage.LoopRecord, loop storage.LoopRecord) []storage.LoopRecord {
@@ -924,29 +963,35 @@ func requeueReviewFixBudgetLoop(ctx context.Context, repos *storage.Repositories
 	return err
 }
 
-func terminateReviewFixPair(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
+func terminateReviewFixPair(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO, terminationReason string) (storage.LoopRecord, error) {
 	// Keep the answered/held loop until every currently held same-lane sibling
 	// is terminated so a later poll can retry the same Stop. Historical
 	// completed or independently finished siblings stay untouched.
+	if strings.TrimSpace(terminationReason) == "" {
+		terminationReason = ReviewFixBudgetTerminationReason
+	}
 	all, err := repos.Loops.List(ctx)
 	if err != nil {
 		return loop, err
 	}
 	for _, sibling := range FindSiblingReviewFixLoops(all, loop) {
-		if !IsReviewFixBudgetHold(sibling) {
+		if !IsReviewFixPairHold(sibling) {
 			continue
 		}
-		if _, err := terminateReviewFixLoop(ctx, repos, sibling, nowISO); err != nil {
+		if _, err := terminateReviewFixLoop(ctx, repos, sibling, nowISO, terminationReason); err != nil {
 			return loop, err
 		}
 	}
-	return terminateReviewFixLoop(ctx, repos, loop, nowISO)
+	return terminateReviewFixLoop(ctx, repos, loop, nowISO, terminationReason)
 }
 
-func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
+func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO, terminationReason string) (storage.LoopRecord, error) {
 	switch loop.Status {
 	case "terminated", "stopped":
 		return loop, nil
+	}
+	if strings.TrimSpace(terminationReason) == "" {
+		terminationReason = ReviewFixBudgetTerminationReason
 	}
 	meta := parseMetadataObject(loop.MetadataJSON)
 	if loop.Type == "reviewer" {
@@ -955,10 +1000,10 @@ func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, lo
 			loopMeta = map[string]any{}
 		}
 		loopMeta["status"] = "terminated"
-		loopMeta["terminationReason"] = ReviewFixBudgetTerminationReason
+		loopMeta["terminationReason"] = terminationReason
 		meta[reviewerLoopMetadataKey] = loopMeta
 	}
-	if reason, _ := stringFromAny(meta["pauseReason"]); reason == ReviewFixBudgetPauseReason || reason == ReviewFixBudgetTerminationReason {
+	if reason, _ := stringFromAny(meta["pauseReason"]); reason == ReviewFixBudgetPauseReason || reason == ReviewFixBudgetTerminationReason || reason == ReviewScopeHumanRequiredReason || reason == ReviewScopeHumanSiblingPauseReason {
 		delete(meta, "pauseReason")
 	}
 	encoded, err := json.Marshal(meta)
@@ -980,6 +1025,17 @@ func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, lo
 	if err != nil {
 		return loop, err
 	}
+	scopeState := ReadReviewScopeHumanState(&cleared)
+	scopeState.HeldBy = ""
+	scopeState.Question = ""
+	if scopeState.PauseReason == ReviewScopeHumanSiblingPauseReason || scopeState.PauseReason == ReviewScopeHumanRequiredReason {
+		scopeState.PauseReason = ""
+	}
+	scopeState.HandoffEventAt = ""
+	cleared, err = WriteReviewScopeHumanState(&cleared, scopeState)
+	if err != nil {
+		return loop, err
+	}
 	updated := loop
 	updated.MetadataJSON = &cleared
 	updated.Status = "terminated"
@@ -989,7 +1045,7 @@ func terminateReviewFixLoop(ctx context.Context, repos *storage.Repositories, lo
 		return loop, err
 	}
 	if repos.Queue != nil {
-		reason := ReviewFixBudgetTerminationReason
+		reason := terminationReason
 		if _, err := repos.Queue.CancelByLoop(ctx, updated.ID, nowISO, &reason); err != nil {
 			return updated, err
 		}

--- a/internal/loops/review_fix_budget.go
+++ b/internal/loops/review_fix_budget.go
@@ -860,6 +860,21 @@ func resetReviewFixBudgetMetersIfNeeded(metadataJSON *string, loopType string, c
 	}
 }
 
+func hasResidualReviewFixBudgetHoldStamps(metadataJSON *string) bool {
+	if ask, ok := ReadHITLAsk(metadataJSON); ok && IsReviewFixBudgetAsk(ask) {
+		return true
+	}
+	state := ReadReviewFixBudgetState(metadataJSON)
+	if strings.TrimSpace(state.SiblingOf) != "" || strings.TrimSpace(state.ExhaustedBy) != "" {
+		return true
+	}
+	if state.PauseReason == ReviewFixBudgetPauseReason || state.PauseReason == ReviewFixBudgetTerminationReason {
+		return true
+	}
+	reason, _ := stringFromAny(parseMetadataObject(metadataJSON)["pauseReason"])
+	return reason == ReviewFixBudgetPauseReason || reason == ReviewFixBudgetTerminationReason
+}
+
 func releaseOneReviewFixBudgetHold(ctx context.Context, repos *storage.Repositories, loopID, nowISO string) error {
 	fresh, err := repos.Loops.GetByID(ctx, loopID)
 	if err != nil {
@@ -868,7 +883,8 @@ func releaseOneReviewFixBudgetHold(ctx context.Context, repos *storage.Repositor
 	if fresh == nil {
 		return nil
 	}
-	if !IsReviewFixBudgetHold(*fresh) {
+	wasBudgetHold := IsReviewFixBudgetHold(*fresh)
+	if !wasBudgetHold && !hasResidualReviewFixBudgetHoldStamps(fresh.MetadataJSON) {
 		return nil
 	}
 	metadata := fresh.MetadataJSON
@@ -901,9 +917,38 @@ func releaseOneReviewFixBudgetHold(ctx context.Context, repos *storage.Repositor
 	text := string(out)
 	updated := *fresh
 	updated.MetadataJSON = &text
+	updated.UpdatedAt = nowISO
+	if !wasBudgetHold {
+		// Scope-primary (or other non-hold) leftover sibling/exhausted stamps
+		// from an earlier budget park. Clear them so a later scope Continue
+		// does not treat stale budget pauseReason as an independent hold.
+		return repos.Loops.Upsert(ctx, updated)
+	}
+
+	// Budget Continue must not queue a sibling that still has an unresolved
+	// scope overlay. Restore a real scope sibling pause so the loop stays
+	// non-runnable and a later scope Continue can requeue it.
+	heldForScope, holdErr := keepReleasedBudgetLoopScopeHeld(&updated, nowISO)
+	if holdErr != nil {
+		return holdErr
+	}
+	if heldForScope {
+		if err := repos.Loops.Upsert(ctx, updated); err != nil {
+			return err
+		}
+		if repos.Queue != nil {
+			reason := ReviewScopeHumanSiblingPauseReason
+			if _, err := repos.Queue.CancelByLoop(ctx, updated.ID, nowISO, &reason); err != nil {
+				return err
+			}
+		}
+		if reviewFixBudgetReleaseHook != nil {
+			return reviewFixBudgetReleaseHook(updated.ID)
+		}
+		return nil
+	}
 	updated.Status = "queued"
 	updated.NextRunAt = &nowISO
-	updated.UpdatedAt = nowISO
 	if err := repos.Loops.Upsert(ctx, updated); err != nil {
 		return err
 	}

--- a/internal/loops/review_fix_budget_test.go
+++ b/internal/loops/review_fix_budget_test.go
@@ -417,7 +417,7 @@ func TestStopReviewFixBudgetRetriesAfterSiblingAlreadyTerminated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParkReviewFixBudget() error = %v", err)
 	}
-	if _, err := terminateReviewFixLoop(context.Background(), repos, fixer, nowISO); err != nil {
+	if _, err := terminateReviewFixLoop(context.Background(), repos, fixer, nowISO, ReviewFixBudgetTerminationReason); err != nil {
 		t.Fatalf("terminateReviewFixLoop(sibling) error = %v", err)
 	}
 

--- a/internal/loops/review_scope_hold.go
+++ b/internal/loops/review_scope_hold.go
@@ -242,7 +242,9 @@ func ParkReviewScopeHuman(ctx context.Context, repos *storage.Repositories, inpu
 
 func parkReviewScopeHumanBody(ctx context.Context, repos *storage.Repositories, input ParkReviewScopeHumanInput) (storage.LoopRecord, error) {
 	held := input.Held
-	if fresh, err := repos.Loops.GetByID(ctx, held.ID); err == nil && fresh != nil {
+	if fresh, err := repos.Loops.GetByID(ctx, held.ID); err != nil {
+		return input.Held, err
+	} else if fresh != nil {
 		held = *fresh
 	}
 	if isReviewScopeHumanPrimaryHold(held) {

--- a/internal/loops/review_scope_hold.go
+++ b/internal/loops/review_scope_hold.go
@@ -452,6 +452,34 @@ func parkOneSiblingReviewScopeHumanLoop(ctx context.Context, repos *storage.Repo
 	return nil
 }
 
+// keepReleasedBudgetLoopScopeHeld converts a just-cleared budget hold into a
+// scope park when overlay or primary scope metadata remains. Returns true when
+// the loop must stay non-runnable (no requeue). Sibling overlays become a real
+// scope sibling pause so a later scope Continue can requeue.
+func keepReleasedBudgetLoopScopeHeld(updated *storage.LoopRecord, nowISO string) (bool, error) {
+	if updated == nil || !IsReviewScopeHumanHold(*updated) {
+		return false, nil
+	}
+	updated.NextRunAt = nil
+	updated.UpdatedAt = nowISO
+	if isReviewScopeHumanPrimaryHold(*updated) {
+		if strings.TrimSpace(updated.Status) != "awaiting_human" {
+			updated.Status = "paused"
+		}
+		return true, nil
+	}
+	meta := parseMetadataObject(updated.MetadataJSON)
+	meta["pauseReason"] = ReviewScopeHumanSiblingPauseReason
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return false, err
+	}
+	text := string(out)
+	updated.MetadataJSON = &text
+	updated.Status = "paused"
+	return true, nil
+}
+
 func ensureReviewScopeHumanHandoffEvent(ctx context.Context, repos *storage.Repositories, held storage.LoopRecord, input ParkReviewScopeHumanInput) error {
 	if repos == nil || repos.Events == nil {
 		return nil

--- a/internal/loops/review_scope_hold.go
+++ b/internal/loops/review_scope_hold.go
@@ -1,0 +1,659 @@
+package loops
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+const (
+	// HITLKindReviewScopeHuman marks a scope-ambiguity ask, not a budget refill.
+	// Continue resumes against current evidence without resetting role meters.
+	HITLKindReviewScopeHuman = "review_scope_human"
+
+	// ReviewScopeHumanRequiredReason is the durable no-HITL / exhausted-role
+	// pause reason when Reviewer emits needs_human.
+	ReviewScopeHumanRequiredReason = "review_scope_human_required"
+
+	// ReviewScopeHumanSiblingPauseReason parks the opposite role while scope is held.
+	ReviewScopeHumanSiblingPauseReason = "sibling_review_scope_human"
+
+	reviewScopeHumanMetadataKey      = "reviewScopeHuman"
+	reviewScopeHumanHandoffEventType = "loop.review_scope_human.required"
+)
+
+// ErrReviewScopeHumanInvalidAnswer is returned when a scope HITL answer is not
+// Continue or Stop.
+var ErrReviewScopeHumanInvalidAnswer = fmt.Errorf("review scope answer must be %q or %q", ReviewFixBudgetAnswerContinue, ReviewFixBudgetAnswerStop)
+
+// ReviewScopeHumanState is durable pair-hold metadata for needs_human scope holds.
+// It does not store role meters; Continue must not refill budgets.
+//
+// Pending marks deferred scope evidence while a budget hold is the sole primary
+// hold (no status/ask change). After budget Continue releases the pair, pending
+// is promoted to a real scope park.
+type ReviewScopeHumanState struct {
+	HeldBy         string `json:"heldBy,omitempty"`
+	PauseReason    string `json:"pauseReason,omitempty"`
+	HandoffEventAt string `json:"handoffEventAt,omitempty"`
+	Question       string `json:"question,omitempty"`
+	Evidence       string `json:"evidence,omitempty"`
+	Pending        bool   `json:"pending,omitempty"`
+	PendingHITL    bool   `json:"pendingHitl,omitempty"`
+}
+
+func NewReviewScopeHumanAsk(role, repo string, prNumber int64, question, nowISO string) HITLAsk {
+	target := strings.TrimSpace(repo)
+	if prNumber > 0 {
+		target = fmt.Sprintf("%s#%d", target, prNumber)
+	}
+	q := strings.TrimSpace(question)
+	if q == "" {
+		q = fmt.Sprintf("%s needs human scope judgment on %s. Clarify the repository rule, PR goal/non-goal, or linked spec that must change before unpause. Continue resumes against current evidence, or stop the pair?", strings.TrimSpace(role), target)
+	}
+	return HITLAsk{
+		Kind:     HITLKindReviewScopeHuman,
+		Question: q,
+		Options:  []string{ReviewFixBudgetAnswerContinue, ReviewFixBudgetAnswerStop},
+		Status:   "awaiting",
+		AskedAt:  nowISO,
+		PRNumber: prNumber,
+	}
+}
+
+func IsReviewScopeHumanAsk(ask HITLAsk) bool {
+	return strings.TrimSpace(ask.Kind) == HITLKindReviewScopeHuman
+}
+
+func ReadReviewScopeHumanState(metadataJSON *string) ReviewScopeHumanState {
+	meta := parseMetadataObject(metadataJSON)
+	raw, ok := meta[reviewScopeHumanMetadataKey]
+	if !ok {
+		return ReviewScopeHumanState{}
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return ReviewScopeHumanState{}
+	}
+	var state ReviewScopeHumanState
+	if err := json.Unmarshal(encoded, &state); err != nil {
+		return ReviewScopeHumanState{}
+	}
+	return state
+}
+
+func WriteReviewScopeHumanState(metadataJSON *string, state ReviewScopeHumanState) (string, error) {
+	meta := parseMetadataObject(metadataJSON)
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(encoded, &asMap); err != nil {
+		return "", err
+	}
+	if len(asMap) == 0 {
+		delete(meta, reviewScopeHumanMetadataKey)
+	} else {
+		meta[reviewScopeHumanMetadataKey] = asMap
+	}
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func IsSiblingReviewScopeHumanPause(metadataJSON *string) bool {
+	if reason, _ := stringFromAny(parseMetadataObject(metadataJSON)["pauseReason"]); reason == ReviewScopeHumanSiblingPauseReason {
+		return true
+	}
+	return ReadReviewScopeHumanState(metadataJSON).PauseReason == ReviewScopeHumanSiblingPauseReason
+}
+
+func IsReviewScopeHumanRequiredPause(metadataJSON *string) bool {
+	if reason, _ := stringFromAny(parseMetadataObject(metadataJSON)["pauseReason"]); reason == ReviewScopeHumanRequiredReason {
+		return true
+	}
+	return ReadReviewScopeHumanState(metadataJSON).PauseReason == ReviewScopeHumanRequiredReason
+}
+
+// IsReviewScopeHumanHold reports a needs_human pair hold (ask, no-ask pause, or sibling).
+// Pure scope holds are not budget holds: Continue must not reset meters.
+// Siblings in failed/interrupted/awaiting_human may carry scope hold metadata without
+// flipping status to paused; HeldBy/pauseReason still gate independent resume.
+// Pending-only evidence (deferred under a budget hold) is not an active scope hold.
+func IsReviewScopeHumanHold(loop storage.LoopRecord) bool {
+	switch strings.TrimSpace(loop.Status) {
+	case "terminated", "stopped", "completed":
+		return false
+	}
+	state := ReadReviewScopeHumanState(loop.MetadataJSON)
+	if strings.TrimSpace(state.HeldBy) != "" {
+		return true
+	}
+	if state.PauseReason == ReviewScopeHumanSiblingPauseReason || state.PauseReason == ReviewScopeHumanRequiredReason {
+		return true
+	}
+	if IsSiblingReviewScopeHumanPause(loop.MetadataJSON) || IsReviewScopeHumanRequiredPause(loop.MetadataJSON) {
+		return true
+	}
+	if strings.TrimSpace(loop.Status) == "awaiting_human" {
+		ask, ok := ReadHITLAsk(loop.MetadataJSON)
+		return ok && IsReviewScopeHumanAsk(ask)
+	}
+	return false
+}
+
+// HasPendingReviewScopeHuman reports deferred needs_human evidence waiting for
+// budget release before a real scope park.
+func HasPendingReviewScopeHuman(loop storage.LoopRecord) bool {
+	state := ReadReviewScopeHumanState(loop.MetadataJSON)
+	return state.Pending && strings.TrimSpace(state.HeldBy) == ""
+}
+
+// PersistPendingReviewScopeHumanEvidence stores needs_human question/evidence
+// without changing status or writing a HITL ask. Used when budget is already the
+// primary hold so the pair never stacks two asks/reasons.
+func PersistPendingReviewScopeHumanEvidence(metadataJSON *string, question, evidence string, hitlEnabled bool) (string, error) {
+	state := ReadReviewScopeHumanState(metadataJSON)
+	if strings.TrimSpace(state.HeldBy) != "" {
+		// Active scope hold already owns the pair; keep existing hold fields.
+		if q := strings.TrimSpace(question); q != "" {
+			state.Question = q
+		}
+		if e := strings.TrimSpace(evidence); e != "" {
+			state.Evidence = e
+		}
+		return WriteReviewScopeHumanState(metadataJSON, state)
+	}
+	state.Pending = true
+	state.PendingHITL = hitlEnabled
+	if q := strings.TrimSpace(question); q != "" {
+		state.Question = q
+	}
+	if e := strings.TrimSpace(evidence); e != "" {
+		state.Evidence = e
+	}
+	// Pending must not look like an active sibling/required pause.
+	if state.PauseReason == ReviewScopeHumanSiblingPauseReason || state.PauseReason == ReviewScopeHumanRequiredReason {
+		state.PauseReason = ""
+	}
+	return WriteReviewScopeHumanState(metadataJSON, state)
+}
+
+// IsReviewFixPairHold is true for budget holds or scope-human holds.
+func IsReviewFixPairHold(loop storage.LoopRecord) bool {
+	return IsReviewFixBudgetHold(loop) || IsReviewScopeHumanHold(loop)
+}
+
+type ParkReviewScopeHumanInput struct {
+	Held        storage.LoopRecord
+	Role        string
+	Repo        string
+	PRNumber    int64
+	NowISO      string
+	HITLEnabled bool
+	// Question is the exact scope question shown on HITL / handoff evidence.
+	Question string
+	// Evidence is optional structured handoff text (authority conflict, etc.).
+	Evidence string
+	DB       *sql.DB
+}
+
+// ParkReviewScopeHuman parks the held role and pauses same-lane siblings for a
+// needs_human scope decision. Does not use budget Continue/Stop refill semantics.
+func ParkReviewScopeHuman(ctx context.Context, repos *storage.Repositories, input ParkReviewScopeHumanInput) (storage.LoopRecord, error) {
+	if repos == nil || repos.Loops == nil {
+		return input.Held, fmt.Errorf("review scope park requires loop storage")
+	}
+	if input.DB != nil {
+		var parked storage.LoopRecord
+		err := storage.WithTransaction(ctx, input.DB, nil, func(tx *sql.Tx) error {
+			var parkErr error
+			parked, parkErr = parkReviewScopeHumanBody(ctx, storage.NewRepositories(tx), input)
+			return parkErr
+		})
+		return parked, err
+	}
+	return parkReviewScopeHumanBody(ctx, repos, input)
+}
+
+func parkReviewScopeHumanBody(ctx context.Context, repos *storage.Repositories, input ParkReviewScopeHumanInput) (storage.LoopRecord, error) {
+	held := input.Held
+	if fresh, err := repos.Loops.GetByID(ctx, held.ID); err == nil && fresh != nil {
+		held = *fresh
+	}
+	if isReviewScopeHumanPrimaryHold(held) {
+		if err := finishReviewScopeHumanPark(ctx, repos, held, input.Role, input.NowISO); err != nil {
+			return held, err
+		}
+		if err := ensureReviewScopeHumanHandoffEvent(ctx, repos, held, input); err != nil {
+			return held, err
+		}
+		return held, nil
+	}
+
+	if err := cancelReviewScopeHumanQueues(ctx, repos, held, input.NowISO); err != nil {
+		return input.Held, err
+	}
+	if err := parkSiblingReviewScopeHumanLoop(ctx, repos, held, input.Role, input.NowISO); err != nil {
+		return input.Held, err
+	}
+
+	role := strings.TrimSpace(input.Role)
+	state := ReadReviewScopeHumanState(held.MetadataJSON)
+	state.HeldBy = role
+	state.Question = strings.TrimSpace(input.Question)
+	if e := strings.TrimSpace(input.Evidence); e != "" {
+		state.Evidence = e
+	}
+	// Promoting from deferred budget path: clear pending markers.
+	state.Pending = false
+	state.PendingHITL = false
+	state.PauseReason = ""
+	if !input.HITLEnabled {
+		state.PauseReason = ReviewScopeHumanRequiredReason
+	}
+	metadata, err := WriteReviewScopeHumanState(held.MetadataJSON, state)
+	if err != nil {
+		return input.Held, err
+	}
+	if input.HITLEnabled {
+		ask := NewReviewScopeHumanAsk(input.Role, input.Repo, input.PRNumber, input.Question, input.NowISO)
+		metadata, err = WriteHITLAsk(&metadata, ask)
+		if err != nil {
+			return input.Held, err
+		}
+		held.Status = "awaiting_human"
+	} else {
+		if ask, ok := ReadHITLAsk(&metadata); ok && IsReviewScopeHumanAsk(ask) {
+			cleared, clearErr := ClearHITLAsk(&metadata)
+			if clearErr != nil {
+				return input.Held, clearErr
+			}
+			metadata = cleared
+		}
+		meta := parseMetadataObject(&metadata)
+		meta["pauseReason"] = ReviewScopeHumanRequiredReason
+		encoded, marshalErr := json.Marshal(meta)
+		if marshalErr != nil {
+			return input.Held, marshalErr
+		}
+		metadata = string(encoded)
+		held.Status = "paused"
+	}
+	held.MetadataJSON = &metadata
+	held.NextRunAt = nil
+	held.UpdatedAt = input.NowISO
+	if err := repos.Loops.Upsert(ctx, held); err != nil {
+		return input.Held, err
+	}
+	if repos.Queue != nil {
+		reason := ReviewScopeHumanRequiredReason
+		if _, err := repos.Queue.CancelByLoop(ctx, held.ID, input.NowISO, &reason); err != nil {
+			return held, err
+		}
+	}
+	if err := ensureReviewScopeHumanHandoffEvent(ctx, repos, held, input); err != nil {
+		return held, err
+	}
+	return held, nil
+}
+
+func isReviewScopeHumanPrimaryHold(loop storage.LoopRecord) bool {
+	switch strings.TrimSpace(loop.Status) {
+	case "awaiting_human":
+		ask, ok := ReadHITLAsk(loop.MetadataJSON)
+		return ok && IsReviewScopeHumanAsk(ask)
+	case "paused":
+		return IsReviewScopeHumanRequiredPause(loop.MetadataJSON) ||
+			(strings.TrimSpace(ReadReviewScopeHumanState(loop.MetadataJSON).HeldBy) != "" && !IsSiblingReviewScopeHumanPause(loop.MetadataJSON))
+	default:
+		return false
+	}
+}
+
+func finishReviewScopeHumanPark(ctx context.Context, repos *storage.Repositories, held storage.LoopRecord, heldBy, nowISO string) error {
+	if err := cancelReviewScopeHumanQueues(ctx, repos, held, nowISO); err != nil {
+		return err
+	}
+	return parkSiblingReviewScopeHumanLoop(ctx, repos, held, heldBy, nowISO)
+}
+
+func cancelReviewScopeHumanQueues(ctx context.Context, repos *storage.Repositories, held storage.LoopRecord, nowISO string) error {
+	if repos.Queue == nil {
+		return nil
+	}
+	reason := ReviewScopeHumanRequiredReason
+	if _, err := repos.Queue.CancelByLoop(ctx, held.ID, nowISO, &reason); err != nil {
+		return err
+	}
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	siblingReason := ReviewScopeHumanSiblingPauseReason
+	for _, sibling := range FindSiblingReviewFixLoops(all, held) {
+		if !isReviewScopeSiblingHoldApplicable(sibling.Status) {
+			continue
+		}
+		if _, err := repos.Queue.CancelByLoop(ctx, sibling.ID, nowISO, &siblingReason); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parkSiblingReviewScopeHumanLoop(ctx context.Context, repos *storage.Repositories, held storage.LoopRecord, heldBy, nowISO string) error {
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, sibling := range FindSiblingReviewFixLoops(all, held) {
+		if err := parkOneSiblingReviewScopeHumanLoop(ctx, repos, sibling, heldBy, nowISO); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isReviewScopeSiblingHoldApplicable is true for every non-terminal opposite-role
+// sibling. Unlike budget park, failed/interrupted/awaiting_human/independently
+// paused siblings still receive scope hold metadata so independent resume is gated.
+func isReviewScopeSiblingHoldApplicable(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "terminated", "stopped", "completed":
+		return false
+	default:
+		return true
+	}
+}
+
+func parkOneSiblingReviewScopeHumanLoop(ctx context.Context, repos *storage.Repositories, sibling storage.LoopRecord, heldBy, nowISO string) error {
+	if !isReviewScopeSiblingHoldApplicable(sibling.Status) {
+		return nil
+	}
+	// Already carrying sibling scope hold: refresh queue cancel only.
+	if IsSiblingReviewScopeHumanPause(sibling.MetadataJSON) && strings.TrimSpace(ReadReviewScopeHumanState(sibling.MetadataJSON).HeldBy) != "" {
+		if repos.Queue != nil {
+			reason := ReviewScopeHumanSiblingPauseReason
+			if _, err := repos.Queue.CancelByLoop(ctx, sibling.ID, nowISO, &reason); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	state := ReadReviewScopeHumanState(sibling.MetadataJSON)
+	state.HeldBy = strings.TrimSpace(heldBy)
+	state.PauseReason = ReviewScopeHumanSiblingPauseReason
+	metadata, err := WriteReviewScopeHumanState(sibling.MetadataJSON, state)
+	if err != nil {
+		return err
+	}
+	updated := sibling
+	updated.MetadataJSON = &metadata
+	updated.UpdatedAt = nowISO
+	// Preserve mid-run HITL asks and non-runnable terminal-ish statuses; only
+	// flip actively schedulable statuses to paused with a top-level pauseReason.
+	switch strings.TrimSpace(sibling.Status) {
+	case "awaiting_human", "failed", "interrupted", "human_takeover":
+		// Keep status and any existing HITL ask body; metadata gates resume.
+		updated.NextRunAt = nil
+	case "paused":
+		// Keep paused. Scope overlay lives only in reviewScopeHuman metadata
+		// (HeldBy / state.PauseReason). Never stamp top-level pauseReason —
+		// manual pause has no reason and must not become scope-primary on Continue.
+		updated.NextRunAt = nil
+	default:
+		// Schedulable → paused with scope sibling as the primary top-level reason.
+		// Continue may requeue only when this top-level stamp is cleared.
+		meta := parseMetadataObject(&metadata)
+		meta["pauseReason"] = ReviewScopeHumanSiblingPauseReason
+		encoded, marshalErr := json.Marshal(meta)
+		if marshalErr != nil {
+			return marshalErr
+		}
+		text := string(encoded)
+		updated.MetadataJSON = &text
+		updated.Status = "paused"
+		updated.NextRunAt = nil
+	}
+	if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		return err
+	}
+	if repos.Queue != nil {
+		reason := ReviewScopeHumanSiblingPauseReason
+		if _, err := repos.Queue.CancelByLoop(ctx, updated.ID, nowISO, &reason); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureReviewScopeHumanHandoffEvent(ctx context.Context, repos *storage.Repositories, held storage.LoopRecord, input ParkReviewScopeHumanInput) error {
+	if repos == nil || repos.Events == nil {
+		return nil
+	}
+	state := ReadReviewScopeHumanState(held.MetadataJSON)
+	if strings.TrimSpace(state.HandoffEventAt) != "" {
+		return nil
+	}
+	if err := appendReviewScopeHumanHandoffEvent(ctx, repos, held, input); err != nil {
+		return err
+	}
+	state = ReadReviewScopeHumanState(held.MetadataJSON)
+	state.HandoffEventAt = input.NowISO
+	encoded, err := WriteReviewScopeHumanState(held.MetadataJSON, state)
+	if err != nil {
+		return err
+	}
+	updated := held
+	updated.MetadataJSON = &encoded
+	updated.UpdatedAt = input.NowISO
+	return repos.Loops.Upsert(ctx, updated)
+}
+
+func appendReviewScopeHumanHandoffEvent(ctx context.Context, repos *storage.Repositories, held storage.LoopRecord, input ParkReviewScopeHumanInput) error {
+	if repos == nil || repos.Events == nil {
+		return nil
+	}
+	lane := reviewFixBudgetLane(held)
+	resume := reviewFixBudgetHandoffResume(held, input.HITLEnabled)
+	projectID := strings.TrimSpace(held.ProjectID)
+	loopID := strings.TrimSpace(held.ID)
+	payload := map[string]any{
+		"level":       "action_required",
+		"kind":        HITLKindReviewScopeHuman,
+		"repo":        strings.TrimSpace(input.Repo),
+		"prNumber":    input.PRNumber,
+		"lane":        lane,
+		"heldBy":      strings.TrimSpace(input.Role),
+		"reason":      ReviewScopeHumanRequiredReason,
+		"hitlEnabled": input.HITLEnabled,
+		"resume":      resume,
+		"question":    strings.TrimSpace(input.Question),
+	}
+	if evidence := strings.TrimSpace(input.Evidence); evidence != "" {
+		payload["evidence"] = evidence
+	}
+	if head := reviewFixBudgetHandoffHead(held); head != "" {
+		payload["head"] = head
+	}
+	return eventlog.Append(ctx, repos, eventlog.AppendInput{
+		EventType:  reviewScopeHumanHandoffEventType,
+		ProjectID:  optionalBudgetString(projectID),
+		LoopID:     optionalBudgetString(loopID),
+		EntityType: optionalBudgetString("loop"),
+		EntityID:   optionalBudgetString(loopID),
+		ActorType:  optionalBudgetString("system"),
+		ActorID:    optionalBudgetString("review-scope-human"),
+		Payload:    payload,
+	})
+}
+
+type ReviewScopeHumanAnswerResult struct {
+	Applied bool
+	Action  string
+	Loop    storage.LoopRecord
+}
+
+// ApplyReviewScopeHumanAnswer handles Continue (release pair, no meter reset) or
+// Stop (terminate both). Returns Applied=false when not a scope hold.
+func ApplyReviewScopeHumanAnswer(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string) (ReviewScopeHumanAnswerResult, error) {
+	if !IsReviewScopeHumanHold(loop) {
+		return ReviewScopeHumanAnswerResult{}, nil
+	}
+	if repos == nil || repos.Loops == nil {
+		return ReviewScopeHumanAnswerResult{}, fmt.Errorf("review scope answer requires loop storage")
+	}
+	if IsReviewFixBudgetStop(answer) {
+		updated, err := terminateReviewFixPair(ctx, repos, loop, nowISO, ReviewScopeHumanRequiredReason)
+		if err != nil {
+			return ReviewScopeHumanAnswerResult{}, err
+		}
+		return ReviewScopeHumanAnswerResult{Applied: true, Action: "stop", Loop: updated}, nil
+	}
+	if !IsReviewFixBudgetContinue(answer) {
+		return ReviewScopeHumanAnswerResult{}, ErrReviewScopeHumanInvalidAnswer
+	}
+	updated, err := continueReviewScopeHuman(ctx, repos, loop, nowISO)
+	if err != nil {
+		return ReviewScopeHumanAnswerResult{}, err
+	}
+	return ReviewScopeHumanAnswerResult{Applied: true, Action: "continue", Loop: updated}, nil
+}
+
+func continueReviewScopeHuman(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, nowISO string) (storage.LoopRecord, error) {
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return loop, err
+	}
+	members := reviewFixBudgetPairMembers(all, loop)
+
+	// Release answered side first; do not touch role meters.
+	if err := releaseOneReviewScopeHumanHold(ctx, repos, loop.ID, nowISO); err != nil {
+		return loop, err
+	}
+	for _, member := range members {
+		if member.ID == loop.ID {
+			continue
+		}
+		if err := releaseOneReviewScopeHumanHold(ctx, repos, member.ID, nowISO); err != nil {
+			return loop, err
+		}
+	}
+	fresh, err := repos.Loops.GetByID(ctx, loop.ID)
+	if err != nil {
+		return loop, err
+	}
+	if fresh == nil {
+		return loop, fmt.Errorf("review scope continue lost loop %s", loop.ID)
+	}
+	return *fresh, nil
+}
+
+func releaseOneReviewScopeHumanHold(ctx context.Context, repos *storage.Repositories, loopID, nowISO string) error {
+	fresh, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return err
+	}
+	if fresh == nil {
+		return nil
+	}
+	if !IsReviewScopeHumanHold(*fresh) {
+		return nil
+	}
+	priorStatus := strings.TrimSpace(fresh.Status)
+	metadata := fresh.MetadataJSON
+	if ask, ok := ReadHITLAsk(metadata); ok && IsReviewScopeHumanAsk(ask) {
+		cleared, clearErr := ClearHITLAsk(metadata)
+		if clearErr != nil {
+			return clearErr
+		}
+		metadata = &cleared
+	}
+	state := ReadReviewScopeHumanState(metadata)
+	state.HeldBy = ""
+	state.Question = ""
+	state.Evidence = ""
+	state.Pending = false
+	state.PendingHITL = false
+	if state.PauseReason == ReviewScopeHumanSiblingPauseReason || state.PauseReason == ReviewScopeHumanRequiredReason {
+		state.PauseReason = ""
+	}
+	// Clear handoff marker so a later park emits a fresh event.
+	state.HandoffEventAt = ""
+	encoded, err := WriteReviewScopeHumanState(metadata, state)
+	if err != nil {
+		return err
+	}
+	meta := parseMetadataObject(&encoded)
+	// Queue only when scope was the primary top-level reason (park flipped a
+	// schedulable loop to paused with sibling/required stamp). Manual pause and
+	// independent reasons never receive that stamp.
+	clearedScopeTopLevel := false
+	if reason, _ := stringFromAny(meta["pauseReason"]); reason == ReviewScopeHumanSiblingPauseReason || reason == ReviewScopeHumanRequiredReason {
+		delete(meta, "pauseReason")
+		clearedScopeTopLevel = true
+	}
+	out, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	text := string(out)
+	updated := *fresh
+	updated.MetadataJSON = &text
+	updated.UpdatedAt = nowISO
+
+	// Preserve a non-scope mid-run HITL ask; do not force-queue over it.
+	if ask, ok := ReadHITLAsk(&text); ok && strings.TrimSpace(ask.Status) == "awaiting" {
+		updated.Status = "awaiting_human"
+		updated.NextRunAt = nil
+		return repos.Loops.Upsert(ctx, updated)
+	}
+	// human_takeover and non-runnable terminal-ish statuses stay put.
+	switch priorStatus {
+	case "human_takeover", "failed", "interrupted":
+		updated.Status = priorStatus
+		updated.NextRunAt = nil
+		return repos.Loops.Upsert(ctx, updated)
+	}
+
+	// After clearing only the scope overlay, restore any independent lifecycle
+	// that remains (budget hold, other pauseReason). Only queue when scope was
+	// the primary reason the loop was non-runnable.
+	updated.Status = priorStatus
+	if IsReviewFixBudgetHold(updated) {
+		if priorStatus != "paused" && priorStatus != "awaiting_human" {
+			updated.Status = "paused"
+		}
+		updated.NextRunAt = nil
+		return repos.Loops.Upsert(ctx, updated)
+	}
+	if reason, ok := stringFromAny(meta["pauseReason"]); ok && reason != "" {
+		// Independent non-scope pause (budget, fixer_zero_progress, etc.).
+		updated.Status = "paused"
+		updated.NextRunAt = nil
+		return repos.Loops.Upsert(ctx, updated)
+	}
+	// Already paused without a top-level scope stamp we just cleared: manual
+	// pause (empty pauseReason) or overlay-only sibling — stay paused.
+	if priorStatus == "paused" && !clearedScopeTopLevel {
+		updated.Status = "paused"
+		updated.NextRunAt = nil
+		return repos.Loops.Upsert(ctx, updated)
+	}
+
+	updated.Status = "queued"
+	updated.NextRunAt = &nowISO
+	if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		return err
+	}
+	return requeueReviewFixBudgetLoop(ctx, repos, updated.ID, nowISO)
+}

--- a/internal/loops/review_scope_hold.go
+++ b/internal/loops/review_scope_hold.go
@@ -34,6 +34,22 @@ var ErrReviewScopeHumanInvalidAnswer = fmt.Errorf("review scope answer must be %
 // ReviewScopeHumanState is durable pair-hold metadata for needs_human scope holds.
 // It does not store role meters; Continue must not refill budgets.
 //
+// Failure it prevents: dropping needs_human (or treating it as follow_up) lets
+// Fixer edit without the required authority input. A prompt-only or in-memory
+// park cannot survive claim finalization, budget Continue, or daemon restart.
+//
+// Costs: pending vs active hold, pair metadata, handoff markers, promotion
+// after budget release, and overlay on failed/awaiting siblings. Those paths
+// can disagree with live status if a later layer overwrites the park.
+//
+// Why simpler alternatives are insufficient:
+//   - Delete the hold and trust the agent: needs_human would vanish and Fixer
+//     would edit. Spec forbids suppress-and-continue.
+//   - Fail loud / terminate: operators cannot Continue against clarified
+//     evidence; the pair would need a new loop.
+//   - Reuse budget hold state: Continue would refill meters for a scope
+//     decision that is not a cap exhaustion.
+//
 // Pending marks deferred scope evidence while a budget hold is the sole primary
 // hold (no status/ask change). After budget Continue releases the pair, pending
 // is promoted to a real scope park.

--- a/internal/loops/review_scope_hold_test.go
+++ b/internal/loops/review_scope_hold_test.go
@@ -1,0 +1,378 @@
+package loops
+
+import (
+	"context"
+	"testing"
+)
+
+func TestParkAndContinueReviewScopeHumanDoesNotResetMeters(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_reviewer", "reviewer", "running")
+	// iterationCount 2 with cap 8 — not budget-exhausted.
+	meta := `{"loop":{"iterationCount":2},"reviewFixBudget":{"pushCount":1}}`
+	reviewer.MetadataJSON = &meta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("upsert reviewer: %v", err)
+	}
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_fixer", "fixer", "queued")
+	fixerMeta := `{"reviewFixBudget":{"pushCount":1}}`
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("upsert fixer: %v", err)
+	}
+
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: false,
+		Question: "Is this in PR scope?",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman() error = %v", err)
+	}
+	if parked.Status != "paused" || !IsReviewScopeHumanRequiredPause(parked.MetadataJSON) {
+		t.Fatalf("parked = %#v, want no-ask scope pause", parked)
+	}
+	if IsReviewFixBudgetHold(parked) {
+		t.Fatal("scope hold must not report as budget hold")
+	}
+	if !IsReviewFixPairHold(parked) {
+		t.Fatal("scope hold must report as pair hold")
+	}
+	if ReviewerPublishCount(parked.MetadataJSON) != 2 {
+		t.Fatalf("publish count = %d, want 2 preserved through park", ReviewerPublishCount(parked.MetadataJSON))
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !IsSiblingReviewScopeHumanPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling = (%#v, %v), want scope sibling pause", sibling, err)
+	}
+
+	result, err := ApplyReviewScopeHumanAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("ApplyReviewScopeHumanAnswer() = (%#v, %v)", result, err)
+	}
+	if ReviewerPublishCount(result.Loop.MetadataJSON) != 2 {
+		t.Fatalf("after continue publish count = %d, want 2 (no meter reset)", ReviewerPublishCount(result.Loop.MetadataJSON))
+	}
+	if FixerPushCount(result.Loop.MetadataJSON) != 1 && FixerPushCount(sibling.MetadataJSON) != 1 {
+		// Fixer meter lives on fixer loop.
+	}
+	freshFixer, _ := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if freshFixer == nil || FixerPushCount(freshFixer.MetadataJSON) != 1 {
+		t.Fatalf("fixer push count after scope continue = %#v, want 1 preserved", freshFixer)
+	}
+	if result.Loop.Status != "queued" || IsReviewScopeHumanHold(result.Loop) {
+		t.Fatalf("continued loop = %#v, want queued and released", result.Loop)
+	}
+	if freshFixer.Status != "queued" || IsReviewScopeHumanHold(*freshFixer) {
+		t.Fatalf("sibling after continue = %#v, want queued and released", freshFixer)
+	}
+}
+
+func TestParkReviewScopeHumanHITLAskNotBudgetKind(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_hitl_reviewer", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_hitl_fixer", "fixer", "queued")
+	_ = fixer
+
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Does AGENTS.md require this change?",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman() error = %v", err)
+	}
+	if parked.Status != "awaiting_human" {
+		t.Fatalf("status = %s, want awaiting_human", parked.Status)
+	}
+	ask, ok := ReadHITLAsk(parked.MetadataJSON)
+	if !ok || !IsReviewScopeHumanAsk(ask) || IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want scope kind not budget", ask, ok)
+	}
+	if ask.Question == "" || len(ask.Options) != 2 {
+		t.Fatalf("ask = %#v, want question and Continue/Stop options", ask)
+	}
+	if IsReviewFixBudgetHold(parked) {
+		t.Fatal("HITL scope hold must not be a budget hold")
+	}
+}
+
+func TestIsReviewFixBudgetHoldExcludesPureScopeHold(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_only", "reviewer", "running")
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	if IsReviewFixBudgetHold(parked) {
+		t.Fatal("IsReviewFixBudgetHold must be false for pure scope hold")
+	}
+	if !IsReviewScopeHumanHold(parked) || !IsReviewFixPairHold(parked) {
+		t.Fatal("want scope + pair hold")
+	}
+}
+
+func TestParkReviewScopeHumanHoldsFailedAndAwaitingHumanSiblings(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_sib_reviewer", "reviewer", "running")
+
+	// Failed fixer sibling must still receive scope hold metadata.
+	failedFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_sib_failed", "fixer", "failed")
+	// Awaiting-human fixer with a mid-run (non-scope) ask must keep the ask body.
+	awaitingFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_sib_awaiting", "fixer", "awaiting_human")
+	// Use a distinct PR so FindSibling only pairs same PR — seed both on same PR as reviewer.
+	// seedBudgetLoop already uses same repo/PR; having two fixers is ok for the hold check.
+	midAsk := HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO, PRNumber: 42,
+	}
+	meta, err := WriteHITLAsk(awaitingFixer.MetadataJSON, midAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk: %v", err)
+	}
+	awaitingFixer.MetadataJSON = &meta
+	if err := repos.Loops.Upsert(context.Background(), awaitingFixer); err != nil {
+		t.Fatalf("upsert awaiting fixer: %v", err)
+	}
+
+	// Park with only one sibling at a time is not required — park finds all siblings.
+	// First park against failed-only pair: remove awaiting temporarily by using failed only.
+	// Both are siblings of reviewer (same lane/PR).
+	_, err = ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause; finding: ambiguous scope",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	freshFailed, err := repos.Loops.GetByID(context.Background(), failedFixer.ID)
+	if err != nil || freshFailed == nil {
+		t.Fatalf("failed sibling get: (%#v, %v)", freshFailed, err)
+	}
+	if freshFailed.Status != "failed" {
+		t.Fatalf("failed sibling status = %s, want failed preserved", freshFailed.Status)
+	}
+	if !IsReviewFixPairHold(*freshFailed) || !IsReviewScopeHumanHold(*freshFailed) {
+		t.Fatalf("failed sibling must be pair/scope hold: %#v meta=%v", freshFailed, derefMeta(freshFailed.MetadataJSON))
+	}
+
+	freshAwaiting, err := repos.Loops.GetByID(context.Background(), awaitingFixer.ID)
+	if err != nil || freshAwaiting == nil {
+		t.Fatalf("awaiting sibling get: (%#v, %v)", freshAwaiting, err)
+	}
+	if freshAwaiting.Status != "awaiting_human" {
+		t.Fatalf("awaiting sibling status = %s, want awaiting_human preserved", freshAwaiting.Status)
+	}
+	ask, ok := ReadHITLAsk(freshAwaiting.MetadataJSON)
+	if !ok || ask.Question != midAsk.Question || IsReviewScopeHumanAsk(ask) {
+		t.Fatalf("mid-run ask lost or replaced: ok=%v ask=%#v", ok, ask)
+	}
+	if !IsReviewFixPairHold(*freshAwaiting) {
+		t.Fatalf("awaiting sibling must refuse independent resume via pair hold: %#v", freshAwaiting)
+	}
+}
+
+func TestContinueReviewScopeHumanPreservesIndependentAndBudgetSiblingLifecycle(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_cont_rev", "reviewer", "running")
+
+	// Ordinary queued sibling → requeued after scope Continue.
+	queuedFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_cont_queued", "fixer", "queued")
+
+	// Budget-paused sibling must stay paused + budget-held after scope Continue.
+	budgetFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_cont_budget", "fixer", "paused")
+	budgetMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"reviewer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	budgetFixer.MetadataJSON = &budgetMeta
+	if err := repos.Loops.Upsert(context.Background(), budgetFixer); err != nil {
+		t.Fatalf("upsert budget fixer: %v", err)
+	}
+
+	// Independently paused sibling keeps its pauseReason and stays paused.
+	indepFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_cont_indep", "fixer", "paused")
+	indepMeta := `{"pauseReason":"fixer_zero_progress"}`
+	indepFixer.MetadataJSON = &indepMeta
+	if err := repos.Loops.Upsert(context.Background(), indepFixer); err != nil {
+		t.Fatalf("upsert indep fixer: %v", err)
+	}
+
+	// Failed sibling keeps failed.
+	failedFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_cont_failed", "fixer", "failed")
+
+	// Park against reviewer; all same-lane fixers are siblings.
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: false,
+		Question: "Clarify scope",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	result, err := ApplyReviewScopeHumanAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("Continue = (%#v, %v)", result, err)
+	}
+	if result.Loop.Status != "queued" || IsReviewScopeHumanHold(result.Loop) {
+		t.Fatalf("reviewer after continue = %#v, want queued and released", result.Loop)
+	}
+
+	freshQueued, err := repos.Loops.GetByID(context.Background(), queuedFixer.ID)
+	if err != nil || freshQueued == nil || freshQueued.Status != "queued" || IsReviewScopeHumanHold(*freshQueued) {
+		t.Fatalf("queued sibling after continue = (%#v, %v), want queued and released", freshQueued, err)
+	}
+
+	freshBudget, err := repos.Loops.GetByID(context.Background(), budgetFixer.ID)
+	if err != nil || freshBudget == nil {
+		t.Fatalf("budget sibling get: (%#v, %v)", freshBudget, err)
+	}
+	if freshBudget.Status != "paused" || !IsReviewFixBudgetHold(*freshBudget) {
+		t.Fatalf("budget sibling after continue = %#v, want paused + budget hold", freshBudget)
+	}
+	if IsReviewScopeHumanHold(*freshBudget) {
+		t.Fatalf("budget sibling still has scope hold: %#v", freshBudget)
+	}
+	if reason, _ := stringFromAny(parseMetadataObject(freshBudget.MetadataJSON)["pauseReason"]); reason != ReviewFixBudgetPauseReason {
+		t.Fatalf("budget sibling pauseReason = %q, want %q", reason, ReviewFixBudgetPauseReason)
+	}
+
+	freshIndep, err := repos.Loops.GetByID(context.Background(), indepFixer.ID)
+	if err != nil || freshIndep == nil || freshIndep.Status != "paused" {
+		t.Fatalf("indep sibling after continue = (%#v, %v), want paused", freshIndep, err)
+	}
+	if IsReviewScopeHumanHold(*freshIndep) {
+		t.Fatalf("indep sibling still has scope hold: %#v", freshIndep)
+	}
+	if reason, _ := stringFromAny(parseMetadataObject(freshIndep.MetadataJSON)["pauseReason"]); reason != "fixer_zero_progress" {
+		t.Fatalf("indep sibling pauseReason = %q, want fixer_zero_progress", reason)
+	}
+
+	freshFailed, err := repos.Loops.GetByID(context.Background(), failedFixer.ID)
+	if err != nil || freshFailed == nil || freshFailed.Status != "failed" {
+		t.Fatalf("failed sibling after continue = (%#v, %v), want failed", freshFailed, err)
+	}
+	if IsReviewScopeHumanHold(*freshFailed) {
+		t.Fatalf("failed sibling still has scope hold: %#v", freshFailed)
+	}
+}
+
+func TestContinueReviewScopeHumanKeepsManuallyPausedSiblingPaused(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_manual_rev", "reviewer", "running")
+
+	// Manual pause: status=paused, no pauseReason (mutateLoopStatus shape).
+	manualFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_manual_fixer", "fixer", "paused")
+	manualMeta := `{"loop":{"iterationCount":0}}`
+	manualFixer.MetadataJSON = &manualMeta
+	if err := repos.Loops.Upsert(context.Background(), manualFixer); err != nil {
+		t.Fatalf("upsert manual fixer: %v", err)
+	}
+
+	// Budget-paused sibling must still stay budget-held after scope Continue.
+	budgetFixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_manual_budget", "fixer", "paused")
+	budgetMeta := `{"loop":{"iterationCount":0},"reviewFixBudget":{"siblingOf":"reviewer","pauseReason":"sibling_review_fix_budget"},"pauseReason":"sibling_review_fix_budget"}`
+	budgetFixer.MetadataJSON = &budgetMeta
+	if err := repos.Loops.Upsert(context.Background(), budgetFixer); err != nil {
+		t.Fatalf("upsert budget fixer: %v", err)
+	}
+
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: false,
+		Question: "Clarify scope",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+
+	// Manual sibling must carry scope overlay without a top-level scope stamp.
+	freshManual, err := repos.Loops.GetByID(context.Background(), manualFixer.ID)
+	if err != nil || freshManual == nil {
+		t.Fatalf("manual sibling get: (%#v, %v)", freshManual, err)
+	}
+	if freshManual.Status != "paused" {
+		t.Fatalf("manual sibling status after park = %s, want paused", freshManual.Status)
+	}
+	if reason, _ := stringFromAny(parseMetadataObject(freshManual.MetadataJSON)["pauseReason"]); reason != "" {
+		t.Fatalf("manual sibling top-level pauseReason = %q, want empty (overlay only)", reason)
+	}
+	if !IsReviewScopeHumanHold(*freshManual) {
+		t.Fatalf("manual sibling must be scope-held via overlay: %#v", freshManual)
+	}
+
+	result, err := ApplyReviewScopeHumanAnswer(context.Background(), repos, parked, "Continue", nowISO)
+	if err != nil || !result.Applied || result.Action != "continue" {
+		t.Fatalf("Continue = (%#v, %v)", result, err)
+	}
+
+	freshManual, err = repos.Loops.GetByID(context.Background(), manualFixer.ID)
+	if err != nil || freshManual == nil {
+		t.Fatalf("manual sibling after continue get: (%#v, %v)", freshManual, err)
+	}
+	if freshManual.Status != "paused" {
+		t.Fatalf("manual sibling after continue = %#v, want paused (not queued)", freshManual)
+	}
+	if IsReviewScopeHumanHold(*freshManual) {
+		t.Fatalf("manual sibling still has scope hold after continue: %#v", freshManual)
+	}
+
+	freshBudget, err := repos.Loops.GetByID(context.Background(), budgetFixer.ID)
+	if err != nil || freshBudget == nil {
+		t.Fatalf("budget sibling get: (%#v, %v)", freshBudget, err)
+	}
+	if freshBudget.Status != "paused" || !IsReviewFixBudgetHold(*freshBudget) {
+		t.Fatalf("budget sibling after continue = %#v, want paused + budget hold", freshBudget)
+	}
+}
+
+func TestApplyReviewScopeHumanStopUsesScopeTerminationReason(t *testing.T) {
+	t.Parallel()
+	repos, nowISO := newBudgetFixture(t)
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_stop_reviewer", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_stop_fixer", "fixer", "queued")
+	_ = fixer
+
+	parked, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify scope",
+	})
+	if err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	result, err := ApplyReviewScopeHumanAnswer(context.Background(), repos, parked, "Stop", nowISO)
+	if err != nil || !result.Applied || result.Action != "stop" {
+		t.Fatalf("Stop = (%#v, %v)", result, err)
+	}
+	if result.Loop.Status != "terminated" {
+		t.Fatalf("status = %s, want terminated", result.Loop.Status)
+	}
+	meta := parseMetadataObject(result.Loop.MetadataJSON)
+	loopMeta, _ := meta["loop"].(map[string]any)
+	if loopMeta == nil {
+		t.Fatalf("missing loop metadata: %#v", meta)
+	}
+	if got, _ := loopMeta["terminationReason"].(string); got != ReviewScopeHumanRequiredReason {
+		t.Fatalf("terminationReason = %q, want %q (not budget exhausted)", got, ReviewScopeHumanRequiredReason)
+	}
+	if got, _ := loopMeta["terminationReason"].(string); got == ReviewFixBudgetTerminationReason {
+		t.Fatal("scope Stop must not write review_fix_budget_exhausted")
+	}
+}
+
+func derefMeta(m *string) string {
+	if m == nil {
+		return ""
+	}
+	return *m
+}

--- a/internal/loops/review_scope_hold_test.go
+++ b/internal/loops/review_scope_hold_test.go
@@ -3,6 +3,8 @@ package loops
 import (
 	"context"
 	"testing"
+
+	"github.com/nexu-io/looper/internal/storage"
 )
 
 func TestParkAndContinueReviewScopeHumanDoesNotResetMeters(t *testing.T) {
@@ -367,6 +369,115 @@ func TestApplyReviewScopeHumanStopUsesScopeTerminationReason(t *testing.T) {
 	}
 	if got, _ := loopMeta["terminationReason"].(string); got == ReviewFixBudgetTerminationReason {
 		t.Fatal("scope Stop must not write review_fix_budget_exhausted")
+	}
+}
+
+func TestBudgetContinueRestoresScopePausedSiblingInsteadOfQueueing(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		budgetHITL bool
+		wantBudget string
+	}{
+		{name: "awaiting_human_budget_ask", budgetHITL: true, wantBudget: "awaiting_human"},
+		{name: "paused_nohitl_budget", budgetHITL: false, wantBudget: "paused"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			repos, nowISO := newBudgetFixture(t)
+			suffix := tc.name
+			reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_budget_ord_rev_"+suffix, "reviewer", "running")
+			fixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_budget_ord_fix_"+suffix, "fixer", "queued")
+			reviewerQueueID := "queue_scope_budget_ord_rev_" + suffix
+			fixerQueueID := "queue_scope_budget_ord_fix_" + suffix
+			seedBudgetQueue(t, repos, nowISO, reviewerQueueID, reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+			seedBudgetQueue(t, repos, nowISO, fixerQueueID, fixer.ID, "fixer", storage.QueuePriorityFixer)
+
+			parkedFixer, err := ParkReviewFixBudget(context.Background(), repos, ParkReviewFixBudgetInput{
+				Exhausted: fixer, Role: "fixer", Repo: "acme/looper", PRNumber: 42,
+				Count: 8, Cap: 8, NowISO: nowISO, HITLEnabled: tc.budgetHITL,
+			})
+			if err != nil {
+				t.Fatalf("ParkReviewFixBudget: %v", err)
+			}
+			if parkedFixer.Status != tc.wantBudget || !IsReviewFixBudgetHold(parkedFixer) {
+				t.Fatalf("budget fixer = %#v, want status %s + budget hold", parkedFixer, tc.wantBudget)
+			}
+
+			freshReviewer, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+			if err != nil || freshReviewer == nil {
+				t.Fatalf("reviewer after budget park: (%#v, %v)", freshReviewer, err)
+			}
+			parkedReviewer, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+				Held: *freshReviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+				NowISO: nowISO, HITLEnabled: true,
+				Question: "Clarify AGENTS.md rule X before unpause; finding: ambiguous scope",
+			})
+			if err != nil {
+				t.Fatalf("ParkReviewScopeHuman: %v", err)
+			}
+			if !IsReviewScopeHumanHold(parkedReviewer) || IsReviewFixBudgetHold(parkedReviewer) {
+				t.Fatalf("reviewer after scope park = %#v, want scope-only hold", parkedReviewer)
+			}
+
+			overlaid, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+			if err != nil || overlaid == nil {
+				t.Fatalf("fixer after overlay: (%#v, %v)", overlaid, err)
+			}
+			if overlaid.Status != tc.wantBudget || !IsReviewFixBudgetHold(*overlaid) || !IsReviewScopeHumanHold(*overlaid) {
+				t.Fatalf("overlaid fixer = %#v meta=%s, want preserved budget status + scope overlay", overlaid, derefMeta(overlaid.MetadataJSON))
+			}
+			if ask, ok := ReadHITLAsk(overlaid.MetadataJSON); tc.budgetHITL && (!ok || !IsReviewFixBudgetAsk(ask)) {
+				t.Fatalf("overlaid fixer ask = (%#v, %v), want preserved budget ask", ask, ok)
+			}
+
+			result, err := ApplyReviewFixBudgetAnswer(context.Background(), repos, *overlaid, "Continue", nowISO, testBudgetCaps(8, 8))
+			if err != nil || !result.Applied || result.Action != "continue" {
+				t.Fatalf("budget Continue = (%#v, %v)", result, err)
+			}
+
+			freshFixer, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+			if err != nil || freshFixer == nil {
+				t.Fatalf("fixer after budget Continue: (%#v, %v)", freshFixer, err)
+			}
+			if freshFixer.Status == "queued" {
+				t.Fatalf("fixer queued after budget Continue while scope overlay remains: %#v", freshFixer)
+			}
+			if freshFixer.Status != "paused" || IsReviewFixBudgetHold(*freshFixer) || !IsReviewScopeHumanHold(*freshFixer) {
+				t.Fatalf("fixer after budget Continue = %#v meta=%s, want paused scope sibling", freshFixer, derefMeta(freshFixer.MetadataJSON))
+			}
+			if !IsSiblingReviewScopeHumanPause(freshFixer.MetadataJSON) {
+				t.Fatalf("fixer after budget Continue missing sibling scope pause: meta=%s", derefMeta(freshFixer.MetadataJSON))
+			}
+			if reason, _ := stringFromAny(parseMetadataObject(freshFixer.MetadataJSON)["pauseReason"]); reason != ReviewScopeHumanSiblingPauseReason {
+				t.Fatalf("fixer top-level pauseReason = %q, want %q", reason, ReviewScopeHumanSiblingPauseReason)
+			}
+			fixerQueue, err := repos.Queue.GetByID(context.Background(), fixerQueueID)
+			if err != nil || fixerQueue == nil || fixerQueue.Status != "cancelled" {
+				t.Fatalf("fixer queue after budget Continue = (%#v, %v), want cancelled", fixerQueue, err)
+			}
+
+			freshReviewer, err = repos.Loops.GetByID(context.Background(), reviewer.ID)
+			if err != nil || freshReviewer == nil || !IsReviewScopeHumanHold(*freshReviewer) {
+				t.Fatalf("reviewer after budget Continue = (%#v, %v), want still scope-held", freshReviewer, err)
+			}
+			if reason, _ := stringFromAny(parseMetadataObject(freshReviewer.MetadataJSON)["pauseReason"]); reason == ReviewFixBudgetPauseReason {
+				t.Fatalf("reviewer still has leftover budget pauseReason after budget Continue: meta=%s", derefMeta(freshReviewer.MetadataJSON))
+			}
+
+			scopeResult, err := ApplyReviewScopeHumanAnswer(context.Background(), repos, *freshReviewer, "Continue", nowISO)
+			if err != nil || !scopeResult.Applied || scopeResult.Action != "continue" {
+				t.Fatalf("scope Continue = (%#v, %v)", scopeResult, err)
+			}
+			freshFixer, err = repos.Loops.GetByID(context.Background(), fixer.ID)
+			if err != nil || freshFixer == nil || freshFixer.Status != "queued" || IsReviewScopeHumanHold(*freshFixer) {
+				t.Fatalf("fixer after scope Continue = (%#v, %v), want queued and released", freshFixer, err)
+			}
+			if scopeResult.Loop.Status != "queued" || IsReviewScopeHumanHold(scopeResult.Loop) {
+				t.Fatalf("reviewer after scope Continue = %#v, want queued and released", scopeResult.Loop)
+			}
+		})
 	}
 }
 

--- a/internal/loops/review_scope_hold_test.go
+++ b/internal/loops/review_scope_hold_test.go
@@ -2,7 +2,9 @@ package loops
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/nexu-io/looper/internal/storage"
 )
@@ -486,4 +488,52 @@ func derefMeta(m *string) string {
 		return ""
 	}
 	return *m
+}
+
+func TestParkReviewScopeHumanFailsClosedWhenRefreshErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "loops.sqlite")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), dbPath, storage.SQLiteCoordinatorOptions{BackupDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	seedProject(t, repos, now)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	reviewer := seedBudgetLoop(t, repos, nowISO, "loop_scope_refresh_err_reviewer", "reviewer", "running")
+	fixer := seedBudgetLoop(t, repos, nowISO, "loop_scope_refresh_err_fixer", "fixer", "queued")
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("close coordinator: %v", err)
+	}
+
+	if _, err := ParkReviewScopeHuman(context.Background(), repos, ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: "acme/looper", PRNumber: 42,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md before unpause",
+	}); err == nil {
+		t.Fatal("ParkReviewScopeHuman error = nil, want refresh error")
+	}
+
+	reopened, err := storage.OpenSQLiteCoordinator(context.Background(), dbPath, storage.SQLiteCoordinatorOptions{BackupDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("reopen coordinator: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	if _, err := reopened.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("reopen RunPending: %v", err)
+	}
+	freshRepos := storage.NewRepositories(reopened.DB())
+	freshReviewer, err := freshRepos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || freshReviewer == nil || freshReviewer.Status != "running" || IsReviewScopeHumanHold(*freshReviewer) {
+		t.Fatalf("reviewer after failed park = (%#v, %v), want still running and unparked", freshReviewer, err)
+	}
+	freshFixer, err := freshRepos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || freshFixer == nil || freshFixer.Status != "queued" || IsReviewScopeHumanHold(*freshFixer) {
+		t.Fatalf("fixer after failed park = (%#v, %v), want still queued and unparked", freshFixer, err)
+	}
 }

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3485,11 +3485,11 @@ func (r *Runner) finishHeldReviewerQueueItem(ctx context.Context, loop storage.L
 	if err := r.repos.Queue.Complete(ctx, queueItem.ID, r.nowISO()); err != nil && !errors.Is(err, storage.ErrQueueItemNotActive) {
 		return ProcessResult{}, err
 	}
+	// Do not revive a review-fix pair hold (or other terminal park) that the
+	// step already persisted — only ordinary label/hold skips re-queue.
 	if _, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
 		updated.LastRunAt = stringPtr(r.nowISO())
-		// Do not revive a review-fix budget hold (or other terminal park) that
-		// the step already persisted — only ordinary label/hold skips re-queue.
-		if loops.IsReviewFixBudgetHold(*updated) || updated.Status == "terminated" || updated.Status == "stopped" || updated.Status == "awaiting_human" || updated.Status == "human_takeover" {
+		if loops.IsReviewFixPairHold(*updated) || updated.Status == "terminated" || updated.Status == "stopped" || updated.Status == "awaiting_human" || updated.Status == "human_takeover" {
 			updated.NextRunAt = nil
 			return
 		}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3113,6 +3113,10 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		if commentOnlyCompletionHasNeedsHuman(completion) {
 			// Pure needs_human: park without publishing/counting.
 			if len(publishableCommentOnlyFindings(completion.Findings)) == 0 {
+				checkpoint, blocked, freshErr := r.applyScopeParkFreshness(ctx, input, checkpoint, checkpoint.Snapshot.HeadSHA)
+				if freshErr != nil || blocked {
+					return checkpoint, freshErr
+				}
 				if err := r.parkOrDeferReviewerScopeHuman(ctx, input.Loop, completion); err != nil {
 					return checkpoint, err
 				}
@@ -3148,11 +3152,24 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
 	if commentOnlyCompletionHasNeedsHuman(nativeCompletion) {
+		// Recheck live state/head before parking obsolete needs_human evidence.
+		checkpoint, blocked, freshErr := r.applyScopeParkFreshness(ctx, input, checkpoint, checkpoint.Snapshot.HeadSHA)
+		if freshErr != nil || blocked {
+			return checkpoint, freshErr
+		}
 		// Agent may already have submitted must_fix comments via review submit
 		// before completing with needs_human. Count that publish before parking.
-		if found, markerErr := r.verifyAgentNativeReviewMarker(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey, cleanReviewAuthorLogin(checkpoint, PullRequestDetail{})); markerErr != nil {
+		found, markerErr := r.verifyAgentNativeReviewMarker(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey, cleanReviewAuthorLogin(checkpoint, PullRequestDetail{}))
+		if markerErr != nil {
 			return checkpoint, &loopError{message: markerErr.Error(), kind: FailureRetryableAfterResume}
-		} else if found.Found {
+		}
+		if len(publishableCommentOnlyFindings(nativeCompletion.Findings)) > 0 && !nativeMustFixReviewMarkerActionable(found) {
+			return checkpoint, &loopError{
+				message: missingReviewMarkerMessage(input, pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey}) + "; mixed must_fix+needs_human requires an actionable review marker before parking scope",
+				kind:    FailureRetryableAfterResume,
+			}
+		}
+		if nativeMustFixReviewMarkerActionable(found) {
 			summary := result.Summary
 			if strings.TrimSpace(nativeCompletion.Summary) != "" {
 				summary = nativeCompletion.Summary
@@ -3565,6 +3582,24 @@ func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepIn
 		return found, err
 	}
 	return found, nil
+}
+
+// nativeMustFixReviewMarkerActionable reports whether a verified marker can
+// stand in for published must_fix feedback. Clean/APPROVE markers and missing
+// markers are not actionable publication.
+func nativeMustFixReviewMarkerActionable(found ReviewMarkerResult) bool {
+	if !found.Found {
+		return false
+	}
+	if len(found.InlineCommentBodies) > 0 {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(found.Outcome)) {
+	case "blocking", "non_blocking", "actionable":
+		return found.Event != ReviewEventApprove
+	default:
+		return false
+	}
 }
 
 func sameReviewAuthorLogin(a string, b string) bool {
@@ -6884,8 +6919,8 @@ func (r *Runner) recoverPublishedNeedsHumanScopeFromLatestRun(ctx context.Contex
 
 // scopeParkRecoveryFreshnessBlockReason views the live PR and returns a non-empty
 // stale/closed reason when scope park/defer must not run. Empty reason means OK
-// to recover. Retryable view failures return an error (fail closed — do not park
-// on unknown state). Missing PRs are treated as non-open drift.
+// to park or recover. Retryable view failures return an error (fail closed — do
+// not park on unknown state). Missing PRs are treated as non-open drift.
 func (r *Runner) scopeParkRecoveryFreshnessBlockReason(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64, pending pendingReviewCheckpoint, checkpoint reviewerCheckpoint) (string, error) {
 	if r.github == nil || strings.TrimSpace(repo) == "" || prNumber == 0 {
 		return "", nil
@@ -6911,6 +6946,19 @@ func (r *Runner) scopeParkRecoveryFreshnessBlockReason(ctx context.Context, proj
 		return fmt.Sprintf("PR drift detected before publish: expected PR state OPEN, observed %s for %s#%d", observed, repo, prNumber), nil
 	}
 	return "", nil
+}
+
+// applyScopeParkFreshness rechecks live PR state/head before a direct needs_human
+// park. blocked=true means the run is stale/closed and must not hold the pair.
+func (r *Runner) applyScopeParkFreshness(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, headSHA string) (reviewerCheckpoint, bool, error) {
+	staleReason, err := r.scopeParkRecoveryFreshnessBlockReason(ctx, input.Project, input.Repo, input.PRNumber, pendingReviewCheckpoint{HeadSHA: headSHA}, checkpoint)
+	if err != nil {
+		return checkpoint, false, err
+	}
+	if staleReason != "" {
+		return markReviewerRunStale(checkpoint, staleReason), true, nil
+	}
+	return checkpoint, false, nil
 }
 
 func reviewerScopeOrBudgetHoldSkip(ctx context.Context, r *Runner, loop storage.LoopRecord) error {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4728,8 +4728,19 @@ func reviewerSummaryPromptContext(issueComments []map[string]any) string {
 
 func buildReviewerSummaryFromCompletion(existing forge.ReviewerSummary, completion reviewerCommentOnlyCompletion) (forge.ReviewerSummary, error) {
 	// Remote Reviewer Summary authority is must_fix only; follow_up/needs_human
-	// stay in the structured completion and must not become open remote items.
+	// stay in the structured completion and must not become new open remote items.
+	// Existing open items referenced by needs_human stay open until the human
+	// decision is applied so Forgejo Fixer still sees them after a scope Continue.
 	publishFindings := publishableCommentOnlyFindings(completion.Findings)
+	needsHumanReferencedIDs := map[string]struct{}{}
+	for _, finding := range completion.Findings {
+		if strings.TrimSpace(finding.Disposition) != reviewFindingDispositionNeedsHuman {
+			continue
+		}
+		if id := strings.TrimSpace(finding.ReviewItemID); id != "" {
+			needsHumanReferencedIDs[id] = struct{}{}
+		}
+	}
 	reviewRoundID := 1
 	if existing.ReviewRoundID > 0 {
 		reviewRoundID = existing.ReviewRoundID + 1
@@ -4802,6 +4813,11 @@ func buildReviewerSummaryFromCompletion(existing forge.ReviewerSummary, completi
 			continue
 		}
 		if item.Status == forge.ReviewItemStatusOpen {
+			if _, keepOpen := needsHumanReferencedIDs[item.ReviewItemID]; keepOpen {
+				item.LastSeenRoundID = reviewRoundID
+				finalItems = append(finalItems, item)
+				continue
+			}
 			item.Status = forge.ReviewItemStatusResolved
 			item.SupersededBy = ""
 			item.LastSeenRoundID = reviewRoundID

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3192,6 +3192,11 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 				ReviewerSummaryJSON: string(payload),
 			}
 			checkpoint.PendingReview = &pending
+			// Persist structured completion before lastPublishedHeadSha so a
+			// crash/retry can reconstruct the scope hold from the checkpoint.
+			if err := r.persistCheckpoint(ctx, input.Run.ID, stepReview, checkpoint); err != nil {
+				return checkpoint, err
+			}
 			alreadyPublished := false
 			if last, ok := stringFromAny(parseJSONObject(input.Loop.MetadataJSON)["lastPublishedHeadSha"]); ok && last == pending.HeadSHA {
 				alreadyPublished = true
@@ -4598,9 +4603,6 @@ func commentOnlyPublishVisibleSummary(completion reviewerCommentOnlyCompletion) 
 		return strings.TrimSpace(completion.Summary)
 	}
 	if len(mustFix) == 0 {
-		if cleanReviewNoopSummary(completion.Summary) {
-			return strings.TrimSpace(completion.Summary)
-		}
 		return "No actionable findings"
 	}
 	parts := make([]string, 0, len(mustFix))

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3602,21 +3602,14 @@ func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepIn
 }
 
 // nativeMustFixReviewMarkerActionable reports whether a verified marker can
-// stand in for published must_fix feedback. Clean/APPROVE markers and missing
-// markers are not actionable publication.
+// stand in for published must_fix feedback. Clean/APPROVE markers, missing
+// markers, and body-only COMMENT/REQUEST_CHANGES without inline comments are
+// not actionable publication.
 func nativeMustFixReviewMarkerActionable(found ReviewMarkerResult) bool {
 	if !found.Found {
 		return false
 	}
-	if len(found.InlineCommentBodies) > 0 {
-		return true
-	}
-	switch strings.ToLower(strings.TrimSpace(found.Outcome)) {
-	case "blocking", "non_blocking", "actionable":
-		return found.Event != ReviewEventApprove
-	default:
-		return false
-	}
+	return len(found.InlineCommentBodies) > 0
 }
 
 func sameReviewAuthorLogin(a string, b string) bool {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3073,6 +3073,11 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		if reason, ok := r.detectHeadChangeRequired(ctx, input, checkpoint); ok {
 			return markReviewerRunStale(checkpoint, reason), nil
 		}
+		if !commentOnlyCompletion {
+			if nativeCompletion, parseErr := parseReviewerNativeCompletion(result); parseErr == nil && commentOnlyCompletionHasNeedsHuman(nativeCompletion) {
+				return r.finishNativeNeedsHumanCompletion(ctx, input, checkpoint, result, nativeCompletion, idempotencyKey)
+			}
+		}
 		if found, err := r.verifyAgentNativeReviewMarker(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey, cleanReviewAuthorLogin(checkpoint, PullRequestDetail{})); err != nil {
 			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 		} else if found.Found {
@@ -3164,68 +3169,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
 	if commentOnlyCompletionHasNeedsHuman(nativeCompletion) {
-		// Recheck live state/head before parking obsolete needs_human evidence.
-		checkpoint, blocked, freshErr := r.applyScopeParkFreshness(ctx, input, checkpoint, checkpoint.Snapshot.HeadSHA)
-		if freshErr != nil || blocked {
-			return checkpoint, freshErr
-		}
-		// Agent may already have submitted must_fix comments via review submit
-		// before completing with needs_human. Count that publish before parking.
-		found, markerErr := r.verifyAgentNativeReviewMarker(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey, cleanReviewAuthorLogin(checkpoint, PullRequestDetail{}))
-		if markerErr != nil {
-			return checkpoint, &loopError{message: markerErr.Error(), kind: FailureRetryableAfterResume}
-		}
-		mustFixCount := len(publishableCommentOnlyFindings(nativeCompletion.Findings))
-		if mustFixCount > 0 && !nativeMustFixReviewMarkerActionable(found, mustFixCount) {
-			return checkpoint, &loopError{
-				message: missingReviewMarkerMessage(input, pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey}) + "; mixed must_fix+needs_human requires an actionable review marker before parking scope",
-				kind:    FailureRetryableAfterResume,
-			}
-		}
-		payload, marshalErr := json.Marshal(nativeCompletion)
-		if marshalErr != nil {
-			return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer native completion: %v", marshalErr), kind: FailureRetryableAfterResume}
-		}
-		if nativeMustFixReviewMarkerActionable(found, mustFixCount) {
-			summary := result.Summary
-			if strings.TrimSpace(nativeCompletion.Summary) != "" {
-				summary = nativeCompletion.Summary
-			}
-			outcome := normalizeCommentOnlyOutcome(found.Outcome)
-			if outcome == "" {
-				outcome = normalizeCommentOnlyOutcome(nativeCompletion.Outcome)
-			}
-			pending := pendingReviewCheckpoint{
-				HeadSHA:             checkpoint.Snapshot.HeadSHA,
-				IdempotencyKey:      idempotencyKey,
-				Event:               found.Event,
-				Summary:             summary,
-				Outcome:             outcome,
-				ContentFingerprint:  reviewMarkerFingerprint(found),
-				ReviewerSummaryJSON: string(payload),
-			}
-			checkpoint.PendingReview = &pending
-			// Persist structured completion before lastPublishedHeadSha so a
-			// crash/retry can reconstruct the scope hold from the checkpoint.
-			if err := r.persistCheckpoint(ctx, input.Run.ID, stepReview, checkpoint); err != nil {
-				return checkpoint, err
-			}
-			alreadyPublished := false
-			if last, ok := stringFromAny(parseJSONObject(input.Loop.MetadataJSON)["lastPublishedHeadSha"]); ok && last == pending.HeadSHA {
-				alreadyPublished = true
-			}
-			if !alreadyPublished {
-				if err := r.recordPublishedReviewProgress(ctx, input, pending, pendingReviewEvent(pending)); err != nil {
-					return checkpoint, err
-				}
-			}
-		}
-		// One authoritative hold: if publish hit the live cap, budget owns the
-		// pair; defer scope evidence without stacking a second ask/reason.
-		if err := r.parkOrDeferReviewerScopeHuman(ctx, input.Loop, nativeCompletion); err != nil {
-			return checkpoint, err
-		}
-		return checkpoint, reviewerScopeOrBudgetHoldSkip(ctx, r, input.Loop)
+		return r.finishNativeNeedsHumanCompletion(ctx, input, checkpoint, result, nativeCompletion, idempotencyKey)
 	}
 	nativeFindingsJSON := ""
 	if len(nativeCompletion.Findings) > 0 {
@@ -3624,6 +3568,68 @@ func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepIn
 		return found, err
 	}
 	return found, nil
+}
+
+// finishNativeNeedsHumanCompletion parks a valid needs_human native completion,
+// counting an already-submitted must_fix marker when present. Shared by the
+// completed parse path and failed-run recovery so a later nonzero exit cannot
+// drop ReviewerSummaryJSON and skip the scope hold.
+func (r *Runner) finishNativeNeedsHumanCompletion(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, result AgentResult, nativeCompletion reviewerCommentOnlyCompletion, idempotencyKey string) (reviewerCheckpoint, error) {
+	checkpoint, blocked, freshErr := r.applyScopeParkFreshness(ctx, input, checkpoint, checkpoint.Snapshot.HeadSHA)
+	if freshErr != nil || blocked {
+		return checkpoint, freshErr
+	}
+	found, markerErr := r.verifyAgentNativeReviewMarker(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey, cleanReviewAuthorLogin(checkpoint, PullRequestDetail{}))
+	if markerErr != nil {
+		return checkpoint, &loopError{message: markerErr.Error(), kind: FailureRetryableAfterResume}
+	}
+	mustFixCount := len(publishableCommentOnlyFindings(nativeCompletion.Findings))
+	if mustFixCount > 0 && !nativeMustFixReviewMarkerActionable(found, mustFixCount) {
+		return checkpoint, &loopError{
+			message: missingReviewMarkerMessage(input, pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey}) + "; mixed must_fix+needs_human requires an actionable review marker before parking scope",
+			kind:    FailureRetryableAfterResume,
+		}
+	}
+	payload, marshalErr := json.Marshal(nativeCompletion)
+	if marshalErr != nil {
+		return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer native completion: %v", marshalErr), kind: FailureRetryableAfterResume}
+	}
+	if nativeMustFixReviewMarkerActionable(found, mustFixCount) {
+		summary := result.Summary
+		if strings.TrimSpace(nativeCompletion.Summary) != "" {
+			summary = nativeCompletion.Summary
+		}
+		outcome := normalizeCommentOnlyOutcome(found.Outcome)
+		if outcome == "" {
+			outcome = normalizeCommentOnlyOutcome(nativeCompletion.Outcome)
+		}
+		pending := pendingReviewCheckpoint{
+			HeadSHA:             checkpoint.Snapshot.HeadSHA,
+			IdempotencyKey:      idempotencyKey,
+			Event:               found.Event,
+			Summary:             summary,
+			Outcome:             outcome,
+			ContentFingerprint:  reviewMarkerFingerprint(found),
+			ReviewerSummaryJSON: string(payload),
+		}
+		checkpoint.PendingReview = &pending
+		if err := r.persistCheckpoint(ctx, input.Run.ID, stepReview, checkpoint); err != nil {
+			return checkpoint, err
+		}
+		alreadyPublished := false
+		if last, ok := stringFromAny(parseJSONObject(input.Loop.MetadataJSON)["lastPublishedHeadSha"]); ok && last == pending.HeadSHA {
+			alreadyPublished = true
+		}
+		if !alreadyPublished {
+			if err := r.recordPublishedReviewProgress(ctx, input, pending, pendingReviewEvent(pending)); err != nil {
+				return checkpoint, err
+			}
+		}
+	}
+	if err := r.parkOrDeferReviewerScopeHuman(ctx, input.Loop, nativeCompletion); err != nil {
+		return checkpoint, err
+	}
+	return checkpoint, reviewerScopeOrBudgetHoldSkip(ctx, r, input.Loop)
 }
 
 // nativeMustFixReviewMarkerActionable reports whether a verified marker can

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3169,6 +3169,10 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 				kind:    FailureRetryableAfterResume,
 			}
 		}
+		payload, marshalErr := json.Marshal(nativeCompletion)
+		if marshalErr != nil {
+			return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer native completion: %v", marshalErr), kind: FailureRetryableAfterResume}
+		}
 		if nativeMustFixReviewMarkerActionable(found) {
 			summary := result.Summary
 			if strings.TrimSpace(nativeCompletion.Summary) != "" {
@@ -3179,15 +3183,23 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 				outcome = normalizeCommentOnlyOutcome(nativeCompletion.Outcome)
 			}
 			pending := pendingReviewCheckpoint{
-				HeadSHA:            checkpoint.Snapshot.HeadSHA,
-				IdempotencyKey:     idempotencyKey,
-				Event:              found.Event,
-				Summary:            summary,
-				Outcome:            outcome,
-				ContentFingerprint: reviewMarkerFingerprint(found),
+				HeadSHA:             checkpoint.Snapshot.HeadSHA,
+				IdempotencyKey:      idempotencyKey,
+				Event:               found.Event,
+				Summary:             summary,
+				Outcome:             outcome,
+				ContentFingerprint:  reviewMarkerFingerprint(found),
+				ReviewerSummaryJSON: string(payload),
 			}
-			if err := r.recordPublishedReviewProgress(ctx, input, pending, pendingReviewEvent(pending)); err != nil {
-				return checkpoint, err
+			checkpoint.PendingReview = &pending
+			alreadyPublished := false
+			if last, ok := stringFromAny(parseJSONObject(input.Loop.MetadataJSON)["lastPublishedHeadSha"]); ok && last == pending.HeadSHA {
+				alreadyPublished = true
+			}
+			if !alreadyPublished {
+				if err := r.recordPublishedReviewProgress(ctx, input, pending, pendingReviewEvent(pending)); err != nil {
+					return checkpoint, err
+				}
 			}
 		}
 		// One authoritative hold: if publish hit the live cap, budget owns the

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3484,6 +3484,18 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		checkpoint.ResumePolicy = "rerun_review"
 		return checkpoint, &loopError{message: message, kind: FailureRetryableAfterResume}
 	}
+	if pendingNativeMustFixRequiresActionableMarker(pending) && !nativeMustFixReviewMarkerActionable(markerResult) {
+		message := missingReviewMarkerMessage(input, pending) + "; must_fix publication requires an actionable review marker with inline comments"
+		if pending.MarkerVerificationMisses == 0 {
+			pending.MarkerVerificationMisses = 1
+			checkpoint.PendingReview = pending.clone()
+			checkpoint.ResumePolicy = "advance_from_checkpoint"
+			return checkpoint, &loopError{message: message + "; retrying marker verification before rerunning review", kind: FailureRetryableAfterResume}
+		}
+		checkpoint.PendingReview = nil
+		checkpoint.ResumePolicy = "rerun_review"
+		return checkpoint, &loopError{message: message, kind: FailureRetryableAfterResume}
+	}
 	reviewPolicy := r.effectiveReviewEvents(input.Project.ID, input.Loop.MetadataJSON)
 	if cleanReviewNoopSummary(pending.Summary) && reviewPolicy.Clean == config.ReviewerReviewEventApprove && !cleanReviewMarkerSatisfiesCleanPolicy(markerResult, cleanReviewAuthorLogin(checkpoint, detail)) {
 		return checkpoint, &loopError{message: "Reviewer agent reported a clean summary-only result, but clean review policy requires an APPROVED review marker or a self-authored clean COMMENT fallback with a valid human approval body; submit the APPROVE review through the trusted wrapper or exit non-zero", kind: FailureRetryableAfterResume}
@@ -3610,6 +3622,17 @@ func nativeMustFixReviewMarkerActionable(found ReviewMarkerResult) bool {
 		return false
 	}
 	return len(found.InlineCommentBodies) > 0
+}
+
+func pendingNativeMustFixRequiresActionableMarker(pending pendingReviewCheckpoint) bool {
+	if strings.TrimSpace(pending.ReviewerSummaryJSON) == "" {
+		return false
+	}
+	var completion reviewerCommentOnlyCompletion
+	if err := json.Unmarshal([]byte(pending.ReviewerSummaryJSON), &completion); err != nil {
+		return false
+	}
+	return len(publishableCommentOnlyFindings(completion.Findings)) > 0
 }
 
 func sameReviewAuthorLogin(a string, b string) bool {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -6945,22 +6945,56 @@ func (r *Runner) parkOrDeferReviewerScopeHuman(ctx context.Context, loop storage
 }
 
 func (r *Runner) persistPendingReviewerScopeHuman(ctx context.Context, loop storage.LoopRecord, completion reviewerCommentOnlyCompletion) error {
-	encoded, err := loops.PersistPendingReviewScopeHumanEvidence(
-		loop.MetadataJSON,
-		commentOnlyNeedsHumanQuestion(completion),
-		commentOnlyNeedsHumanEvidence(completion),
-		r.reviewFixHITLEnabled(),
-	)
-	if err != nil {
-		return err
-	}
-	updated := loop
-	updated.MetadataJSON = &encoded
-	updated.UpdatedAt = r.nowISO()
 	if r.repos == nil || r.repos.Loops == nil {
 		return fmt.Errorf("persist pending review scope requires loop storage")
 	}
-	return r.repos.Loops.Upsert(ctx, updated)
+	unlock := loops.LockLoopRequeue(loop.ID)
+	defer unlock()
+	unlockTarget := loops.LockLoopTarget(loops.LoopTargetGuardKeyFromRecord(loop))
+	defer unlockTarget()
+
+	parkLive := false
+	write := func(writeRepos *storage.Repositories) error {
+		fresh, err := writeRepos.Loops.GetByID(ctx, loop.ID)
+		if err != nil {
+			return fmt.Errorf("refresh loop before pending review scope persist: %w", err)
+		}
+		if fresh == nil {
+			return fmt.Errorf("persist pending review scope lost loop %s", loop.ID)
+		}
+		if !loops.IsReviewFixBudgetHold(*fresh) {
+			// Continue already released the budget hold. Park scope on the live
+			// record instead of restoring the stale budget snapshot.
+			parkLive = true
+			return nil
+		}
+		encoded, err := loops.PersistPendingReviewScopeHumanEvidence(
+			fresh.MetadataJSON,
+			commentOnlyNeedsHumanQuestion(completion),
+			commentOnlyNeedsHumanEvidence(completion),
+			r.reviewFixHITLEnabled(),
+		)
+		if err != nil {
+			return err
+		}
+		updated := *fresh
+		updated.MetadataJSON = &encoded
+		updated.UpdatedAt = r.nowISO()
+		return writeRepos.Loops.Upsert(ctx, updated)
+	}
+	if r.db != nil {
+		if err := storage.WithTransaction(ctx, r.db, nil, func(tx *sql.Tx) error {
+			return write(storage.NewRepositories(tx))
+		}); err != nil {
+			return err
+		}
+	} else if err := write(r.repos); err != nil {
+		return err
+	}
+	if parkLive {
+		return r.parkReviewerScopeHuman(ctx, loop, completion)
+	}
+	return nil
 }
 
 // afterCommentOnlyPublishMaybeParkScope runs after a successful comment-only

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -4620,6 +4620,12 @@ func validateReviewerCommentOnlyCompletion(completion reviewerCommentOnlyComplet
 	if mustFixCount == 0 && !commentOnlyCompletionHasNeedsHuman(completion) {
 		return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only actionable completion must include at least one must_fix finding")
 	}
+	if mustFixCount > 0 {
+		required := requiredOutcomeForMustFixFindings(completion.Findings)
+		if required != "" && completion.Outcome != required {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only completion outcome %q does not match highest must_fix severity (want %s)", completion.Outcome, required)
+		}
+	}
 	return completion, nil
 }
 
@@ -4630,6 +4636,26 @@ func commentOnlyCompletionHasNeedsHuman(completion reviewerCommentOnlyCompletion
 		}
 	}
 	return false
+}
+
+// requiredOutcomeForMustFixFindings maps the highest published must_fix severity
+// onto the completion outcome contract: blocking findings require outcome=blocking;
+// non_blocking/nit must_fix findings require outcome=non_blocking. Empty means no
+// must_fix findings were present.
+func requiredOutcomeForMustFixFindings(findings []reviewerCommentOnlyFindingResult) string {
+	required := ""
+	for _, finding := range findings {
+		if strings.TrimSpace(finding.Disposition) != reviewFindingDispositionMustFix {
+			continue
+		}
+		switch strings.TrimSpace(finding.Severity) {
+		case reviewFindingSeverityBlocking:
+			return "blocking"
+		case reviewFindingSeverityNonBlocking, reviewFindingSeverityNit:
+			required = "non_blocking"
+		}
+	}
+	return required
 }
 
 // publishableCommentOnlyFindings returns only must_fix findings for remote summary items.
@@ -7566,13 +7592,13 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	submitPayloadInstruction := fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries. Each actionable comment MUST include GitHub fields `path`, `line`, `side` (`RIGHT` for new diff lines, `LEFT` for old diff lines), optional `start_line` and `start_side` for multiline ranges, `body`, plus Looper-only fields `disposition` (must be `must_fix`), `scopeBasis`, and `scopeEvidence` (and preferably `severity`). The trusted wrapper rejects missing disposition/scope fields and rejects `follow_up`/`needs_human` in actionable comments or the visible review body; those dispositions stay out of the submit payload. Looper strips Looper-only fields before calling GitHub/Forgejo.", looperCLICommand)
 	idempotencyInstruction := "Idempotency requirement: before posting anything, use `gh api` to list existing PR reviews for this PR. Only treat an existing marker as satisfying this run when the review body contains the exact idempotency id and expected head SHA, and the review state matches the required outcome-specific policy for this run. If such a matching review already exists, do not post another review. Instead, rely on Looper to validate that marker after the agent exits and to reconcile clean-signal reactions/spec label transitions as needed. If the marker exists but the outcome/review-state combination does not satisfy this run, ignore it and publish the correct review for this run instead."
 	freshnessInstruction := "Before posting, use `gh` to confirm the PR is still open and the head SHA still matches the expected head SHA. If it changed, do not post a review and exit non-zero with the exact message `PR head changed before publish`."
-	anchorInstruction := "Before posting, validate every inline review comment's `path`, `line`, `side`, `start_line`, and `start_side` against the live PR diff fetched with `gh pr diff`. Preserve exact anchors that fit the live diff. If an otherwise useful comment is outside the live diff's anchorable locations, safely downgrade it to top-level review body feedback that starts with clear fallback location text instead of submitting an invalid inline anchor."
+	anchorInstruction := "Before posting, validate every inline review comment's `path`, `line`, `side`, `start_line`, and `start_side` against the live PR diff fetched with `gh pr diff`. Preserve exact anchors that fit the live diff. If a must_fix location is outside the live diff's exact line, attach it to the nearest anchorable changed-file location instead of submitting an invalid inline anchor. Do not move must_fix findings into the top-level review body; the trusted wrapper rejects actionable body-only reviews, and body-only markers are not published must_fix."
 	if forgejoNative {
 		githubOperationContract = fmt.Sprintf("Forgejo operation contract: submit exactly one native PR review for this run through the trusted Looper CLI at %s, with review JSON on stdin. The wrapper validates the expected head, current review request, content safety, provider capability, and idempotency marker before it calls Forgejo. Do not call the Forgejo review API directly.", actionableReviewSubmitCommand)
 		submitPayloadInstruction = fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries using `path`, `line`, `side` (`RIGHT` for new lines, `LEFT` for old lines), `body`, plus Looper-only `disposition=must_fix`, `scopeBasis`, and `scopeEvidence`; the wrapper validates those fields, rejects `follow_up`/`needs_human` in comments or the visible review body, then maps anchors to Forgejo and strips Looper-only fields before the provider call.", looperCLICommand)
 		idempotencyInstruction = "Idempotency requirement: submit only through the trusted Looper wrapper. The wrapper lists existing native Forgejo reviews and reuses an exact id/head/outcome/state marker match; after the agent exits, the runner verifies the same marker before recording publication. Never call the Forgejo review endpoint directly."
 		freshnessInstruction = "Before posting, rely on the trusted Looper wrapper to confirm the Forgejo PR is still open and the head SHA still matches. If it reports drift, exit non-zero with the exact message `PR head changed before publish`."
-		anchorInstruction = "Before posting, validate every inline review comment against the supplied Forgejo diff and local worktree. Preserve exact changed-file anchors; downgrade unanchorable feedback to a top-level review-body item with an exact file/section/symbol reference."
+		anchorInstruction = "Before posting, validate every inline review comment against the supplied Forgejo diff and local worktree. Preserve exact changed-file anchors. If a must_fix location is not exactly on the supplied diff, attach it to the nearest anchorable changed-file location. Do not downgrade must_fix findings to a top-level review-body item; every must_fix must remain an inline comment."
 	}
 	if looperCLIPath == "" {
 		githubOperationContract = "GitHub operation contract: a trusted Looper CLI path was not detected for this reviewer run, so you cannot safely publish a GitHub review. Do not call PATH-based `looper`, repository-local `go run ./cmd/looper`, `gh api repos/.../pulls/.../reviews`, or `gh pr review` directly; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
@@ -7605,12 +7631,12 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		"For complex linting/parsing logic, prefer recommending fixture-matrix tests over isolated one-regression tests. For CSS linting specifically, consider coverage for multiple style blocks, inline styles, comments, at-rules, cascade order, custom properties, var() fallbacks, theme scopes, and px/em/rem unit handling.",
 		"Every comment MUST include: (1) a location via inline anchor or exact file/section/symbol reference, (2) the concrete problem, (3) why it matters, (4) evidence from the changed lines or spec section, and (5) a specific suggested change.",
 		"Prefer inline comments for specific code-level feedback when you can anchor them confidently to the diff using the changed file path and file line numbers shown in the PR diff.",
-		"Use top-level comments without path/line only for architectural, cross-cutting, or otherwise unanchorable feedback; top-level comment bodies must still name the exact file, section, symbol, or behavior they refer to.",
-		"Flag any top-level actionable comment that lacks exact file, section, symbol, or behavior context as a follow-up quality-gating failure; do not publish vague unlocated feedback.",
+		"Cross-cutting or otherwise unanchorable must_fix findings still require an inline comment on a representative changed-file location; do not submit them as body-only top-level feedback.",
+		"Flag vague unlocated must_fix feedback as a follow-up quality-gating failure; every must_fix must be an inline comment with an exact file, section, symbol, or behavior reference.",
 		"Do not repeat the overall body/summary as a comment; comments must add distinct actionable feedback.",
 		"Resolvable inline review comments are required for code-anchored actionable feedback: when a finding refers to specific changed lines and you can identify the changed file path plus RIGHT/LEFT line numbers from the diff, submit it as an inline review comment in the PR review `comments` array, not in the review body and not as a separate issue/PR conversation comment.",
-		"Inline review comments posted through the PR review `comments` array create resolvable GitHub review threads. Top-level review bodies and issue comments are not resolvable; use them only for clean summaries or genuinely cross-cutting/unanchorable feedback.",
-		"For non-blocking or blocking finding reviews with any anchorable findings, the review body should be a short overview plus markers/disclosure; the detailed findings must live in inline `comments` so maintainers can resolve them individually.",
+		"Inline review comments posted through the PR review `comments` array create resolvable GitHub review threads. Top-level review bodies and issue comments are not resolvable; use the review body only for clean summaries or a short overview of already-submitted inline must_fix findings.",
+		"For non-blocking or blocking must_fix reviews, the review body should be a short overview plus markers/disclosure; every must_fix finding must live in inline `comments` so maintainers can resolve them individually.",
 		"For multiline inline comments, `start_line`/`start_side` must identify the first line and `line`/`side` the last line; omit `start_line`/`start_side` for single-line comments.",
 		"Write substantially more detail than a brief summary; every comment should explain the problem, why it matters, and the concrete change to make.",
 		"A comment is invalid if it only names a category (for example, 'gaps around X', 'issues with Y', or 'concerns about Z'), says only 'add tests' without naming the behavior and where the test belongs, lacks a concrete location or section reference, asks a question without proposing a resolution path, or compresses multiple unrelated concerns into one vague summary.",

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -6842,7 +6842,11 @@ func (r *Runner) parkReviewerScopeHuman(ctx context.Context, loop storage.LoopRe
 // without stacking a second HITL ask/primary pause reason; otherwise park scope.
 func (r *Runner) parkOrDeferReviewerScopeHuman(ctx context.Context, loop storage.LoopRecord, completion reviewerCommentOnlyCompletion) error {
 	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
-		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+		fresh, err := r.repos.Loops.GetByID(ctx, loop.ID)
+		if err != nil {
+			return fmt.Errorf("refresh loop before review scope park: %w", err)
+		}
+		if fresh != nil {
 			loop = *fresh
 		}
 	}

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -648,12 +648,24 @@ type reviewerCommentOnlyCompletion struct {
 }
 
 type reviewerCommentOnlyFindingResult struct {
-	ReviewItemID string   `json:"review_item_id,omitempty"`
-	Title        string   `json:"title"`
-	Body         string   `json:"body"`
-	Files        []string `json:"files,omitempty"`
-	Supersedes   []string `json:"supersedes,omitempty"`
+	ReviewItemID  string   `json:"review_item_id,omitempty"`
+	Title         string   `json:"title"`
+	Body          string   `json:"body"`
+	Files         []string `json:"files,omitempty"`
+	Path          string   `json:"path,omitempty"`
+	Line          int      `json:"line,omitempty"`
+	Supersedes    []string `json:"supersedes,omitempty"`
+	Disposition   string   `json:"disposition,omitempty"`
+	Severity      string   `json:"severity,omitempty"`
+	ScopeBasis    string   `json:"scopeBasis,omitempty"`
+	ScopeEvidence string   `json:"scopeEvidence,omitempty"`
 }
+
+const (
+	reviewFindingDispositionMustFix    = "must_fix"
+	reviewFindingDispositionFollowUp   = "follow_up"
+	reviewFindingDispositionNeedsHuman = "needs_human"
+)
 
 type threadResolutionCheckpoint struct {
 	HeadSHA   string `json:"headSha,omitempty"`
@@ -1077,13 +1089,15 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		result.Skipped++
 		return nil
 	}
-	// Sibling pause / exhausted hold must not be revived by discovery enqueue.
+	// Sibling pause / exhausted / scope hold must not be revived by discovery enqueue.
 	// Notify only from discovery after a successful park (not from shared park).
-	if loops.IsReviewFixBudgetHold(loopResult.record) {
-		if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
-			return err
-		} else if parked {
-			r.notifyHumanAttentionBestEffort(ctx, loopResult.record.ID)
+	if loops.IsReviewFixPairHold(loopResult.record) {
+		if loops.IsReviewFixBudgetHold(loopResult.record) {
+			if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
+				return err
+			} else if parked {
+				r.notifyHumanAttentionBestEffort(ctx, loopResult.record.ID)
+			}
 		}
 		result.Skipped++
 		return nil
@@ -1614,12 +1628,16 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 		return ProcessResult{}, fmt.Errorf("loop not found: %s", *queueItem.LoopID)
 	}
 	if reason := terminalReviewerLoopReason(*loop); reason != "" {
-		cancelReason := "loop_" + reason
-		if _, err := r.repos.Queue.CancelByLoop(ctx, loop.ID, r.nowISO(), &cancelReason); err != nil {
-			return ProcessResult{}, err
+		// Budget holds stay non-terminal for claim preflight so at-cap recovery can
+		// still persist deferred needs_human scope before the budget skip return.
+		if !loops.IsReviewFixBudgetHold(*loop) {
+			cancelReason := "loop_" + reason
+			if _, err := r.repos.Queue.CancelByLoop(ctx, loop.ID, r.nowISO(), &cancelReason); err != nil {
+				return ProcessResult{}, err
+			}
+			summary := fmt.Sprintf("Skipped terminal reviewer loop %s: %s", loop.ID, reason)
+			return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, nil
 		}
-		summary := fmt.Sprintf("Skipped terminal reviewer loop %s: %s", loop.ID, reason)
-		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, nil
 	}
 	project, err := r.repos.Projects.GetByID(ctx, loop.ProjectID)
 	if err != nil {
@@ -1645,6 +1663,12 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, *loop); err != nil {
 		return ProcessResult{}, err
 	} else if parked {
+		// Crash gap: publish + budget park may have landed without scope
+		// park/defer. Recover pending/scope from the latest checkpoint before
+		// skipping — never start the agent or re-publish on this path.
+		if err := r.recoverPublishedNeedsHumanScopeFromLatestRun(ctx, *project, *loop); err != nil {
+			return ProcessResult{}, err
+		}
 		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: "review-fix budget exhausted"}, nil
 	}
 	resumedRun, err := r.createRunContext(ctx, *loop)
@@ -3081,22 +3105,93 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		return checkpoint, &loopError{message: "Reviewer agent did not report a valid completion marker after publishing review", kind: FailureRetryableAfterResume}
 	}
-	if cleanReviewNoopSummary(result.Summary) {
-		if commentOnlyCompletion {
-			completion, err := parseReviewerCommentOnlyCompletion(result)
-			if err != nil {
-				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	if commentOnlyCompletion {
+		completion, err := parseReviewerCommentOnlyCompletion(result)
+		if err != nil {
+			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		}
+		if commentOnlyCompletionHasNeedsHuman(completion) {
+			// Pure needs_human: park without publishing/counting.
+			if len(publishableCommentOnlyFindings(completion.Findings)) == 0 {
+				if err := r.parkOrDeferReviewerScopeHuman(ctx, input.Loop, completion); err != nil {
+					return checkpoint, err
+				}
+				return checkpoint, reviewerScopeOrBudgetHoldSkip(ctx, r, input.Loop)
 			}
-			payload, err := json.Marshal(completion)
-			if err != nil {
-				return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer comment-only completion: %v", err), kind: FailureRetryableAfterResume}
+			// Mixed must_fix + needs_human: publish must_fix first (publish step),
+			// then apply the one-hold rule after recordPublishedReviewProgress.
+			payload, marshalErr := json.Marshal(completion)
+			if marshalErr != nil {
+				return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer comment-only completion: %v", marshalErr), kind: FailureRetryableAfterResume}
 			}
-			checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload), CleanNoop: completion.Outcome == "clean"}
+			checkpoint.PendingReview = &pendingReviewCheckpoint{
+				HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative,
+				Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+			}
 			checkpoint.ResumePolicy = "advance_from_checkpoint"
 			return checkpoint, nil
 		}
+		payload, err := json.Marshal(completion)
+		if err != nil {
+			return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer comment-only completion: %v", err), kind: FailureRetryableAfterResume}
+		}
+		cleanNoop := cleanReviewNoopSummary(result.Summary) && completion.Outcome == "clean"
+		checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload), CleanNoop: cleanNoop}
+		checkpoint.ResumePolicy = "advance_from_checkpoint"
+		return checkpoint, nil
+	}
+
+	// Native path: parse __LOOPER_RESULT__ findings (same disposition contract).
+	// Summary-only markers without findings stay valid; remote marker is publish authority.
+	nativeCompletion, err := parseReviewerNativeCompletion(result)
+	if err != nil {
+		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if commentOnlyCompletionHasNeedsHuman(nativeCompletion) {
+		// Agent may already have submitted must_fix comments via review submit
+		// before completing with needs_human. Count that publish before parking.
+		if found, markerErr := r.verifyAgentNativeReviewMarker(ctx, input, checkpoint.Snapshot.HeadSHA, idempotencyKey, cleanReviewAuthorLogin(checkpoint, PullRequestDetail{})); markerErr != nil {
+			return checkpoint, &loopError{message: markerErr.Error(), kind: FailureRetryableAfterResume}
+		} else if found.Found {
+			summary := result.Summary
+			if strings.TrimSpace(nativeCompletion.Summary) != "" {
+				summary = nativeCompletion.Summary
+			}
+			outcome := normalizeCommentOnlyOutcome(found.Outcome)
+			if outcome == "" {
+				outcome = normalizeCommentOnlyOutcome(nativeCompletion.Outcome)
+			}
+			pending := pendingReviewCheckpoint{
+				HeadSHA:            checkpoint.Snapshot.HeadSHA,
+				IdempotencyKey:     idempotencyKey,
+				Event:              found.Event,
+				Summary:            summary,
+				Outcome:            outcome,
+				ContentFingerprint: reviewMarkerFingerprint(found),
+			}
+			if err := r.recordPublishedReviewProgress(ctx, input, pending, pendingReviewEvent(pending)); err != nil {
+				return checkpoint, err
+			}
+		}
+		// One authoritative hold: if publish hit the live cap, budget owns the
+		// pair; defer scope evidence without stacking a second ask/reason.
+		if err := r.parkOrDeferReviewerScopeHuman(ctx, input.Loop, nativeCompletion); err != nil {
+			return checkpoint, err
+		}
+		return checkpoint, reviewerScopeOrBudgetHoldSkip(ctx, r, input.Loop)
+	}
+	nativeFindingsJSON := ""
+	if len(nativeCompletion.Findings) > 0 {
+		payload, marshalErr := json.Marshal(nativeCompletion)
+		if marshalErr != nil {
+			return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer native completion: %v", marshalErr), kind: FailureRetryableAfterResume}
+		}
+		nativeFindingsJSON = string(payload)
+	}
+
+	if cleanReviewNoopSummary(result.Summary) {
 		if reviewEvents.Clean == config.ReviewerReviewEventApprove && r.reviewerAutoMergeConfigForProject(input.Project.ID).Enabled && resolvePullRequestPhase(detailLabels(checkpoint.Detail)) != "spec" {
-			checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", CleanNoop: true}
+			checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", ReviewerSummaryJSON: nativeFindingsJSON, CleanNoop: true}
 			checkpoint.ResumePolicy = "advance_from_checkpoint"
 			return checkpoint, nil
 		}
@@ -3107,30 +3202,25 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 				if err := validateCleanApprovedReviewMarkerBody(found, cleanReviewAuthorLogin(checkpoint, PullRequestDetail{})); err != nil {
 					return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 				}
-				checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", ContentFingerprint: reviewMarkerFingerprint(found), CleanNoop: true}
+				checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", ContentFingerprint: reviewMarkerFingerprint(found), ReviewerSummaryJSON: nativeFindingsJSON, CleanNoop: true}
 				checkpoint.ResumePolicy = "advance_from_checkpoint"
 				return checkpoint, nil
 			}
 			return checkpoint, &loopError{message: "Reviewer agent reported a clean summary-only result, but clean review policy requires an APPROVED review marker; submit the APPROVE review through the trusted wrapper or exit non-zero", kind: FailureRetryableAfterResume}
 		}
-		checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", CleanNoop: true}
+		checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: "clean", ReviewerSummaryJSON: nativeFindingsJSON, CleanNoop: true}
 		checkpoint.ResumePolicy = "advance_from_checkpoint"
 		return checkpoint, nil
 	}
-	if commentOnlyCompletion {
-		completion, err := parseReviewerCommentOnlyCompletion(result)
-		if err != nil {
-			return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
-		}
-		payload, err := json.Marshal(completion)
-		if err != nil {
-			return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer comment-only completion: %v", err), kind: FailureRetryableAfterResume}
-		}
-		checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload)}
-		checkpoint.ResumePolicy = "advance_from_checkpoint"
-		return checkpoint, nil
+	outcome := normalizeCommentOnlyOutcome(reviewCompletionOutcome(result))
+	if nativeCompletion.Outcome != "" {
+		outcome = nativeCompletion.Outcome
 	}
-	checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: result.Summary, Outcome: normalizeCommentOnlyOutcome(reviewCompletionOutcome(result))}
+	summary := result.Summary
+	if strings.TrimSpace(nativeCompletion.Summary) != "" {
+		summary = nativeCompletion.Summary
+	}
+	checkpoint.PendingReview = &pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey, Event: reviewEventAgentNative, Summary: summary, Outcome: outcome, ReviewerSummaryJSON: nativeFindingsJSON}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
 }
@@ -3146,6 +3236,19 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 	pending := *checkpoint.PendingReview
 	meta := parseJSONObject(input.Loop.MetadataJSON)
 	if last, ok := stringFromAny(meta["lastPublishedHeadSha"]); ok && last == pending.HeadSHA {
+		// Crash/retry gap: recordPublishedReviewProgress may have written
+		// lastPublishedHeadSha (and budget park) before
+		// afterCommentOnlyPublishMaybeParkScope ran. Recover park/defer
+		// without re-publishing. Freshness gates refuse stale/closed PRs.
+		// No-ops when pending has no needs_human.
+		next, err := r.recoverAlreadyPublishedScopePark(ctx, input, checkpoint, pending)
+		if err != nil {
+			return next, err
+		}
+		if next.SkipReason != "" || next.SkipKind != "" {
+			return next, nil
+		}
+		checkpoint = next
 		checkpoint.SkipReason = fmt.Sprintf("Skipped already-published review for head %s", pending.HeadSHA)
 		return checkpoint, nil
 	}
@@ -3202,7 +3305,7 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 			if err := r.recordPublishedReviewProgress(ctx, input, pending, ReviewEventComment); err != nil {
 				return checkpoint, err
 			}
-			return checkpoint, nil
+			return r.afterCommentOnlyPublishMaybeParkScope(ctx, input, checkpoint, pending)
 		}
 		if reviewEvents.Clean == config.ReviewerReviewEventApprove {
 			found, err := r.verifyAgentNativeReviewMarker(ctx, input, pending.HeadSHA, pending.IdempotencyKey, cleanReviewAuthorLogin(checkpoint, detail))
@@ -3285,7 +3388,7 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		if err := r.recordPublishedReviewProgress(ctx, input, pending, ReviewEventComment); err != nil {
 			return checkpoint, err
 		}
-		return checkpoint, nil
+		return r.afterCommentOnlyPublishMaybeParkScope(ctx, input, checkpoint, pending)
 	}
 	markerResult := ReviewMarkerResult{}
 	if pending.Event == reviewEventAgentNative {
@@ -3980,6 +4083,14 @@ func (r *Runner) publishCommentOnlyReview(ctx context.Context, input stepInput, 
 	if err != nil {
 		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
+	// Pure needs_human: park without publishing. Mixed must_fix+needs_human
+	// publishes must_fix only; caller parks/defers scope after recordPublished.
+	if commentOnlyCompletionHasNeedsHuman(completion) && len(publishableCommentOnlyFindings(completion.Findings)) == 0 {
+		if err := r.parkOrDeferReviewerScopeHuman(ctx, input.Loop, completion); err != nil {
+			return err
+		}
+		return reviewerScopeOrBudgetHoldSkip(ctx, r, input.Loop)
+	}
 	comments, err := r.github.ListIssueComments(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 	if err != nil {
 		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
@@ -3996,7 +4107,7 @@ func (r *Runner) publishCommentOnlyReview(ctx context.Context, input stepInput, 
 	if err != nil {
 		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
-	body, err := renderReviewerSummaryComment(summary, completion.Summary)
+	body, err := renderReviewerSummaryComment(summary, commentOnlyPublishVisibleSummary(completion))
 	if err != nil {
 		return &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
@@ -4270,6 +4381,35 @@ func reviewCompletionOutcome(result AgentResult) string {
 }
 
 func parseReviewerCommentOnlyCompletion(result AgentResult) (reviewerCommentOnlyCompletion, error) {
+	completion, err := unmarshalReviewerCompletionMarker(result)
+	if err != nil {
+		return reviewerCommentOnlyCompletion{}, fmt.Errorf("parse reviewer comment-only completion: %w", err)
+	}
+	return validateReviewerCommentOnlyCompletion(completion)
+}
+
+// parseReviewerNativeCompletion parses __LOOPER_RESULT__ after a native review step.
+// Summary-only markers without findings remain valid (remote review marker is publish
+// authority). When findings are present, validation is fail-closed.
+func parseReviewerNativeCompletion(result AgentResult) (reviewerCommentOnlyCompletion, error) {
+	completion, err := unmarshalReviewerCompletionMarker(result)
+	if err != nil {
+		// Native agents historically emit a parsed completion without a strict
+		// findings payload; treat missing marker payload as empty findings.
+		if strings.Contains(err.Error(), "completion marker is required") {
+			return reviewerCommentOnlyCompletion{Summary: strings.TrimSpace(result.Summary)}, nil
+		}
+		return reviewerCommentOnlyCompletion{}, fmt.Errorf("parse reviewer native completion: %w", err)
+	}
+	if len(completion.Findings) == 0 {
+		completion.Summary = strings.TrimSpace(completion.Summary)
+		completion.Outcome = normalizeCommentOnlyOutcome(completion.Outcome)
+		return completion, nil
+	}
+	return validateReviewerCommentOnlyCompletion(completion)
+}
+
+func unmarshalReviewerCompletionMarker(result AgentResult) (reviewerCommentOnlyCompletion, error) {
 	var completion reviewerCommentOnlyCompletion
 	raw := result.Stdout
 	if strings.TrimSpace(result.Stderr) != "" {
@@ -4283,11 +4423,11 @@ func parseReviewerCommentOnlyCompletion(result AgentResult) (reviewerCommentOnly
 		}
 		payload := strings.TrimPrefix(line, agent.CompletionMarkerPrefix)
 		if err := json.Unmarshal([]byte(payload), &completion); err != nil {
-			return reviewerCommentOnlyCompletion{}, fmt.Errorf("parse reviewer comment-only completion: %w", err)
+			return reviewerCommentOnlyCompletion{}, err
 		}
-		return validateReviewerCommentOnlyCompletion(completion)
+		return completion, nil
 	}
-	return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only completion marker is required")
+	return reviewerCommentOnlyCompletion{}, fmt.Errorf("completion marker is required")
 }
 
 func validateReviewerCommentOnlyCompletion(completion reviewerCommentOnlyCompletion) (reviewerCommentOnlyCompletion, error) {
@@ -4299,26 +4439,37 @@ func validateReviewerCommentOnlyCompletion(completion reviewerCommentOnlyComplet
 	if completion.Outcome == "" {
 		return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only completion outcome must be clean, non_blocking, or blocking")
 	}
-	if completion.Outcome == "clean" {
-		if len(completion.Findings) != 0 {
-			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only clean completion must not include findings")
-		}
-		if !cleanReviewNoopSummary(completion.Summary) {
-			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only clean completion summary must start with \"No actionable findings\"")
-		}
-		return completion, nil
-	}
-	if len(completion.Findings) == 0 {
-		return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only actionable completion must include at least one finding")
-	}
 	seenFindingIDs := map[string]struct{}{}
+	mustFixCount := 0
 	for i := range completion.Findings {
 		finding := &completion.Findings[i]
 		finding.ReviewItemID = strings.TrimSpace(finding.ReviewItemID)
 		finding.Title = strings.TrimSpace(finding.Title)
 		finding.Body = strings.TrimSpace(finding.Body)
+		finding.Path = strings.TrimSpace(finding.Path)
+		finding.Disposition = strings.TrimSpace(finding.Disposition)
+		finding.Severity = strings.TrimSpace(finding.Severity)
+		finding.ScopeBasis = strings.TrimSpace(finding.ScopeBasis)
+		finding.ScopeEvidence = strings.TrimSpace(finding.ScopeEvidence)
 		if finding.Title == "" || finding.Body == "" {
 			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d requires title and body", i)
+		}
+		if finding.Disposition == "" {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d requires disposition", i)
+		}
+		if finding.ScopeBasis == "" {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d requires scopeBasis", i)
+		}
+		if finding.ScopeEvidence == "" {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d requires scopeEvidence", i)
+		}
+		switch finding.Disposition {
+		case reviewFindingDispositionMustFix, reviewFindingDispositionFollowUp, reviewFindingDispositionNeedsHuman:
+		default:
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d has invalid disposition %q", i, finding.Disposition)
+		}
+		if finding.Disposition == reviewFindingDispositionMustFix {
+			mustFixCount++
 		}
 		if finding.ReviewItemID != "" {
 			if _, exists := seenFindingIDs[finding.ReviewItemID]; exists {
@@ -4349,7 +4500,153 @@ func validateReviewerCommentOnlyCompletion(completion reviewerCommentOnlyComplet
 		}
 		finding.Supersedes = supersedes
 	}
+	if completion.Outcome == "clean" {
+		if mustFixCount != 0 {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only clean completion must not include must_fix findings")
+		}
+		if !cleanReviewNoopSummary(completion.Summary) {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only clean completion summary must start with \"No actionable findings\"")
+		}
+		return completion, nil
+	}
+	if mustFixCount == 0 && !commentOnlyCompletionHasNeedsHuman(completion) {
+		return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only actionable completion must include at least one must_fix finding")
+	}
 	return completion, nil
+}
+
+func commentOnlyCompletionHasNeedsHuman(completion reviewerCommentOnlyCompletion) bool {
+	for _, finding := range completion.Findings {
+		if strings.TrimSpace(finding.Disposition) == reviewFindingDispositionNeedsHuman {
+			return true
+		}
+	}
+	return false
+}
+
+// publishableCommentOnlyFindings returns only must_fix findings for remote summary items.
+func publishableCommentOnlyFindings(findings []reviewerCommentOnlyFindingResult) []reviewerCommentOnlyFindingResult {
+	out := make([]reviewerCommentOnlyFindingResult, 0, len(findings))
+	for _, finding := range findings {
+		if strings.TrimSpace(finding.Disposition) == reviewFindingDispositionMustFix {
+			out = append(out, finding)
+		}
+	}
+	return out
+}
+
+// commentOnlyPublishVisibleSummary is the remote-visible prose for comment-only
+// publish. It must not smuggle follow_up/needs_human content into the PR comment;
+// those stay in the structured local completion/event only.
+func commentOnlyPublishVisibleSummary(completion reviewerCommentOnlyCompletion) string {
+	mustFix := publishableCommentOnlyFindings(completion.Findings)
+	hasSuppressed := false
+	for _, finding := range completion.Findings {
+		switch strings.TrimSpace(finding.Disposition) {
+		case reviewFindingDispositionFollowUp, reviewFindingDispositionNeedsHuman:
+			hasSuppressed = true
+		}
+	}
+	if !hasSuppressed {
+		return strings.TrimSpace(completion.Summary)
+	}
+	if len(mustFix) == 0 {
+		if cleanReviewNoopSummary(completion.Summary) {
+			return strings.TrimSpace(completion.Summary)
+		}
+		return "No actionable findings"
+	}
+	parts := make([]string, 0, len(mustFix))
+	for _, finding := range mustFix {
+		title := strings.TrimSpace(finding.Title)
+		body := strings.TrimSpace(finding.Body)
+		switch {
+		case title != "" && body != "":
+			parts = append(parts, title+": "+body)
+		case title != "":
+			parts = append(parts, title)
+		case body != "":
+			parts = append(parts, body)
+		}
+	}
+	if len(parts) == 0 {
+		return "Must-fix findings require attention."
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func commentOnlyNeedsHumanQuestion(completion reviewerCommentOnlyCompletion) string {
+	var parts []string
+	for _, finding := range completion.Findings {
+		if strings.TrimSpace(finding.Disposition) != reviewFindingDispositionNeedsHuman {
+			continue
+		}
+		title := strings.TrimSpace(finding.Title)
+		body := strings.TrimSpace(finding.Body)
+		basis := strings.TrimSpace(finding.ScopeBasis)
+		evidence := strings.TrimSpace(finding.ScopeEvidence)
+		if title == "" && body == "" {
+			continue
+		}
+		authority := authorityInputChangeHint(basis, evidence)
+		findingText := title
+		if findingText == "" {
+			findingText = body
+		} else if body != "" {
+			findingText = title + ": " + body
+		}
+		parts = append(parts, fmt.Sprintf("%s before unpause; finding: %s", authority, findingText))
+	}
+	if len(parts) == 0 {
+		return "Clarify the repository rule, PR goal/non-goal, or linked spec that governs this scope before unpause. Continue resumes against current evidence, or stop the pair?"
+	}
+	return strings.Join(parts, " ") + " Continue resumes against current evidence, or stop the pair?"
+}
+
+// authorityInputChangeHint names which authority input must change before unpause.
+func authorityInputChangeHint(scopeBasis, scopeEvidence string) string {
+	basis := strings.TrimSpace(scopeBasis)
+	evidence := strings.TrimSpace(scopeEvidence)
+	switch basis {
+	case "stated_intent":
+		if evidence != "" {
+			return "Clarify PR goal/non-goal or stated intent (" + evidence + ")"
+		}
+		return "Clarify PR goal/non-goal or stated intent"
+	case "required_invariant":
+		if evidence != "" {
+			return "Clarify repository rule / required invariant (" + evidence + ")"
+		}
+		return "Clarify repository rule or required invariant"
+	case "introduced_regression":
+		if evidence != "" {
+			return "Clarify regression evidence or acceptance boundary (" + evidence + ")"
+		}
+		return "Clarify regression evidence or acceptance boundary"
+	case "independent_improvement":
+		if evidence != "" {
+			return "Clarify whether this independent improvement is in PR scope (" + evidence + ")"
+		}
+		return "Clarify whether this independent improvement is in PR scope"
+	case "ambiguous_intent":
+		if evidence != "" {
+			return "Clarify ambiguous PR intent / non-goals or AGENTS.md rule (" + evidence + ")"
+		}
+		return "Clarify ambiguous PR intent, non-goals, or AGENTS.md rule"
+	default:
+		if evidence != "" {
+			return "Clarify authority input (" + evidence + ")"
+		}
+		return "Clarify repository rule, PR goal/non-goal, or linked spec"
+	}
+}
+
+func commentOnlyNeedsHumanEvidence(completion reviewerCommentOnlyCompletion) string {
+	payload, err := json.Marshal(completion.Findings)
+	if err != nil {
+		return ""
+	}
+	return string(payload)
 }
 
 func pendingReviewerCommentOnlyCompletion(pending pendingReviewCheckpoint) (reviewerCommentOnlyCompletion, error) {
@@ -4381,6 +4678,9 @@ func reviewerSummaryPromptContext(issueComments []map[string]any) string {
 }
 
 func buildReviewerSummaryFromCompletion(existing forge.ReviewerSummary, completion reviewerCommentOnlyCompletion) (forge.ReviewerSummary, error) {
+	// Remote Reviewer Summary authority is must_fix only; follow_up/needs_human
+	// stay in the structured completion and must not become open remote items.
+	publishFindings := publishableCommentOnlyFindings(completion.Findings)
 	reviewRoundID := 1
 	if existing.ReviewRoundID > 0 {
 		reviewRoundID = existing.ReviewRoundID + 1
@@ -4394,15 +4694,15 @@ func buildReviewerSummaryFromCompletion(existing forge.ReviewerSummary, completi
 		}
 	}
 	updatedExistingIDs := map[string]struct{}{}
-	for _, finding := range completion.Findings {
+	for _, finding := range publishFindings {
 		if finding.ReviewItemID != "" {
 			updatedExistingIDs[finding.ReviewItemID] = struct{}{}
 		}
 	}
 	assigned := map[string]struct{}{}
 	supersededTargets := map[string]string{}
-	updated := make([]forge.ReviewItem, 0, len(existing.Items)+len(completion.Findings))
-	for _, finding := range completion.Findings {
+	updated := make([]forge.ReviewItem, 0, len(existing.Items)+len(publishFindings))
+	for _, finding := range publishFindings {
 		id := finding.ReviewItemID
 		if id != "" {
 			if _, ok := itemsByID[id]; !ok {
@@ -4708,11 +5008,14 @@ func (r *Runner) refusePublishIfBudgetExhausted(ctx context.Context, input stepI
 	if !loops.ParticipatesInReviewFixBudget(loop) {
 		return false, nil
 	}
-	if loops.IsReviewFixBudgetHold(loop) {
-		if _, err := r.parkReviewerBudgetIfExhausted(ctx, loop); err != nil {
-			return true, err
+	if loops.IsReviewFixPairHold(loop) {
+		if loops.IsReviewFixBudgetHold(loop) {
+			if _, err := r.parkReviewerBudgetIfExhausted(ctx, loop); err != nil {
+				return true, err
+			}
+			return true, &holdSkipError{summary: "Reviewer stopped because review-fix budget is held"}
 		}
-		return true, &holdSkipError{summary: "Reviewer stopped because review-fix budget is held"}
+		return true, &holdSkipError{summary: "Reviewer stopped because review scope requires human judgment"}
 	}
 	cap := r.maxPublishesPerPR(loop.ProjectID)
 	if !loops.BudgetExhausted(loops.ReviewerPublishCount(loop.MetadataJSON), cap) {
@@ -5199,8 +5502,8 @@ func (r *Runner) markLoopQueuedForReview(ctx context.Context, loop storage.LoopR
 		return nil
 	}
 	_, err := r.updateLoop(ctx, loop, func(updated *storage.LoopRecord) {
-		// Never flip a budget hold (exhausted or sibling pause) back to queued.
-		if loops.IsReviewFixBudgetHold(*updated) {
+		// Never flip a budget/scope pair hold back to queued.
+		if loops.IsReviewFixPairHold(*updated) {
 			return
 		}
 		if active, activeErr := r.hasActiveRunningRun(ctx, updated.ID); activeErr == nil && active {
@@ -6358,7 +6661,7 @@ func (r *Runner) shouldCreateReviewerBudgetPark(loop storage.LoopRecord) bool {
 	if loop.Status == "terminated" || loop.Status == "stopped" || loop.Status == "awaiting_human" {
 		return false
 	}
-	if loop.Status == "paused" && loops.IsReviewFixBudgetHold(loop) {
+	if loop.Status == "paused" && loops.IsReviewFixPairHold(loop) {
 		return false
 	}
 	if !loops.ParticipatesInReviewFixBudget(loop) {
@@ -6384,13 +6687,17 @@ func (r *Runner) parkReviewerBudgetIfExhausted(ctx context.Context, loop storage
 	if loop.Status == "terminated" || loop.Status == "stopped" {
 		return false, nil
 	}
-	// Sibling pause is already a hold; finish cancel/sibling work on re-entry
-	// but do not treat "not self-exhausted" as permission to proceed.
-	if loop.Status == "paused" && loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) {
+	// Sibling pause / scope hold is already a hold; finish cancel/sibling work on
+	// re-entry but do not treat "not self-exhausted" as permission to proceed.
+	if loop.Status == "paused" && (loops.IsSiblingReviewFixBudgetPause(loop.MetadataJSON) || loops.IsSiblingReviewScopeHumanPause(loop.MetadataJSON)) {
+		return true, nil
+	}
+	if loops.IsReviewScopeHumanHold(loop) && !loops.IsReviewFixBudgetHold(loop) {
 		return true, nil
 	}
 	if loop.Status == "awaiting_human" {
 		if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); !ok || !loops.IsReviewFixBudgetAsk(ask) {
+			// Agent ask or scope ask: not a budget park target.
 			return true, nil
 		}
 	} else if loop.Status == "paused" && loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
@@ -6441,6 +6748,184 @@ func (r *Runner) notifyHumanAttentionBestEffort(ctx context.Context, loopID stri
 		return
 	}
 	r.notifyHumanAttention(ctx, loopID)
+}
+
+// parkReviewerScopeHuman parks the review-fix pair for needs_human findings.
+// Does not use budget Continue/Stop refill; notify is best-effort at this site
+// because park can happen outside a claim finalization path.
+func (r *Runner) parkReviewerScopeHuman(ctx context.Context, loop storage.LoopRecord, completion reviewerCommentOnlyCompletion) error {
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+			loop = *fresh
+		}
+	}
+	_, err := loops.ParkReviewScopeHuman(ctx, r.repos, loops.ParkReviewScopeHumanInput{
+		Held: loop, Role: "reviewer", Repo: derefString(loop.Repo), PRNumber: derefInt64(loop.PRNumber),
+		NowISO: r.nowISO(), HITLEnabled: r.reviewFixHITLEnabled(),
+		Question: commentOnlyNeedsHumanQuestion(completion), Evidence: commentOnlyNeedsHumanEvidence(completion),
+		DB: r.db,
+	})
+	if err != nil {
+		return err
+	}
+	r.notifyHumanAttentionBestEffort(ctx, loop.ID)
+	return nil
+}
+
+// parkOrDeferReviewerScopeHuman applies the one-hold rule after a counted publish
+// or pure needs_human: if the loop is already budget-held, persist scope evidence
+// without stacking a second HITL ask/primary pause reason; otherwise park scope.
+func (r *Runner) parkOrDeferReviewerScopeHuman(ctx context.Context, loop storage.LoopRecord, completion reviewerCommentOnlyCompletion) error {
+	if r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+			loop = *fresh
+		}
+	}
+	if loops.IsReviewFixBudgetHold(loop) {
+		return r.persistPendingReviewerScopeHuman(ctx, loop, completion)
+	}
+	return r.parkReviewerScopeHuman(ctx, loop, completion)
+}
+
+func (r *Runner) persistPendingReviewerScopeHuman(ctx context.Context, loop storage.LoopRecord, completion reviewerCommentOnlyCompletion) error {
+	encoded, err := loops.PersistPendingReviewScopeHumanEvidence(
+		loop.MetadataJSON,
+		commentOnlyNeedsHumanQuestion(completion),
+		commentOnlyNeedsHumanEvidence(completion),
+		r.reviewFixHITLEnabled(),
+	)
+	if err != nil {
+		return err
+	}
+	updated := loop
+	updated.MetadataJSON = &encoded
+	updated.UpdatedAt = r.nowISO()
+	if r.repos == nil || r.repos.Loops == nil {
+		return fmt.Errorf("persist pending review scope requires loop storage")
+	}
+	return r.repos.Loops.Upsert(ctx, updated)
+}
+
+// afterCommentOnlyPublishMaybeParkScope runs after a successful comment-only
+// publish + counted progress. Mixed must_fix+needs_human parks/defers scope
+// under the one-hold rule; pure must_fix returns nil.
+func (r *Runner) afterCommentOnlyPublishMaybeParkScope(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, pending pendingReviewCheckpoint) (reviewerCheckpoint, error) {
+	completion, err := pendingReviewerCommentOnlyCompletion(pending)
+	if err != nil || !commentOnlyCompletionHasNeedsHuman(completion) {
+		return checkpoint, nil
+	}
+	if err := r.parkOrDeferReviewerScopeHuman(ctx, input.Loop, completion); err != nil {
+		return checkpoint, err
+	}
+	return checkpoint, reviewerScopeOrBudgetHoldSkip(ctx, r, input.Loop)
+}
+
+// recoverAlreadyPublishedScopePark recovers needs_human scope park/defer after a
+// crash between recordPublishedReviewProgress and afterCommentOnlyPublishMaybeParkScope.
+// Applies live PR freshness gates so closed/new-head retries do not pause on
+// obsolete findings. Returns a stale/skip checkpoint without parking when drift
+// is detected; retryable GitHub view failures surface as errors.
+func (r *Runner) recoverAlreadyPublishedScopePark(ctx context.Context, input stepInput, checkpoint reviewerCheckpoint, pending pendingReviewCheckpoint) (reviewerCheckpoint, error) {
+	completion, err := pendingReviewerCommentOnlyCompletion(pending)
+	if err != nil || !commentOnlyCompletionHasNeedsHuman(completion) {
+		return checkpoint, nil
+	}
+	staleReason, err := r.scopeParkRecoveryFreshnessBlockReason(ctx, input.Project, input.Repo, input.PRNumber, pending, checkpoint)
+	if err != nil {
+		return checkpoint, err
+	}
+	if staleReason != "" {
+		return markReviewerRunStale(checkpoint, staleReason), nil
+	}
+	return r.afterCommentOnlyPublishMaybeParkScope(ctx, input, checkpoint, pending)
+}
+
+// recoverPublishedNeedsHumanScopeFromLatestRun is the ProcessClaimedItem preflight
+// counterpart: when budget already parks/skips the claim, still recover deferred
+// scope from the latest run checkpoint if publish landed with needs_human.
+// Does not start the agent or re-publish.
+func (r *Runner) recoverPublishedNeedsHumanScopeFromLatestRun(ctx context.Context, project storage.ProjectRecord, loop storage.LoopRecord) error {
+	if r.repos == nil || r.repos.Runs == nil {
+		return nil
+	}
+	latestRun, err := r.repos.Runs.GetLatestByLoopID(ctx, loop.ID)
+	if err != nil {
+		return err
+	}
+	if latestRun == nil {
+		return nil
+	}
+	checkpoint := parseCheckpoint(latestRun.CheckpointJSON)
+	if checkpoint.PendingReview == nil {
+		return nil
+	}
+	pending := *checkpoint.PendingReview
+	meta := parseJSONObject(loop.MetadataJSON)
+	last, ok := stringFromAny(meta["lastPublishedHeadSha"])
+	if !ok || last == "" || last != pending.HeadSHA {
+		return nil
+	}
+	completion, err := pendingReviewerCommentOnlyCompletion(pending)
+	if err != nil || !commentOnlyCompletionHasNeedsHuman(completion) {
+		return nil
+	}
+	repo := derefString(loop.Repo)
+	prNumber := derefInt64(loop.PRNumber)
+	staleReason, err := r.scopeParkRecoveryFreshnessBlockReason(ctx, project, repo, prNumber, pending, checkpoint)
+	if err != nil {
+		return err
+	}
+	if staleReason != "" {
+		// Closed PR or new head: do not park/defer obsolete scope evidence.
+		return nil
+	}
+	return r.parkOrDeferReviewerScopeHuman(ctx, loop, completion)
+}
+
+// scopeParkRecoveryFreshnessBlockReason views the live PR and returns a non-empty
+// stale/closed reason when scope park/defer must not run. Empty reason means OK
+// to recover. Retryable view failures return an error (fail closed — do not park
+// on unknown state). Missing PRs are treated as non-open drift.
+func (r *Runner) scopeParkRecoveryFreshnessBlockReason(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64, pending pendingReviewCheckpoint, checkpoint reviewerCheckpoint) (string, error) {
+	if r.github == nil || strings.TrimSpace(repo) == "" || prNumber == 0 {
+		return "", nil
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: project.RepoPath})
+	if err != nil {
+		if githubinfra.IsPullRequestNotFoundError(err) {
+			return fmt.Sprintf("PR drift detected before publish: expected PR state OPEN, observed missing for %s#%d", repo, prNumber), nil
+		}
+		return "", &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+	}
+	if detail.HeadSHA != "" && pending.HeadSHA != "" && detail.HeadSHA != pending.HeadSHA {
+		return fmt.Sprintf("PR head changed before publish: expected %s, got %s", pending.HeadSHA, detail.HeadSHA), nil
+	}
+	if reason := reviewerPublishDriftReason(stepInput{Repo: repo, PRNumber: prNumber}, checkpoint, detail); reason != "" {
+		return reason, nil
+	}
+	if normalizePRState(detail.State) != "open" {
+		observed := strings.ToUpper(strings.TrimSpace(detail.State))
+		if observed == "" {
+			observed = "NON_OPEN"
+		}
+		return fmt.Sprintf("PR drift detected before publish: expected PR state OPEN, observed %s for %s#%d", observed, repo, prNumber), nil
+	}
+	return "", nil
+}
+
+func reviewerScopeOrBudgetHoldSkip(ctx context.Context, r *Runner, loop storage.LoopRecord) error {
+	if r != nil && r.repos != nil && r.repos.Loops != nil && strings.TrimSpace(loop.ID) != "" {
+		if fresh, err := r.repos.Loops.GetByID(ctx, loop.ID); err == nil && fresh != nil {
+			loop = *fresh
+		}
+	}
+	if loops.IsReviewFixBudgetHold(loop) {
+		return &holdSkipError{summary: "Reviewer stopped because review-fix budget is exhausted"}
+	}
+	if loops.IsReviewScopeHumanHold(loop) || loops.HasPendingReviewScopeHuman(loop) {
+		return &holdSkipError{summary: "Reviewer stopped because review scope requires human judgment"}
+	}
+	return &holdSkipError{summary: "Reviewer stopped because review scope requires human judgment"}
 }
 
 func terminalReviewerLoopReason(loop storage.LoopRecord) string {
@@ -6843,15 +7328,15 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	if forgejoNative {
 		forgeName = "Forgejo"
 	}
-	publishInstruction := fmt.Sprintf("For actionable findings, you must publish the %s review yourself by calling looper's enforced review-submit wrapper from the shell. For no-actionable-finding results, follow the clean-result publishing instructions for this run. Do not return review JSON for looper to parse; looper will not parse review content or post forge comments for you after the agent exits.", forgeName)
+	publishInstruction := fmt.Sprintf("For actionable must_fix findings, you must publish the %s review yourself by calling looper's enforced review-submit wrapper from the shell (inline comments only for must_fix). For no-actionable-finding results, follow the clean-result publishing instructions for this run. After the agent step, finish with `__LOOPER_RESULT__` JSON that includes `summary`, optional `outcome`, and `findings` using the same disposition fields as comment-only (`disposition`, `severity`, `scopeBasis`, `scopeEvidence`, `title`, `body`, optional `path`/`line`). Looper **does** parse this findings list: `follow_up` is retained locally only and must not be submitted; `needs_human` parks the pair and must not be submitted as change-request comments. Do not smuggle follow_up/needs_human into unstructured top-level review body prose as the only carrier of a blocking finding.", forgeName)
 	if looperCLIPath == "" {
 		publishInstruction = "A trusted Looper CLI review-submit wrapper is unavailable for this run, so fail closed: do not publish any GitHub review, do not add or remove any GitHub reaction, and exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
 	}
-	outcomeInstruction := "Use outcome=clean only when there are no blocking or non-blocking findings, outcome=non_blocking for actionable feedback that should not block merge, and outcome=blocking for findings that should block merge. Legacy outcome=actionable may be treated as comment-only compatibility, but prefer non_blocking or blocking. For no-actionable-finding results, follow the clean-result instructions for this run and finish with a completion summary that starts with `No actionable findings`."
-	cleanResultCompletionInstruction := "Prefer 3 deeply specific comments over 10 shallow comments. Group related findings by file, subsystem, function, or rule in a single review round instead of splitting adjacent concerns across multiple small reviews. If there is no concrete actionable feedback, follow the clean-result instructions for this run and finish successfully with a summary beginning `No actionable findings`. Do not invent feedback."
+	outcomeInstruction := "Use outcome=clean only when there are no must_fix findings, outcome=non_blocking for must_fix feedback that should not block merge, and outcome=blocking for must_fix findings that should block merge. Legacy outcome=actionable may be treated as comment-only compatibility, but prefer non_blocking or blocking. For no-actionable-finding results, follow the clean-result instructions for this run and finish with a completion summary that starts with `No actionable findings`."
+	cleanResultCompletionInstruction := "Group findings only when they share the same root cause; keep unrelated concerns as separate findings. Accumulate every independent in-scope must_fix before publishing — do not intentionally defer an already observed in-scope issue. The publication budget limits review publications, not findings per publication. If there is no concrete must_fix feedback, follow the clean-result instructions for this run and finish successfully with a summary beginning `No actionable findings`. Do not invent feedback."
 	if looperCLIPath == "" {
-		outcomeInstruction = "Use outcome=clean only when there are no blocking or non-blocking findings, outcome=non_blocking for actionable feedback that should not block merge, and outcome=blocking for findings that should block merge. Legacy outcome=actionable may be treated as comment-only compatibility, but prefer non_blocking or blocking. For no-actionable-finding results, do not report clean success because the trusted review-submit wrapper is unavailable; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
-		cleanResultCompletionInstruction = "Prefer 3 deeply specific comments over 10 shallow comments. Group related findings by file, subsystem, function, or rule in a single review round instead of splitting adjacent concerns across multiple small reviews. If there is no concrete actionable feedback, do not finish successfully or add a clean signal because the trusted wrapper is unavailable; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`. Do not invent feedback."
+		outcomeInstruction = "Use outcome=clean only when there are no must_fix findings, outcome=non_blocking for must_fix feedback that should not block merge, and outcome=blocking for must_fix findings that should block merge. Legacy outcome=actionable may be treated as comment-only compatibility, but prefer non_blocking or blocking. For no-actionable-finding results, do not report clean success because the trusted review-submit wrapper is unavailable; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
+		cleanResultCompletionInstruction = "Group findings only when they share the same root cause; keep unrelated concerns as separate findings. Accumulate every independent in-scope must_fix before publishing — do not intentionally defer an already observed in-scope issue. The publication budget limits review publications, not findings per publication. If there is no concrete must_fix feedback, do not finish successfully or add a clean signal because the trusted wrapper is unavailable; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`. Do not invent feedback."
 	}
 	fetchContract := reviewerAgentSideGitHubFetchContract()
 	if forgejoNative {
@@ -6859,8 +7344,8 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	}
 	if commentOnlyPublish {
 		publishInstruction = "This provider is comment-only. Looper supplied the PR metadata and diff in this prompt/context and will publish exactly one top-level PR comment from your final completion summary after re-checking local idempotency. Do not publish anything yourself or attempt native review features."
-		outcomeInstruction = "If there are actionable findings, finish successfully with a concise markdown summary and set the final `__LOOPER_RESULT__` JSON fields to include: `summary` (same human summary), `outcome` (`non_blocking` or `blocking`), and `findings` (an array of actionable issues only). Each finding object MUST contain `title`, `body`, and optional `files`; include `review_item_id` when the issue matches an existing Reviewer Summary item unchanged, and include `supersedes` with prior `review_item_id` values only when this finding materially replaces older items. If there are no actionable findings, set `outcome` to `clean`, keep `findings` empty, and start `summary` with `No actionable findings`. Do not include terminal logs, extra JSON payloads, or publishing commands."
-		cleanResultCompletionInstruction = "Prefer a concise, specific final summary over many shallow notes. If there is no concrete actionable feedback, start the final summary with `No actionable findings`. Do not invent feedback."
+		outcomeInstruction = "Classify every candidate finding with disposition `must_fix` | `follow_up` | `needs_human`, plus `severity`, `scopeBasis`, and `scopeEvidence`. Include all candidates in `__LOOPER_RESULT__.findings`. Looper publishes only `must_fix` findings into the remote Reviewer Summary; `follow_up` stays in the structured result only; `needs_human` parks the pair and is never posted as a change request. If there are must_fix findings, finish successfully with a concise markdown summary and set `summary`, `outcome` (`non_blocking` or `blocking`), and `findings`. Each finding object MUST contain `title`, `body`, `disposition`, `severity`, `scopeBasis`, `scopeEvidence`, and optional `files`; include `review_item_id` when the issue matches an existing Reviewer Summary item unchanged, and include `supersedes` with prior `review_item_id` values only when this finding materially replaces older items. If there are no must_fix findings and no needs_human, set `outcome` to `clean` (follow_up-only findings may remain in `findings`), and start `summary` with `No actionable findings` when there are no must_fix items. Do not include terminal logs, extra JSON payloads, or publishing commands."
+		cleanResultCompletionInstruction = "Group findings only when they share the same root cause; keep unrelated concerns separate. Accumulate every independent in-scope must_fix before finalizing. If there is no concrete must_fix feedback, start the final summary with `No actionable findings`. Do not invent feedback."
 		fetchContract = "Provider-supplied Forgejo review context: Looper fetched PR metadata and diff before invoking you. Use the prepared local worktree plus the supplied metadata/diff as the review context; do not use GitHub CLI/API commands or native review/thread features."
 	}
 	parts := []string{fmt.Sprintf("Review pull request %s#%d.", repo, prNumber), buildReviewerMinimalPRSeed(repo, prNumber, checkpoint, scope), fetchContract, "Phase: " + phase, phaseInstruction, reviewerScopeInstruction(scope), publishInstruction, fmt.Sprintf("Review idempotency marker prefix: <!-- looper:review id=%s head=%s outcome=clean|non_blocking|blocking -->", idempotencyKey, snapshotHeadSHA(checkpoint)), outcomeInstruction, "Run ID for logging only, not for idempotency: " + runID}
@@ -6927,25 +7412,26 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	}
 	if commentOnlyPublish {
 		parts = append(parts,
-			"Comment-only publish contract: Looper will post your final completion summary as one top-level PR comment after it verifies the PR is still open, the head SHA still matches, and this head has not already been published locally. Do not publish anything yourself.",
-			"Review pass contract: complete one full review pass before finalizing. Use the supplied PR metadata, supplied diff, and local worktree to inspect every changed file/range in scope. Do not stop after the first issue. If a blocking issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass.",
-			"Finding accumulator contract: accumulate candidate findings internally before finalizing. For each candidate, track location, severity, evidence, why it matters, and a suggested fix. Deduplicate, merge same-root-cause findings, and prefer fewer deep comments over many shallow ones.",
+			"Comment-only publish contract: Looper will post your final completion summary as one top-level PR comment after it verifies the PR is still open, the head SHA still matches, and this head has not already been published locally. Do not publish anything yourself. Only must_fix findings become remote Reviewer Summary items; follow_up and needs_human remain in structured completion only.",
+			"Review pass contract: complete one full review pass before finalizing. Use the supplied PR metadata, supplied diff, and local worktree to inspect every changed file/range in scope. Do not stop after the first issue. If an in-scope must_fix issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass.",
+			"Finding disposition contract: every candidate uses disposition must_fix|follow_up|needs_human, severity blocking|non_blocking|nit, scopeBasis (stated_intent|introduced_regression|required_invariant|independent_improvement|ambiguous_intent), scopeEvidence (specific repository rule, PR goal/non-goal, linked spec section, or regression evidence), plus title/body/location. must_fix becomes remote feedback; follow_up is retained only in structured completion; needs_human must not be published as a change request and parks the pair for human judgment.",
+			"Finding accumulator contract: accumulate candidate findings internally before finalizing. For each candidate, track disposition, severity, scopeBasis, scopeEvidence, location, problem, why it matters, and a suggested fix. Deduplicate only the same root cause or a genuinely repeated pattern; keep unrelated concerns separate. Grouping is valid only for a shared root cause with representative locations.",
 			"Severity rubric: mark a finding as BLOCKING only when it can realistically cause incorrect behavior, data loss/corruption, security exposure, broken public API/protocol/config/migration/backward compatibility, failing existing or necessary tests, race/deadlock/resource leak, transaction/lifecycle inconsistency, clear production risk, or failure to satisfy the PR's stated goal. Mark actionable but merge-safe improvements as NON_BLOCKING. Mark tiny style, naming, wording, formatting, or subjective preferences as NIT; NITs must not block merge.",
-			"Finalization gate before completion: verify that the scoped changed files/ranges were reviewed, all observed blocking findings are included, repeated patterns are consolidated, non-blocking/nit feedback is not escalated, every finding has concrete evidence and a suggested fix, and the summary outcome matches the highest severity.",
+			"Finalization gate before completion: verify that the scoped changed files/ranges were reviewed, all observed in-scope must_fix findings are included, repeated patterns are consolidated only when they share a root cause, non-blocking/nit feedback is not escalated, every finding has disposition/scope evidence and a suggested fix, and the summary outcome matches the highest must_fix severity.",
 			cleanResultCompletionInstruction,
-			"Every finding MUST include: (1) an exact file/section/symbol reference, (2) the concrete problem, (3) why it matters, (4) evidence from the changed lines or spec section, and (5) a specific suggested change.",
+			"Every finding MUST include: (1) disposition/severity/scopeBasis/scopeEvidence, (2) an exact file/section/symbol reference, (3) the concrete problem, (4) why it matters, (5) evidence from the changed lines or spec section, and (6) a specific suggested change.",
 			"Implementation review rubric: check correctness, error handling, tests, concurrency, config compatibility, security, resource lifecycle, observability, migrations, and backward compatibility. Only report issues that are concrete and actionable.",
 		)
 		return agent.AppendCompletionInstruction(strings.Join(parts, "\n\n")), instructionBlock
 	}
 	githubOperationContract := fmt.Sprintf("GitHub operation contract: when there are actionable findings, submit exactly one PR review for this run through the trusted Looper CLI at %s, with the review JSON on stdin. The wrapper validates inline anchors against the live PR diff before it calls GitHub; do not use PATH-based `looper`, repository-local `go run ./cmd/looper`, `gh api repos/%s/pulls/%d/reviews`, or `gh pr review` directly for the review submission.", actionableReviewSubmitCommand, repo, prNumber)
-	submitPayloadInstruction := fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries using GitHub's review comment fields: `path`, `line`, `side` (`RIGHT` for new diff lines, `LEFT` for old diff lines), optional `start_line` and `start_side` for multiline ranges, and `body` for the actionable feedback.", looperCLICommand)
+	submitPayloadInstruction := fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries. Each actionable comment MUST include GitHub fields `path`, `line`, `side` (`RIGHT` for new diff lines, `LEFT` for old diff lines), optional `start_line` and `start_side` for multiline ranges, `body`, plus Looper-only fields `disposition` (must be `must_fix`), `scopeBasis`, and `scopeEvidence` (and preferably `severity`). The trusted wrapper rejects missing disposition/scope fields and rejects `follow_up`/`needs_human` in actionable comments; those dispositions stay out of the submit payload. Looper strips Looper-only fields before calling GitHub/Forgejo.", looperCLICommand)
 	idempotencyInstruction := "Idempotency requirement: before posting anything, use `gh api` to list existing PR reviews for this PR. Only treat an existing marker as satisfying this run when the review body contains the exact idempotency id and expected head SHA, and the review state matches the required outcome-specific policy for this run. If such a matching review already exists, do not post another review. Instead, rely on Looper to validate that marker after the agent exits and to reconcile clean-signal reactions/spec label transitions as needed. If the marker exists but the outcome/review-state combination does not satisfy this run, ignore it and publish the correct review for this run instead."
 	freshnessInstruction := "Before posting, use `gh` to confirm the PR is still open and the head SHA still matches the expected head SHA. If it changed, do not post a review and exit non-zero with the exact message `PR head changed before publish`."
 	anchorInstruction := "Before posting, validate every inline review comment's `path`, `line`, `side`, `start_line`, and `start_side` against the live PR diff fetched with `gh pr diff`. Preserve exact anchors that fit the live diff. If an otherwise useful comment is outside the live diff's anchorable locations, safely downgrade it to top-level review body feedback that starts with clear fallback location text instead of submitting an invalid inline anchor."
 	if forgejoNative {
 		githubOperationContract = fmt.Sprintf("Forgejo operation contract: submit exactly one native PR review for this run through the trusted Looper CLI at %s, with review JSON on stdin. The wrapper validates the expected head, current review request, content safety, provider capability, and idempotency marker before it calls Forgejo. Do not call the Forgejo review API directly.", actionableReviewSubmitCommand)
-		submitPayloadInstruction = fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries using `path`, `line`, `side` (`RIGHT` for new lines, `LEFT` for old lines), and `body`; the wrapper maps validated anchors to Forgejo positions.", looperCLICommand)
+		submitPayloadInstruction = fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries using `path`, `line`, `side` (`RIGHT` for new lines, `LEFT` for old lines), `body`, plus Looper-only `disposition=must_fix`, `scopeBasis`, and `scopeEvidence`; the wrapper validates those fields then maps anchors to Forgejo and strips Looper-only fields before the provider call.", looperCLICommand)
 		idempotencyInstruction = "Idempotency requirement: submit only through the trusted Looper wrapper. The wrapper lists existing native Forgejo reviews and reuses an exact id/head/outcome/state marker match; after the agent exits, the runner verifies the same marker before recording publication. Never call the Forgejo review endpoint directly."
 		freshnessInstruction = "Before posting, rely on the trusted Looper wrapper to confirm the Forgejo PR is still open and the head SHA still matches. If it reports drift, exit non-zero with the exact message `PR head changed before publish`."
 		anchorInstruction = "Before posting, validate every inline review comment against the supplied Forgejo diff and local worktree. Preserve exact changed-file anchors; downgrade unanchorable feedback to a top-level review-body item with an exact file/section/symbol reference."
@@ -6958,10 +7444,11 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		idempotencyInstruction,
 		existingMarkerEventInstruction,
 		githubOperationContract,
-		"Review pass contract: complete one full review pass before publishing. Collect PR metadata, changed-file list, live diffs, prior unresolved feedback, and necessary surrounding context; then scan every changed file/range in scope. Do not stop after the first issue. If a blocking issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass.",
-		"Finding accumulator contract: accumulate candidate findings internally before publishing. For each candidate, track location, severity, evidence, why it matters, and a suggested fix. Before submitting, deduplicate, merge same-root-cause findings, group repeated patterns into systemic comments with representative examples, and prefer fewer deep comments over many shallow ones. If there are more than 15 blocking findings or more than 25 total comments, avoid comment flooding by publishing grouped systemic blockers instead of many repetitive inline comments.",
+		"Review pass contract: complete one full review pass before publishing. Collect PR metadata, changed-file list, live diffs, prior unresolved feedback, and necessary surrounding context; then scan every changed file/range in scope. Do not stop after the first issue. If an in-scope must_fix issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass.",
+		"Finding disposition contract: every candidate uses disposition must_fix|follow_up|needs_human, severity blocking|non_blocking|nit, scopeBasis (stated_intent|introduced_regression|required_invariant|independent_improvement|ambiguous_intent), scopeEvidence (specific repository rule, PR goal/non-goal, linked spec section, or regression evidence), path/line, problem, why, and suggestedChange. Emit the full candidate list in `__LOOPER_RESULT__.findings` — Looper parses this JSON. Only must_fix may be submitted through `looper review submit` as remote actionable feedback. Retain follow_up in structured completion only — do not submit follow_up as review comments. For needs_human, do not submit change-request comments; include them in `__LOOPER_RESULT__.findings` so Looper can park the pair for human judgment. Actionable/blocking reviews must carry must_fix as inline comments, not body-only prose.",
+		"Finding accumulator contract: accumulate candidate findings internally before publishing. For each candidate, track disposition, severity, scopeBasis, scopeEvidence, location, problem, why it matters, and a suggested fix. Before submitting, deduplicate only the same root cause or a genuinely repeated pattern; group repeated patterns into systemic comments with representative examples only when they share a root cause. Keep unrelated concerns as separate comments. The publication budget limits review publications, not findings per publication.",
 		"Severity rubric: mark a finding as BLOCKING only when it can realistically cause incorrect behavior, data loss/corruption, security exposure, broken public API/protocol/config/migration/backward compatibility, failing existing or necessary tests, race/deadlock/resource leak, transaction/lifecycle inconsistency, clear production risk, or failure to satisfy the PR's stated goal. Mark actionable but merge-safe improvements as NON_BLOCKING. Mark tiny style, naming, wording, formatting, or subjective preferences as NIT; NITs must not block merge.",
-		"Finalization gate before submit: verify that the scoped changed files/ranges were reviewed, all observed blocking findings are included, repeated patterns are consolidated, non-blocking/nit feedback is not escalated, every published finding has concrete evidence and a suggested fix, and the review outcome matches the highest published severity.",
+		"Finalization gate before submit: verify that the scoped changed files/ranges were reviewed, all observed in-scope must_fix findings are included in this publication, repeated patterns are consolidated only for a shared root cause, non-blocking/nit feedback is not escalated, every published comment has disposition=must_fix with scopeBasis/scopeEvidence plus concrete evidence and a suggested fix, and the review outcome matches the highest published severity.",
 		freshnessInstruction,
 		reviewRequestInstruction,
 		"Review body style contract: the visible body must be human-authored review prose only. Never post terminal/tool output, ANSI escape sequences, file-read traces, command logs, JSON parsing artifacts, or your internal scratch work as the GitHub review body. If you have actionable findings but do not have concrete actionable prose yet, exit non-zero instead of posting logs. For a clean APPROVE review, write the required author mention, change/verification summary, and warm acknowledgement; never use an LGTM, empty, or disclosure-only clean body as a fallback.",

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -3163,7 +3163,8 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		if markerErr != nil {
 			return checkpoint, &loopError{message: markerErr.Error(), kind: FailureRetryableAfterResume}
 		}
-		if len(publishableCommentOnlyFindings(nativeCompletion.Findings)) > 0 && !nativeMustFixReviewMarkerActionable(found) {
+		mustFixCount := len(publishableCommentOnlyFindings(nativeCompletion.Findings))
+		if mustFixCount > 0 && !nativeMustFixReviewMarkerActionable(found, mustFixCount) {
 			return checkpoint, &loopError{
 				message: missingReviewMarkerMessage(input, pendingReviewCheckpoint{HeadSHA: checkpoint.Snapshot.HeadSHA, IdempotencyKey: idempotencyKey}) + "; mixed must_fix+needs_human requires an actionable review marker before parking scope",
 				kind:    FailureRetryableAfterResume,
@@ -3173,7 +3174,7 @@ func (r *Runner) runReviewStep(ctx context.Context, input stepInput) (reviewerCh
 		if marshalErr != nil {
 			return checkpoint, &loopError{message: fmt.Sprintf("marshal reviewer native completion: %v", marshalErr), kind: FailureRetryableAfterResume}
 		}
-		if nativeMustFixReviewMarkerActionable(found) {
+		if nativeMustFixReviewMarkerActionable(found, mustFixCount) {
 			summary := result.Summary
 			if strings.TrimSpace(nativeCompletion.Summary) != "" {
 				summary = nativeCompletion.Summary
@@ -3484,8 +3485,8 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 		checkpoint.ResumePolicy = "rerun_review"
 		return checkpoint, &loopError{message: message, kind: FailureRetryableAfterResume}
 	}
-	if pendingNativeMustFixRequiresActionableMarker(pending) && !nativeMustFixReviewMarkerActionable(markerResult) {
-		message := missingReviewMarkerMessage(input, pending) + "; must_fix publication requires an actionable review marker with inline comments"
+	if pendingNativeMustFixRequiresActionableMarker(pending) && !nativeMustFixReviewMarkerActionable(markerResult, pendingNativeMustFixCount(pending)) {
+		message := missingReviewMarkerMessage(input, pending) + "; must_fix publication requires an actionable review marker with inline comments for every finding"
 		if pending.MarkerVerificationMisses == 0 {
 			pending.MarkerVerificationMisses = 1
 			checkpoint.PendingReview = pending.clone()
@@ -3615,24 +3616,38 @@ func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepIn
 
 // nativeMustFixReviewMarkerActionable reports whether a verified marker can
 // stand in for published must_fix feedback. Clean/APPROVE markers, missing
-// markers, and body-only COMMENT/REQUEST_CHANGES without inline comments are
-// not actionable publication.
-func nativeMustFixReviewMarkerActionable(found ReviewMarkerResult) bool {
+// markers, body-only COMMENT/REQUEST_CHANGES, and markers with fewer non-empty
+// inline comments than structured must_fix findings are not actionable
+// publication: leftover must_fix never becomes remote feedback or Fixer input.
+func nativeMustFixReviewMarkerActionable(found ReviewMarkerResult, mustFixCount int) bool {
 	if !found.Found {
 		return false
 	}
-	return len(found.InlineCommentBodies) > 0
+	n := 0
+	for _, body := range found.InlineCommentBodies {
+		if strings.TrimSpace(body) != "" {
+			n++
+		}
+	}
+	if mustFixCount < 1 {
+		return n > 0
+	}
+	return n >= mustFixCount
 }
 
-func pendingNativeMustFixRequiresActionableMarker(pending pendingReviewCheckpoint) bool {
+func pendingNativeMustFixCount(pending pendingReviewCheckpoint) int {
 	if strings.TrimSpace(pending.ReviewerSummaryJSON) == "" {
-		return false
+		return 0
 	}
 	var completion reviewerCommentOnlyCompletion
 	if err := json.Unmarshal([]byte(pending.ReviewerSummaryJSON), &completion); err != nil {
-		return false
+		return 0
 	}
-	return len(publishableCommentOnlyFindings(completion.Findings)) > 0
+	return len(publishableCommentOnlyFindings(completion.Findings))
+}
+
+func pendingNativeMustFixRequiresActionableMarker(pending pendingReviewCheckpoint) bool {
+	return pendingNativeMustFixCount(pending) > 0
 }
 
 func sameReviewAuthorLogin(a string, b string) bool {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -667,6 +667,18 @@ const (
 	reviewFindingDispositionNeedsHuman = "needs_human"
 )
 
+const (
+	reviewFindingSeverityBlocking    = "blocking"
+	reviewFindingSeverityNonBlocking = "non_blocking"
+	reviewFindingSeverityNit         = "nit"
+
+	reviewFindingScopeStatedIntent           = "stated_intent"
+	reviewFindingScopeIntroducedRegression   = "introduced_regression"
+	reviewFindingScopeRequiredInvariant      = "required_invariant"
+	reviewFindingScopeIndependentImprovement = "independent_improvement"
+	reviewFindingScopeAmbiguousIntent        = "ambiguous_intent"
+)
+
 type threadResolutionCheckpoint struct {
 	HeadSHA   string `json:"headSha,omitempty"`
 	Processed int    `json:"processed,omitempty"`
@@ -4551,6 +4563,19 @@ func validateReviewerCommentOnlyCompletion(completion reviewerCommentOnlyComplet
 		default:
 			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d has invalid disposition %q", i, finding.Disposition)
 		}
+		if finding.Severity == "" {
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d requires severity", i)
+		}
+		switch finding.Severity {
+		case reviewFindingSeverityBlocking, reviewFindingSeverityNonBlocking, reviewFindingSeverityNit:
+		default:
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d has invalid severity %q", i, finding.Severity)
+		}
+		switch finding.ScopeBasis {
+		case reviewFindingScopeStatedIntent, reviewFindingScopeIntroducedRegression, reviewFindingScopeRequiredInvariant, reviewFindingScopeIndependentImprovement, reviewFindingScopeAmbiguousIntent:
+		default:
+			return reviewerCommentOnlyCompletion{}, fmt.Errorf("reviewer comment-only finding %d has invalid scopeBasis %q", i, finding.ScopeBasis)
+		}
 		if finding.Disposition == reviewFindingDispositionMustFix {
 			mustFixCount++
 		}
@@ -7538,13 +7563,13 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		return agent.AppendCompletionInstruction(strings.Join(parts, "\n\n")), instructionBlock
 	}
 	githubOperationContract := fmt.Sprintf("GitHub operation contract: when there are actionable findings, submit exactly one PR review for this run through the trusted Looper CLI at %s, with the review JSON on stdin. The wrapper validates inline anchors against the live PR diff before it calls GitHub; do not use PATH-based `looper`, repository-local `go run ./cmd/looper`, `gh api repos/%s/pulls/%d/reviews`, or `gh pr review` directly for the review submission.", actionableReviewSubmitCommand, repo, prNumber)
-	submitPayloadInstruction := fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries. Each actionable comment MUST include GitHub fields `path`, `line`, `side` (`RIGHT` for new diff lines, `LEFT` for old diff lines), optional `start_line` and `start_side` for multiline ranges, `body`, plus Looper-only fields `disposition` (must be `must_fix`), `scopeBasis`, and `scopeEvidence` (and preferably `severity`). The trusted wrapper rejects missing disposition/scope fields and rejects `follow_up`/`needs_human` in actionable comments; those dispositions stay out of the submit payload. Looper strips Looper-only fields before calling GitHub/Forgejo.", looperCLICommand)
+	submitPayloadInstruction := fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries. Each actionable comment MUST include GitHub fields `path`, `line`, `side` (`RIGHT` for new diff lines, `LEFT` for old diff lines), optional `start_line` and `start_side` for multiline ranges, `body`, plus Looper-only fields `disposition` (must be `must_fix`), `scopeBasis`, and `scopeEvidence` (and preferably `severity`). The trusted wrapper rejects missing disposition/scope fields and rejects `follow_up`/`needs_human` in actionable comments or the visible review body; those dispositions stay out of the submit payload. Looper strips Looper-only fields before calling GitHub/Forgejo.", looperCLICommand)
 	idempotencyInstruction := "Idempotency requirement: before posting anything, use `gh api` to list existing PR reviews for this PR. Only treat an existing marker as satisfying this run when the review body contains the exact idempotency id and expected head SHA, and the review state matches the required outcome-specific policy for this run. If such a matching review already exists, do not post another review. Instead, rely on Looper to validate that marker after the agent exits and to reconcile clean-signal reactions/spec label transitions as needed. If the marker exists but the outcome/review-state combination does not satisfy this run, ignore it and publish the correct review for this run instead."
 	freshnessInstruction := "Before posting, use `gh` to confirm the PR is still open and the head SHA still matches the expected head SHA. If it changed, do not post a review and exit non-zero with the exact message `PR head changed before publish`."
 	anchorInstruction := "Before posting, validate every inline review comment's `path`, `line`, `side`, `start_line`, and `start_side` against the live PR diff fetched with `gh pr diff`. Preserve exact anchors that fit the live diff. If an otherwise useful comment is outside the live diff's anchorable locations, safely downgrade it to top-level review body feedback that starts with clear fallback location text instead of submitting an invalid inline anchor."
 	if forgejoNative {
 		githubOperationContract = fmt.Sprintf("Forgejo operation contract: submit exactly one native PR review for this run through the trusted Looper CLI at %s, with review JSON on stdin. The wrapper validates the expected head, current review request, content safety, provider capability, and idempotency marker before it calls Forgejo. Do not call the Forgejo review API directly.", actionableReviewSubmitCommand)
-		submitPayloadInstruction = fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries using `path`, `line`, `side` (`RIGHT` for new lines, `LEFT` for old lines), `body`, plus Looper-only `disposition=must_fix`, `scopeBasis`, and `scopeEvidence`; the wrapper validates those fields then maps anchors to Forgejo and strips Looper-only fields before the provider call.", looperCLICommand)
+		submitPayloadInstruction = fmt.Sprintf("When submitting through `%s review submit`, pass stdin JSON with `body` and optional `comments` entries using `path`, `line`, `side` (`RIGHT` for new lines, `LEFT` for old lines), `body`, plus Looper-only `disposition=must_fix`, `scopeBasis`, and `scopeEvidence`; the wrapper validates those fields, rejects `follow_up`/`needs_human` in comments or the visible review body, then maps anchors to Forgejo and strips Looper-only fields before the provider call.", looperCLICommand)
 		idempotencyInstruction = "Idempotency requirement: submit only through the trusted Looper wrapper. The wrapper lists existing native Forgejo reviews and reuses an exact id/head/outcome/state marker match; after the agent exits, the runner verifies the same marker before recording publication. Never call the Forgejo review endpoint directly."
 		freshnessInstruction = "Before posting, rely on the trusted Looper wrapper to confirm the Forgejo PR is still open and the head SHA still matches. If it reports drift, exit non-zero with the exact message `PR head changed before publish`."
 		anchorInstruction = "Before posting, validate every inline review comment against the supplied Forgejo diff and local worktree. Preserve exact changed-file anchors; downgrade unanchorable feedback to a top-level review-body item with an exact file/section/symbol reference."

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -10256,16 +10256,25 @@ func TestCommentOnlyNeedsHumanQuestionNamesAuthority(t *testing.T) {
 
 func TestNativeMustFixReviewMarkerActionableRequiresInlineComments(t *testing.T) {
 	t.Parallel()
-	if nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventComment, Outcome: "actionable"}) {
+	if nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventComment, Outcome: "actionable"}, 1) {
 		t.Fatal("body-only COMMENT must not count as published must_fix")
 	}
-	if nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventRequestChanges, Outcome: "blocking"}) {
+	if nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventRequestChanges, Outcome: "blocking"}, 1) {
 		t.Fatal("body-only REQUEST_CHANGES must not count as published must_fix")
 	}
-	if !nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventComment, Outcome: "actionable", InlineCommentBodies: []string{"fix it"}}) {
+	if !nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventComment, Outcome: "actionable", InlineCommentBodies: []string{"fix it"}}, 1) {
 		t.Fatal("COMMENT with inline comments must count as published must_fix")
 	}
-	if nativeMustFixReviewMarkerActionable(ReviewMarkerResult{}) {
+	if nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventComment, Outcome: "blocking", InlineCommentBodies: []string{"fix first"}}, 2) {
+		t.Fatal("one inline comment must not cover two must_fix findings")
+	}
+	if nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventComment, Outcome: "blocking", InlineCommentBodies: []string{"fix first", ""}}, 2) {
+		t.Fatal("empty inline bodies must not count toward must_fix coverage")
+	}
+	if !nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventComment, Outcome: "blocking", InlineCommentBodies: []string{"fix first", "fix second"}}, 2) {
+		t.Fatal("two inline comments must cover two must_fix findings")
+	}
+	if nativeMustFixReviewMarkerActionable(ReviewMarkerResult{}, 1) {
 		t.Fatal("missing marker must not count as published must_fix")
 	}
 }
@@ -10369,6 +10378,103 @@ func TestRunPublishStepNativeMustFixRequiresActionableMarker(t *testing.T) {
 	}
 }
 
+func TestRunPublishStepNativeMustFixRequiresInlineCommentPerFinding(t *testing.T) {
+	t.Parallel()
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Two blocking must_fix findings",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug one", Body: "fix first", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+			{Title: "Bug two", Body: "fix second", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"b.go"}},
+		},
+	}
+	payload, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, tc := range []struct {
+		name         string
+		inlineBodies []string
+		wantPublish  bool
+	}{
+		{name: "one_inline", inlineBodies: []string{"fix first"}},
+		{name: "two_inlines", inlineBodies: []string{"fix first", "fix second"}, wantPublish: true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			repo := "acme/looper"
+			prNumber := int64(42)
+			nowISO := fixture.nowISO()
+			target := "pr:acme/looper:42"
+			metadata := `{"loop":{"iterationCount":0}}`
+			loop := storage.LoopRecord{
+				ID: "loop_native_must_fix_multi_" + tc.name, Seq: 119, ProjectID: "project_1", Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+				Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+				t.Fatalf("upsert loop: %v", err)
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			runner := New(Options{
+				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{
+					reviewMarkerMissing:             false,
+					reviewMarkerEvent:               ReviewEventComment,
+					reviewMarkerOutcome:             "blocking",
+					reviewMarkerInlineCommentBodies: tc.inlineBodies,
+				}, Git: &fakeGitGateway{},
+				Logger: fixture.logger, Now: fixture.now,
+				LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+			})
+			project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+			if err != nil || project == nil {
+				t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+			}
+			_, err = runner.runPublishStep(context.Background(), stepInput{
+				Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_native_must_fix_multi_" + tc.name},
+				Repo: repo, PRNumber: prNumber,
+				Checkpoint: reviewerCheckpoint{
+					Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+					Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+					PendingReview: &pendingReviewCheckpoint{
+						HeadSHA: "abc123", IdempotencyKey: "idem-native-must-fix-multi-" + tc.name, Event: reviewEventAgentNative,
+						Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+					},
+				},
+			})
+			updated, getErr := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if getErr != nil || updated == nil {
+				t.Fatalf("after publish = (%#v, %v)", updated, getErr)
+			}
+			gotHead, _ := stringFromAny(parseJSONObject(updated.MetadataJSON)["lastPublishedHeadSha"])
+			if tc.wantPublish {
+				if err != nil {
+					t.Fatalf("runPublishStep() error = %v, want published native must_fix", err)
+				}
+				if loops.ReviewerPublishCount(updated.MetadataJSON) != 1 || gotHead != "abc123" {
+					t.Fatalf("published loop = %#v head=%q, want count=1 lastPublishedHeadSha=abc123", updated, gotHead)
+				}
+				return
+			}
+			var le *loopError
+			if !errors.As(err, &le) || le.kind != FailureRetryableAfterResume {
+				t.Fatalf("runPublishStep() error = %v, want retryable loopError", err)
+			}
+			if !strings.Contains(err.Error(), "inline comments for every finding") {
+				t.Fatalf("error = %q, want per-finding inline publication failure", err)
+			}
+			if loops.ReviewerPublishCount(updated.MetadataJSON) != 0 || gotHead != "" {
+				t.Fatalf("partial marker consumed budget/head: count=%d head=%q meta=%v", loops.ReviewerPublishCount(updated.MetadataJSON), gotHead, updated.MetadataJSON)
+			}
+		})
+	}
+}
+
 func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -10461,6 +10567,106 @@ func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 				}
 				if loops.IsReviewScopeHumanHold(*updated) || loops.HasPendingReviewScopeHuman(*updated) {
 					t.Fatalf("must not park mixed must_fix without an actionable marker: meta=%s", derefString(updated.MetadataJSON))
+				}
+				return
+			}
+			var hold *holdSkipError
+			if !errors.As(err, &hold) {
+				t.Fatalf("runReviewStep() error = %v, want holdSkipError", err)
+			}
+			if !tc.wantHold || !loops.IsReviewScopeHumanHold(*updated) {
+				t.Fatalf("after park = (%#v, %v), want scope hold", updated, err)
+			}
+		})
+	}
+}
+
+func TestRunReviewStepMixedNativeMustFixRequiresInlineCommentPerFinding(t *testing.T) {
+	t.Parallel()
+	stdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug one","body":"fix first","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Bug two","body":"fix second","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"c.go","line":3},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+	for _, tc := range []struct {
+		name          string
+		inlineBodies  []string
+		wantHold      bool
+		wantRetryable bool
+		wantPublish   int
+		wantLastHead  string
+	}{
+		{name: "one_inline", inlineBodies: []string{"fix first"}, wantRetryable: true, wantPublish: 0},
+		{name: "two_inlines", inlineBodies: []string{"fix first", "fix second"}, wantHold: true, wantPublish: 1, wantLastHead: "abc123"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			repo := "acme/looper"
+			prNumber := int64(42)
+			nowISO := fixture.nowISO()
+			target := "pr:acme/looper:42"
+			metadata := `{"loop":{"iterationCount":0}}`
+			loop := storage.LoopRecord{
+				ID: "loop_mixed_must_fix_multi_" + tc.name, Seq: 120, ProjectID: "project_1", Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+				Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+				t.Fatalf("upsert loop: %v", err)
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			cfg.HITL.Enabled = false
+			runner := New(Options{
+				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{
+					reviewMarkerMissing:             false,
+					reviewMarkerEvent:               ReviewEventComment,
+					reviewMarkerOutcome:             "blocking",
+					reviewMarkerInlineCommentBodies: tc.inlineBodies,
+				}, Git: &fakeGitGateway{},
+				AgentExecutor: &fakeAgentExecutor{results: []AgentResult{{
+					Status: "completed", Summary: "Mixed must_fix and needs_human", Stdout: stdout, ParseStatus: "parsed",
+				}}},
+				Logger: fixture.logger, Now: fixture.now,
+				LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+			})
+			project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+			if err != nil || project == nil {
+				t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+			}
+			_, err = runner.runReviewStep(context.Background(), stepInput{
+				Project:  *project,
+				Loop:     loop,
+				Run:      storage.RunRecord{ID: "run_mixed_must_fix_multi_" + tc.name},
+				Repo:     repo,
+				PRNumber: prNumber,
+				Checkpoint: reviewerCheckpoint{
+					Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+					Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+					Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: nowISO},
+				},
+			})
+			updated, getErr := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if getErr != nil || updated == nil {
+				t.Fatalf("after step = (%#v, %v)", updated, getErr)
+			}
+			if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != tc.wantPublish {
+				t.Fatalf("ReviewerPublishCount = %d, want %d", got, tc.wantPublish)
+			}
+			gotHead, _ := stringFromAny(parseJSONObject(updated.MetadataJSON)["lastPublishedHeadSha"])
+			if gotHead != tc.wantLastHead {
+				t.Fatalf("lastPublishedHeadSha = %q, want %q", gotHead, tc.wantLastHead)
+			}
+			if tc.wantRetryable {
+				var le *loopError
+				if !errors.As(err, &le) || le.kind != FailureRetryableAfterResume {
+					t.Fatalf("runReviewStep() error = %v, want retryable loopError", err)
+				}
+				if !strings.Contains(err.Error(), "actionable review marker") {
+					t.Fatalf("error = %q, want actionable-marker publication failure", err)
+				}
+				if loops.IsReviewScopeHumanHold(*updated) || loops.HasPendingReviewScopeHuman(*updated) {
+					t.Fatalf("must not park mixed must_fix with a partial marker: meta=%s", derefString(updated.MetadataJSON))
 				}
 				return
 			}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -10270,6 +10270,105 @@ func TestNativeMustFixReviewMarkerActionableRequiresInlineComments(t *testing.T)
 	}
 }
 
+func TestRunPublishStepNativeMustFixRequiresActionableMarker(t *testing.T) {
+	t.Parallel()
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Blocking must_fix only",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "fix it", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+		},
+	}
+	payload, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, tc := range []struct {
+		name         string
+		markerEvent  ReviewEvent
+		markerOut    string
+		inlineBodies []string
+		wantPublish  bool
+	}{
+		{name: "body_only_comment", markerEvent: ReviewEventComment, markerOut: "actionable"},
+		{name: "body_only_request_changes", markerEvent: ReviewEventRequestChanges, markerOut: "blocking"},
+		{name: "inline_comment", markerEvent: ReviewEventComment, markerOut: "blocking", inlineBodies: []string{"fix it"}, wantPublish: true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			repo := "acme/looper"
+			prNumber := int64(42)
+			nowISO := fixture.nowISO()
+			target := "pr:acme/looper:42"
+			metadata := `{"loop":{"iterationCount":0}}`
+			loop := storage.LoopRecord{
+				ID: "loop_native_must_fix_" + tc.name, Seq: 118, ProjectID: "project_1", Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+				Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+				t.Fatalf("upsert loop: %v", err)
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			runner := New(Options{
+				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{
+					reviewMarkerMissing:             false,
+					reviewMarkerEvent:               tc.markerEvent,
+					reviewMarkerOutcome:             tc.markerOut,
+					reviewMarkerInlineCommentBodies: tc.inlineBodies,
+				}, Git: &fakeGitGateway{},
+				Logger: fixture.logger, Now: fixture.now,
+				LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+			})
+			project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+			if err != nil || project == nil {
+				t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+			}
+			_, err = runner.runPublishStep(context.Background(), stepInput{
+				Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_native_must_fix_" + tc.name},
+				Repo: repo, PRNumber: prNumber,
+				Checkpoint: reviewerCheckpoint{
+					Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+					Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+					PendingReview: &pendingReviewCheckpoint{
+						HeadSHA: "abc123", IdempotencyKey: "idem-native-must-fix-" + tc.name, Event: reviewEventAgentNative,
+						Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+					},
+				},
+			})
+			updated, getErr := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if getErr != nil || updated == nil {
+				t.Fatalf("after publish = (%#v, %v)", updated, getErr)
+			}
+			gotHead, _ := stringFromAny(parseJSONObject(updated.MetadataJSON)["lastPublishedHeadSha"])
+			if tc.wantPublish {
+				if err != nil {
+					t.Fatalf("runPublishStep() error = %v, want published native must_fix", err)
+				}
+				if loops.ReviewerPublishCount(updated.MetadataJSON) != 1 || gotHead != "abc123" {
+					t.Fatalf("published loop = %#v head=%q, want count=1 lastPublishedHeadSha=abc123", updated, gotHead)
+				}
+				return
+			}
+			var le *loopError
+			if !errors.As(err, &le) || le.kind != FailureRetryableAfterResume {
+				t.Fatalf("runPublishStep() error = %v, want retryable loopError", err)
+			}
+			if !strings.Contains(err.Error(), "actionable review marker") {
+				t.Fatalf("error = %q, want actionable-marker publication failure", err)
+			}
+			if loops.ReviewerPublishCount(updated.MetadataJSON) != 0 || gotHead != "" {
+				t.Fatalf("unpublished loop consumed budget/head: count=%d head=%q meta=%v", loops.ReviewerPublishCount(updated.MetadataJSON), gotHead, updated.MetadataJSON)
+			}
+		})
+	}
+}
+
 func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -10132,6 +10132,21 @@ func TestCommentOnlyPublishVisibleSummaryOmitsSuppressedFindings(t *testing.T) {
 	}
 }
 
+func TestCommentOnlyPublishVisibleSummaryRedactsFollowUpFromCleanSummary(t *testing.T) {
+	t.Parallel()
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "No actionable findings. Follow-up: rename the helper later.",
+		Outcome: "clean",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Rename helper", Body: "later", Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "style"},
+		},
+	}
+	visible := commentOnlyPublishVisibleSummary(completion)
+	if visible != "No actionable findings" {
+		t.Fatalf("visible = %q, want fixed clean summary without follow_up details", visible)
+	}
+}
+
 func TestParseReviewerNativeCompletionFindingsAndLegacy(t *testing.T) {
 	t.Parallel()
 	// Legacy summary-only remains valid.
@@ -10278,6 +10293,82 @@ func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 	}
 }
 
+func TestRunReviewStepMixedNativePersistsCompletionBeforePublishedHead(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":0}}`
+	loop := storage.LoopRecord{
+		ID: "loop_mixed_persist_before_publish", Seq: 97, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert loop: %v", err)
+	}
+	runID := "run_mixed_persist_before_publish"
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: runID, LoopID: loop.ID, Status: "running", StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = false
+	stdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{
+			reviewMarkerMissing: false, reviewMarkerEvent: ReviewEventComment, reviewMarkerOutcome: "blocking",
+		}, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{results: []AgentResult{{
+			Status: "completed", Summary: "Mixed must_fix and needs_human", Stdout: stdout, ParseStatus: "parsed",
+		}}},
+		Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+	}
+	_, err = runner.runReviewStep(context.Background(), stepInput{
+		Project: *project, Loop: loop, Run: storage.RunRecord{ID: runID, LoopID: loop.ID},
+		Repo: repo, PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: nowISO},
+		},
+	})
+	var hold *holdSkipError
+	if !errors.As(err, &hold) {
+		t.Fatalf("runReviewStep() error = %v, want holdSkipError", err)
+	}
+	updated, getErr := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if getErr != nil || updated == nil {
+		t.Fatalf("after step = (%#v, %v)", updated, getErr)
+	}
+	gotHead, _ := stringFromAny(parseJSONObject(updated.MetadataJSON)["lastPublishedHeadSha"])
+	if gotHead != "abc123" {
+		t.Fatalf("lastPublishedHeadSha = %q, want abc123", gotHead)
+	}
+	if !loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("after park = %#v, want scope hold", updated)
+	}
+	persisted, err := fixture.repos.Runs.GetByID(context.Background(), runID)
+	if err != nil || persisted == nil {
+		t.Fatalf("Runs.GetByID = (%#v, %v)", persisted, err)
+	}
+	checkpoint := parseCheckpoint(persisted.CheckpointJSON)
+	if checkpoint.PendingReview == nil || !strings.Contains(checkpoint.PendingReview.ReviewerSummaryJSON, `"disposition":"needs_human"`) {
+		t.Fatalf("checkpoint pending = %#v, want persisted native completion with needs_human before lastPublishedHeadSha", checkpoint.PendingReview)
+	}
+}
+
 func TestRunReviewStepNeedsHumanDoesNotRecountAlreadyPublishedHead(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
@@ -10338,7 +10429,6 @@ func TestRunReviewStepNeedsHumanDoesNotRecountAlreadyPublishedHead(t *testing.T)
 		t.Fatalf("after retry = %#v, want recovered scope hold", updated)
 	}
 }
-
 
 func TestRunReviewStepNeedsHumanAtCapBudgetHoldOnlyNoStackedScope(t *testing.T) {
 	t.Parallel()

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -10180,11 +10180,16 @@ func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
 		markerMissing bool
+		markerEvent   ReviewEvent
+		markerOutcome string
+		wantHold      bool
+		wantRetryable bool
 		wantPublish   int
 		wantLastHead  string
 	}{
-		{name: "with_marker", markerMissing: false, wantPublish: 1, wantLastHead: "abc123"},
-		{name: "without_marker", markerMissing: true, wantPublish: 0, wantLastHead: ""},
+		{name: "with_marker", markerMissing: false, markerEvent: ReviewEventComment, markerOutcome: "blocking", wantHold: true, wantPublish: 1, wantLastHead: "abc123"},
+		{name: "without_marker", markerMissing: true, wantRetryable: true, wantPublish: 0},
+		{name: "clean_marker", markerMissing: false, markerEvent: ReviewEventApprove, markerOutcome: "clean", wantRetryable: true, wantPublish: 0},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -10214,8 +10219,8 @@ func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 			}}}
 			github := &fakeGitHubGateway{
 				reviewMarkerMissing: tc.markerMissing,
-				reviewMarkerEvent:   ReviewEventComment,
-				reviewMarkerOutcome: "blocking",
+				reviewMarkerEvent:   tc.markerEvent,
+				reviewMarkerOutcome: tc.markerOutcome,
 			}
 			runner := New(Options{
 				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
@@ -10238,13 +10243,9 @@ func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 					Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: nowISO},
 				},
 			})
-			var hold *holdSkipError
-			if !errors.As(err, &hold) {
-				t.Fatalf("runReviewStep() error = %v, want holdSkipError", err)
-			}
-			updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
-			if err != nil || updated == nil || !loops.IsReviewScopeHumanHold(*updated) {
-				t.Fatalf("after park = (%#v, %v), want scope hold", updated, err)
+			updated, getErr := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if getErr != nil || updated == nil {
+				t.Fatalf("after step = (%#v, %v)", updated, getErr)
 			}
 			if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != tc.wantPublish {
 				t.Fatalf("ReviewerPublishCount = %d, want %d", got, tc.wantPublish)
@@ -10252,6 +10253,26 @@ func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 			gotHead, _ := stringFromAny(parseJSONObject(updated.MetadataJSON)["lastPublishedHeadSha"])
 			if gotHead != tc.wantLastHead {
 				t.Fatalf("lastPublishedHeadSha = %q, want %q", gotHead, tc.wantLastHead)
+			}
+			if tc.wantRetryable {
+				var le *loopError
+				if !errors.As(err, &le) || le.kind != FailureRetryableAfterResume {
+					t.Fatalf("runReviewStep() error = %v, want retryable loopError", err)
+				}
+				if !strings.Contains(err.Error(), "actionable review marker") {
+					t.Fatalf("error = %q, want actionable-marker publication failure", err)
+				}
+				if loops.IsReviewScopeHumanHold(*updated) || loops.HasPendingReviewScopeHuman(*updated) {
+					t.Fatalf("must not park mixed must_fix without an actionable marker: meta=%s", derefString(updated.MetadataJSON))
+				}
+				return
+			}
+			var hold *holdSkipError
+			if !errors.As(err, &hold) {
+				t.Fatalf("runReviewStep() error = %v, want holdSkipError", err)
+			}
+			if !tc.wantHold || !loops.IsReviewScopeHumanHold(*updated) {
+				t.Fatalf("after park = (%#v, %v), want scope hold", updated, err)
 			}
 		})
 	}
@@ -10833,6 +10854,107 @@ func TestPublishAlreadyPublishedNeedsHumanSkipsScopeOnClosedPR(t *testing.T) {
 	}
 }
 
+func TestRunReviewStepNeedsHumanSkipsParkOnStaleOrClosedPR(t *testing.T) {
+	t.Parallel()
+	pureStdout := `__LOOPER_RESULT__={"summary":"Need human","outcome":"blocking","findings":[{"title":"Ambiguous","body":"Unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"AGENTS.md rule X","path":"a.go","line":1}]}`
+	mixedStdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+	for _, tc := range []struct {
+		name          string
+		commentOnly   bool
+		stdout        string
+		markerMissing bool
+		changeHead    bool
+		closeAfter    bool
+		wantInReason  string
+	}{
+		{name: "comment_only_new_head", commentOnly: true, stdout: pureStdout, markerMissing: true, changeHead: true, wantInReason: "head changed"},
+		{name: "comment_only_closed", commentOnly: true, stdout: pureStdout, markerMissing: true, closeAfter: true, wantInReason: "CLOSED"},
+		{name: "native_mixed_new_head", stdout: mixedStdout, changeHead: true, wantInReason: "head changed"},
+		{name: "native_mixed_closed", stdout: mixedStdout, closeAfter: true, wantInReason: "CLOSED"},
+		{name: "native_pure_new_head", stdout: pureStdout, markerMissing: true, changeHead: true, wantInReason: "head changed"},
+		{name: "native_pure_closed", stdout: pureStdout, markerMissing: true, closeAfter: true, wantInReason: "CLOSED"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			repo := "acme/looper"
+			prNumber := int64(42)
+			nowISO := fixture.nowISO()
+			target := "pr:acme/looper:42"
+			metadata := `{"loop":{"iterationCount":0}}`
+			loop := storage.LoopRecord{
+				ID: "loop_scope_fresh_" + tc.name, Seq: 120, ProjectID: "project_1", Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+				Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+				t.Fatalf("upsert loop: %v", err)
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			cfg.HITL.Enabled = true
+			if tc.commentOnly {
+				cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventComment
+			}
+			closedAfterFirst := ""
+			if tc.closeAfter {
+				closedAfterFirst = "CLOSED"
+			}
+			github := &fakeGitHubGateway{
+				changeHeadOnSecondView:  tc.changeHead,
+				viewStateAfterFirstView: closedAfterFirst,
+				reviewMarkerMissing:     tc.markerMissing,
+				reviewMarkerEvent:       ReviewEventComment,
+				reviewMarkerOutcome:     "blocking",
+			}
+			runner := New(Options{
+				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+				AgentExecutor: &fakeAgentExecutor{results: []AgentResult{{
+					Status: "completed", Summary: "Need human", Stdout: tc.stdout, ParseStatus: "parsed",
+				}}},
+				Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: tc.commentOnly,
+				LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+				ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents,
+			})
+			project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+			if err != nil || project == nil {
+				t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+			}
+			checkpoint, err := runner.runReviewStep(context.Background(), stepInput{
+				Project:  *project,
+				Loop:     loop,
+				Run:      storage.RunRecord{ID: "run_scope_fresh_" + tc.name},
+				Repo:     repo,
+				PRNumber: prNumber,
+				Checkpoint: reviewerCheckpoint{
+					Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+					Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+					Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: nowISO},
+				},
+			})
+			if err != nil {
+				t.Fatalf("runReviewStep() error = %v, want stale skip", err)
+			}
+			if checkpoint.SkipKind != "stale" || !strings.Contains(checkpoint.SkipReason, tc.wantInReason) {
+				t.Fatalf("checkpoint = %#v, want stale %q", checkpoint, tc.wantInReason)
+			}
+			updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if err != nil || updated == nil {
+				t.Fatalf("get loop: (%#v, %v)", updated, err)
+			}
+			if loops.IsReviewScopeHumanHold(*updated) || loops.HasPendingReviewScopeHuman(*updated) {
+				t.Fatalf("must not park obsolete needs_human: meta=%s", derefString(updated.MetadataJSON))
+			}
+			if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != 0 {
+				t.Fatalf("ReviewerPublishCount = %d, want 0", got)
+			}
+		})
+	}
+}
+
 func TestPublishCommentOnlyMixedMustFixNeedsHumanPublishesThenParksScope(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -11120,6 +11242,61 @@ func TestProcessClaimedItemPreservesParkedScopeHoldStatus(t *testing.T) {
 				t.Fatalf("want scope hold preserved: %#v meta=%v", updated, updated.MetadataJSON)
 			}
 		})
+	}
+}
+
+func TestProcessClaimedItemMixedNeedsHumanMissingMarkerFailsRetryable(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	ctx := context.Background()
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopID := "loop_mixed_missing_marker"
+	metadata := `{"followUpdates":true,"loop":{"enabled":true}}`
+	loop := storage.LoopRecord{
+		ID: loopID, Seq: 211, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber,
+		Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = false
+	stdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos,
+		GitHub:        &fakeGitHubGateway{reviewRequests: []string{"octocat"}, reviewMarkerMissing: true},
+		Git:           &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Mixed", Stdout: stdout, ParseStatus: "parsed"}}},
+		Logger:        fixture.logger, Now: fixture.now, CustomInstructions: &cfg,
+		LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 2, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25},
+	})
+	queue, err := runner.enqueue(ctx, enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queued item %s", claimed, err, queue.ID)
+	}
+	result, err := runner.ProcessClaimedItem(ctx, *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "failed" || result.FailureKind != FailureRetryableAfterResume || !strings.Contains(result.Summary, "actionable review marker") {
+		t.Fatalf("result = %#v, want retryable mixed-marker publication failure", result)
+	}
+	updated, err := fixture.repos.Loops.GetByID(ctx, loopID)
+	if err != nil || updated == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v)", updated, err)
+	}
+	if loops.IsReviewScopeHumanHold(*updated) || loops.HasPendingReviewScopeHuman(*updated) {
+		t.Fatalf("must not park mixed must_fix without a marker: status=%s meta=%v", updated.Status, updated.MetadataJSON)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -11048,6 +11048,81 @@ func TestParkReviewerScopeHumanHITLOnAskNotBudgetKind(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemPreservesParkedScopeHoldStatus(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		hitl       bool
+		wantStatus string
+	}{
+		{name: "hitl_awaiting", hitl: true, wantStatus: "awaiting_human"},
+		{name: "no_hitl_paused", hitl: false, wantStatus: "paused"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			ctx := context.Background()
+			nowISO := fixture.nowISO()
+			repo := "acme/looper"
+			prNumber := int64(42)
+			loopID := "loop_scope_finalizer_" + tc.name
+			metadata := `{"followUpdates":true,"loop":{"enabled":true}}`
+			loop := storage.LoopRecord{
+				ID: loopID, Seq: 210, ProjectID: "project_1", Type: "reviewer",
+				TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber,
+				Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+				t.Fatalf("Loops.Upsert() error = %v", err)
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			cfg.HITL.Enabled = tc.hitl
+			stdout := `__LOOPER_RESULT__={"summary":"Need human","outcome":"blocking","findings":[{"title":"Ambiguous","body":"Unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"AGENTS.md rule X","path":"a.go","line":1}]}`
+			agent := &fakeAgentExecutor{results: []AgentResult{{
+				Status: "completed", Summary: "Need human", Stdout: stdout, ParseStatus: "parsed",
+			}}}
+			github := &fakeGitHubGateway{reviewRequests: []string{"octocat"}, reviewMarkerMissing: true}
+			runner := New(Options{
+				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+				AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg,
+				LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 2, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25},
+			})
+			queue, err := runner.enqueue(ctx, enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+			if err != nil {
+				t.Fatalf("enqueue() error = %v", err)
+			}
+			claimed, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "reviewer-worker-1", "reviewer")
+			if err != nil || claimed == nil || claimed.ID != queue.ID {
+				t.Fatalf("ClaimNextOfType() = (%#v, %v), want queued item %s", claimed, err, queue.ID)
+			}
+			result, err := runner.ProcessClaimedItem(ctx, *claimed)
+			if err != nil {
+				t.Fatalf("ProcessClaimedItem() error = %v", err)
+			}
+			if result.Status != "skipped" {
+				t.Fatalf("result = %#v, want skipped after in-claim needs_human park", result)
+			}
+			if !strings.Contains(result.Summary, "review scope requires human judgment") {
+				t.Fatalf("result.Summary = %q, want scope hold skip", result.Summary)
+			}
+			updated, err := fixture.repos.Loops.GetByID(ctx, loopID)
+			if err != nil || updated == nil {
+				t.Fatalf("Loops.GetByID() = (%#v, %v)", updated, err)
+			}
+			if updated.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want parked %q (not queued)", updated.Status, tc.wantStatus)
+			}
+			if !loops.IsReviewScopeHumanHold(*updated) {
+				t.Fatalf("want scope hold preserved: %#v meta=%v", updated, updated.MetadataJSON)
+			}
+		})
+	}
+}
+
 func TestProcessClaimedItemCommentOnlySkipsWhenReviewRequestRemovedBeforePublish(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -8482,20 +8482,25 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"Spec/docs review rubric",
 		"suggestedChange",
 		"do not write or publish a bare LGTM review body",
-		"Group related findings by file, subsystem, function, or rule",
+		"Group findings only when they share the same root cause",
 		"fixture-matrix tests",
 		"'/opt/looper/bin/looper' review submit acme/looper#42 --event COMMENT --commit-id abc123 --reviewer-run-id run_1 --clean-review-event APPROVE --blocking-review-event COMMENT`",
 		"wrapper validates inline anchors against the live PR diff before it calls GitHub",
 		"Review pass contract",
 		"Do not stop after the first issue",
 		"include it in this review rather than deferring it to a later pass",
+		"Finding disposition contract",
+		"disposition must_fix|follow_up|needs_human",
+		"Looper parses this JSON",
+		"__LOOPER_RESULT__.findings",
 		"Finding accumulator contract",
-		"group repeated patterns into systemic comments with representative examples",
+		"group repeated patterns into systemic comments with representative examples only when they share a root cause",
 		"Severity rubric",
 		"mark a finding as BLOCKING only when",
 		"Mark actionable but merge-safe improvements as NON_BLOCKING",
 		"NITs must not block merge",
 		"Finalization gate before submit",
+		"disposition=must_fix with scopeBasis/scopeEvidence",
 		"review outcome matches the highest published severity",
 		"do not use PATH-based `looper`",
 		"repository-local `go run ./cmd/looper`",
@@ -8557,6 +8562,7 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"`path`, `line`, `side`",
 		"`start_line` and `start_side`",
 		"the detailed findings must live in inline `comments`",
+		"Looper **does** parse this findings list",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
@@ -8577,6 +8583,10 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"after the APPROVE review is posted",
 		"ensure +1 reaction",
 		"remove any existing +1 reaction",
+		"Prefer 3 deeply specific comments",
+		"prefer fewer deep comments",
+		"more than 15 blocking findings",
+		"more than 25 total comments",
 	} {
 		if strings.Contains(prompt, forbidden) {
 			t.Fatalf("prompt contains conflicting no-actionable clean-review instruction %q:\n%s", forbidden, prompt)
@@ -9585,9 +9595,14 @@ func TestBuildReviewPromptCommentOnlyOmitsGitHubPublishInstructions(t *testing.T
 	if !strings.Contains(prompt, "comment-only") || !strings.Contains(prompt, "Looper will post your final completion summary") {
 		t.Fatalf("prompt missing comment-only publish instructions:\n%s", prompt)
 	}
-	for _, required := range []string{"`findings`", "`review_item_id`", "`supersedes`"} {
+	for _, required := range []string{"`findings`", "`review_item_id`", "`supersedes`", "disposition `must_fix`", "follow_up", "needs_human", "scopeBasis", "scopeEvidence"} {
 		if !strings.Contains(prompt, required) {
 			t.Fatalf("prompt missing %s contract:\n%s", required, prompt)
+		}
+	}
+	for _, forbidden := range []string{"Prefer 3 deeply specific comments", "prefer fewer deep comments", "more than 15 blocking", "more than 25 total"} {
+		if strings.Contains(prompt, forbidden) {
+			t.Fatalf("comment-only prompt retains flood language %q:\n%s", forbidden, prompt)
 		}
 	}
 }
@@ -9616,7 +9631,7 @@ func TestProcessClaimedItemCommentOnlyPublishesOneCommentAndSkipsRediscoveryForS
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{labels: []string{"looper:review"}, reviewRequests: []string{}, currentLogin: "reviewer"}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "internal/reviewer/runner.go: add a regression test for Forgejo comment-only publish", Stdout: `__LOOPER_RESULT__={"summary":"internal/reviewer/runner.go: add a regression test for Forgejo comment-only publish","outcome":"non_blocking","findings":[{"title":"Regression coverage missing for comment-only publish","body":"Add a focused reviewer test that proves Forgejo comment-only publish upserts the fixed Reviewer Summary comment instead of treating freeform markdown as authority.","files":["internal/reviewer/runner_test.go"]}]}`}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "internal/reviewer/runner.go: add a regression test for Forgejo comment-only publish", Stdout: `__LOOPER_RESULT__={"summary":"internal/reviewer/runner.go: add a regression test for Forgejo comment-only publish","outcome":"non_blocking","findings":[{"title":"Regression coverage missing for comment-only publish","body":"Add a focused reviewer test that proves Forgejo comment-only publish upserts the fixed Reviewer Summary comment instead of treating freeform markdown as authority.","files":["internal/reviewer/runner_test.go"],"disposition":"must_fix","severity":"non_blocking","scopeBasis":"required_invariant","scopeEvidence":"comment-only publish contract"}]}`}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: false, Labels: []string{"looper:review"}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
 
 	discovery, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
@@ -9882,7 +9897,7 @@ func TestProcessClaimedItemCommentOnlyPublishesBlockingOutcome(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{labels: []string{"looper:review"}, reviewRequests: []string{}, currentLogin: "reviewer"}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "internal/reviewer/runner.go: nil worktree cleanup can deadlock reviewer retries", Stdout: `__LOOPER_RESULT__={"summary":"internal/reviewer/runner.go: nil worktree cleanup can deadlock reviewer retries","outcome":"blocking","findings":[{"title":"Nil worktree cleanup can deadlock retries","body":"Guard the cleanup path so retry resume does not block forever when the worktree record is missing.","files":["internal/reviewer/runner.go"]}]}`, ParseStatus: "parsed"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "internal/reviewer/runner.go: nil worktree cleanup can deadlock reviewer retries", Stdout: `__LOOPER_RESULT__={"summary":"internal/reviewer/runner.go: nil worktree cleanup can deadlock reviewer retries","outcome":"blocking","findings":[{"title":"Nil worktree cleanup can deadlock retries","body":"Guard the cleanup path so retry resume does not block forever when the worktree record is missing.","files":["internal/reviewer/runner.go"],"disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"nil worktree path"}]}`, ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: false, Labels: []string{"looper:review"}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
@@ -9923,7 +9938,7 @@ func TestProcessClaimedItemCommentOnlyUpdatesSingleReviewerSummaryCommentAndReus
 		t.Fatalf("renderReviewerSummaryComment() error = %v", err)
 	}
 	github := &fakeGitHubGateway{labels: []string{"looper:review"}, reviewRequests: []string{}, currentLogin: "reviewer", issueComments: []map[string]any{{"id": int64(91), "body": existingBody}}}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Updated findings", Stdout: `__LOOPER_RESULT__={"summary":"Updated findings","outcome":"blocking","findings":[{"review_item_id":"R-001","title":"Keep ID","body":"Still broken after the latest patch.","files":["internal/reviewer/runner.go"]},{"title":"Split replacement","body":"This issue replaces the old broad item with a narrower actionable finding.","files":["internal/reviewer/runner.go"],"supersedes":["R-002"]}]}`, ParseStatus: "parsed"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Updated findings", Stdout: `__LOOPER_RESULT__={"summary":"Updated findings","outcome":"blocking","findings":[{"review_item_id":"R-001","title":"Keep ID","body":"Still broken after the latest patch.","files":["internal/reviewer/runner.go"],"disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"still broken"},{"title":"Split replacement","body":"This issue replaces the old broad item with a narrower actionable finding.","files":["internal/reviewer/runner.go"],"supersedes":["R-002"],"disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"narrower split"}]}`, ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: false, Labels: []string{"looper:review"}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
@@ -9974,14 +9989,1062 @@ func TestBuildReviewerSummaryFromCompletionRejectsSupersededUpdatedReviewItemID(
 		Summary: "Updated findings",
 		Outcome: "blocking",
 		Findings: []reviewerCommentOnlyFindingResult{
-			{ReviewItemID: "R-001", Title: "Keep ID", Body: "Still broken after the latest patch."},
-			{Title: "Replacement", Body: "This narrows the old broad issue.", Supersedes: []string{"R-001"}},
+			{ReviewItemID: "R-001", Title: "Keep ID", Body: "Still broken after the latest patch.", Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "still broken"},
+			{Title: "Replacement", Body: "This narrows the old broad issue.", Supersedes: []string{"R-001"}, Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "narrower"},
 		},
 	}
 
 	_, err := buildReviewerSummaryFromCompletion(existing, completion)
 	if err == nil || !strings.Contains(err.Error(), `supersedes updated review_item_id "R-001"`) {
 		t.Fatalf("buildReviewerSummaryFromCompletion() error = %v, want updated supersedes failure", err)
+	}
+}
+
+func TestValidateReviewerCommentOnlyCompletionDispositions(t *testing.T) {
+	t.Parallel()
+
+	ok, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Must fix one",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{
+				Title: "Bug", Body: "Nil deref", Disposition: "must_fix", Severity: "blocking",
+				ScopeBasis: "introduced_regression", ScopeEvidence: "new path",
+			},
+			{
+				Title: "Later", Body: "Nice refactor", Disposition: "follow_up", Severity: "nit",
+				ScopeBasis: "independent_improvement", ScopeEvidence: "not required",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("validate must_fix+follow_up: %v", err)
+	}
+	if len(ok.Findings) != 2 {
+		t.Fatalf("findings = %#v", ok.Findings)
+	}
+
+	// follow_up alone is not actionable remote work; outcome must be clean.
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "No actionable findings",
+		Outcome: "clean",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Later", Body: "Nice", Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "x"},
+		},
+	}); err != nil {
+		t.Fatalf("clean with follow_up only: %v", err)
+	}
+
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "No actionable findings",
+		Outcome: "clean",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "x", Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "y"},
+		},
+	}); err == nil || !strings.Contains(err.Error(), "must_fix") {
+		t.Fatalf("clean with must_fix error = %v", err)
+	}
+
+	// Fail-closed: missing disposition/scope fields are rejected (no default must_fix).
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Missing fields",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "x"},
+		},
+	}); err == nil || !strings.Contains(err.Error(), "requires disposition") {
+		t.Fatalf("missing disposition error = %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Missing scope",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "x", Disposition: "must_fix"},
+		},
+	}); err == nil || !strings.Contains(err.Error(), "requires scopeBasis") {
+		t.Fatalf("missing scopeBasis error = %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Missing evidence",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "x", Disposition: "must_fix", ScopeBasis: "introduced_regression"},
+		},
+	}); err == nil || !strings.Contains(err.Error(), "requires scopeEvidence") {
+		t.Fatalf("missing scopeEvidence error = %v", err)
+	}
+}
+
+func TestBuildReviewerSummaryFromCompletionFiltersFollowUpAndNeedsHuman(t *testing.T) {
+	t.Parallel()
+
+	existing := forge.NewReviewerSummary(1, nil)
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Must", Body: "fix", Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "e1", Files: []string{"a.go"}},
+			{Title: "Later", Body: "follow", Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "e2"},
+			{Title: "Human", Body: "ask", Disposition: "needs_human", ScopeBasis: "ambiguous_intent", ScopeEvidence: "e3"},
+		},
+	}
+	summary, err := buildReviewerSummaryFromCompletion(existing, completion)
+	if err != nil {
+		t.Fatalf("buildReviewerSummaryFromCompletion: %v", err)
+	}
+	if len(summary.Items) != 1 || summary.Items[0].Title != "Must" {
+		t.Fatalf("items = %#v, want only must_fix remote item", summary.Items)
+	}
+}
+
+func TestPublishableCommentOnlyFindingsFiltersNonMustFix(t *testing.T) {
+	t.Parallel()
+	got := publishableCommentOnlyFindings([]reviewerCommentOnlyFindingResult{
+		{Title: "a", Disposition: "must_fix"},
+		{Title: "b", Disposition: "follow_up"},
+		{Title: "c", Disposition: "needs_human"},
+		{Title: "d"}, // empty disposition is not publishable
+	})
+	if len(got) != 1 || got[0].Title != "a" {
+		t.Fatalf("publishable = %#v", got)
+	}
+}
+
+func TestCommentOnlyPublishVisibleSummaryOmitsSuppressedFindings(t *testing.T) {
+	t.Parallel()
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Must fix nil deref. Also needs human on scope and a follow-up rename.",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Nil deref", Body: "Guard the pointer", Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "new path"},
+			{Title: "Rename", Body: "later", Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "style"},
+			{Title: "Scope", Body: "unclear", Disposition: "needs_human", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+		},
+	}
+	visible := commentOnlyPublishVisibleSummary(completion)
+	if !strings.Contains(visible, "Nil deref") {
+		t.Fatalf("visible missing must_fix: %q", visible)
+	}
+	for _, banned := range []string{"needs human", "follow-up", "Rename", "Scope", "unclear", "PR non-goals"} {
+		if strings.Contains(visible, banned) {
+			t.Fatalf("visible smuggles %q: %q", banned, visible)
+		}
+	}
+}
+
+func TestParseReviewerNativeCompletionFindingsAndLegacy(t *testing.T) {
+	t.Parallel()
+	// Legacy summary-only remains valid.
+	legacy, err := parseReviewerNativeCompletion(AgentResult{Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`, Summary: "posted review", ParseStatus: "parsed"})
+	if err != nil {
+		t.Fatalf("legacy native: %v", err)
+	}
+	if legacy.Summary != "posted review" || len(legacy.Findings) != 0 {
+		t.Fatalf("legacy = %#v", legacy)
+	}
+	// Findings present → fail-closed validation.
+	if _, err := parseReviewerNativeCompletion(AgentResult{Stdout: `__LOOPER_RESULT__={"summary":"x","outcome":"blocking","findings":[{"title":"t","body":"b"}]}`}); err == nil {
+		t.Fatal("want disposition rejection when findings lack contract fields")
+	}
+	ok, err := parseReviewerNativeCompletion(AgentResult{Stdout: `__LOOPER_RESULT__={"summary":"Need human","outcome":"blocking","findings":[{"title":"Ambiguous","body":"Unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"AGENTS.md rule X","path":"a.go","line":1}]}`})
+	if err != nil {
+		t.Fatalf("needs_human native: %v", err)
+	}
+	if !commentOnlyCompletionHasNeedsHuman(ok) {
+		t.Fatalf("want needs_human: %#v", ok)
+	}
+}
+
+func TestCommentOnlyNeedsHumanQuestionNamesAuthority(t *testing.T) {
+	t.Parallel()
+	q := commentOnlyNeedsHumanQuestion(reviewerCommentOnlyCompletion{
+		Findings: []reviewerCommentOnlyFindingResult{
+			{
+				Title: "Out of scope?", Body: "Expanding API surface", Disposition: "needs_human",
+				ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals exclude API expansion",
+			},
+		},
+	})
+	for _, want := range []string{"before unpause", "PR non-goals", "Out of scope?", "Continue resumes against current evidence"} {
+		if !strings.Contains(q, want) {
+			t.Fatalf("question missing %q: %s", want, q)
+		}
+	}
+	if strings.Contains(q, "Resume against current evidence, or stop") && !strings.Contains(q, "before unpause") {
+		t.Fatalf("legacy handoff text without authority: %s", q)
+	}
+}
+
+func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name          string
+		markerMissing bool
+		wantPublish   int
+		wantLastHead  string
+	}{
+		{name: "with_marker", markerMissing: false, wantPublish: 1, wantLastHead: "abc123"},
+		{name: "without_marker", markerMissing: true, wantPublish: 0, wantLastHead: ""},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			repo := "acme/looper"
+			prNumber := int64(42)
+			nowISO := fixture.nowISO()
+			target := "pr:acme/looper:42"
+			metadata := `{"loop":{"iterationCount":0}}`
+			loop := storage.LoopRecord{
+				ID: "loop_needs_human_pub_" + tc.name, Seq: 94, ProjectID: "project_1", Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+				Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+				t.Fatalf("upsert loop: %v", err)
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			cfg.HITL.Enabled = false
+			stdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+			agent := &fakeAgentExecutor{results: []AgentResult{{
+				Status: "completed", Summary: "Mixed must_fix and needs_human", Stdout: stdout, ParseStatus: "parsed",
+			}}}
+			github := &fakeGitHubGateway{
+				reviewMarkerMissing: tc.markerMissing,
+				reviewMarkerEvent:   ReviewEventComment,
+				reviewMarkerOutcome: "blocking",
+			}
+			runner := New(Options{
+				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+				AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+				LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+			})
+			project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+			if err != nil || project == nil {
+				t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+			}
+			_, err = runner.runReviewStep(context.Background(), stepInput{
+				Project:  *project,
+				Loop:     loop,
+				Run:      storage.RunRecord{ID: "run_needs_human_pub_" + tc.name},
+				Repo:     repo,
+				PRNumber: prNumber,
+				Checkpoint: reviewerCheckpoint{
+					Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+					Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+					Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: nowISO},
+				},
+			})
+			var hold *holdSkipError
+			if !errors.As(err, &hold) {
+				t.Fatalf("runReviewStep() error = %v, want holdSkipError", err)
+			}
+			updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if err != nil || updated == nil || !loops.IsReviewScopeHumanHold(*updated) {
+				t.Fatalf("after park = (%#v, %v), want scope hold", updated, err)
+			}
+			if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != tc.wantPublish {
+				t.Fatalf("ReviewerPublishCount = %d, want %d", got, tc.wantPublish)
+			}
+			gotHead, _ := stringFromAny(parseJSONObject(updated.MetadataJSON)["lastPublishedHeadSha"])
+			if gotHead != tc.wantLastHead {
+				t.Fatalf("lastPublishedHeadSha = %q, want %q", gotHead, tc.wantLastHead)
+			}
+		})
+	}
+}
+
+func TestRunReviewStepNeedsHumanAtCapBudgetHoldOnlyNoStackedScope(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	// One publish away from cap=1 so recording the marker parks budget.
+	metadata := `{"loop":{"iterationCount":0}}`
+	loop := storage.LoopRecord{
+		ID: "loop_needs_human_at_cap", Seq: 95, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert loop: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 1
+	stdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed", Summary: "Mixed must_fix and needs_human", Stdout: stdout, ParseStatus: "parsed",
+	}}}
+	github := &fakeGitHubGateway{
+		reviewMarkerMissing: false,
+		reviewMarkerEvent:   ReviewEventComment,
+		reviewMarkerOutcome: "blocking",
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+	}
+	_, err = runner.runReviewStep(context.Background(), stepInput{
+		Project:  *project,
+		Loop:     loop,
+		Run:      storage.RunRecord{ID: "run_needs_human_at_cap"},
+		Repo:     repo,
+		PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: nowISO},
+		},
+	})
+	var hold *holdSkipError
+	if !errors.As(err, &hold) {
+		t.Fatalf("runReviewStep() error = %v, want holdSkipError", err)
+	}
+	if !strings.Contains(hold.summary, "budget") {
+		t.Fatalf("hold summary = %q, want budget hold (not stacked scope ask)", hold.summary)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil {
+		t.Fatalf("after park = (%#v, %v)", updated, err)
+	}
+	if !loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("want budget hold only: status=%s meta=%s", updated.Status, derefString(updated.MetadataJSON))
+	}
+	if loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("must not stack active scope hold under budget: %#v", updated)
+	}
+	if !loops.HasPendingReviewScopeHuman(*updated) {
+		t.Fatalf("want pending scope evidence under budget hold: meta=%s", derefString(updated.MetadataJSON))
+	}
+	ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+	if !ok || !loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want single budget ask", ask, ok)
+	}
+	if loops.IsReviewScopeHumanAsk(ask) {
+		t.Fatal("must not write a second scope HITL ask")
+	}
+	if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != 1 {
+		t.Fatalf("ReviewerPublishCount = %d, want 1", got)
+	}
+}
+
+func TestRunReviewStepNeedsHumanUnderCapScopeHoldOnly(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":0}}`
+	loop := storage.LoopRecord{
+		ID: "loop_needs_human_under_cap", Seq: 96, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert loop: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 8
+	stdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "completed", Summary: "Mixed", Stdout: stdout, ParseStatus: "parsed",
+	}}}
+	github := &fakeGitHubGateway{
+		reviewMarkerMissing: false,
+		reviewMarkerEvent:   ReviewEventComment,
+		reviewMarkerOutcome: "blocking",
+	}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+	}
+	_, err = runner.runReviewStep(context.Background(), stepInput{
+		Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_needs_human_under_cap"},
+		Repo: repo, PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: nowISO},
+		},
+	})
+	var hold *holdSkipError
+	if !errors.As(err, &hold) {
+		t.Fatalf("runReviewStep() error = %v, want holdSkipError", err)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil || !loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("after park = (%#v, %v), want scope hold", updated, err)
+	}
+	if loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatal("under-cap must not budget-hold")
+	}
+	if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != 1 {
+		t.Fatalf("ReviewerPublishCount = %d, want 1", got)
+	}
+	ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+	if !ok || !loops.IsReviewScopeHumanAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want scope ask only", ask, ok)
+	}
+}
+
+func TestPublishAlreadyPublishedRecoversScopeParkWithoutRepublish(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name        string
+		cap         int
+		budgetHeld  bool
+		wantBudget  bool
+		wantScope   bool
+		wantPending bool
+		wantPublish int
+	}{
+		// lastPublishedHeadSha already set (progress recorded); scope park never ran.
+		{name: "under_cap", cap: 8, budgetHeld: false, wantBudget: false, wantScope: true, wantPending: false, wantPublish: 1},
+		// At cap: budget hold already applied after publish; recover deferred scope evidence only.
+		{name: "at_cap_budget_held", cap: 1, budgetHeld: true, wantBudget: true, wantScope: false, wantPending: true, wantPublish: 1},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			repo := "acme/looper"
+			prNumber := int64(42)
+			nowISO := fixture.nowISO()
+			target := "pr:acme/looper:42"
+			// Simulate crash after recordPublishedReviewProgress wrote the head marker.
+			metadata := `{"lastPublishedHeadSha":"abc123","loop":{"iterationCount":1}}`
+			loop := storage.LoopRecord{
+				ID: "loop_already_pub_scope_" + tc.name, Seq: 98, ProjectID: "project_1", Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+				Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if tc.budgetHeld {
+				parked, err := loops.ParkReviewFixBudget(context.Background(), fixture.repos, loops.ParkReviewFixBudgetInput{
+					Exhausted: loop, Role: "reviewer", Repo: repo, PRNumber: prNumber,
+					Count: 1, Cap: tc.cap, NowISO: nowISO, HITLEnabled: true,
+					LiveCaps: loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: tc.cap},
+					DB:       fixture.coordinator.DB(),
+				})
+				if err != nil {
+					t.Fatalf("ParkReviewFixBudget: %v", err)
+				}
+				loop = parked
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			cfg.HITL.Enabled = true
+			cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = tc.cap
+			cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventComment
+			completion := reviewerCommentOnlyCompletion{
+				Summary: "Mixed must_fix and needs_human",
+				Outcome: "blocking",
+				Findings: []reviewerCommentOnlyFindingResult{
+					{Title: "Bug", Body: "fix it", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+					{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+				},
+			}
+			payload, err := json.Marshal(completion)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			github := &fakeGitHubGateway{}
+			runner := New(Options{
+				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+				Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true,
+				LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+				ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents,
+			})
+			project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+			if err != nil || project == nil {
+				t.Fatalf("project: (%#v, %v)", project, err)
+			}
+			// Reload loop so stepInput sees post-budget-park status/metadata.
+			fresh, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if err != nil || fresh == nil {
+				t.Fatalf("reload loop: (%#v, %v)", fresh, err)
+			}
+			pending := pendingReviewCheckpoint{
+				HeadSHA: "abc123", IdempotencyKey: "idem-already-pub-" + tc.name, Event: reviewEventAgentNative,
+				Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+			}
+			_, err = runner.runPublishStep(context.Background(), stepInput{
+				Project: *project, Loop: *fresh, Run: storage.RunRecord{ID: "run_already_pub_" + tc.name},
+				Repo: repo, PRNumber: prNumber,
+				Checkpoint: reviewerCheckpoint{
+					Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+					Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+					PendingReview: &pending,
+				},
+			})
+			var hold *holdSkipError
+			if !errors.As(err, &hold) {
+				t.Fatalf("runPublishStep() error = %v, want holdSkipError", err)
+			}
+			if len(github.issueCommentCalls) != 0 {
+				t.Fatalf("issueCommentCalls = %d, want 0 (no re-publish)", len(github.issueCommentCalls))
+			}
+			updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if err != nil || updated == nil {
+				t.Fatalf("get loop: (%#v, %v)", updated, err)
+			}
+			if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != tc.wantPublish {
+				t.Fatalf("publish count = %d, want %d", got, tc.wantPublish)
+			}
+			if tc.wantBudget != loops.IsReviewFixBudgetHold(*updated) {
+				t.Fatalf("budget hold = %v, want %v (status=%s)", loops.IsReviewFixBudgetHold(*updated), tc.wantBudget, updated.Status)
+			}
+			if tc.wantScope != loops.IsReviewScopeHumanHold(*updated) {
+				t.Fatalf("scope hold = %v, want %v", loops.IsReviewScopeHumanHold(*updated), tc.wantScope)
+			}
+			if tc.wantPending != loops.HasPendingReviewScopeHuman(*updated) {
+				t.Fatalf("pending scope = %v, want %v meta=%s", loops.HasPendingReviewScopeHuman(*updated), tc.wantPending, derefString(updated.MetadataJSON))
+			}
+			if tc.wantBudget {
+				ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+				if !ok || !loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask) {
+					t.Fatalf("at-cap ask = (%#v, %v), want budget only (no stacked scope ask)", ask, ok)
+				}
+			}
+			if tc.wantScope {
+				ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+				if !ok || !loops.IsReviewScopeHumanAsk(ask) {
+					t.Fatalf("under-cap ask = (%#v, %v), want scope", ask, ok)
+				}
+			}
+		})
+	}
+}
+
+func TestProcessClaimedItemAtCapRecoversPendingScopeWithoutAgent(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	projectID := "project_1"
+	loopID := "loop_claim_at_cap_scope_recover"
+	// Crash after publish + budget park; scope park/defer never ran.
+	metadata := `{"lastPublishedHeadSha":"abc123","loop":{"iterationCount":1}}`
+	loop := storage.LoopRecord{
+		ID: loopID, Seq: 110, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert loop: %v", err)
+	}
+	parked, err := loops.ParkReviewFixBudget(context.Background(), fixture.repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: loop, Role: "reviewer", Repo: repo, PRNumber: prNumber,
+		Count: 1, Cap: 1, NowISO: nowISO, HITLEnabled: true,
+		LiveCaps: loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 1},
+		DB:       fixture.coordinator.DB(),
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+	loop = parked
+	if !loops.IsReviewFixBudgetHold(loop) {
+		t.Fatalf("precondition: want budget hold, got status=%s meta=%s", loop.Status, derefString(loop.MetadataJSON))
+	}
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed must_fix and needs_human",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "fix it", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+			{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+		},
+	}
+	payload, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	checkpointJSON := mustMarshalJSON(reviewerCheckpoint{
+		Detail:   &checkpointDetail{Title: "Review me", State: "OPEN", HeadSHA: "abc123", BaseRefName: "main", HeadRefName: "feature/review-me"},
+		Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+		PendingReview: &pendingReviewCheckpoint{
+			HeadSHA: "abc123", IdempotencyKey: "idem-claim-at-cap", Event: reviewEventAgentNative,
+			Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+		},
+		ResumePolicy: "advance_from_checkpoint",
+	})
+	if err := fixture.repos.Runs.Upsert(context.Background(), storage.RunRecord{
+		ID: "run_claim_at_cap_scope", LoopID: loopID, Status: "failed",
+		CurrentStep: stringPtr(string(stepPublish)), LastCompletedStep: stringPtr(string(stepReview)),
+		CheckpointJSON: &checkpointJSON, StartedAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Runs.Upsert: %v", err)
+	}
+	queueID := "queue_claim_at_cap_scope"
+	lockKey := target
+	queue := storage.QueueItemRecord{
+		ID: queueID, ProjectID: &projectID, LoopID: &loopID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber,
+		DedupeKey: "reviewer:claim-at-cap-scope", Priority: storage.QueuePriorityReviewer,
+		Status: "running", AvailableAt: nowISO, LockKey: &lockKey, MaxAttempts: 3,
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), queue); err != nil {
+		t.Fatalf("Queue.Upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 1
+	agent := &fakeAgentExecutor{}
+	github := &fakeGitHubGateway{viewHeadSHA: "abc123", viewState: "OPEN"}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+	})
+
+	result, err := runner.ProcessClaimedItem(context.Background(), queue)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" || !strings.Contains(result.Summary, "budget") {
+		t.Fatalf("result = %#v, want budget skipped", result)
+	}
+	if len(agent.starts) != 0 {
+		t.Fatalf("agent.starts = %#v, want none", agent.starts)
+	}
+	if len(github.issueCommentCalls) != 0 {
+		t.Fatalf("issueCommentCalls = %d, want 0 (no re-publish)", len(github.issueCommentCalls))
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || updated == nil {
+		t.Fatalf("get loop: (%#v, %v)", updated, err)
+	}
+	if !loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("want budget hold retained: status=%s meta=%s", updated.Status, derefString(updated.MetadataJSON))
+	}
+	if loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("must not stack active scope hold under budget: meta=%s", derefString(updated.MetadataJSON))
+	}
+	if !loops.HasPendingReviewScopeHuman(*updated) {
+		t.Fatalf("want pending scope after claim preflight recovery: meta=%s", derefString(updated.MetadataJSON))
+	}
+	ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+	if !ok || !loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want budget only", ask, ok)
+	}
+
+	// Budget Continue promotes deferred scope to a real scope hold.
+	continued, err := loops.ApplyReviewFixBudgetAnswer(context.Background(), fixture.repos, *updated, "Continue", nowISO, loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 1, FixerMaxPushes: 8})
+	if err != nil || !continued.Applied {
+		t.Fatalf("ApplyReviewFixBudgetAnswer = (%#v, %v)", continued, err)
+	}
+	afterContinue, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || afterContinue == nil {
+		t.Fatalf("after continue: (%#v, %v)", afterContinue, err)
+	}
+	if loops.IsReviewFixBudgetHold(*afterContinue) {
+		t.Fatalf("budget hold should clear after Continue: %#v", afterContinue)
+	}
+	if !loops.IsReviewScopeHumanHold(*afterContinue) {
+		t.Fatalf("want scope hold after pending promote: status=%s meta=%s", afterContinue.Status, derefString(afterContinue.MetadataJSON))
+	}
+	if loops.HasPendingReviewScopeHuman(*afterContinue) {
+		t.Fatalf("pending should clear after promote: meta=%s", derefString(afterContinue.MetadataJSON))
+	}
+}
+
+func TestPublishAlreadyPublishedNeedsHumanSkipsScopeOnNewHead(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"lastPublishedHeadSha":"abc123","loop":{"iterationCount":1}}`
+	loop := storage.LoopRecord{
+		ID: "loop_already_pub_new_head", Seq: 111, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 8
+	cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventComment
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed", Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "fix", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+			{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+		},
+	}
+	payload, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	github := &fakeGitHubGateway{viewHeadSHA: "new-head", viewState: "OPEN"}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("project: (%#v, %v)", project, err)
+	}
+	pending := pendingReviewCheckpoint{
+		HeadSHA: "abc123", IdempotencyKey: "idem-new-head", Event: reviewEventAgentNative,
+		Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+	}
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_already_pub_new_head"},
+		Repo: repo, PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pending,
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v, want nil stale skip", err)
+	}
+	if checkpoint.SkipKind != "stale" || !strings.Contains(checkpoint.SkipReason, "head changed") {
+		t.Fatalf("checkpoint = %#v, want stale head-changed skip", checkpoint)
+	}
+	if len(github.issueCommentCalls) != 0 {
+		t.Fatalf("issueCommentCalls = %d, want 0", len(github.issueCommentCalls))
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil {
+		t.Fatalf("get loop: (%#v, %v)", updated, err)
+	}
+	if loops.IsReviewScopeHumanHold(*updated) || loops.HasPendingReviewScopeHuman(*updated) {
+		t.Fatalf("must not park/defer scope on new head: meta=%s", derefString(updated.MetadataJSON))
+	}
+}
+
+func TestPublishAlreadyPublishedNeedsHumanSkipsScopeOnClosedPR(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"lastPublishedHeadSha":"abc123","loop":{"iterationCount":1}}`
+	loop := storage.LoopRecord{
+		ID: "loop_already_pub_closed", Seq: 112, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 8
+	cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventComment
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed", Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "fix", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+			{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+		},
+	}
+	payload, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	github := &fakeGitHubGateway{viewHeadSHA: "abc123", viewState: "CLOSED"}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("project: (%#v, %v)", project, err)
+	}
+	pending := pendingReviewCheckpoint{
+		HeadSHA: "abc123", IdempotencyKey: "idem-closed", Event: reviewEventAgentNative,
+		Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+	}
+	checkpoint, err := runner.runPublishStep(context.Background(), stepInput{
+		Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_already_pub_closed"},
+		Repo: repo, PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pending,
+		},
+	})
+	if err != nil {
+		t.Fatalf("runPublishStep() error = %v, want nil closed-PR skip", err)
+	}
+	if checkpoint.SkipKind != "stale" || !strings.Contains(checkpoint.SkipReason, "CLOSED") {
+		t.Fatalf("checkpoint = %#v, want stale closed-PR skip", checkpoint)
+	}
+	if len(github.issueCommentCalls) != 0 {
+		t.Fatalf("issueCommentCalls = %d, want 0", len(github.issueCommentCalls))
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil {
+		t.Fatalf("get loop: (%#v, %v)", updated, err)
+	}
+	if loops.IsReviewScopeHumanHold(*updated) || loops.HasPendingReviewScopeHuman(*updated) {
+		t.Fatalf("must not park/defer scope on closed PR: meta=%s", derefString(updated.MetadataJSON))
+	}
+}
+
+func TestPublishCommentOnlyMixedMustFixNeedsHumanPublishesThenParksScope(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name        string
+		cap         int
+		wantBudget  bool
+		wantScope   bool
+		wantPending bool
+		wantPublish int
+	}{
+		{name: "under_cap", cap: 8, wantBudget: false, wantScope: true, wantPending: false, wantPublish: 1},
+		{name: "at_cap_after_publish", cap: 1, wantBudget: true, wantScope: false, wantPending: true, wantPublish: 1},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			repo := "acme/looper"
+			prNumber := int64(42)
+			nowISO := fixture.nowISO()
+			target := "pr:acme/looper:42"
+			metadata := `{"loop":{"iterationCount":0}}`
+			loop := storage.LoopRecord{
+				ID: "loop_mixed_comment_" + tc.name, Seq: 97, ProjectID: "project_1", Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+				Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatalf("DefaultConfig: %v", err)
+			}
+			cfg.HITL.Enabled = true
+			cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = tc.cap
+			// Comment-only completion path requires Clean != APPROVE (or Forgejo summary mode).
+			cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventComment
+			completion := reviewerCommentOnlyCompletion{
+				Summary: "Mixed must_fix and needs_human",
+				Outcome: "blocking",
+				Findings: []reviewerCommentOnlyFindingResult{
+					{Title: "Bug", Body: "fix it", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+					{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+				},
+			}
+			payload, err := json.Marshal(completion)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			github := &fakeGitHubGateway{}
+			runner := New(Options{
+				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+				Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true,
+				LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+				ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents,
+			})
+			project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+			if err != nil || project == nil {
+				t.Fatalf("project: (%#v, %v)", project, err)
+			}
+			pending := pendingReviewCheckpoint{
+				HeadSHA: "abc123", IdempotencyKey: "idem-mixed-" + tc.name, Event: reviewEventAgentNative,
+				Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+			}
+			_, err = runner.runPublishStep(context.Background(), stepInput{
+				Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_mixed_" + tc.name},
+				Repo: repo, PRNumber: prNumber,
+				Checkpoint: reviewerCheckpoint{
+					Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+					Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+					PendingReview: &pending,
+				},
+			})
+			var hold *holdSkipError
+			if !errors.As(err, &hold) {
+				t.Fatalf("runPublishStep() error = %v, want holdSkipError", err)
+			}
+			if len(github.issueCommentCalls) != 1 {
+				t.Fatalf("issueCommentCalls = %d, want 1 must_fix summary publish", len(github.issueCommentCalls))
+			}
+			body := github.issueCommentCalls[0].Body
+			if strings.Contains(strings.ToLower(body), "ambiguous") || strings.Contains(body, "needs_human") {
+				t.Fatalf("published body smuggles needs_human: %s", body)
+			}
+			updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+			if err != nil || updated == nil {
+				t.Fatalf("get loop: (%#v, %v)", updated, err)
+			}
+			if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != tc.wantPublish {
+				t.Fatalf("publish count = %d, want %d", got, tc.wantPublish)
+			}
+			if tc.wantBudget != loops.IsReviewFixBudgetHold(*updated) {
+				t.Fatalf("budget hold = %v, want %v (status=%s)", loops.IsReviewFixBudgetHold(*updated), tc.wantBudget, updated.Status)
+			}
+			if tc.wantScope != loops.IsReviewScopeHumanHold(*updated) {
+				t.Fatalf("scope hold = %v, want %v", loops.IsReviewScopeHumanHold(*updated), tc.wantScope)
+			}
+			if tc.wantPending != loops.HasPendingReviewScopeHuman(*updated) {
+				t.Fatalf("pending scope = %v, want %v meta=%s", loops.HasPendingReviewScopeHuman(*updated), tc.wantPending, derefString(updated.MetadataJSON))
+			}
+			if tc.wantBudget {
+				ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+				if !ok || !loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask) {
+					t.Fatalf("at-cap ask = (%#v, %v), want budget only", ask, ok)
+				}
+			}
+			if tc.wantScope {
+				ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+				if !ok || !loops.IsReviewScopeHumanAsk(ask) {
+					t.Fatalf("under-cap ask = (%#v, %v), want scope", ask, ok)
+				}
+			}
+		})
+	}
+}
+
+func TestParkReviewerScopeHumanHITLOffNoAsk(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":1}}`
+	reviewer := storage.LoopRecord{ID: "loop_scope_no_hitl", Seq: 91, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	fixer := storage.LoopRecord{ID: "loop_scope_no_hitl_fixer", Seq: 92, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("upsert reviewer: %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("upsert fixer: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = false
+	var notified []string
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		NotifyHumanAttention: func(_ context.Context, loopID string) { notified = append(notified, loopID) },
+	})
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Need human",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Ambiguous", Body: "Unclear scope", Disposition: "needs_human", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals conflict"},
+		},
+	}
+	if err := runner.parkReviewerScopeHuman(context.Background(), reviewer, completion); err != nil {
+		t.Fatalf("parkReviewerScopeHuman: %v", err)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || updated == nil || updated.Status != "paused" || !loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("reviewer = (%#v, %v), want scope pause", updated, err)
+	}
+	if loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatal("must not be budget hold")
+	}
+	if ask, ok := loops.ReadHITLAsk(updated.MetadataJSON); ok {
+		t.Fatalf("HITL-off must not write ask, got %#v", ask)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewScopeHumanPause(sibling.MetadataJSON) {
+		t.Fatalf("sibling = (%#v, %v), want scope sibling pause", sibling, err)
+	}
+	if len(notified) != 1 || notified[0] != reviewer.ID {
+		t.Fatalf("NotifyHumanAttention = %#v", notified)
+	}
+}
+
+func TestParkReviewerScopeHumanHITLOnAskNotBudgetKind(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":1}}`
+	reviewer := storage.LoopRecord{ID: "loop_scope_hitl", Seq: 93, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+	})
+	if err := runner.parkReviewerScopeHuman(context.Background(), reviewer, reviewerCommentOnlyCompletion{
+		Summary: "Need human", Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Ambiguous", Body: "x", Disposition: "needs_human", ScopeBasis: "ambiguous_intent", ScopeEvidence: "e"},
+		},
+	}); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || updated == nil || updated.Status != "awaiting_human" {
+		t.Fatalf("updated = (%#v, %v)", updated, err)
+	}
+	ask, ok := loops.ReadHITLAsk(updated.MetadataJSON)
+	if !ok || !loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want scope kind", ask, ok)
+	}
+	if loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatal("scope HITL hold must not be budget hold")
 	}
 }
 
@@ -9994,7 +11057,7 @@ func TestProcessClaimedItemCommentOnlySkipsWhenReviewRequestRemovedBeforePublish
 		currentLogin:                    "reviewer",
 		removeReviewRequestOnSecondView: true,
 	}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Blocking issue remains", Stdout: `__LOOPER_RESULT__={"summary":"Blocking issue remains","outcome":"blocking","findings":[{"title":"Blocking issue remains","body":"Must not publish summary when request was removed.","files":["internal/reviewer/runner.go"]}]}`, ParseStatus: "parsed"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Blocking issue remains", Stdout: `__LOOPER_RESULT__={"summary":"Blocking issue remains","outcome":"blocking","findings":[{"title":"Blocking issue remains","body":"Must not publish summary when request was removed.","files":["internal/reviewer/runner.go"],"disposition":"must_fix","severity":"blocking","scopeBasis":"required_invariant","scopeEvidence":"request gate"}]}`, ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{"looper:review"}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
@@ -10028,7 +11091,7 @@ func TestProcessClaimedItemCommentOnlyDoesNotMarkActionableNoActionSummaryAsClea
 
 	fixture := newRunnerFixture(t)
 	github := &fakeGitHubGateway{labels: []string{"looper:review"}, reviewRequests: []string{}, currentLogin: "reviewer"}
-	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings, but this still has a blocking issue", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings, but this still has a blocking issue","outcome":"blocking","findings":[{"title":"Blocking issue remains","body":"The structured outcome is still blocking and must publish an open reviewer item.","files":["internal/reviewer/runner.go"]}]}`, ParseStatus: "parsed"}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings, but this still has a blocking issue", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings, but this still has a blocking issue","outcome":"blocking","findings":[{"title":"Blocking issue remains","body":"The structured outcome is still blocking and must publish an open reviewer item.","files":["internal/reviewer/runner.go"],"disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"structured outcome"}]}`, ParseStatus: "parsed"}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: false, Labels: []string{"looper:review"}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig()})
 
 	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -12114,6 +12114,89 @@ func TestProcessClaimedItemPreservesParkedScopeHoldStatus(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemFailedRunNeedsHumanParksBeforeMarkerRecovery(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	ctx := context.Background()
+	nowISO := fixture.nowISO()
+	repo := "acme/looper"
+	prNumber := int64(42)
+	loopID := "loop_failed_run_needs_human"
+	metadata := `{"followUpdates":true,"loop":{"enabled":true}}`
+	loop := storage.LoopRecord{
+		ID: loopID, Seq: 212, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber,
+		Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = false
+	stdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+	github := &fakeGitHubGateway{
+		reviewRequests:                  []string{"octocat"},
+		reviewMarkerMissing:             false,
+		reviewMarkerEvent:               ReviewEventComment,
+		reviewMarkerOutcome:             "blocking",
+		reviewMarkerInlineCommentBodies: []string{"fix it"},
+	}
+	agent := &fakeAgentExecutor{results: []AgentResult{{
+		Status: "failed", Summary: "posted review, later command failed", Stdout: stdout,
+	}}}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CustomInstructions: &cfg,
+		LoopConfig: config.ReviewerLoopConfig{EnabledByDefault: true, QuietPeriodSeconds: 120, MaxIterationsPerPR: 20, MaxIterationsPerHead: 2, MaxWallClockSeconds: 14400, MaxConsecutiveFailures: 3, MaxAgentExecutionsPerPR: 25},
+	})
+	queue, err := runner.enqueue(ctx, enqueueInput{ProjectID: "project_1", LoopID: loop.ID, Repo: repo, PRNumber: prNumber})
+	if err != nil {
+		t.Fatalf("enqueue() error = %v", err)
+	}
+	claimed, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claimed == nil || claimed.ID != queue.ID {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want queued item %s", claimed, err, queue.ID)
+	}
+	result, err := runner.ProcessClaimedItem(ctx, *claimed)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Fatalf("result = %#v, want skipped after failed-run needs_human park", result)
+	}
+	if !strings.Contains(result.Summary, "review scope requires human judgment") {
+		t.Fatalf("result.Summary = %q, want scope hold skip", result.Summary)
+	}
+	updated, err := fixture.repos.Loops.GetByID(ctx, loopID)
+	if err != nil || updated == nil {
+		t.Fatalf("Loops.GetByID() = (%#v, %v)", updated, err)
+	}
+	if updated.Status != "paused" {
+		t.Fatalf("status = %q, want paused scope hold (not published-and-queued)", updated.Status)
+	}
+	if !loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("want scope hold after failed-run needs_human: %#v meta=%v", updated, updated.MetadataJSON)
+	}
+	gotHead, _ := stringFromAny(parseJSONObject(updated.MetadataJSON)["lastPublishedHeadSha"])
+	if gotHead == "" {
+		t.Fatalf("lastPublishedHeadSha missing; mixed must_fix should count before park: %s", derefString(updated.MetadataJSON))
+	}
+	if result.RunID == "" {
+		t.Fatal("result.RunID empty, want persisted run checkpoint")
+	}
+	persisted, err := fixture.repos.Runs.GetByID(ctx, result.RunID)
+	if err != nil || persisted == nil {
+		t.Fatalf("Runs.GetByID = (%#v, %v)", persisted, err)
+	}
+	checkpoint := parseCheckpoint(persisted.CheckpointJSON)
+	if checkpoint.PendingReview == nil || !strings.Contains(checkpoint.PendingReview.ReviewerSummaryJSON, `"disposition":"needs_human"`) {
+		t.Fatalf("checkpoint pending = %#v, want persisted native completion with needs_human before marker recovery", checkpoint.PendingReview)
+	}
+}
+
 func TestProcessClaimedItemMixedNeedsHumanMissingMarkerFailsRetryable(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -2,15 +2,10 @@ package reviewer
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
-	"time"
-
 	"github.com/nexu-io/looper/internal/config"
 	"github.com/nexu-io/looper/internal/domain"
 	"github.com/nexu-io/looper/internal/eventlog"
@@ -26,6 +21,11 @@ import (
 	"github.com/nexu-io/looper/internal/reviewer/criteria"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/nexu-io/looper/internal/worktreesafety"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
 )
 
 func TestDiscoverPullRequestsCreatesLoopAndQueue(t *testing.T) {
@@ -11285,6 +11285,124 @@ func TestPublishCommentOnlyMixedMustFixNeedsHumanPublishesThenParksScope(t *test
 				}
 			}
 		})
+	}
+}
+
+// failOnceBudgetHeldLoopGet fails the first loops-by-id read after a budget
+// hold is durable, then succeeds. Models a transient storage error between
+// recordPublishedReviewProgress and parkOrDeferReviewerScopeHuman.
+type failOnceBudgetHeldLoopGet struct {
+	db         *sql.DB
+	failedOnce bool
+}
+
+func (q *failOnceBudgetHeldLoopGet) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return q.db.ExecContext(ctx, query, args...)
+}
+
+func (q *failOnceBudgetHeldLoopGet) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return q.db.QueryContext(ctx, query, args...)
+}
+
+func (q *failOnceBudgetHeldLoopGet) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	if !q.failedOnce && strings.Contains(query, "SELECT * FROM loops WHERE id") && len(args) == 1 {
+		id, _ := args[0].(string)
+		var status string
+		var meta *string
+		if err := q.db.QueryRowContext(ctx, `SELECT status, metadata_json FROM loops WHERE id = ?`, id).Scan(&status, &meta); err == nil {
+			if loops.IsReviewFixBudgetHold(storage.LoopRecord{Status: status, MetadataJSON: meta}) {
+				q.failedOnce = true
+				return q.db.QueryRowContext(ctx, `SELECT * FROM loops_refresh_probe_missing WHERE id = ?`, id)
+			}
+		}
+	}
+	return q.db.QueryRowContext(ctx, query, args...)
+}
+
+func TestPublishCommentOnlyMixedMustFixNeedsHumanRefreshErrorDoesNotStackHolds(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":0}}`
+	loop := storage.LoopRecord{
+		ID: "loop_mixed_refresh_fail", Seq: 99, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 1
+	cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventComment
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed must_fix and needs_human",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "fix it", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+			{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+		},
+	}
+	payload, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	querier := &failOnceBudgetHeldLoopGet{db: fixture.coordinator.DB()}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: storage.NewRepositories(querier), GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{},
+		Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("project: (%#v, %v)", project, err)
+	}
+	pending := pendingReviewCheckpoint{
+		HeadSHA: "abc123", IdempotencyKey: "idem-mixed-refresh-fail", Event: reviewEventAgentNative,
+		Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+	}
+	_, err = runner.runPublishStep(context.Background(), stepInput{
+		Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_mixed_refresh_fail"},
+		Repo: repo, PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pending,
+		},
+	})
+	if err == nil {
+		t.Fatal("runPublishStep() error = nil, want refresh failure")
+	}
+	var hold *holdSkipError
+	if errors.As(err, &hold) {
+		t.Fatalf("runPublishStep() = holdSkipError %q, want fail-closed refresh error", hold.summary)
+	}
+	if !strings.Contains(err.Error(), "refresh loop before review scope park") {
+		t.Fatalf("runPublishStep() error = %v, want refresh loop before review scope park", err)
+	}
+	updated, getErr := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if getErr != nil || updated == nil {
+		t.Fatalf("get loop: (%#v, %v)", updated, getErr)
+	}
+	if !loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("want durable budget hold after publish: status=%s meta=%s", updated.Status, derefString(updated.MetadataJSON))
+	}
+	if loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("refresh failure must not stack a scope hold: %#v", updated)
+	}
+	if loops.HasPendingReviewScopeHuman(*updated) {
+		t.Fatalf("refresh failure must not guess pending scope: meta=%s", derefString(updated.MetadataJSON))
+	}
+	if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != 1 {
+		t.Fatalf("ReviewerPublishCount = %d, want 1", got)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -8501,6 +8501,7 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"NITs must not block merge",
 		"Finalization gate before submit",
 		"disposition=must_fix with scopeBasis/scopeEvidence",
+		"rejects `follow_up`/`needs_human` in actionable comments or the visible review body",
 		"review outcome matches the highest published severity",
 		"do not use PATH-based `looper`",
 		"repository-local `go run ./cmd/looper`",
@@ -10029,7 +10030,7 @@ func TestValidateReviewerCommentOnlyCompletionDispositions(t *testing.T) {
 		Summary: "No actionable findings",
 		Outcome: "clean",
 		Findings: []reviewerCommentOnlyFindingResult{
-			{Title: "Later", Body: "Nice", Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "x"},
+			{Title: "Later", Body: "Nice", Disposition: "follow_up", Severity: "nit", ScopeBasis: "independent_improvement", ScopeEvidence: "x"},
 		},
 	}); err != nil {
 		t.Fatalf("clean with follow_up only: %v", err)
@@ -10039,7 +10040,7 @@ func TestValidateReviewerCommentOnlyCompletionDispositions(t *testing.T) {
 		Summary: "No actionable findings",
 		Outcome: "clean",
 		Findings: []reviewerCommentOnlyFindingResult{
-			{Title: "Bug", Body: "x", Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "y"},
+			{Title: "Bug", Body: "x", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "y"},
 		},
 	}); err == nil || !strings.Contains(err.Error(), "must_fix") {
 		t.Fatalf("clean with must_fix error = %v", err)
@@ -10072,6 +10073,33 @@ func TestValidateReviewerCommentOnlyCompletionDispositions(t *testing.T) {
 		},
 	}); err == nil || !strings.Contains(err.Error(), "requires scopeEvidence") {
 		t.Fatalf("missing scopeEvidence error = %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Missing severity",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "x", Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "y"},
+		},
+	}); err == nil || !strings.Contains(err.Error(), "requires severity") {
+		t.Fatalf("missing severity error = %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Arbitrary severity",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "x", Disposition: "must_fix", Severity: "major", ScopeBasis: "introduced_regression", ScopeEvidence: "y"},
+		},
+	}); err == nil || !strings.Contains(err.Error(), "invalid severity") {
+		t.Fatalf("arbitrary severity error = %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Unknown scopeBasis",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "x", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "vibes", ScopeEvidence: "y"},
+		},
+	}); err == nil || !strings.Contains(err.Error(), "invalid scopeBasis") {
+		t.Fatalf("unknown scopeBasis error = %v", err)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -10254,6 +10254,22 @@ func TestCommentOnlyNeedsHumanQuestionNamesAuthority(t *testing.T) {
 	}
 }
 
+func TestNativeMustFixReviewMarkerActionableRequiresInlineComments(t *testing.T) {
+	t.Parallel()
+	if nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventComment, Outcome: "actionable"}) {
+		t.Fatal("body-only COMMENT must not count as published must_fix")
+	}
+	if nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventRequestChanges, Outcome: "blocking"}) {
+		t.Fatal("body-only REQUEST_CHANGES must not count as published must_fix")
+	}
+	if !nativeMustFixReviewMarkerActionable(ReviewMarkerResult{Found: true, Event: ReviewEventComment, Outcome: "actionable", InlineCommentBodies: []string{"fix it"}}) {
+		t.Fatal("COMMENT with inline comments must count as published must_fix")
+	}
+	if nativeMustFixReviewMarkerActionable(ReviewMarkerResult{}) {
+		t.Fatal("missing marker must not count as published must_fix")
+	}
+}
+
 func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -10261,14 +10277,16 @@ func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 		markerMissing bool
 		markerEvent   ReviewEvent
 		markerOutcome string
+		inlineBodies  []string
 		wantHold      bool
 		wantRetryable bool
 		wantPublish   int
 		wantLastHead  string
 	}{
-		{name: "with_marker", markerMissing: false, markerEvent: ReviewEventComment, markerOutcome: "blocking", wantHold: true, wantPublish: 1, wantLastHead: "abc123"},
+		{name: "with_marker", markerMissing: false, markerEvent: ReviewEventComment, markerOutcome: "blocking", inlineBodies: []string{"fix it"}, wantHold: true, wantPublish: 1, wantLastHead: "abc123"},
 		{name: "without_marker", markerMissing: true, wantRetryable: true, wantPublish: 0},
 		{name: "clean_marker", markerMissing: false, markerEvent: ReviewEventApprove, markerOutcome: "clean", wantRetryable: true, wantPublish: 0},
+		{name: "body_only_comment", markerMissing: false, markerEvent: ReviewEventComment, markerOutcome: "actionable", wantRetryable: true, wantPublish: 0},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -10297,9 +10315,10 @@ func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 				Status: "completed", Summary: "Mixed must_fix and needs_human", Stdout: stdout, ParseStatus: "parsed",
 			}}}
 			github := &fakeGitHubGateway{
-				reviewMarkerMissing: tc.markerMissing,
-				reviewMarkerEvent:   tc.markerEvent,
-				reviewMarkerOutcome: tc.markerOutcome,
+				reviewMarkerMissing:             tc.markerMissing,
+				reviewMarkerEvent:               tc.markerEvent,
+				reviewMarkerOutcome:             tc.markerOutcome,
+				reviewMarkerInlineCommentBodies: tc.inlineBodies,
 			}
 			runner := New(Options{
 				DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
@@ -10388,6 +10407,7 @@ func TestRunReviewStepMixedNativePersistsCompletionBeforePublishedHead(t *testin
 	runner := New(Options{
 		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{
 			reviewMarkerMissing: false, reviewMarkerEvent: ReviewEventComment, reviewMarkerOutcome: "blocking",
+			reviewMarkerInlineCommentBodies: []string{"fix it"},
 		}, Git: &fakeGitGateway{},
 		AgentExecutor: &fakeAgentExecutor{results: []AgentResult{{
 			Status: "completed", Summary: "Mixed must_fix and needs_human", Stdout: stdout, ParseStatus: "parsed",
@@ -10458,6 +10478,7 @@ func TestRunReviewStepNeedsHumanDoesNotRecountAlreadyPublishedHead(t *testing.T)
 	runner := New(Options{
 		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{
 			reviewMarkerMissing: false, reviewMarkerEvent: ReviewEventComment, reviewMarkerOutcome: "blocking",
+			reviewMarkerInlineCommentBodies: []string{"fix it"},
 		}, Git: &fakeGitGateway{},
 		AgentExecutor: &fakeAgentExecutor{results: []AgentResult{{
 			Status: "completed", Summary: "Mixed must_fix and needs_human", Stdout: stdout, ParseStatus: "parsed",
@@ -10522,9 +10543,10 @@ func TestRunReviewStepNeedsHumanAtCapBudgetHoldOnlyNoStackedScope(t *testing.T) 
 		Status: "completed", Summary: "Mixed must_fix and needs_human", Stdout: stdout, ParseStatus: "parsed",
 	}}}
 	github := &fakeGitHubGateway{
-		reviewMarkerMissing: false,
-		reviewMarkerEvent:   ReviewEventComment,
-		reviewMarkerOutcome: "blocking",
+		reviewMarkerMissing:             false,
+		reviewMarkerEvent:               ReviewEventComment,
+		reviewMarkerOutcome:             "blocking",
+		reviewMarkerInlineCommentBodies: []string{"fix it"},
 	}
 	runner := New(Options{
 		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
@@ -10606,9 +10628,10 @@ func TestRunReviewStepNeedsHumanUnderCapScopeHoldOnly(t *testing.T) {
 		Status: "completed", Summary: "Mixed", Stdout: stdout, ParseStatus: "parsed",
 	}}}
 	github := &fakeGitHubGateway{
-		reviewMarkerMissing: false,
-		reviewMarkerEvent:   ReviewEventComment,
-		reviewMarkerOutcome: "blocking",
+		reviewMarkerMissing:             false,
+		reviewMarkerEvent:               ReviewEventComment,
+		reviewMarkerOutcome:             "blocking",
+		reviewMarkerInlineCommentBodies: []string{"fix it"},
 	}
 	runner := New(Options{
 		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -8554,7 +8554,7 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"structured error with `type` set to one of `auth`, `network`, `rate_limit`, or `pr_drift`",
 		"validate every inline review comment's `path`, `line`, `side`, `start_line`, and `start_side` against the live PR diff fetched with `gh pr diff`",
 		"Preserve exact anchors that fit the live diff",
-		"safely downgrade it to top-level review body feedback",
+		"Do not move must_fix findings into the top-level review body",
 		"follow-up quality-gating failure",
 		"Resolvable inline review comments are required",
 		"PR review `comments` array",
@@ -8562,7 +8562,7 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"create resolvable GitHub review threads",
 		"`path`, `line`, `side`",
 		"`start_line` and `start_side`",
-		"the detailed findings must live in inline `comments`",
+		"every must_fix finding must live in inline `comments`",
 		"Looper **does** parse this findings list",
 	} {
 		if !strings.Contains(prompt, want) {
@@ -8588,10 +8588,30 @@ func TestBuildReviewPromptIncludesActionableQualityContract(t *testing.T) {
 		"prefer fewer deep comments",
 		"more than 15 blocking findings",
 		"more than 25 total comments",
+		"safely downgrade it to top-level review body feedback",
+		"Use top-level comments without path/line only",
+		"downgrade unanchorable feedback to a top-level review-body item",
 	} {
 		if strings.Contains(prompt, forbidden) {
 			t.Fatalf("prompt contains conflicting no-actionable clean-review instruction %q:\n%s", forbidden, prompt)
 		}
+	}
+}
+
+func TestBuildReviewPromptForgejoNativeKeepsMustFixInline(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.Providers = []config.ProviderConfig{{ID: "forgejo-main", Kind: config.ProviderKindForgejo, BaseURL: "https://forgejo.example.test", TokenEnv: stringPtr("FORGEJO_TOKEN")}}
+	cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Provider: "forgejo-main", Repo: "acme/looper"}}
+	prompt, _ := buildReviewPromptWithInstructions("project_1", cfg, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove, Blocking: config.ReviewerReviewEventRequestChanges}, false, true, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "/opt/looper/bin/looper", false, false)
+	if !strings.Contains(prompt, "every must_fix must remain an inline comment") {
+		t.Fatalf("forgejo prompt missing inline-only must_fix contract:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "downgrade unanchorable feedback to a top-level review-body item") {
+		t.Fatalf("forgejo prompt still instructs body-only must_fix:\n%s", prompt)
 	}
 }
 
@@ -10103,6 +10123,55 @@ func TestValidateReviewerCommentOnlyCompletionDispositions(t *testing.T) {
 	}
 }
 
+func TestValidateReviewerCommentOnlyCompletionOutcomeMatchesHighestMustFixSeverity(t *testing.T) {
+	t.Parallel()
+	mustFix := func(severity string) reviewerCommentOnlyFindingResult {
+		return reviewerCommentOnlyFindingResult{
+			Title: "Bug", Body: "fix it", Disposition: "must_fix", Severity: severity,
+			ScopeBasis: "introduced_regression", ScopeEvidence: "diff",
+		}
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Blocking issue", Outcome: "non_blocking",
+		Findings: []reviewerCommentOnlyFindingResult{mustFix("blocking")},
+	}); err == nil || !strings.Contains(err.Error(), "highest must_fix severity") {
+		t.Fatalf("blocking finding with non_blocking outcome error = %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Nit only", Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{mustFix("nit")},
+	}); err == nil || !strings.Contains(err.Error(), "highest must_fix severity") {
+		t.Fatalf("nit finding with blocking outcome error = %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Non-blocking only", Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{mustFix("non_blocking")},
+	}); err == nil || !strings.Contains(err.Error(), "highest must_fix severity") {
+		t.Fatalf("non_blocking finding with blocking outcome error = %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Blocking issue", Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{mustFix("blocking"), mustFix("nit")},
+	}); err != nil {
+		t.Fatalf("mixed blocking+nit with blocking outcome: %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Nit only", Outcome: "non_blocking",
+		Findings: []reviewerCommentOnlyFindingResult{mustFix("nit")},
+	}); err != nil {
+		t.Fatalf("nit with non_blocking outcome: %v", err)
+	}
+	if _, err := validateReviewerCommentOnlyCompletion(reviewerCommentOnlyCompletion{
+		Summary: "Need human", Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{{
+			Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking",
+			ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals",
+		}},
+	}); err != nil {
+		t.Fatalf("needs_human-only: %v", err)
+	}
+}
+
 func TestBuildReviewerSummaryFromCompletionFiltersFollowUpAndNeedsHuman(t *testing.T) {
 	t.Parallel()
 
@@ -10260,6 +10329,10 @@ func TestParseReviewerNativeCompletionFindingsAndLegacy(t *testing.T) {
 	if !commentOnlyCompletionHasNeedsHuman(ok) {
 		t.Fatalf("want needs_human: %#v", ok)
 	}
+	if _, err := parseReviewerNativeCompletion(AgentResult{Stdout: `__LOOPER_RESULT__={"summary":"Blocking issue remains","outcome":"non_blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1}]}`}); err == nil || !strings.Contains(err.Error(), "highest must_fix severity") {
+		t.Fatalf("native blocking finding with non_blocking outcome error = %v, want publication-contract rejection", err)
+	}
+
 }
 
 func TestCommentOnlyNeedsHumanQuestionNamesAuthority(t *testing.T) {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -10097,6 +10097,70 @@ func TestBuildReviewerSummaryFromCompletionFiltersFollowUpAndNeedsHuman(t *testi
 	}
 }
 
+func TestBuildReviewerSummaryFromCompletionKeepsNeedsHumanReferencedOpenItems(t *testing.T) {
+	t.Parallel()
+
+	existing := forge.NewReviewerSummary(1, []forge.ReviewItem{
+		{ReviewItemID: "R-001", Status: forge.ReviewItemStatusOpen, Title: "Ambiguous scope", Body: "Is this in PR scope?", Files: []string{"a.go"}, LastSeenRoundID: 1},
+		{ReviewItemID: "R-002", Status: forge.ReviewItemStatusOpen, Title: "Stale leftover", Body: "Truly gone.", LastSeenRoundID: 1},
+		{ReviewItemID: "R-003", Status: forge.ReviewItemStatusOpen, Title: "Later rename", Body: "Follow-up only.", LastSeenRoundID: 1},
+	})
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed publish and park",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Must", Body: "fix", Disposition: "must_fix", ScopeBasis: "introduced_regression", ScopeEvidence: "e1", Files: []string{"b.go"}},
+			{ReviewItemID: "R-001", Title: "Ambiguous scope", Body: "Still undecided.", Disposition: "needs_human", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+			{ReviewItemID: "R-003", Title: "Later rename", Body: "Not this round.", Disposition: "follow_up", ScopeBasis: "independent_improvement", ScopeEvidence: "style"},
+		},
+	}
+	summary, err := buildReviewerSummaryFromCompletion(existing, completion)
+	if err != nil {
+		t.Fatalf("buildReviewerSummaryFromCompletion: %v", err)
+	}
+	byID := map[string]forge.ReviewItem{}
+	for _, item := range summary.Items {
+		byID[item.ReviewItemID] = item
+	}
+	if len(byID) != 4 {
+		t.Fatalf("items = %#v, want 4", summary.Items)
+	}
+	kept := byID["R-001"]
+	if kept.Status != forge.ReviewItemStatusOpen || kept.Title != "Ambiguous scope" || kept.Body != "Is this in PR scope?" {
+		t.Fatalf("R-001 = %#v, want original open needs_human-referenced item", kept)
+	}
+	if kept.LastSeenRoundID != 2 {
+		t.Fatalf("R-001 LastSeenRoundID = %d, want 2", kept.LastSeenRoundID)
+	}
+	if byID["R-002"].Status != forge.ReviewItemStatusResolved {
+		t.Fatalf("R-002 = %#v, want omitted leftover resolved", byID["R-002"])
+	}
+	if byID["R-003"].Status != forge.ReviewItemStatusResolved {
+		t.Fatalf("R-003 = %#v, want follow_up-referenced item resolved", byID["R-003"])
+	}
+	var publishedOpen []forge.ReviewItem
+	for _, item := range summary.Items {
+		if item.Status == forge.ReviewItemStatusOpen {
+			publishedOpen = append(publishedOpen, item)
+		}
+	}
+	if len(publishedOpen) != 2 {
+		t.Fatalf("open items = %#v, want R-001 plus new must_fix", publishedOpen)
+	}
+	foundMust := false
+	for _, item := range publishedOpen {
+		if item.Title == "Must" {
+			foundMust = true
+		}
+		if strings.Contains(item.Body, "Still undecided") {
+			t.Fatalf("needs_human content leaked into remote item: %#v", item)
+		}
+	}
+	if !foundMust {
+		t.Fatalf("open items missing must_fix: %#v", publishedOpen)
+	}
+}
+
 func TestPublishableCommentOnlyFindingsFiltersNonMustFix(t *testing.T) {
 	t.Parallel()
 	got := publishableCommentOnlyFindings([]reviewerCommentOnlyFindingResult{
@@ -11221,6 +11285,112 @@ func TestPublishCommentOnlyMixedMustFixNeedsHumanPublishesThenParksScope(t *test
 				}
 			}
 		})
+	}
+}
+
+func TestPublishCommentOnlyMixedMustFixNeedsHumanKeepsReferencedOpenItems(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":0}}`
+	loop := storage.LoopRecord{
+		ID: "loop_mixed_keep_open", Seq: 98, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	existing := forge.NewReviewerSummary(1, []forge.ReviewItem{
+		{ReviewItemID: "R-001", Status: forge.ReviewItemStatusOpen, Title: "Ambiguous scope", Body: "Is this in PR scope?", Files: []string{"a.go"}, LastSeenRoundID: 1},
+		{ReviewItemID: "R-002", Status: forge.ReviewItemStatusOpen, Title: "Stale leftover", Body: "Truly gone.", LastSeenRoundID: 1},
+	})
+	existingBody, err := renderReviewerSummaryComment(existing, "Previous summary")
+	if err != nil {
+		t.Fatalf("renderReviewerSummaryComment: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventComment
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed must_fix and needs_human",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "fix it", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"b.go"}},
+			{ReviewItemID: "R-001", Title: "Ambiguous scope", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+		},
+	}
+	payload, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	github := &fakeGitHubGateway{issueComments: []map[string]any{{"id": int64(91), "body": existingBody}}}
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{},
+		Logger: fixture.logger, Now: fixture.now, CommentOnlyPublish: true,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+		ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("project: (%#v, %v)", project, err)
+	}
+	pending := pendingReviewCheckpoint{
+		HeadSHA: "abc123", IdempotencyKey: "idem-mixed-keep-open", Event: reviewEventAgentNative,
+		Summary: completion.Summary, Outcome: completion.Outcome, ReviewerSummaryJSON: string(payload),
+	}
+	_, err = runner.runPublishStep(context.Background(), stepInput{
+		Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_mixed_keep_open"},
+		Repo: repo, PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:        &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main", HeadSHA: "abc123", State: "OPEN"},
+			Snapshot:      &checkpointSnapshot{HeadSHA: "abc123"},
+			PendingReview: &pending,
+		},
+	})
+	var hold *holdSkipError
+	if !errors.As(err, &hold) {
+		t.Fatalf("runPublishStep() error = %v, want holdSkipError", err)
+	}
+	if len(github.updateIssueCommentCalls) != 1 {
+		t.Fatalf("updateIssueCommentCalls = %d, want 1", len(github.updateIssueCommentCalls))
+	}
+	parsed, err := forge.ParseReviewerSummary(github.updateIssueCommentCalls[0].Body)
+	if err != nil {
+		t.Fatalf("ParseReviewerSummary: %v", err)
+	}
+	byID := map[string]forge.ReviewItem{}
+	openIDs := map[string]struct{}{}
+	for _, item := range parsed.Items {
+		byID[item.ReviewItemID] = item
+		if item.Status == forge.ReviewItemStatusOpen {
+			openIDs[item.ReviewItemID] = struct{}{}
+		}
+	}
+	if byID["R-001"].Status != forge.ReviewItemStatusOpen {
+		t.Fatalf("R-001 = %#v, want still open for Forgejo Fixer after mixed publish/park", byID["R-001"])
+	}
+	if byID["R-002"].Status != forge.ReviewItemStatusResolved {
+		t.Fatalf("R-002 = %#v, want omitted leftover resolved", byID["R-002"])
+	}
+	if _, ok := openIDs["R-001"]; !ok || len(openIDs) != 2 {
+		t.Fatalf("open IDs = %#v, want R-001 plus published must_fix", openIDs)
+	}
+	if strings.Contains(github.updateIssueCommentCalls[0].Body, "unclear") {
+		t.Fatalf("published body smuggles needs_human: %s", github.updateIssueCommentCalls[0].Body)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || updated == nil {
+		t.Fatalf("get loop: (%#v, %v)", updated, err)
+	}
+	if !loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("scope hold = false, want parked after mixed publish")
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -11347,6 +11347,80 @@ func TestProcessClaimedItemAtCapRecoversPendingScopeWithoutAgent(t *testing.T) {
 	}
 }
 
+func TestPersistPendingReviewerScopeHumanDoesNotClobberBudgetContinue(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":1}}`
+	loop := storage.LoopRecord{
+		ID: "loop_pending_vs_continue", Seq: 111, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert loop: %v", err)
+	}
+	parked, err := loops.ParkReviewFixBudget(context.Background(), fixture.repos, loops.ParkReviewFixBudgetInput{
+		Exhausted: loop, Role: "reviewer", Repo: repo, PRNumber: prNumber,
+		Count: 1, Cap: 1, NowISO: nowISO, HITLEnabled: true,
+		LiveCaps: loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 1},
+		DB:       fixture.coordinator.DB(),
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewFixBudget: %v", err)
+	}
+	if !loops.IsReviewFixBudgetHold(parked) {
+		t.Fatalf("precondition: want budget hold, got status=%s meta=%s", parked.Status, derefString(parked.MetadataJSON))
+	}
+	stale := parked
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = true
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 1
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{}, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+	})
+	continued, err := loops.ApplyReviewFixBudgetAnswer(context.Background(), fixture.repos, parked, "Continue", nowISO, loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 1, FixerMaxPushes: 8})
+	if err != nil || !continued.Applied {
+		t.Fatalf("ApplyReviewFixBudgetAnswer = (%#v, %v)", continued, err)
+	}
+	completion := reviewerCommentOnlyCompletion{
+		Summary: "Mixed must_fix and needs_human",
+		Outcome: "blocking",
+		Findings: []reviewerCommentOnlyFindingResult{
+			{Title: "Bug", Body: "fix it", Disposition: "must_fix", Severity: "blocking", ScopeBasis: "introduced_regression", ScopeEvidence: "diff", Files: []string{"a.go"}},
+			{Title: "Ambiguous", Body: "unclear", Disposition: "needs_human", Severity: "blocking", ScopeBasis: "ambiguous_intent", ScopeEvidence: "PR non-goals"},
+		},
+	}
+	if err := runner.persistPendingReviewerScopeHuman(context.Background(), stale, completion); err != nil {
+		t.Fatalf("persistPendingReviewerScopeHuman: %v", err)
+	}
+	fresh, err := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if err != nil || fresh == nil {
+		t.Fatalf("get loop: (%#v, %v)", fresh, err)
+	}
+	if loops.IsReviewFixBudgetHold(*fresh) {
+		t.Fatalf("stale persist restored budget hold after Continue: status=%s meta=%s", fresh.Status, derefString(fresh.MetadataJSON))
+	}
+	if !loops.IsReviewScopeHumanHold(*fresh) {
+		t.Fatalf("want scope hold after Continue-then-persist: status=%s meta=%s", fresh.Status, derefString(fresh.MetadataJSON))
+	}
+	if loops.HasPendingReviewScopeHuman(*fresh) {
+		t.Fatalf("pending must not land on the released loop: meta=%s", derefString(fresh.MetadataJSON))
+	}
+	ask, ok := loops.ReadHITLAsk(fresh.MetadataJSON)
+	if !ok || !loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want scope ask without restored budget ask", ask, ok)
+	}
+}
+
 func TestPublishAlreadyPublishedNeedsHumanSkipsScopeOnNewHead(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -10278,6 +10278,68 @@ func TestRunReviewStepNeedsHumanRecordsPublishedMarkerBeforePark(t *testing.T) {
 	}
 }
 
+func TestRunReviewStepNeedsHumanDoesNotRecountAlreadyPublishedHead(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	metadata := `{"loop":{"iterationCount":0},"lastPublishedHeadSha":"abc123"}`
+	loop := storage.LoopRecord{
+		ID: "loop_needs_human_recount", Seq: 96, ProjectID: "project_1", Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber,
+		Status: "running", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+		t.Fatalf("upsert loop: %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig: %v", err)
+	}
+	cfg.HITL.Enabled = false
+	stdout := `__LOOPER_RESULT__={"summary":"Mixed must_fix and needs_human","outcome":"blocking","findings":[{"title":"Bug","body":"fix it","disposition":"must_fix","severity":"blocking","scopeBasis":"introduced_regression","scopeEvidence":"diff","path":"a.go","line":1},{"title":"Ambiguous","body":"unclear","disposition":"needs_human","severity":"blocking","scopeBasis":"ambiguous_intent","scopeEvidence":"PR non-goals","path":"b.go","line":2}]}`
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{
+			reviewMarkerMissing: false, reviewMarkerEvent: ReviewEventComment, reviewMarkerOutcome: "blocking",
+		}, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{results: []AgentResult{{
+			Status: "completed", Summary: "Mixed must_fix and needs_human", Stdout: stdout, ParseStatus: "parsed",
+		}}},
+		Logger: fixture.logger, Now: fixture.now,
+		LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg,
+	})
+	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
+	if err != nil || project == nil {
+		t.Fatalf("Projects.GetByID() = (%#v, %v)", project, err)
+	}
+	_, err = runner.runReviewStep(context.Background(), stepInput{
+		Project: *project, Loop: loop, Run: storage.RunRecord{ID: "run_needs_human_recount"},
+		Repo: repo, PRNumber: prNumber,
+		Checkpoint: reviewerCheckpoint{
+			Detail:   &checkpointDetail{HeadRefName: "feature/review-me", BaseRefName: "main"},
+			Snapshot: &checkpointSnapshot{HeadSHA: "abc123"},
+			Worktree: &checkpointWorktree{Path: t.TempDir(), Branch: "feature/review-me", PreparedAt: nowISO},
+		},
+	})
+	var hold *holdSkipError
+	if !errors.As(err, &hold) {
+		t.Fatalf("runReviewStep() error = %v, want holdSkipError", err)
+	}
+	updated, getErr := fixture.repos.Loops.GetByID(context.Background(), loop.ID)
+	if getErr != nil || updated == nil {
+		t.Fatalf("after retry = (%#v, %v)", updated, getErr)
+	}
+	if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != 0 {
+		t.Fatalf("ReviewerPublishCount = %d, want 0 on already-published head", got)
+	}
+	if !loops.IsReviewScopeHumanHold(*updated) {
+		t.Fatalf("after retry = %#v, want recovered scope hold", updated)
+	}
+}
+
+
 func TestRunReviewStepNeedsHumanAtCapBudgetHoldOnlyNoStackedScope(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -289,6 +289,9 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 			if loop, err := input.Repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
 				caps = reviewFixBudgetLiveCaps(input.Config, loop.ProjectID)
 			}
+			if err := drainScopeHoldOnStop(ctx, input.Repos, loopID, answer, input.DrainHITLPair); err != nil {
+				return err
+			}
 			if err := deliverHITLAnswerToLoopWithCaps(ctx, input.Repos, input.DB, nowISO, loopID, answer, caps); err != nil {
 				return err
 			}

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -224,6 +224,43 @@ func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, 
 	return nil
 }
 
+// deliverFeishuHITLCardAction applies a card-action click. Overlay siblings keep
+// an ordinary agent card interactive; those option clicks are not pair
+// Continue/Stop decisions and must not fail-close the inbox cursor ahead of the
+// primary scope card.
+func deliverFeishuHITLCardAction(ctx context.Context, repos *storage.Repositories, db *sql.DB, cfg *config.Config, nowISO, loopID, answer string, drain func(context.Context, storage.LoopRecord) error, onAnswered func(context.Context, string, string)) error {
+	caps := reviewFixBudgetLiveCaps(cfg, "")
+	if repos != nil && repos.Loops != nil {
+		if loop, err := repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
+			caps = reviewFixBudgetLiveCaps(cfg, loop.ProjectID)
+			if feishuOverlayResidualCardIsNotPairDecision(*loop, answer) {
+				return nil
+			}
+		}
+	}
+	if err := drainScopeHoldOnStop(ctx, repos, loopID, answer, drain); err != nil {
+		return err
+	}
+	if err := deliverHITLAnswerToLoopWithCaps(ctx, repos, db, nowISO, loopID, answer, caps); err != nil {
+		return err
+	}
+	if onAnswered != nil {
+		onAnswered(ctx, loopID, answer)
+	}
+	return nil
+}
+
+func feishuOverlayResidualCardIsNotPairDecision(loop storage.LoopRecord, answer string) bool {
+	if !loops.IsReviewScopeHumanHold(loop) {
+		return false
+	}
+	if loops.IsReviewFixBudgetContinue(answer) || loops.IsReviewFixBudgetStop(answer) {
+		return false
+	}
+	ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
+	return ok && githubHITLResidualOrdinaryAsk(ask)
+}
+
 // feishuDecisionCardLoopID returns the loop whose Continue/Stop Feishu card
 // should be resolved for a typed decision. Overlay siblings keep an ordinary
 // agent ask, so the pair's scope/budget primary card is the one that must close.
@@ -336,21 +373,7 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 			return loop.ID
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			caps := reviewFixBudgetLiveCaps(input.Config, "")
-			if loop, err := input.Repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
-				caps = reviewFixBudgetLiveCaps(input.Config, loop.ProjectID)
-			}
-			if err := drainScopeHoldOnStop(ctx, input.Repos, loopID, answer, input.DrainHITLPair); err != nil {
-				return err
-			}
-			if err := deliverHITLAnswerToLoopWithCaps(ctx, input.Repos, input.DB, nowISO, loopID, answer, caps); err != nil {
-				return err
-			}
-			// Mark the ask card resolved ("✅ 已选:X", brief preserved).
-			if input.OnHITLAnswerDelivered != nil {
-				input.OnHITLAnswerDelivered(ctx, loopID, answer)
-			}
-			return nil
+			return deliverFeishuHITLCardAction(ctx, input.Repos, input.DB, input.Config, nowISO, loopID, answer, input.DrainHITLPair, input.OnHITLAnswerDelivered)
 		},
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
 			return enqueueFeishuHITLMessage(ctx, input.Repos, input.DB, input.Config, nowISO, loopID, text, input.OnHITLAnswerDelivered, input.DrainHITLPair)

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -174,11 +174,14 @@ func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopR
 // too, or the cached loop-seq buttons can answer a later budget cycle.
 // Typed Stop on a scope hold drains live pair agents before records terminalize,
 // matching card-action deliverAnswer.
+// Overlay siblings keep an ordinary agent card: Continue/Stop typed in that
+// thread must resolve the pair's scope-primary card, not the sibling card.
 func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, db *sql.DB, cfg *config.Config, nowISO, loopID, text string, onAnswered func(context.Context, string, string), drain func(context.Context, storage.LoopRecord) error) error {
 	if err := drainScopeHoldOnStop(ctx, repos, loopID, text, drain); err != nil {
 		return err
 	}
 	shouldResolve := false
+	resolveLoopID := loopID
 	caps := reviewFixBudgetLiveCaps(cfg, "")
 	if repos != nil && repos.Loops != nil {
 		loop, err := repos.Loops.GetByID(ctx, loopID)
@@ -188,8 +191,13 @@ func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, 
 		if loop != nil {
 			caps = reviewFixBudgetLiveCaps(cfg, loop.ProjectID)
 			if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
-				if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && (loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask)) {
+				cardLoopID, err := feishuDecisionCardLoopID(ctx, repos, *loop)
+				if err != nil {
+					return err
+				}
+				if cardLoopID != "" {
 					shouldResolve = true
+					resolveLoopID = cardLoopID
 				}
 			}
 		}
@@ -198,9 +206,32 @@ func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, 
 		return err
 	}
 	if shouldResolve && onAnswered != nil {
-		onAnswered(ctx, loopID, text)
+		onAnswered(ctx, resolveLoopID, text)
 	}
 	return nil
+}
+
+// feishuDecisionCardLoopID returns the loop whose Continue/Stop Feishu card
+// should be resolved for a typed decision. Overlay siblings keep an ordinary
+// agent ask, so the pair's scope/budget primary card is the one that must close.
+func feishuDecisionCardLoopID(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord) (string, error) {
+	if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && (loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask)) {
+		return loop.ID, nil
+	}
+	if !loops.IsReviewScopeHumanHold(loop) || repos == nil || repos.Loops == nil {
+		return "", nil
+	}
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, sibling := range loops.FindSiblingReviewFixLoops(all, loop) {
+		ask, ok := loops.ReadHITLAsk(sibling.MetadataJSON)
+		if ok && (loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask)) {
+			return sibling.ID, nil
+		}
+	}
+	return "", nil
 }
 
 func sendFeishuBudgetAsk(ctx context.Context, input defaultSchedulerTickInput, loop storage.LoopRecord, ask loops.HITLAsk) error {

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -172,7 +172,12 @@ func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopR
 // an explicit budget Continue/Stop, invokes onAnswered so the live ask card is
 // marked resolved. Card-action delivery already does this; typed decisions must
 // too, or the cached loop-seq buttons can answer a later budget cycle.
-func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, db *sql.DB, cfg *config.Config, nowISO, loopID, text string, onAnswered func(context.Context, string, string)) error {
+// Typed Stop on a scope hold drains live pair agents before records terminalize,
+// matching card-action deliverAnswer.
+func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, db *sql.DB, cfg *config.Config, nowISO, loopID, text string, onAnswered func(context.Context, string, string), drain func(context.Context, storage.LoopRecord) error) error {
+	if err := drainScopeHoldOnStop(ctx, repos, loopID, text, drain); err != nil {
+		return err
+	}
 	shouldResolve := false
 	caps := reviewFixBudgetLiveCaps(cfg, "")
 	if repos != nil && repos.Loops != nil {
@@ -302,7 +307,7 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 			return nil
 		},
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
-			return enqueueFeishuHITLMessage(ctx, input.Repos, input.DB, input.Config, nowISO, loopID, text, input.OnHITLAnswerDelivered)
+			return enqueueFeishuHITLMessage(ctx, input.Repos, input.DB, input.Config, nowISO, loopID, text, input.OnHITLAnswerDelivered, input.DrainHITLPair)
 		},
 	}
 	if input.Logger != nil {

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -227,13 +227,20 @@ func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, 
 // deliverFeishuHITLCardAction applies a card-action click. Overlay siblings keep
 // an ordinary agent card interactive; those option clicks are not pair
 // Continue/Stop decisions and must not fail-close the inbox cursor ahead of the
-// primary scope card.
+// primary scope card. The ordinary answer is recorded on the residual HITL ask
+// while the pair stays held, then Continue resumes from that stored answer.
 func deliverFeishuHITLCardAction(ctx context.Context, repos *storage.Repositories, db *sql.DB, cfg *config.Config, nowISO, loopID, answer string, drain func(context.Context, storage.LoopRecord) error, onAnswered func(context.Context, string, string)) error {
 	caps := reviewFixBudgetLiveCaps(cfg, "")
 	if repos != nil && repos.Loops != nil {
 		if loop, err := repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
 			caps = reviewFixBudgetLiveCaps(cfg, loop.ProjectID)
 			if feishuOverlayResidualCardIsNotPairDecision(*loop, answer) {
+				if err := preserveFeishuOverlayResidualCardAnswer(ctx, repos, loopID, answer, nowISO); err != nil {
+					return err
+				}
+				if onAnswered != nil {
+					onAnswered(ctx, loopID, answer)
+				}
 				return nil
 			}
 		}
@@ -258,7 +265,47 @@ func feishuOverlayResidualCardIsNotPairDecision(loop storage.LoopRecord, answer 
 		return false
 	}
 	ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
-	return ok && githubHITLResidualOrdinaryAsk(ask)
+	if !ok || loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask) {
+		return false
+	}
+	return true
+}
+
+// preserveFeishuOverlayResidualCardAnswer records an ordinary card option on the
+// preserved agent ask without treating it as a scope Continue/Stop. The pair
+// stays held; releaseOneReviewScopeHumanHold later queues the answered sibling.
+func preserveFeishuOverlayResidualCardAnswer(ctx context.Context, repos *storage.Repositories, loopID, answer, nowISO string) error {
+	if repos == nil || repos.Loops == nil {
+		return nil
+	}
+	unlock := LockLoopRequeue(loopID)
+	defer unlock()
+	fresh, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return err
+	}
+	if fresh == nil || !feishuOverlayResidualCardIsNotPairDecision(*fresh, answer) {
+		return nil
+	}
+	ask, ok := loops.ReadHITLAsk(fresh.MetadataJSON)
+	if !ok {
+		return nil
+	}
+	status := strings.TrimSpace(ask.Status)
+	if strings.EqualFold(status, "answered") || strings.EqualFold(status, "consumed") {
+		return nil
+	}
+	ask.Answer = answer
+	ask.Status = "answered"
+	ask.AnsweredAt = nowISO
+	meta, err := loops.WriteHITLAsk(fresh.MetadataJSON, ask)
+	if err != nil {
+		return err
+	}
+	updated := *fresh
+	updated.MetadataJSON = &meta
+	updated.UpdatedAt = nowISO
+	return repos.Loops.Upsert(ctx, updated)
 }
 
 // feishuDecisionCardLoopID returns the loop whose Continue/Stop Feishu card

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -181,7 +181,11 @@ func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, 
 	shouldResolve := false
 	caps := reviewFixBudgetLiveCaps(cfg, "")
 	if repos != nil && repos.Loops != nil {
-		if loop, err := repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
+		loop, err := repos.Loops.GetByID(ctx, loopID)
+		if err != nil {
+			return err
+		}
+		if loop != nil {
 			caps = reviewFixBudgetLiveCaps(cfg, loop.ProjectID)
 			if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
 				if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && (loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask)) {

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -157,23 +157,17 @@ func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopR
 			}
 			continue
 		}
-		ask.Transport = "feishu"
-		meta, werr := loops.WriteHITLAsk(loop.MetadataJSON, ask)
-		if werr != nil {
-			if deps.logWarn != nil {
-				deps.logWarn("hitl feishu: budget ask metadata write failed", map[string]any{"loopId": loop.ID, "error": werr.Error()})
-			}
-			continue
-		}
-		updated := loop
-		updated.MetadataJSON = &meta
-		if deps.nowISO != "" {
-			updated.UpdatedAt = deps.nowISO
-		}
-		if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		posted := ask
+		persisted, err := persistPairAskDelivery(ctx, repos, loop.ID, deps.nowISO, posted, func(live *loops.HITLAsk) {
+			live.Transport = "feishu"
+		})
+		if err != nil {
 			if deps.logWarn != nil {
 				deps.logWarn("hitl feishu: budget ask persist failed", map[string]any{"loopId": loop.ID, "error": err.Error()})
 			}
+			continue
+		}
+		if !persisted {
 			continue
 		}
 		delivered++

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -189,8 +189,9 @@ func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopR
 // matching card-action deliverAnswer.
 // Overlay siblings keep an ordinary agent card: Continue/Stop typed in that
 // thread must resolve the pair's scope-primary card, not the sibling card.
-func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, db *sql.DB, cfg *config.Config, nowISO, loopID, text string, onAnswered func(context.Context, string, string), drain func(context.Context, storage.LoopRecord) error) error {
-	if err := drainScopeHoldOnStop(ctx, repos, loopID, text, drain); err != nil {
+func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, db *sql.DB, cfg *config.Config, nowISO, loopID, text string, onAnswered func(context.Context, string, string), drain func(context.Context, storage.LoopRecord) error, executions *ActiveExecutionRegistry) error {
+	drained, err := drainScopeHoldOnStop(ctx, repos, loopID, text, drain)
+	if err != nil {
 		return err
 	}
 	shouldResolve := false
@@ -212,10 +213,19 @@ func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, 
 					shouldResolve = true
 					resolveLoopID = cardLoopID
 				}
+				if drained && !loops.IsReviewFixPairHold(*loop) {
+					if loops.IsReviewFixBudgetStop(text) {
+						ReopenUnappliedScopeStopGates(ctx, repos, executions, loopID)
+					}
+					if shouldResolve && onAnswered != nil {
+						onAnswered(ctx, resolveLoopID, text)
+					}
+					return nil
+				}
 			}
 		}
 	}
-	if err := enqueueHumanMessageToLoopWithCaps(ctx, repos, db, nowISO, loopID, text, caps); err != nil {
+	if err := enqueueHumanMessageToLoopWithCaps(ctx, repos, db, nowISO, loopID, text, caps, executions); err != nil {
 		return err
 	}
 	if shouldResolve && onAnswered != nil {
@@ -229,13 +239,13 @@ func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, 
 // Continue/Stop decisions and must not fail-close the inbox cursor ahead of the
 // primary scope card. The ordinary answer is recorded on the residual HITL ask
 // while the pair stays held, then Continue resumes from that stored answer.
-func deliverFeishuHITLCardAction(ctx context.Context, repos *storage.Repositories, db *sql.DB, cfg *config.Config, nowISO, loopID, answer string, drain func(context.Context, storage.LoopRecord) error, onAnswered func(context.Context, string, string)) error {
+func deliverFeishuHITLCardAction(ctx context.Context, repos *storage.Repositories, db *sql.DB, cfg *config.Config, nowISO, loopID, answer string, drain func(context.Context, storage.LoopRecord) error, onAnswered func(context.Context, string, string), executions *ActiveExecutionRegistry) error {
 	caps := reviewFixBudgetLiveCaps(cfg, "")
 	if repos != nil && repos.Loops != nil {
 		if loop, err := repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
 			caps = reviewFixBudgetLiveCaps(cfg, loop.ProjectID)
 			if feishuOverlayResidualCardIsNotPairDecision(*loop, answer) {
-				if err := preserveFeishuOverlayResidualCardAnswer(ctx, repos, loopID, answer, nowISO); err != nil {
+				if err := preserveFeishuOverlayResidualCardAnswer(ctx, repos, db, loopID, answer, nowISO); err != nil {
 					return err
 				}
 				if onAnswered != nil {
@@ -245,10 +255,7 @@ func deliverFeishuHITLCardAction(ctx context.Context, repos *storage.Repositorie
 			}
 		}
 	}
-	if err := drainScopeHoldOnStop(ctx, repos, loopID, answer, drain); err != nil {
-		return err
-	}
-	if err := deliverHITLAnswerToLoopWithCaps(ctx, repos, db, nowISO, loopID, answer, caps); err != nil {
+	if err := deliverHITLAnswerAfterScopeDrain(ctx, repos, db, nowISO, loopID, answer, caps, drain, executions); err != nil {
 		return err
 	}
 	if onAnswered != nil {
@@ -271,10 +278,14 @@ func feishuOverlayResidualCardIsNotPairDecision(loop storage.LoopRecord, answer 
 	return true
 }
 
+// afterFeishuResidualCardLoadHook is test-only: runs after the residual sibling
+// snapshot and before the pair-target lock / conditional write.
+var afterFeishuResidualCardLoadHook func()
+
 // preserveFeishuOverlayResidualCardAnswer records an ordinary card option on the
 // preserved agent ask without treating it as a scope Continue/Stop. The pair
 // stays held; releaseOneReviewScopeHumanHold later queues the answered sibling.
-func preserveFeishuOverlayResidualCardAnswer(ctx context.Context, repos *storage.Repositories, loopID, answer, nowISO string) error {
+func preserveFeishuOverlayResidualCardAnswer(ctx context.Context, repos *storage.Repositories, db *sql.DB, loopID, answer, nowISO string) error {
 	if repos == nil || repos.Loops == nil {
 		return nil
 	}
@@ -287,25 +298,45 @@ func preserveFeishuOverlayResidualCardAnswer(ctx context.Context, repos *storage
 	if fresh == nil || !feishuOverlayResidualCardIsNotPairDecision(*fresh, answer) {
 		return nil
 	}
-	ask, ok := loops.ReadHITLAsk(fresh.MetadataJSON)
-	if !ok {
-		return nil
+	if afterFeishuResidualCardLoadHook != nil {
+		afterFeishuResidualCardLoadHook()
 	}
-	status := strings.TrimSpace(ask.Status)
-	if strings.EqualFold(status, "answered") || strings.EqualFold(status, "consumed") {
-		return nil
+	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*fresh))
+	defer unlockTarget()
+	write := func(writeRepos *storage.Repositories) error {
+		current, err := writeRepos.Loops.GetByID(ctx, loopID)
+		if err != nil {
+			return err
+		}
+		if current == nil || !feishuOverlayResidualCardIsNotPairDecision(*current, answer) {
+			return nil
+		}
+		ask, ok := loops.ReadHITLAsk(current.MetadataJSON)
+		if !ok {
+			return nil
+		}
+		status := strings.TrimSpace(ask.Status)
+		if strings.EqualFold(status, "answered") || strings.EqualFold(status, "consumed") {
+			return nil
+		}
+		ask.Answer = answer
+		ask.Status = "answered"
+		ask.AnsweredAt = nowISO
+		meta, err := loops.WriteHITLAsk(current.MetadataJSON, ask)
+		if err != nil {
+			return err
+		}
+		updated := *current
+		updated.MetadataJSON = &meta
+		updated.UpdatedAt = nowISO
+		return writeRepos.Loops.Upsert(ctx, updated)
 	}
-	ask.Answer = answer
-	ask.Status = "answered"
-	ask.AnsweredAt = nowISO
-	meta, err := loops.WriteHITLAsk(fresh.MetadataJSON, ask)
-	if err != nil {
-		return err
+	if db != nil {
+		return storage.WithTransaction(ctx, db, nil, func(tx *sql.Tx) error {
+			return write(storage.NewRepositories(tx))
+		})
 	}
-	updated := *fresh
-	updated.MetadataJSON = &meta
-	updated.UpdatedAt = nowISO
-	return repos.Loops.Upsert(ctx, updated)
+	return write(repos)
 }
 
 // feishuDecisionCardLoopID returns the loop whose Continue/Stop Feishu card
@@ -420,10 +451,10 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 			return loop.ID
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			return deliverFeishuHITLCardAction(ctx, input.Repos, input.DB, input.Config, nowISO, loopID, answer, input.DrainHITLPair, input.OnHITLAnswerDelivered)
+			return deliverFeishuHITLCardAction(ctx, input.Repos, input.DB, input.Config, nowISO, loopID, answer, input.DrainHITLPair, input.OnHITLAnswerDelivered, input.ActiveExecutions)
 		},
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
-			return enqueueFeishuHITLMessage(ctx, input.Repos, input.DB, input.Config, nowISO, loopID, text, input.OnHITLAnswerDelivered, input.DrainHITLPair)
+			return enqueueFeishuHITLMessage(ctx, input.Repos, input.DB, input.Config, nowISO, loopID, text, input.OnHITLAnswerDelivered, input.DrainHITLPair, input.ActiveExecutions)
 		},
 	}
 	if input.Logger != nil {

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -53,14 +53,12 @@ type feishuHITLPollDeps struct {
 
 // pollFeishuHITLInboxOnce delivers the answers among a batch of inbox events that
 // belong to this looper's awaiting loops, self-selecting by thread root (typed
-// replies) or loop seq (card-action clicks). Returns the highest event id seen so
-// the caller can advance its cursor. Idempotent: an event whose loop is no longer
-// awaiting is a no-op in deliverAnswer.
+// replies) or loop seq (card-action clicks). Returns the highest event id that
+// was safely consumed so the caller can advance its cursor. A delivery error
+// leaves that event and every later event unconsumed so the next poll retries.
+// Idempotent: an event whose loop is no longer awaiting is a no-op in deliverAnswer.
 func pollFeishuHITLInboxOnce(ctx contextType, events []feishuInboxEvent, deps feishuHITLPollDeps) (delivered int, maxID int64) {
 	for _, e := range events {
-		if e.ID > maxID {
-			maxID = e.ID
-		}
 		loopID := ""
 		value := ""
 		var deliver func(contextType, string, string) error
@@ -72,6 +70,9 @@ func pollFeishuHITLInboxOnce(ctx contextType, events []feishuInboxEvent, deps fe
 			text := strings.TrimSpace(e.Text)
 			root := strings.TrimSpace(e.RootID)
 			if text == "" || root == "" || deps.loopByRoot == nil || deps.enqueueMessage == nil {
+				if e.ID > maxID {
+					maxID = e.ID
+				}
 				continue
 			}
 			loopID = deps.loopByRoot(ctx, root)
@@ -82,24 +83,36 @@ func pollFeishuHITLInboxOnce(ctx contextType, events []feishuInboxEvent, deps fe
 			ans := strings.TrimSpace(e.Value.Answer)
 			seq, err := strconv.ParseInt(strings.TrimSpace(e.Value.LoopSeq), 10, 64)
 			if ans == "" || err != nil || deps.loopBySeq == nil {
+				if e.ID > maxID {
+					maxID = e.ID
+				}
 				continue
 			}
 			loopID = deps.loopBySeq(ctx, seq)
 			value = ans
 			deliver = deps.deliverAnswer
 		default:
+			if e.ID > maxID {
+				maxID = e.ID
+			}
 			continue
 		}
 		if strings.TrimSpace(loopID) == "" {
+			if e.ID > maxID {
+				maxID = e.ID
+			}
 			continue // belongs to another looper (or already resumed)
 		}
 		if err := deliver(ctx, loopID, value); err != nil {
 			if deps.logWarn != nil {
 				deps.logWarn("hitl feishu poll: deliver failed", map[string]any{"loopId": loopID, "kind": e.Kind, "error": err.Error()})
 			}
-			continue
+			return delivered, maxID
 		}
 		delivered++
+		if e.ID > maxID {
+			maxID = e.ID
+		}
 	}
 	return delivered, maxID
 }

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -127,9 +127,10 @@ var feishuInboxCursor struct {
 var feishuInboxHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
 type feishuHITLDeliveryDeps struct {
-	sendAsk func(ctx contextType, loop storage.LoopRecord, ask loops.HITLAsk) error
-	nowISO  string
-	logWarn func(msg string, fields map[string]any)
+	sendAsk  func(ctx contextType, loop storage.LoopRecord, ask loops.HITLAsk) error
+	closeAsk func(ctx contextType, loopID string)
+	nowISO   string
+	logWarn  func(msg string, fields map[string]any)
 }
 
 func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopRecord, repos *storage.Repositories, deps feishuHITLDeliveryDeps) int {
@@ -168,11 +169,34 @@ func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopR
 			continue
 		}
 		if !persisted {
+			if deps.closeAsk != nil {
+				deps.closeAsk(ctx, loop.ID)
+			}
 			continue
 		}
+
 		delivered++
 	}
 	return delivered
+}
+
+// closeObsoleteFeishuPairAskCard resolves a card that SendHITLAsk already posted
+// when persistPairAskDelivery reports the ask is no longer current. Loop-seq
+// buttons on a leftover card can answer a later hold on the same loop.
+func closeObsoleteFeishuPairAskCard(ctx contextType, repos *storage.Repositories, loopID string, onAnswered func(context.Context, string, string)) {
+	if onAnswered == nil || strings.TrimSpace(loopID) == "" {
+		return
+	}
+	answer := loops.ReviewFixBudgetAnswerContinue
+	if repos != nil && repos.Loops != nil {
+		if fresh, err := repos.Loops.GetByID(ctx, loopID); err == nil && fresh != nil {
+			switch strings.TrimSpace(fresh.Status) {
+			case "terminated", "stopped":
+				answer = loops.ReviewFixBudgetAnswerStop
+			}
+		}
+	}
+	onAnswered(ctx, loopID, answer)
 }
 
 // enqueueFeishuHITLMessage applies a typed inbox reply and, when that reply is
@@ -425,8 +449,12 @@ func runFeishuHITLPoll(ctx context.Context, input defaultSchedulerTickInput) {
 			sendAsk: func(ctx contextType, loop storage.LoopRecord, ask loops.HITLAsk) error {
 				return sendFeishuBudgetAsk(ctx, input, loop, ask)
 			},
+			closeAsk: func(ctx contextType, loopID string) {
+				closeObsoleteFeishuPairAskCard(ctx, input.Repos, loopID, input.OnHITLAnswerDelivered)
+			},
 			nowISO: nowISO,
 		}
+
 		if input.Logger != nil {
 			deliveryDeps.logWarn = func(msg string, fields map[string]any) { input.Logger.Warn(msg, fields) }
 		}

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -190,8 +190,6 @@ func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, 
 			if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
 				if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && (loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask)) {
 					shouldResolve = true
-				} else if loops.IsReviewFixPairHold(*loop) {
-					shouldResolve = true
 				}
 			}
 		}

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -129,7 +129,7 @@ func deliverUndeliveredFeishuBudgetAsks(ctx contextType, records []storage.LoopR
 			continue
 		}
 		ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
-		if !ok || !loops.IsReviewFixBudgetAsk(ask) {
+		if !ok || (!loops.IsReviewFixBudgetAsk(ask) && !loops.IsReviewScopeHumanAsk(ask)) {
 			continue
 		}
 		if strings.EqualFold(strings.TrimSpace(ask.Transport), "feishu") {
@@ -179,9 +179,9 @@ func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, 
 		if loop, err := repos.Loops.GetByID(ctx, loopID); err == nil && loop != nil {
 			caps = reviewFixBudgetLiveCaps(cfg, loop.ProjectID)
 			if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
-				if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && loops.IsReviewFixBudgetAsk(ask) {
+				if ask, ok := loops.ReadHITLAsk(loop.MetadataJSON); ok && (loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask)) {
 					shouldResolve = true
-				} else if loops.IsReviewFixBudgetHold(*loop) {
+				} else if loops.IsReviewFixPairHold(*loop) {
 					shouldResolve = true
 				}
 			}

--- a/internal/runtime/hitl_feishu_poll.go
+++ b/internal/runtime/hitl_feishu_poll.go
@@ -204,6 +204,15 @@ func enqueueFeishuHITLMessage(ctx context.Context, repos *storage.Repositories, 
 		}
 		if loop != nil {
 			caps = reviewFixBudgetLiveCaps(cfg, loop.ProjectID)
+			if feishuOverlayResidualCardIsNotPairDecision(*loop, text) {
+				if err := preserveFeishuOverlayResidualCardAnswer(ctx, repos, db, loopID, text, nowISO); err != nil {
+					return err
+				}
+				if onAnswered != nil {
+					onAnswered(ctx, loopID, text)
+				}
+				return nil
+			}
 			if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
 				cardLoopID, err := feishuDecisionCardLoopID(ctx, repos, *loop)
 				if err != nil {
@@ -304,32 +313,7 @@ func preserveFeishuOverlayResidualCardAnswer(ctx context.Context, repos *storage
 	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*fresh))
 	defer unlockTarget()
 	write := func(writeRepos *storage.Repositories) error {
-		current, err := writeRepos.Loops.GetByID(ctx, loopID)
-		if err != nil {
-			return err
-		}
-		if current == nil || !feishuOverlayResidualCardIsNotPairDecision(*current, answer) {
-			return nil
-		}
-		ask, ok := loops.ReadHITLAsk(current.MetadataJSON)
-		if !ok {
-			return nil
-		}
-		status := strings.TrimSpace(ask.Status)
-		if strings.EqualFold(status, "answered") || strings.EqualFold(status, "consumed") {
-			return nil
-		}
-		ask.Answer = answer
-		ask.Status = "answered"
-		ask.AnsweredAt = nowISO
-		meta, err := loops.WriteHITLAsk(current.MetadataJSON, ask)
-		if err != nil {
-			return err
-		}
-		updated := *current
-		updated.MetadataJSON = &meta
-		updated.UpdatedAt = nowISO
-		return writeRepos.Loops.Upsert(ctx, updated)
+		return persistOverlayResidualAskAnswer(ctx, writeRepos, loopID, answer, nowISO)
 	}
 	if db != nil {
 		return storage.WithTransaction(ctx, db, nil, func(tx *sql.Tx) error {
@@ -337,6 +321,41 @@ func preserveFeishuOverlayResidualCardAnswer(ctx context.Context, repos *storage
 		})
 	}
 	return write(repos)
+}
+
+// persistOverlayResidualAskAnswer writes a residual ordinary ask answer without
+// taking pair locks. Callers must already hold requeue+target serialization or
+// be inside the preserve TX that re-reads under those locks.
+func persistOverlayResidualAskAnswer(ctx context.Context, writeRepos *storage.Repositories, loopID, answer, nowISO string) error {
+	if writeRepos == nil || writeRepos.Loops == nil {
+		return nil
+	}
+	current, err := writeRepos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return err
+	}
+	if current == nil || !feishuOverlayResidualCardIsNotPairDecision(*current, answer) {
+		return nil
+	}
+	ask, ok := loops.ReadHITLAsk(current.MetadataJSON)
+	if !ok {
+		return nil
+	}
+	status := strings.TrimSpace(ask.Status)
+	if strings.EqualFold(status, "answered") || strings.EqualFold(status, "consumed") {
+		return nil
+	}
+	ask.Answer = answer
+	ask.Status = "answered"
+	ask.AnsweredAt = nowISO
+	meta, err := loops.WriteHITLAsk(current.MetadataJSON, ask)
+	if err != nil {
+		return err
+	}
+	updated := *current
+	updated.MetadataJSON = &meta
+	updated.UpdatedAt = nowISO
+	return writeRepos.Loops.Upsert(ctx, updated)
 }
 
 // feishuDecisionCardLoopID returns the loop whose Continue/Stop Feishu card

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -507,6 +507,185 @@ func TestFeishuHITLPollTypedScopeStopDrainsLiveSibling(t *testing.T) {
 	}
 }
 
+func TestFeishuHITLPollTypedScopeContinueResolvesOverlayCard(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_feishu_typed_continue"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_feishu_typed_scope_continue_rev", Seq: 93, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	agentAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+		Transport: "feishu",
+	}
+	fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(fixer): %v", err)
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_feishu_typed_scope_continue_fix", Seq: 94, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &fixerMeta,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	parked, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	overlaid, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || overlaid == nil || !loops.IsReviewScopeHumanHold(*overlaid) {
+		t.Fatalf("fixer after overlay = (%#v, %v), want preserved ask under scope hold", overlaid, err)
+	}
+
+	var resolved []string
+	deps := feishuHITLPollDeps{
+		loopByRoot: func(_ contextType, rootID string) string {
+			if rootID == "om_scope_continue_root" {
+				return parked.ID
+			}
+			return ""
+		},
+		enqueueMessage: func(ctx contextType, loopID, text string) error {
+			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
+				resolved = append(resolved, answeredLoopID+"="+answer)
+			}, nil)
+		},
+	}
+	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{{
+		ID: 41, Kind: "message", RootID: "om_scope_continue_root", Text: "Continue",
+	}}, deps)
+	if n != 1 || maxID != 41 {
+		t.Fatalf("typed Continue poll = %d maxID=%d, want applied Continue", n, maxID)
+	}
+	if len(resolved) != 1 || resolved[0] != parked.ID+"=Continue" {
+		t.Fatalf("card resolution after typed scope Continue = %#v, want primary Continue", resolved)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "queued" || loops.IsReviewScopeHumanHold(*fresh) {
+		t.Fatalf("reviewer after typed Continue = (%#v, %v), want queued and released", fresh, err)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "awaiting_human" || loops.IsReviewScopeHumanHold(*sibling) {
+		t.Fatalf("fixer after typed Continue = (%#v, %v), want awaiting preserved agent ask", sibling, err)
+	}
+	remaining, ok := loops.ReadHITLAsk(sibling.MetadataJSON)
+	if !ok || remaining.Question != agentAsk.Question || remaining.Answer != "" {
+		t.Fatalf("fixer ask after typed Continue = (%#v, %v), want unanswered agent question", remaining, ok)
+	}
+}
+
+func TestEnqueueFeishuHITLMessageFailsClosedWhenLookupErrors(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	dbPath := filepath.Join(root, "looper.sqlite")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), dbPath, storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_feishu_lookup_err"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_feishu_lookup_err_rev", Seq: 95, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_feishu_lookup_err_fix", Seq: 96, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	if err := coordinator.Close(); err != nil {
+		t.Fatalf("close coordinator: %v", err)
+	}
+
+	resolved := 0
+	if err := enqueueFeishuHITLMessage(context.Background(), repos, nil, nil, nowISO, reviewer.ID, "Continue", func(context.Context, string, string) {
+		resolved++
+	}, nil); err == nil {
+		t.Fatal("enqueueFeishuHITLMessage error = nil, want lookup failure")
+	}
+	if resolved != 0 {
+		t.Fatalf("card resolved %d times, want 0 when lookup fails", resolved)
+	}
+
+	reopened, err := storage.OpenSQLiteCoordinator(context.Background(), dbPath, storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("reopen coordinator: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	if _, err := reopened.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("reopen RunPending: %v", err)
+	}
+	freshRepos := storage.NewRepositories(reopened.DB())
+	fresh, err := freshRepos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || !loops.IsReviewScopeHumanHold(*fresh) {
+		t.Fatalf("reviewer after lookup failure = (%#v, %v), want still held", fresh, err)
+	}
+	sibling, err := freshRepos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status == "queued" || sibling.Status == "terminated" {
+		t.Fatalf("fixer after lookup failure = (%#v, %v), want still parked", sibling, err)
+	}
+}
+
 func mustCardAction(id int64, seq, answer string) feishuInboxEvent {
 	e := feishuInboxEvent{ID: id, Kind: "card_action"}
 	e.Value.LoopSeq = seq

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -247,7 +247,7 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
 			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
 				resolved = append(resolved, answeredLoopID+"="+answer)
-			})
+			}, nil)
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
 			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
@@ -415,6 +415,95 @@ func TestGenericMessageDoesNotQueueNoAskBudgetHold(t *testing.T) {
 	}
 	if loops.ReviewerPublishCount(fresh.MetadataJSON) != 3 {
 		t.Fatalf("publish count = %d, want unchanged 3", loops.ReviewerPublishCount(fresh.MetadataJSON))
+	}
+}
+
+func TestFeishuHITLPollTypedScopeStopDrainsLiveSibling(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_feishu_typed_stop"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_feishu_typed_scope_reviewer", Seq: 91, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_feishu_typed_scope_fixer", Seq: 92, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	parked, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	reg := NewActiveExecutionRegistry()
+	var drained []string
+	drain := func(ctx context.Context, loop storage.LoopRecord) error {
+		if loop.Status == "terminated" || loop.Status == "stopped" {
+			t.Fatalf("drain after terminalize: status=%s", loop.Status)
+		}
+		drained = append(drained, loop.ID)
+		return drainReviewFixPairExecutions(ctx, repos, loop, reg)
+	}
+	deps := feishuHITLPollDeps{
+		loopByRoot: func(_ contextType, rootID string) string {
+			if rootID == "om_scope_root" {
+				return parked.ID
+			}
+			return ""
+		},
+		enqueueMessage: func(ctx contextType, loopID, text string) error {
+			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, nil, drain)
+		},
+	}
+	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{{
+		ID: 40, Kind: "message", RootID: "om_scope_root", Text: "Stop",
+	}}, deps)
+	if n != 1 || maxID != 40 {
+		t.Fatalf("typed Stop poll = %d maxID=%d, want applied Stop", n, maxID)
+	}
+	if len(drained) != 1 || drained[0] != parked.ID {
+		t.Fatalf("typed Stop drained = %v, want [%s] before terminalize", drained, parked.ID)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "terminated" {
+		t.Fatalf("reviewer after typed Stop = (%#v, %v), want terminated", fresh, err)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "terminated" {
+		t.Fatalf("fixer after typed Stop = (%#v, %v), want terminated", sibling, err)
+	}
+	if !reg.LoopStopActive(reviewer.ID) || !reg.LoopStopActive(fixer.ID) {
+		t.Fatal("pair stop gates not closed after typed Feishu scope Stop")
 	}
 }
 

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -867,6 +867,123 @@ func TestFeishuHITLPollTypedScopeDecisionResolvesPrimaryPreservesSiblingAgentCar
 	}
 }
 
+func TestFeishuHITLPollOverlayResidualCardDoesNotBlockScopeContinue(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_feishu_residual_card"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_feishu_residual_card_rev", Seq: 101, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	agentAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+		Transport: "feishu",
+	}
+	fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(fixer): %v", err)
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_feishu_residual_card_fix", Seq: 102, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &fixerMeta,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	overlaid, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || overlaid == nil || !loops.IsReviewScopeHumanHold(*overlaid) {
+		t.Fatalf("fixer after overlay = (%#v, %v), want preserved ask under scope hold", overlaid, err)
+	}
+
+	var resolved []string
+	deps := feishuHITLPollDeps{
+		loopBySeq: func(_ contextType, seq int64) string {
+			switch seq {
+			case reviewer.Seq:
+				return reviewer.ID
+			case fixer.Seq:
+				return fixer.ID
+			default:
+				return ""
+			}
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			return deliverFeishuHITLCardAction(ctx, repos, coordinator.DB(), nil, nowISO, loopID, answer, nil, func(_ contextType, answeredLoopID, got string) {
+				resolved = append(resolved, answeredLoopID+"="+got)
+			})
+		},
+	}
+	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{
+		mustCardAction(60, "102", "A"),
+		mustCardAction(61, "101", "Continue"),
+	}, deps)
+	if n != 2 || maxID != 61 {
+		t.Fatalf("overlay residual then Continue poll = %d maxID=%d, want both consumed", n, maxID)
+	}
+	if len(resolved) != 1 || resolved[0] != reviewer.ID+"=Continue" {
+		t.Fatalf("card resolution = %#v, want primary Continue only", resolved)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "queued" || loops.IsReviewScopeHumanHold(*fresh) {
+		t.Fatalf("reviewer after Continue = (%#v, %v), want queued and released", fresh, err)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "awaiting_human" || loops.IsReviewScopeHumanHold(*sibling) {
+		t.Fatalf("fixer after Continue = (%#v, %v), want awaiting preserved agent ask", sibling, err)
+	}
+	remaining, ok := loops.ReadHITLAsk(sibling.MetadataJSON)
+	if !ok || remaining.Question != agentAsk.Question || remaining.Answer != "" || remaining.Status != "awaiting" {
+		t.Fatalf("fixer ask after overlay A+Continue = (%#v, %v), want unanswered agent question", remaining, ok)
+	}
+
+	n, maxID = pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{
+		mustCardAction(62, "102", "A"),
+	}, deps)
+	if n != 1 || maxID != 62 {
+		t.Fatalf("post-release residual card poll = %d maxID=%d, want ordinary A delivered", n, maxID)
+	}
+	sibling, err = repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "running" {
+		t.Fatalf("fixer after post-release A = (%#v, %v), want running ordinary answer", sibling, err)
+	}
+	answered, ok := loops.ReadHITLAsk(sibling.MetadataJSON)
+	if !ok || answered.Answer != "A" || answered.Status != "answered" {
+		t.Fatalf("fixer ask after post-release A = (%#v, %v), want answered A", answered, ok)
+	}
+}
+
 func TestEnqueueFeishuHITLMessageFailsClosedWhenLookupErrors(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -197,7 +197,7 @@ func TestFeishuHITLPollDeliversAndContinuesReviewFixBudget(t *testing.T) {
 			return ""
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
+			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""), nil)
 		},
 	})
 	if n != 1 || maxID != 20 {
@@ -291,10 +291,10 @@ func TestFeishuHITLPollTypedBudgetMessageStaysParkedUntilContinue(t *testing.T) 
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
 			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
 				resolved = append(resolved, answeredLoopID+"="+answer)
-			}, nil)
+			}, nil, nil)
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
+			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""), nil)
 		},
 	}
 
@@ -398,7 +398,7 @@ func TestFeishuContinueUsesLiveProjectCaps(t *testing.T) {
 	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 2
 	cfg.Roles.Fixer.Behavior.Loop.MaxPushesPerPR = 5
 
-	if err := deliverHITLAnswerToLoopWithCaps(context.Background(), repos, coordinator.DB(), nowISO, reviewer.ID, "Continue", reviewFixBudgetLiveCaps(&cfg, projectID)); err != nil {
+	if err := deliverHITLAnswerToLoopWithCaps(context.Background(), repos, coordinator.DB(), nowISO, reviewer.ID, "Continue", reviewFixBudgetLiveCaps(&cfg, projectID), nil); err != nil {
 		t.Fatalf("Continue: %v", err)
 	}
 	fresh, _ := repos.Loops.GetByID(context.Background(), reviewer.ID)
@@ -526,7 +526,7 @@ func TestFeishuHITLPollTypedScopeStopDrainsLiveSibling(t *testing.T) {
 			return ""
 		},
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
-			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, nil, drain)
+			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, nil, drain, nil)
 		},
 	}
 	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{{
@@ -613,14 +613,14 @@ func TestFeishuHITLPollScopeStopRetriesAfterFailedDurableMutation(t *testing.T) 
 			return ""
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			if err := drainScopeHoldOnStop(ctx, repos, loopID, answer, drain); err != nil {
+			if _, err := drainScopeHoldOnStop(ctx, repos, loopID, answer, drain); err != nil {
 				return err
 			}
 			attempts++
 			if attempts == 1 {
 				return errors.New("apply review scope stop failed")
 			}
-			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
+			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""), nil)
 		},
 	}
 	events := []feishuInboxEvent{mustCardAction(50, "93", "Stop")}
@@ -724,7 +724,7 @@ func TestFeishuHITLPollTypedScopeContinueResolvesOverlayCard(t *testing.T) {
 		enqueueMessage: func(ctx contextType, loopID, text string) error {
 			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
 				resolved = append(resolved, answeredLoopID+"="+answer)
-			}, nil)
+			}, nil, nil)
 		},
 	}
 	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{{
@@ -836,7 +836,7 @@ func TestFeishuHITLPollTypedScopeDecisionResolvesPrimaryPreservesSiblingAgentCar
 				enqueueMessage: func(ctx contextType, loopID, text string) error {
 					return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
 						resolved = append(resolved, answeredLoopID+"="+answer)
-					}, nil)
+					}, nil, nil)
 				},
 			}
 			n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{{
@@ -942,7 +942,7 @@ func TestFeishuHITLPollOverlayResidualCardPreservedThroughScopeContinue(t *testi
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
 			return deliverFeishuHITLCardAction(ctx, repos, coordinator.DB(), nil, nowISO, loopID, answer, nil, func(_ contextType, answeredLoopID, got string) {
 				resolved = append(resolved, answeredLoopID+"="+got)
-			})
+			}, nil)
 		},
 	}
 	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{
@@ -987,6 +987,107 @@ func TestFeishuHITLPollOverlayResidualCardPreservedThroughScopeContinue(t *testi
 	answered, ok := loops.ReadHITLAsk(sibling.MetadataJSON)
 	if !ok || answered.Question != agentAsk.Question || answered.Answer != "A" || answered.Status != "answered" {
 		t.Fatalf("fixer ask after Continue = (%#v, %v), want stored A applied without a second click", answered, ok)
+	}
+}
+
+func TestFeishuResidualCardDoesNotClobberPairTransition(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		answer string
+	}{
+		{name: "continue", answer: "Continue"},
+		{name: "stop", answer: "Stop"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+			nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+			coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+				Now: func() time.Time { return now },
+			})
+			if err != nil {
+				t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+			}
+			t.Cleanup(func() { _ = coordinator.Close() })
+			if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+				t.Fatalf("RunPending() error = %v", err)
+			}
+			repos := storage.NewRepositories(coordinator.DB())
+			projectID := "project_residual_race_" + tc.name
+			if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+				ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}); err != nil {
+				t.Fatalf("Projects.Upsert() error = %v", err)
+			}
+			repo := "acme/looper"
+			pr := int64(42)
+			target := "pr:acme/looper:42"
+			reviewer := storage.LoopRecord{
+				ID: "loop_residual_race_rev_" + tc.name, Seq: 201, ProjectID: projectID, Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			agentAsk := loops.HITLAsk{
+				Kind: "agent_question", Question: "Which approach should Fixer take?",
+				Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+				Transport: "feishu",
+			}
+			fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+			if err != nil {
+				t.Fatalf("WriteHITLAsk(fixer): %v", err)
+			}
+			fixer := storage.LoopRecord{
+				ID: "loop_residual_race_fix_" + tc.name, Seq: 202, ProjectID: projectID, Type: "fixer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &fixerMeta,
+			}
+			if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+				t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+			}
+			if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+				t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+			}
+			if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+				Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+				Question: "Clarify AGENTS.md rule X before unpause",
+			}); err != nil {
+				t.Fatalf("ParkReviewScopeHuman: %v", err)
+			}
+			afterFeishuResidualCardLoadHook = func() {
+				fresh, getErr := repos.Loops.GetByID(context.Background(), reviewer.ID)
+				if getErr != nil || fresh == nil {
+					t.Errorf("hook GetByID: (%v, %v)", fresh, getErr)
+					return
+				}
+				if _, applyErr := loops.ApplyReviewScopeHumanAnswer(context.Background(), repos, *fresh, tc.answer, nowISO); applyErr != nil {
+					t.Errorf("racing %s: %v", tc.answer, applyErr)
+				}
+			}
+			t.Cleanup(func() { afterFeishuResidualCardLoadHook = nil })
+			if err := preserveFeishuOverlayResidualCardAnswer(context.Background(), repos, coordinator.DB(), fixer.ID, "A", nowISO); err != nil {
+				t.Fatalf("preserve residual A: %v", err)
+			}
+			freshReviewer, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+			if err != nil || freshReviewer == nil || loops.IsReviewScopeHumanHold(*freshReviewer) {
+				t.Fatalf("reviewer after residual vs %s = (%#v, %v), want hold released", tc.answer, freshReviewer, err)
+			}
+			freshFixer, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+			if err != nil || freshFixer == nil || loops.IsReviewScopeHumanHold(*freshFixer) {
+				t.Fatalf("fixer after residual vs %s = (%#v, %v), want hold not restored", tc.answer, freshFixer, err)
+			}
+			if tc.answer == "Stop" {
+				if freshReviewer.Status != "terminated" || freshFixer.Status != "terminated" {
+					t.Fatalf("pair after residual vs Stop = reviewer=%s fixer=%s, want terminated", freshReviewer.Status, freshFixer.Status)
+				}
+				return
+			}
+			if freshReviewer.Status != "queued" {
+				t.Fatalf("reviewer after residual vs Continue = %s, want queued", freshReviewer.Status)
+			}
+			if freshFixer.Status == "terminated" {
+				t.Fatalf("fixer after residual vs Continue = %s, want released sibling", freshFixer.Status)
+			}
+		})
 	}
 }
 
@@ -1043,7 +1144,7 @@ func TestEnqueueFeishuHITLMessageFailsClosedWhenLookupErrors(t *testing.T) {
 	resolved := 0
 	if err := enqueueFeishuHITLMessage(context.Background(), repos, nil, nil, nowISO, reviewer.ID, "Continue", func(context.Context, string, string) {
 		resolved++
-	}, nil); err == nil {
+	}, nil, nil); err == nil {
 		t.Fatal("enqueueFeishuHITLMessage error = nil, want lookup failure")
 	}
 	if resolved != 0 {

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -605,6 +605,106 @@ func TestFeishuHITLPollTypedScopeContinueResolvesOverlayCard(t *testing.T) {
 	}
 }
 
+func TestFeishuHITLPollTypedScopeContinuePreservesSiblingAgentCard(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_feishu_sibling_card"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_feishu_sibling_card_rev", Seq: 97, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	agentAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+		Transport: "feishu",
+	}
+	fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(fixer): %v", err)
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_feishu_sibling_card_fix", Seq: 98, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &fixerMeta,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	overlaid, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || overlaid == nil || !loops.IsReviewScopeHumanHold(*overlaid) {
+		t.Fatalf("fixer after overlay = (%#v, %v), want preserved ask under scope hold", overlaid, err)
+	}
+	if ask, ok := loops.ReadHITLAsk(overlaid.MetadataJSON); !ok || loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("overlaid ask = (%#v, %v), want ordinary agent question", ask, ok)
+	}
+
+	var resolved []string
+	deps := feishuHITLPollDeps{
+		loopByRoot: func(_ contextType, rootID string) string {
+			if rootID == "om_scope_sibling_root" {
+				return fixer.ID
+			}
+			return ""
+		},
+		enqueueMessage: func(ctx contextType, loopID, text string) error {
+			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
+				resolved = append(resolved, answeredLoopID+"="+answer)
+			}, nil)
+		},
+	}
+	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{{
+		ID: 42, Kind: "message", RootID: "om_scope_sibling_root", Text: "Continue",
+	}}, deps)
+	if n != 1 || maxID != 42 {
+		t.Fatalf("typed sibling Continue poll = %d maxID=%d, want applied Continue", n, maxID)
+	}
+	if len(resolved) != 0 {
+		t.Fatalf("card resolution after sibling-root Continue = %#v, want preserved agent card", resolved)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "queued" || loops.IsReviewScopeHumanHold(*fresh) {
+		t.Fatalf("reviewer after sibling Continue = (%#v, %v), want queued and released", fresh, err)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "awaiting_human" || loops.IsReviewScopeHumanHold(*sibling) {
+		t.Fatalf("fixer after sibling Continue = (%#v, %v), want awaiting preserved agent ask", sibling, err)
+	}
+	remaining, ok := loops.ReadHITLAsk(sibling.MetadataJSON)
+	if !ok || remaining.Question != agentAsk.Question || remaining.Answer != "" {
+		t.Fatalf("fixer ask after sibling Continue = (%#v, %v), want unanswered agent question", remaining, ok)
+	}
+}
+
 func TestEnqueueFeishuHITLMessageFailsClosedWhenLookupErrors(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -990,6 +990,141 @@ func TestFeishuHITLPollOverlayResidualCardPreservedThroughScopeContinue(t *testi
 	}
 }
 
+func TestFeishuHITLPollOverlayTypedReplyPreservedThroughScopeContinue(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_feishu_residual_typed"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_feishu_residual_typed_rev", Seq: 103, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	agentAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+		Transport: "feishu",
+	}
+	fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(fixer): %v", err)
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_feishu_residual_typed_fix", Seq: 104, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &fixerMeta,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	overlaid, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || overlaid == nil || !loops.IsReviewScopeHumanHold(*overlaid) {
+		t.Fatalf("fixer after overlay = (%#v, %v), want preserved ask under scope hold", overlaid, err)
+	}
+
+	const siblingRoot = "om_residual_typed_root"
+	var resolved []string
+	deps := feishuHITLPollDeps{
+		loopByRoot: func(_ contextType, rootID string) string {
+			if rootID == siblingRoot {
+				return fixer.ID
+			}
+			return ""
+		},
+		loopBySeq: func(_ contextType, seq int64) string {
+			switch seq {
+			case reviewer.Seq:
+				return reviewer.ID
+			case fixer.Seq:
+				return fixer.ID
+			default:
+				return ""
+			}
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			return deliverFeishuHITLCardAction(ctx, repos, coordinator.DB(), nil, nowISO, loopID, answer, nil, func(_ contextType, answeredLoopID, got string) {
+				resolved = append(resolved, answeredLoopID+"="+got)
+			}, nil)
+		},
+		enqueueMessage: func(ctx contextType, loopID, text string) error {
+			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, func(_ contextType, answeredLoopID, got string) {
+				resolved = append(resolved, answeredLoopID+"="+got)
+			}, nil, nil)
+		},
+	}
+	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{{
+		ID: 70, Kind: "message", RootID: siblingRoot, Text: "A",
+	}}, deps)
+	if n != 1 || maxID != 70 {
+		t.Fatalf("overlay typed poll = %d maxID=%d, want A consumed while held", n, maxID)
+	}
+	if len(resolved) != 1 || resolved[0] != fixer.ID+"=A" {
+		t.Fatalf("resolution after typed residual A = %#v, want sibling A only", resolved)
+	}
+	heldReviewer, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || heldReviewer == nil || !loops.IsReviewScopeHumanHold(*heldReviewer) {
+		t.Fatalf("reviewer after typed residual A = (%#v, %v), want still scope-held", heldReviewer, err)
+	}
+	heldSibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || heldSibling == nil || heldSibling.Status != "awaiting_human" || !loops.IsReviewScopeHumanHold(*heldSibling) {
+		t.Fatalf("fixer after typed residual A = (%#v, %v), want held awaiting ordinary ask", heldSibling, err)
+	}
+	stored, ok := loops.ReadHITLAsk(heldSibling.MetadataJSON)
+	if !ok || stored.Question != agentAsk.Question || stored.Answer != "A" || stored.Status != "answered" {
+		t.Fatalf("fixer ask after typed residual A = (%#v, %v), want durable answered A while held", stored, ok)
+	}
+
+	n, maxID = pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{
+		mustCardAction(71, "103", "Continue"),
+	}, deps)
+	if n != 1 || maxID != 71 {
+		t.Fatalf("scope Continue poll = %d maxID=%d, want primary Continue consumed", n, maxID)
+	}
+	if len(resolved) != 2 || resolved[1] != reviewer.ID+"=Continue" {
+		t.Fatalf("resolution after Continue = %#v, want residual A then primary Continue", resolved)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "queued" || loops.IsReviewScopeHumanHold(*fresh) {
+		t.Fatalf("reviewer after Continue = (%#v, %v), want queued and released", fresh, err)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "queued" || loops.IsReviewScopeHumanHold(*sibling) {
+		t.Fatalf("fixer after Continue = (%#v, %v), want queued resume from stored A", sibling, err)
+	}
+	answered, ok := loops.ReadHITLAsk(sibling.MetadataJSON)
+	if !ok || answered.Question != agentAsk.Question || answered.Answer != "A" || answered.Status != "answered" {
+		t.Fatalf("fixer ask after Continue = (%#v, %v), want stored A applied without repeating typed input", answered, ok)
+	}
+}
+
 func TestFeishuResidualCardDoesNotClobberPairTransition(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -48,6 +49,49 @@ func TestPollFeishuHITLInboxOnce(t *testing.T) {
 	}
 	if len(answers) != 1 || answers[0] != "loop-seq71=redis" {
 		t.Fatalf("delivered answers = %v, want the button click", answers)
+	}
+}
+
+func TestPollFeishuHITLInboxOnceDoesNotAdvanceCursorPastFailedDelivery(t *testing.T) {
+	var answers []string
+	attempts := 0
+	deps := feishuHITLPollDeps{
+		loopBySeq: func(_ contextType, seq int64) string {
+			switch seq {
+			case 91:
+				return "loop-scope"
+			case 99:
+				return "loop-later"
+			default:
+				return ""
+			}
+		},
+		deliverAnswer: func(_ contextType, loopID, answer string) error {
+			attempts++
+			if attempts == 1 {
+				return errors.New("apply failed")
+			}
+			answers = append(answers, loopID+"="+answer)
+			return nil
+		},
+	}
+	events := []feishuInboxEvent{
+		mustCardAction(50, "91", "Stop"),
+		mustCardAction(51, "99", "Continue"), // later event must stay unconsumed
+	}
+	n, maxID := pollFeishuHITLInboxOnce(context.Background(), events, deps)
+	if n != 0 || maxID != 0 {
+		t.Fatalf("failed Stop poll = %d maxID=%d, want unconsumed cursor", n, maxID)
+	}
+	if len(answers) != 0 {
+		t.Fatalf("answers = %v, want none on first failed Stop", answers)
+	}
+	n, maxID = pollFeishuHITLInboxOnce(context.Background(), events, deps)
+	if n != 2 || maxID != 51 {
+		t.Fatalf("retry poll = %d maxID=%d, want Stop then preserved later Continue", n, maxID)
+	}
+	if len(answers) != 2 || answers[0] != "loop-scope=Stop" || answers[1] != "loop-later=Continue" {
+		t.Fatalf("answers = %v, want retried Stop then later Continue", answers)
 	}
 }
 
@@ -504,6 +548,107 @@ func TestFeishuHITLPollTypedScopeStopDrainsLiveSibling(t *testing.T) {
 	}
 	if !reg.LoopStopActive(reviewer.ID) || !reg.LoopStopActive(fixer.ID) {
 		t.Fatal("pair stop gates not closed after typed Feishu scope Stop")
+	}
+}
+
+func TestFeishuHITLPollScopeStopRetriesAfterFailedDurableMutation(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_feishu_stop_retry"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_feishu_scope_stop_retry_reviewer", Seq: 93, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_feishu_scope_stop_retry_fixer", Seq: 94, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	parked, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	reg := NewActiveExecutionRegistry()
+	var drained []string
+	drain := func(ctx context.Context, loop storage.LoopRecord) error {
+		drained = append(drained, loop.ID)
+		return drainReviewFixPairExecutions(ctx, repos, loop, reg)
+	}
+	attempts := 0
+	deps := feishuHITLPollDeps{
+		loopBySeq: func(_ contextType, seq int64) string {
+			if seq == reviewer.Seq {
+				return parked.ID
+			}
+			return ""
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			if err := drainScopeHoldOnStop(ctx, repos, loopID, answer, drain); err != nil {
+				return err
+			}
+			attempts++
+			if attempts == 1 {
+				return errors.New("apply review scope stop failed")
+			}
+			return deliverHITLAnswerToLoopWithCaps(ctx, repos, coordinator.DB(), nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
+		},
+	}
+	events := []feishuInboxEvent{mustCardAction(50, "93", "Stop")}
+	n, maxID := pollFeishuHITLInboxOnce(context.Background(), events, deps)
+	if n != 0 || maxID != 0 {
+		t.Fatalf("failed scope Stop poll = %d maxID=%d, want unconsumed event", n, maxID)
+	}
+	if len(drained) != 1 || drained[0] != parked.ID {
+		t.Fatalf("first Stop drained = %v, want [%s]", drained, parked.ID)
+	}
+	held, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || held == nil || !loops.IsReviewScopeHumanHold(*held) {
+		t.Fatalf("reviewer after failed Stop = (%#v, %v), want still held", held, err)
+	}
+	if !reg.LoopStopActive(reviewer.ID) || !reg.LoopStopActive(fixer.ID) {
+		t.Fatal("pair stop gates not closed after drain that preceded failed apply")
+	}
+	n, maxID = pollFeishuHITLInboxOnce(context.Background(), events, deps)
+	if n != 1 || maxID != 50 {
+		t.Fatalf("retried scope Stop poll = %d maxID=%d, want applied Stop", n, maxID)
+	}
+	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || fresh == nil || fresh.Status != "terminated" {
+		t.Fatalf("reviewer after retried Stop = (%#v, %v), want terminated", fresh, err)
+	}
+	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "terminated" {
+		t.Fatalf("fixer after retried Stop = (%#v, %v), want terminated", sibling, err)
 	}
 }
 

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -1377,6 +1377,7 @@ func TestFeishuScopeAskDeliveryDoesNotClobberContinueOrStop(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Loops.List() error = %v", err)
 			}
+			var closed []string
 			delivered := deliverUndeliveredFeishuBudgetAsks(context.Background(), all, repos, feishuHITLDeliveryDeps{
 				sendAsk: func(ctx contextType, loop storage.LoopRecord, _ loops.HITLAsk) error {
 					if tc.race != "" {
@@ -1390,6 +1391,12 @@ func TestFeishuScopeAskDeliveryDoesNotClobberContinueOrStop(t *testing.T) {
 					}
 					return nil
 				},
+				closeAsk: func(ctx contextType, loopID string) {
+					closeObsoleteFeishuPairAskCard(ctx, repos, loopID, func(_ context.Context, id, answer string) {
+						closed = append(closed, id+"="+answer)
+					})
+				},
+
 				nowISO: nowISO,
 			})
 			if delivered != tc.wantDelivered {
@@ -1410,11 +1417,18 @@ func TestFeishuScopeAskDeliveryDoesNotClobberContinueOrStop(t *testing.T) {
 				if !ok || !loops.IsReviewScopeHumanAsk(ask) || ask.Transport != "feishu" {
 					t.Fatalf("delivered scope ask = (%#v, %v), want feishu transport", ask, ok)
 				}
+				if len(closed) != 0 {
+					t.Fatalf("closed = %v, want empty when persist kept the ask", closed)
+				}
 				return
 			}
 			if ok && loops.IsReviewScopeHumanAsk(ask) {
 				t.Fatalf("stale persist restored scope ask after %s: %#v", tc.race, ask)
 			}
+			if len(closed) != 1 || closed[0] != reviewer.ID+"="+tc.race {
+				t.Fatalf("closed = %v, want posted card closed after %s", closed, tc.race)
+			}
+
 		})
 	}
 }

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -605,103 +605,120 @@ func TestFeishuHITLPollTypedScopeContinueResolvesOverlayCard(t *testing.T) {
 	}
 }
 
-func TestFeishuHITLPollTypedScopeContinuePreservesSiblingAgentCard(t *testing.T) {
-	root := t.TempDir()
-	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
-	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
-	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
-		Now: func() time.Time { return now },
-	})
-	if err != nil {
-		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
-	}
-	t.Cleanup(func() { _ = coordinator.Close() })
-	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
-		t.Fatalf("RunPending() error = %v", err)
-	}
-	repos := storage.NewRepositories(coordinator.DB())
-	const projectID = "project_scope_feishu_sibling_card"
-	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
-		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
-	}); err != nil {
-		t.Fatalf("Projects.Upsert() error = %v", err)
-	}
-	repo := "acme/looper"
-	pr := int64(42)
-	target := "pr:acme/looper:42"
-	reviewer := storage.LoopRecord{
-		ID: "loop_feishu_sibling_card_rev", Seq: 97, ProjectID: projectID, Type: "reviewer",
-		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
-		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
-	}
-	agentAsk := loops.HITLAsk{
-		Kind: "agent_question", Question: "Which approach should Fixer take?",
-		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
-		Transport: "feishu",
-	}
-	fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
-	if err != nil {
-		t.Fatalf("WriteHITLAsk(fixer): %v", err)
-	}
-	fixer := storage.LoopRecord{
-		ID: "loop_feishu_sibling_card_fix", Seq: 98, ProjectID: projectID, Type: "fixer",
-		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
-		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &fixerMeta,
-	}
-	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
-		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
-	}
-	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
-		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
-	}
-	if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
-		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
-		Question: "Clarify AGENTS.md rule X before unpause",
-	}); err != nil {
-		t.Fatalf("ParkReviewScopeHuman: %v", err)
-	}
-	overlaid, err := repos.Loops.GetByID(context.Background(), fixer.ID)
-	if err != nil || overlaid == nil || !loops.IsReviewScopeHumanHold(*overlaid) {
-		t.Fatalf("fixer after overlay = (%#v, %v), want preserved ask under scope hold", overlaid, err)
-	}
-	if ask, ok := loops.ReadHITLAsk(overlaid.MetadataJSON); !ok || loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewFixBudgetAsk(ask) {
-		t.Fatalf("overlaid ask = (%#v, %v), want ordinary agent question", ask, ok)
-	}
-
-	var resolved []string
-	deps := feishuHITLPollDeps{
-		loopByRoot: func(_ contextType, rootID string) string {
-			if rootID == "om_scope_sibling_root" {
-				return fixer.ID
+func TestFeishuHITLPollTypedScopeDecisionResolvesPrimaryPreservesSiblingAgentCard(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		text           string
+		reviewerStatus string
+		fixerStatus    string
+	}{
+		{name: "continue", text: "Continue", reviewerStatus: "queued", fixerStatus: "awaiting_human"},
+		{name: "stop", text: "Stop", reviewerStatus: "terminated", fixerStatus: "terminated"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+			nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+			coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+				Now: func() time.Time { return now },
+			})
+			if err != nil {
+				t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
 			}
-			return ""
-		},
-		enqueueMessage: func(ctx contextType, loopID, text string) error {
-			return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
-				resolved = append(resolved, answeredLoopID+"="+answer)
-			}, nil)
-		},
-	}
-	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{{
-		ID: 42, Kind: "message", RootID: "om_scope_sibling_root", Text: "Continue",
-	}}, deps)
-	if n != 1 || maxID != 42 {
-		t.Fatalf("typed sibling Continue poll = %d maxID=%d, want applied Continue", n, maxID)
-	}
-	if len(resolved) != 0 {
-		t.Fatalf("card resolution after sibling-root Continue = %#v, want preserved agent card", resolved)
-	}
-	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
-	if err != nil || fresh == nil || fresh.Status != "queued" || loops.IsReviewScopeHumanHold(*fresh) {
-		t.Fatalf("reviewer after sibling Continue = (%#v, %v), want queued and released", fresh, err)
-	}
-	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
-	if err != nil || sibling == nil || sibling.Status != "awaiting_human" || loops.IsReviewScopeHumanHold(*sibling) {
-		t.Fatalf("fixer after sibling Continue = (%#v, %v), want awaiting preserved agent ask", sibling, err)
-	}
-	remaining, ok := loops.ReadHITLAsk(sibling.MetadataJSON)
-	if !ok || remaining.Question != agentAsk.Question || remaining.Answer != "" {
-		t.Fatalf("fixer ask after sibling Continue = (%#v, %v), want unanswered agent question", remaining, ok)
+			t.Cleanup(func() { _ = coordinator.Close() })
+			if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+				t.Fatalf("RunPending() error = %v", err)
+			}
+			repos := storage.NewRepositories(coordinator.DB())
+			projectID := "project_scope_feishu_sibling_card_" + tc.name
+			if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+				ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}); err != nil {
+				t.Fatalf("Projects.Upsert() error = %v", err)
+			}
+			repo := "acme/looper"
+			pr := int64(42)
+			target := "pr:acme/looper:42"
+			reviewer := storage.LoopRecord{
+				ID: "loop_feishu_sibling_card_rev_" + tc.name, Seq: 97, ProjectID: projectID, Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			agentAsk := loops.HITLAsk{
+				Kind: "agent_question", Question: "Which approach should Fixer take?",
+				Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+				Transport: "feishu",
+			}
+			fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+			if err != nil {
+				t.Fatalf("WriteHITLAsk(fixer): %v", err)
+			}
+			fixer := storage.LoopRecord{
+				ID: "loop_feishu_sibling_card_fix_" + tc.name, Seq: 98, ProjectID: projectID, Type: "fixer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &fixerMeta,
+			}
+			if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+				t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+			}
+			if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+				t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+			}
+			if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+				Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+				Question: "Clarify AGENTS.md rule X before unpause",
+			}); err != nil {
+				t.Fatalf("ParkReviewScopeHuman: %v", err)
+			}
+			overlaid, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+			if err != nil || overlaid == nil || !loops.IsReviewScopeHumanHold(*overlaid) {
+				t.Fatalf("fixer after overlay = (%#v, %v), want preserved ask under scope hold", overlaid, err)
+			}
+			if ask, ok := loops.ReadHITLAsk(overlaid.MetadataJSON); !ok || loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewFixBudgetAsk(ask) {
+				t.Fatalf("overlaid ask = (%#v, %v), want ordinary agent question", ask, ok)
+			}
+
+			threadRoot := "om_scope_sibling_root_" + tc.name
+			var resolved []string
+			deps := feishuHITLPollDeps{
+				loopByRoot: func(_ contextType, rootID string) string {
+					if rootID == threadRoot {
+						return fixer.ID
+					}
+					return ""
+				},
+				enqueueMessage: func(ctx contextType, loopID, text string) error {
+					return enqueueFeishuHITLMessage(ctx, repos, coordinator.DB(), nil, nowISO, loopID, text, func(_ contextType, answeredLoopID, answer string) {
+						resolved = append(resolved, answeredLoopID+"="+answer)
+					}, nil)
+				},
+			}
+			n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{{
+				ID: 42, Kind: "message", RootID: threadRoot, Text: tc.text,
+			}}, deps)
+			if n != 1 || maxID != 42 {
+				t.Fatalf("typed sibling %s poll = %d maxID=%d, want applied %s", tc.text, n, maxID, tc.text)
+			}
+			if len(resolved) != 1 || resolved[0] != reviewer.ID+"="+tc.text {
+				t.Fatalf("card resolution after sibling-root %s = %#v, want primary %s only", tc.text, resolved, tc.text)
+			}
+			fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+			if err != nil || fresh == nil || fresh.Status != tc.reviewerStatus || loops.IsReviewScopeHumanHold(*fresh) {
+				t.Fatalf("reviewer after sibling %s = (%#v, %v), want %s and released", tc.text, fresh, err, tc.reviewerStatus)
+			}
+			sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+			if err != nil || sibling == nil || sibling.Status != tc.fixerStatus || loops.IsReviewScopeHumanHold(*sibling) {
+				t.Fatalf("fixer after sibling %s = (%#v, %v), want %s without overlay", tc.text, sibling, err, tc.fixerStatus)
+			}
+			if tc.fixerStatus != "awaiting_human" {
+				return
+			}
+			remaining, ok := loops.ReadHITLAsk(sibling.MetadataJSON)
+			if !ok || remaining.Question != agentAsk.Question || remaining.Answer != "" {
+				t.Fatalf("fixer ask after sibling Continue = (%#v, %v), want unanswered agent question", remaining, ok)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -1307,6 +1307,118 @@ func TestEnqueueFeishuHITLMessageFailsClosedWhenLookupErrors(t *testing.T) {
 	}
 }
 
+func TestFeishuScopeAskDeliveryDoesNotClobberContinueOrStop(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		race          string
+		wantDelivered int
+		wantStatus    string
+		wantHold      bool
+	}{
+		{name: "no_race", wantDelivered: 1, wantStatus: "awaiting_human", wantHold: true},
+		{name: "continue", race: loops.ReviewFixBudgetAnswerContinue, wantDelivered: 0, wantStatus: "queued", wantHold: false},
+		{name: "stop", race: loops.ReviewFixBudgetAnswerStop, wantDelivered: 0, wantStatus: "terminated", wantHold: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+			nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+			coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+				Now: func() time.Time { return now },
+			})
+			if err != nil {
+				t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+			}
+			t.Cleanup(func() { _ = coordinator.Close() })
+			if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+				t.Fatalf("RunPending() error = %v", err)
+			}
+			repos := storage.NewRepositories(coordinator.DB())
+			projectID := "project_scope_feishu_delivery_" + tc.name
+			if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+				ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}); err != nil {
+				t.Fatalf("Projects.Upsert() error = %v", err)
+			}
+			repo := "acme/looper"
+			pr := int64(42)
+			target := "pr:acme/looper:42"
+			reviewer := storage.LoopRecord{
+				ID: "loop_scope_feishu_delivery_rev_" + tc.name, Seq: 401, ProjectID: projectID, Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			fixer := storage.LoopRecord{
+				ID: "loop_scope_feishu_delivery_fix_" + tc.name, Seq: 402, ProjectID: projectID, Type: "fixer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+				t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+			}
+			if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+				t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+			}
+			for _, item := range []storage.QueueItemRecord{
+				{ID: "queue_scope_feishu_rev_" + tc.name, ProjectID: stringPtr(projectID), LoopID: &reviewer.ID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Status: "queued", Priority: storage.QueuePriorityReviewer, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO, DedupeKey: "reviewer:queue_scope_feishu_rev_" + tc.name},
+				{ID: "queue_scope_feishu_fix_" + tc.name, ProjectID: stringPtr(projectID), LoopID: &fixer.ID, Type: "fixer", TargetType: "pull_request", TargetID: target, Status: "queued", Priority: storage.QueuePriorityFixer, MaxAttempts: 3, AvailableAt: nowISO, CreatedAt: nowISO, UpdatedAt: nowISO, DedupeKey: "fixer:queue_scope_feishu_fix_" + tc.name},
+			} {
+				if err := repos.Queue.Upsert(context.Background(), item); err != nil {
+					t.Fatalf("Queue.Upsert(%s) error = %v", item.ID, err)
+				}
+			}
+			if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+				Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+				Question: "Clarify AGENTS.md rule X before unpause",
+			}); err != nil {
+				t.Fatalf("ParkReviewScopeHuman: %v", err)
+			}
+			all, err := repos.Loops.List(context.Background())
+			if err != nil {
+				t.Fatalf("Loops.List() error = %v", err)
+			}
+			delivered := deliverUndeliveredFeishuBudgetAsks(context.Background(), all, repos, feishuHITLDeliveryDeps{
+				sendAsk: func(ctx contextType, loop storage.LoopRecord, _ loops.HITLAsk) error {
+					if tc.race != "" {
+						fresh, err := repos.Loops.GetByID(ctx, loop.ID)
+						if err != nil || fresh == nil {
+							t.Fatalf("GetByID during sendAsk = (%#v, %v)", fresh, err)
+						}
+						if _, err := loops.ApplyReviewScopeHumanAnswer(ctx, repos, *fresh, tc.race, nowISO); err != nil {
+							t.Fatalf("ApplyReviewScopeHumanAnswer(%s): %v", tc.race, err)
+						}
+					}
+					return nil
+				},
+				nowISO: nowISO,
+			})
+			if delivered != tc.wantDelivered {
+				t.Fatalf("deliverUndeliveredFeishuBudgetAsks() = %d, want %d", delivered, tc.wantDelivered)
+			}
+			fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+			if err != nil || fresh == nil {
+				t.Fatalf("Loops.GetByID(reviewer) = (%#v, %v)", fresh, err)
+			}
+			if fresh.Status != tc.wantStatus {
+				t.Fatalf("reviewer status = %s, want %s meta=%s", fresh.Status, tc.wantStatus, derefString(fresh.MetadataJSON))
+			}
+			if loops.IsReviewScopeHumanHold(*fresh) != tc.wantHold {
+				t.Fatalf("reviewer hold = %v, want %v meta=%s", loops.IsReviewScopeHumanHold(*fresh), tc.wantHold, derefString(fresh.MetadataJSON))
+			}
+			ask, ok := loops.ReadHITLAsk(fresh.MetadataJSON)
+			if tc.wantHold {
+				if !ok || !loops.IsReviewScopeHumanAsk(ask) || ask.Transport != "feishu" {
+					t.Fatalf("delivered scope ask = (%#v, %v), want feishu transport", ask, ok)
+				}
+				return
+			}
+			if ok && loops.IsReviewScopeHumanAsk(ask) {
+				t.Fatalf("stale persist restored scope ask after %s: %#v", tc.race, ask)
+			}
+		})
+	}
+}
+
 func mustCardAction(id int64, seq, answer string) feishuInboxEvent {
 	e := feishuInboxEvent{ID: id, Kind: "card_action"}
 	e.Value.LoopSeq = seq

--- a/internal/runtime/hitl_feishu_poll_test.go
+++ b/internal/runtime/hitl_feishu_poll_test.go
@@ -867,7 +867,7 @@ func TestFeishuHITLPollTypedScopeDecisionResolvesPrimaryPreservesSiblingAgentCar
 	}
 }
 
-func TestFeishuHITLPollOverlayResidualCardDoesNotBlockScopeContinue(t *testing.T) {
+func TestFeishuHITLPollOverlayResidualCardPreservedThroughScopeContinue(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
 	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
@@ -947,40 +947,46 @@ func TestFeishuHITLPollOverlayResidualCardDoesNotBlockScopeContinue(t *testing.T
 	}
 	n, maxID := pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{
 		mustCardAction(60, "102", "A"),
+	}, deps)
+	if n != 1 || maxID != 60 {
+		t.Fatalf("overlay residual poll = %d maxID=%d, want A consumed while held", n, maxID)
+	}
+	if len(resolved) != 1 || resolved[0] != fixer.ID+"=A" {
+		t.Fatalf("card resolution after residual A = %#v, want sibling A only", resolved)
+	}
+	heldReviewer, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || heldReviewer == nil || !loops.IsReviewScopeHumanHold(*heldReviewer) {
+		t.Fatalf("reviewer after residual A = (%#v, %v), want still scope-held", heldReviewer, err)
+	}
+	heldSibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || heldSibling == nil || heldSibling.Status != "awaiting_human" || !loops.IsReviewScopeHumanHold(*heldSibling) {
+		t.Fatalf("fixer after residual A = (%#v, %v), want held awaiting ordinary ask", heldSibling, err)
+	}
+	stored, ok := loops.ReadHITLAsk(heldSibling.MetadataJSON)
+	if !ok || stored.Question != agentAsk.Question || stored.Answer != "A" || stored.Status != "answered" {
+		t.Fatalf("fixer ask after residual A = (%#v, %v), want durable answered A while held", stored, ok)
+	}
+
+	n, maxID = pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{
 		mustCardAction(61, "101", "Continue"),
 	}, deps)
-	if n != 2 || maxID != 61 {
-		t.Fatalf("overlay residual then Continue poll = %d maxID=%d, want both consumed", n, maxID)
+	if n != 1 || maxID != 61 {
+		t.Fatalf("scope Continue poll = %d maxID=%d, want primary Continue consumed", n, maxID)
 	}
-	if len(resolved) != 1 || resolved[0] != reviewer.ID+"=Continue" {
-		t.Fatalf("card resolution = %#v, want primary Continue only", resolved)
+	if len(resolved) != 2 || resolved[1] != reviewer.ID+"=Continue" {
+		t.Fatalf("card resolution after Continue = %#v, want residual A then primary Continue", resolved)
 	}
 	fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
 	if err != nil || fresh == nil || fresh.Status != "queued" || loops.IsReviewScopeHumanHold(*fresh) {
 		t.Fatalf("reviewer after Continue = (%#v, %v), want queued and released", fresh, err)
 	}
 	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
-	if err != nil || sibling == nil || sibling.Status != "awaiting_human" || loops.IsReviewScopeHumanHold(*sibling) {
-		t.Fatalf("fixer after Continue = (%#v, %v), want awaiting preserved agent ask", sibling, err)
-	}
-	remaining, ok := loops.ReadHITLAsk(sibling.MetadataJSON)
-	if !ok || remaining.Question != agentAsk.Question || remaining.Answer != "" || remaining.Status != "awaiting" {
-		t.Fatalf("fixer ask after overlay A+Continue = (%#v, %v), want unanswered agent question", remaining, ok)
-	}
-
-	n, maxID = pollFeishuHITLInboxOnce(context.Background(), []feishuInboxEvent{
-		mustCardAction(62, "102", "A"),
-	}, deps)
-	if n != 1 || maxID != 62 {
-		t.Fatalf("post-release residual card poll = %d maxID=%d, want ordinary A delivered", n, maxID)
-	}
-	sibling, err = repos.Loops.GetByID(context.Background(), fixer.ID)
-	if err != nil || sibling == nil || sibling.Status != "running" {
-		t.Fatalf("fixer after post-release A = (%#v, %v), want running ordinary answer", sibling, err)
+	if err != nil || sibling == nil || sibling.Status != "queued" || loops.IsReviewScopeHumanHold(*sibling) {
+		t.Fatalf("fixer after Continue = (%#v, %v), want queued resume from stored A", sibling, err)
 	}
 	answered, ok := loops.ReadHITLAsk(sibling.MetadataJSON)
-	if !ok || answered.Answer != "A" || answered.Status != "answered" {
-		t.Fatalf("fixer ask after post-release A = (%#v, %v), want answered A", answered, ok)
+	if !ok || answered.Question != agentAsk.Question || answered.Answer != "A" || answered.Status != "answered" {
+		t.Fatalf("fixer ask after Continue = (%#v, %v), want stored A applied without a second click", answered, ok)
 	}
 }
 

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -106,7 +106,7 @@ func deliverUndeliveredGitHubBudgetAsks(ctx contextType, projectID string, recor
 			continue
 		}
 		ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
-		if !ok || !loops.IsReviewFixBudgetAsk(ask) {
+		if !ok || (!loops.IsReviewFixBudgetAsk(ask) && !loops.IsReviewScopeHumanAsk(ask)) {
 			continue
 		}
 		if ask.AskCommentID != 0 && strings.EqualFold(strings.TrimSpace(ask.Transport), "github") {
@@ -383,11 +383,17 @@ func enqueueHumanMessageToLoopWithCaps(ctx context.Context, repos *storage.Repos
 	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*loop))
 	defer unlockTarget()
 
-	// Budget holds (HITL ask or no-ask exhausted/sibling pause) are never
-	// conversational inbox turns. Only explicit Continue/Stop may unpark.
+	// Budget/scope pair holds (HITL ask or no-ask pause) are never conversational
+	// inbox turns. Only explicit Continue/Stop may unpark.
 	if loops.IsReviewFixBudgetHold(*loop) {
 		if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
 			return applyReviewFixBudgetAnswerTX(ctx, db, repos, *loop, text, nowISO, caps)
+		}
+		return nil
+	}
+	if loops.IsReviewScopeHumanHold(*loop) {
+		if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
+			return applyReviewScopeHumanAnswerTX(ctx, db, repos, *loop, text, nowISO)
 		}
 		return nil
 	}
@@ -448,6 +454,25 @@ func applyReviewFixBudgetAnswerTX(ctx context.Context, db *sql.DB, repos *storag
 	return err
 }
 
+func applyReviewScopeHumanAnswerTX(ctx context.Context, db *sql.DB, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string) error {
+	if db != nil {
+		return storage.WithTransaction(ctx, db, nil, func(tx *sql.Tx) error {
+			txRepos := storage.NewRepositories(tx)
+			fresh, err := txRepos.Loops.GetByID(ctx, loop.ID)
+			if err != nil {
+				return err
+			}
+			if fresh == nil {
+				return nil
+			}
+			_, err = loops.ApplyReviewScopeHumanAnswer(ctx, txRepos, *fresh, answer, nowISO)
+			return err
+		})
+	}
+	_, err := loops.ApplyReviewScopeHumanAnswer(ctx, repos, loop, answer, nowISO)
+	return err
+}
+
 func deliverHITLAnswerToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, answer string) error {
 	return deliverHITLAnswerToLoopWithCaps(ctx, repos, nil, nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
 }
@@ -461,7 +486,7 @@ func deliverHITLAnswerToLoopWithCaps(ctx context.Context, repos *storage.Reposit
 	if err != nil || loop == nil {
 		return err
 	}
-	if loop.Status != "awaiting_human" && !loops.IsReviewFixBudgetHold(*loop) {
+	if loop.Status != "awaiting_human" && !loops.IsReviewFixPairHold(*loop) {
 		return nil
 	}
 	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*loop))
@@ -469,6 +494,9 @@ func deliverHITLAnswerToLoopWithCaps(ctx context.Context, repos *storage.Reposit
 	if loops.IsReviewFixBudgetHold(*loop) {
 		// Budget Continue/Stop (HITL ask or no-ask hold) — fail-closed TX when DB set.
 		return applyReviewFixBudgetAnswerTX(ctx, db, repos, *loop, answer, nowISO, caps)
+	}
+	if loops.IsReviewScopeHumanHold(*loop) {
+		return applyReviewScopeHumanAnswerTX(ctx, db, repos, *loop, answer, nowISO)
 	}
 	if loop.Status != "awaiting_human" {
 		return nil
@@ -578,7 +606,9 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 		awaiting = append(awaiting, githubHITLAwaitingLoop{
 			ID: l.ID, ProjectID: l.ProjectID, Repo: repo,
 			Transport: ask.Transport, AskStatus: ask.Status, PRNumber: ask.PRNumber, AskCommentID: ask.AskCommentID,
-			BudgetAsk: loops.IsReviewFixBudgetAsk(ask),
+			// Scope asks share Continue/Stop-only filtering with budget asks so
+			// unrelated PR chatter does not poison the decision.
+			BudgetAsk: loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask),
 		})
 	}
 	if len(awaiting) == 0 {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -41,11 +41,11 @@ func detectGitHubHITLAnswer(comments []githubAnswerComment, askCommentID int64, 
 }
 
 func detectGitHubHITLAnswerMatching(comments []githubAnswerComment, askCommentID int64, answerAuthors []string, accept func(string) bool) string {
-	answer, _ := detectGitHubHITLAnswerMatchingWithID(comments, askCommentID, answerAuthors, accept)
+	answer, _ := detectGitHubHITLAnswerMatchingWithID(comments, askCommentID, answerAuthors, accept, nil)
 	return answer
 }
 
-func detectGitHubHITLAnswerMatchingWithID(comments []githubAnswerComment, askCommentID int64, answerAuthors []string, accept func(string) bool) (string, int64) {
+func detectGitHubHITLAnswerMatchingWithID(comments []githubAnswerComment, askCommentID int64, answerAuthors []string, accept func(string) bool, skipIDs map[int64]struct{}) (string, int64) {
 	allow := make(map[string]bool, len(answerAuthors))
 	for _, a := range answerAuthors {
 		if a = strings.TrimSpace(a); a != "" {
@@ -56,6 +56,9 @@ func detectGitHubHITLAnswerMatchingWithID(comments []githubAnswerComment, askCom
 	answer := ""
 	for _, c := range comments {
 		if c.ID <= askCommentID {
+			continue
+		}
+		if _, skip := skipIDs[c.ID]; skip {
 			continue
 		}
 		if strings.Contains(c.Body, looperCommentMarker) {
@@ -285,7 +288,8 @@ type githubHITLPollDeps struct {
 	// advanceAskPastComment moves remaining GitHub asks on the same
 	// review-fix pair past a consumed Continue/Stop so a later poll cannot
 	// treat that comment as an ordinary answer after a scope overlay is released.
-	advanceAskPastComment func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64) error
+	// Residual ordinary asks are advanced only when they have no earlier free-text.
+	advanceAskPastComment func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error
 	// projectCWD returns the local repo path for a project (gh runs there).
 	projectCWD    func(projectID string) string
 	answerAuthors []string
@@ -373,13 +377,14 @@ func drainReviewFixPairExecutions(ctx context.Context, repos *storage.Repositori
 // waiting on a GitHub HITL answer, it looks for a human's reply after the ask and
 // delivers it. It is idempotent — a loop that leaves awaiting_human on delivery
 // simply won't be passed in again. A Continue/Stop consumed by a decision-only
-// pair member is remembered in-process for this poll. Residual ordinary sibling
-// asks keep their original AskCommentID so earlier free-text replies stay
-// visible after the overlay is released; those asks also ignore Continue/Stop
-// so the pair decision cannot become their answer.
+// pair member is remembered in-process for this poll and persisted onto siblings.
+// Residual ordinary sibling asks keep earlier free-text visible; they skip only
+// the consumed decision comment so a standalone ordinary ask can still answer
+// Continue or Stop.
 func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoop, deps githubHITLPollDeps) int {
 	delivered := 0
 	consumedDecisionPairs := make(map[string]struct{})
+	consumedDecisionComments := make(map[int64]struct{})
 	for i, loop := range awaiting {
 		if !strings.EqualFold(strings.TrimSpace(loop.Transport), "github") || loop.PRNumber == 0 {
 			continue
@@ -413,18 +418,14 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 			accept = func(body string) bool {
 				return loops.IsReviewFixBudgetContinue(body) || loops.IsReviewFixBudgetStop(body)
 			}
-		} else {
-			accept = func(body string) bool {
-				return !loops.IsReviewFixBudgetContinue(body) && !loops.IsReviewFixBudgetStop(body)
-			}
 		}
-		answer, commentID := detectGitHubHITLAnswerMatchingWithID(comments, loop.AskCommentID, deps.answerAuthors, accept)
+		answer, commentID := detectGitHubHITLAnswerMatchingWithID(comments, loop.AskCommentID, deps.answerAuthors, accept, consumedDecisionComments)
 		if answer == "" {
 			continue
 		}
 		if loop.BudgetAsk && pairKey != "" && commentID != 0 && (loops.IsReviewFixBudgetContinue(answer) || loops.IsReviewFixBudgetStop(answer)) {
 			if deps.advanceAskPastComment != nil {
-				if err := deps.advanceAskPastComment(ctx, loop.ProjectID, repo, loop.PRNumber, loop.ID, commentID); err != nil {
+				if err := deps.advanceAskPastComment(ctx, loop.ProjectID, repo, loop.PRNumber, loop.ID, commentID, comments); err != nil {
 					if deps.logWarn != nil {
 						deps.logWarn("hitl github poll: advance consumed decision failed", map[string]any{"loopId": loop.ID, "error": err.Error()})
 					}
@@ -436,12 +437,15 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 					continue
 				}
 				if !awaiting[j].BudgetAsk {
-					continue
+					if residualOrdinaryHasEarlierAnswer(comments, awaiting[j].AskCommentID, commentID) {
+						continue
+					}
 				}
 				if awaiting[j].AskCommentID < commentID {
 					awaiting[j].AskCommentID = commentID
 				}
 			}
+			consumedDecisionComments[commentID] = struct{}{}
 		}
 		if err := deps.deliverAnswer(ctx, loop.ID, answer); err != nil {
 			if deps.logWarn != nil {
@@ -460,7 +464,17 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 	return delivered
 }
 
-func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage.Repositories, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64) error {
+func residualOrdinaryHasEarlierAnswer(comments []githubAnswerComment, askCommentID, consumedID int64) bool {
+	if consumedID == 0 {
+		return false
+	}
+	_, id := detectGitHubHITLAnswerMatchingWithID(comments, askCommentID, nil, func(body string) bool {
+		return !loops.IsReviewFixBudgetContinue(body) && !loops.IsReviewFixBudgetStop(body)
+	}, map[int64]struct{}{consumedID: {}})
+	return id != 0 && id < consumedID
+}
+
+func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage.Repositories, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error {
 	if repos == nil || repos.Loops == nil || commentID == 0 || prNumber == 0 {
 		return nil
 	}
@@ -507,7 +521,7 @@ func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage
 		if ask.AskCommentID >= commentID {
 			continue
 		}
-		if githubHITLResidualOrdinaryAsk(ask) {
+		if githubHITLResidualOrdinaryAsk(ask) && residualOrdinaryHasEarlierAnswer(comments, ask.AskCommentID, commentID) {
 			continue
 		}
 		ask.AskCommentID = commentID
@@ -880,8 +894,8 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 		remainingAwaiting: func(ctx contextType, repo string, pr int64) bool {
 			return githubHITLPRHasRemainingAwaiting(ctx, input.Repos, project.ID, repo, pr)
 		},
-		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64) error {
-			return advanceSiblingGitHubHITLAsksPastComment(ctx, input.Repos, projectID, repo, prNumber, exceptLoopID, commentID)
+		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error {
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, input.Repos, projectID, repo, prNumber, exceptLoopID, commentID, comments)
 		},
 		projectCWD:    func(string) string { return project.RepoPath },
 		answerAuthors: answerAuthors,

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -145,30 +145,80 @@ func deliverUndeliveredGitHubBudgetAsks(ctx contextType, projectID string, recor
 		if deps.addLabel != nil {
 			deps.addLabel(ctx, repo, prNumber, awaitingLabel, cwd)
 		}
-		ask.Transport = "github"
-		ask.PRNumber = prNumber
-		ask.AskCommentID = commentID
-		meta, werr := loops.WriteHITLAsk(loop.MetadataJSON, ask)
-		if werr != nil {
-			if deps.logWarn != nil {
-				deps.logWarn("hitl github: budget ask metadata write failed", map[string]any{"loopId": loop.ID, "error": werr.Error()})
-			}
-			continue
-		}
-		updated := loop
-		updated.MetadataJSON = &meta
-		if deps.nowISO != "" {
-			updated.UpdatedAt = deps.nowISO
-		}
-		if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		posted := ask
+		persisted, err := persistPairAskDelivery(ctx, repos, loop.ID, deps.nowISO, posted, func(live *loops.HITLAsk) {
+			live.Transport = "github"
+			live.PRNumber = prNumber
+			live.AskCommentID = commentID
+		})
+		if err != nil {
 			if deps.logWarn != nil {
 				deps.logWarn("hitl github: budget ask persist failed", map[string]any{"loopId": loop.ID, "error": err.Error()})
 			}
 			continue
 		}
+		if !persisted {
+			continue
+		}
 		delivered++
 	}
 	return delivered
+}
+
+// persistPairAskDelivery writes ask-delivery fields onto the live loop when the
+// same awaiting pair ask is still current. A racing Continue/Stop can release
+// the hold while createComment/sendAsk is in flight; a whole-record upsert of
+// the pre-delivery snapshot would restore awaiting_human and scope metadata.
+func persistPairAskDelivery(ctx context.Context, repos *storage.Repositories, loopID, nowISO string, posted loops.HITLAsk, apply func(*loops.HITLAsk)) (bool, error) {
+	if repos == nil || repos.Loops == nil || strings.TrimSpace(loopID) == "" || apply == nil {
+		return false, nil
+	}
+	unlock := LockLoopRequeue(loopID)
+	defer unlock()
+	fresh, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return false, err
+	}
+	if fresh == nil {
+		return false, nil
+	}
+	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*fresh))
+	defer unlockTarget()
+	current, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return false, err
+	}
+	if current == nil || current.Status != "awaiting_human" {
+		return false, nil
+	}
+	ask, ok := loops.ReadHITLAsk(current.MetadataJSON)
+	if !ok {
+		return false, nil
+	}
+	if !loops.IsReviewFixBudgetAsk(ask) && !loops.IsReviewScopeHumanAsk(ask) {
+		return false, nil
+	}
+	if strings.TrimSpace(ask.Kind) != strings.TrimSpace(posted.Kind) || strings.TrimSpace(ask.AskedAt) != strings.TrimSpace(posted.AskedAt) {
+		return false, nil
+	}
+	status := strings.TrimSpace(ask.Status)
+	if strings.EqualFold(status, "answered") || strings.EqualFold(status, "consumed") {
+		return false, nil
+	}
+	apply(&ask)
+	meta, err := loops.WriteHITLAsk(current.MetadataJSON, ask)
+	if err != nil {
+		return false, err
+	}
+	updated := *current
+	updated.MetadataJSON = &meta
+	if strings.TrimSpace(nowISO) != "" {
+		updated.UpdatedAt = nowISO
+	}
+	if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func githubBudgetAskMarker(loopSeq int64, askedAt string) string {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -382,6 +382,11 @@ func githubHITLResidualOrdinaryAsk(ask loops.HITLAsk) bool {
 // the caller applies the answer, so tests can commit a racing Continue.
 var afterDrainScopeStopHook func()
 
+// afterAdvanceSiblingGitHubAskListHook is test-only: runs after the sibling List
+// snapshot and before per-sibling cursor writes, so tests can commit a racing
+// Continue/Stop from another transport.
+var afterAdvanceSiblingGitHubAskListHook func()
+
 func drainScopeHoldOnStop(ctx context.Context, repos *storage.Repositories, loopID, answer string, drain func(context.Context, storage.LoopRecord) error) (bool, error) {
 	if drain == nil || repos == nil || repos.Loops == nil || !loops.IsReviewFixBudgetStop(answer) {
 		return false, nil
@@ -560,6 +565,9 @@ func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage
 	if err != nil {
 		return err
 	}
+	if afterAdvanceSiblingGitHubAskListHook != nil {
+		afterAdvanceSiblingGitHubAskListHook()
+	}
 	var except *storage.LoopRecord
 	for i := range all {
 		if strings.TrimSpace(all[i].ID) == exceptLoopID {
@@ -582,34 +590,61 @@ func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage
 		if derefLoopPRNumber(loop) != prNumber {
 			continue
 		}
-		if strings.TrimSpace(loop.Status) != "awaiting_human" {
-			continue
-		}
-		ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
-		if !ok || !strings.EqualFold(strings.TrimSpace(ask.Transport), "github") {
-			continue
-		}
-		if ask.PRNumber != 0 && ask.PRNumber != prNumber {
-			continue
-		}
-		if ask.AskCommentID >= commentID {
-			continue
-		}
-		if githubHITLResidualOrdinaryAsk(ask) && residualOrdinaryHasEarlierAnswer(comments, ask.AskCommentID, commentID, answerAuthors) {
-			continue
-		}
-		ask.AskCommentID = commentID
-		meta, err := loops.WriteHITLAsk(loop.MetadataJSON, ask)
-		if err != nil {
-			return err
-		}
-		updated := loop
-		updated.MetadataJSON = &meta
-		if err := repos.Loops.Upsert(ctx, updated); err != nil {
+		if err := advanceOneSiblingGitHubHITLAskPastComment(ctx, repos, loop.ID, prNumber, commentID, comments, answerAuthors); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// advanceOneSiblingGitHubHITLAskPastComment writes only AskCommentID onto a
+// freshly read sibling. A whole-record upsert of the preceding List snapshot
+// would restore awaiting_human and scope-hold metadata after a racing
+// Continue/Stop released the overlay.
+func advanceOneSiblingGitHubHITLAskPastComment(ctx context.Context, repos *storage.Repositories, loopID string, prNumber, commentID int64, comments []githubAnswerComment, answerAuthors []string) error {
+	loopID = strings.TrimSpace(loopID)
+	if repos == nil || repos.Loops == nil || loopID == "" || commentID == 0 {
+		return nil
+	}
+	unlock := LockLoopRequeue(loopID)
+	defer unlock()
+	fresh, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return err
+	}
+	if fresh == nil {
+		return nil
+	}
+	unlockTarget := LockLoopTarget(LoopTargetGuardKeyFromRecord(*fresh))
+	defer unlockTarget()
+	current, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return err
+	}
+	if current == nil || strings.TrimSpace(current.Status) != "awaiting_human" {
+		return nil
+	}
+	ask, ok := loops.ReadHITLAsk(current.MetadataJSON)
+	if !ok || !strings.EqualFold(strings.TrimSpace(ask.Transport), "github") {
+		return nil
+	}
+	if ask.PRNumber != 0 && ask.PRNumber != prNumber {
+		return nil
+	}
+	if ask.AskCommentID >= commentID {
+		return nil
+	}
+	if githubHITLResidualOrdinaryAsk(ask) && residualOrdinaryHasEarlierAnswer(comments, ask.AskCommentID, commentID, answerAuthors) {
+		return nil
+	}
+	ask.AskCommentID = commentID
+	meta, err := loops.WriteHITLAsk(current.MetadataJSON, ask)
+	if err != nil {
+		return err
+	}
+	updated := *current
+	updated.MetadataJSON = &meta
+	return repos.Loops.Upsert(ctx, updated)
 }
 
 func githubHITLDecisionPairKey(loop githubHITLAwaitingLoop) string {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -282,9 +282,9 @@ type githubHITLPollDeps struct {
 	// remainingAwaiting, when set, is consulted after a successful delivery.
 	// clearAwaiting is skipped when another awaiting GitHub ask remains on the PR.
 	remainingAwaiting func(ctx contextType, repo string, prNumber int64) bool
-	// advanceAskPastComment moves remaining GitHub asks on the same repo#PR
-	// past a consumed Continue/Stop so a later poll cannot treat that comment
-	// as an ordinary answer after a scope overlay is released.
+	// advanceAskPastComment moves remaining GitHub asks on the same
+	// review-fix pair past a consumed Continue/Stop so a later poll cannot
+	// treat that comment as an ordinary answer after a scope overlay is released.
 	advanceAskPastComment func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64) error
 	// projectCWD returns the local repo path for a project (gh runs there).
 	projectCWD    func(projectID string) string
@@ -302,6 +302,9 @@ type githubHITLAwaitingLoop struct {
 	PRNumber     int64
 	AskCommentID int64
 	BudgetAsk    bool
+	// Lane is the review-fix pairing lane (automatic or continuous_manual).
+	// Empty means the loop does not pair (one-shot manual).
+	Lane string
 }
 
 // githubHITLDecisionOnlyAsk reports Continue/Stop-only GitHub answer filtering.
@@ -360,8 +363,9 @@ func drainReviewFixPairExecutions(ctx context.Context, repos *storage.Repositori
 // waiting on a GitHub HITL answer, it looks for a human's reply after the ask and
 // delivers it. It is idempotent — a loop that leaves awaiting_human on delivery
 // simply won't be passed in again. A Continue/Stop consumed by a decision-only
-// pair member is persisted onto remaining sibling GitHub asks so the next poll
-// cannot treat that comment as an ordinary answer after the overlay is gone.
+// pair member is persisted onto remaining sibling GitHub asks in that same
+// review-fix lane so the next poll cannot treat that comment as an ordinary
+// answer after the overlay is gone.
 func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoop, deps githubHITLPollDeps) int {
 	delivered := 0
 	consumedDecisionPairs := make(map[string]struct{})
@@ -442,28 +446,44 @@ func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage
 	if repos == nil || repos.Loops == nil || commentID == 0 || prNumber == 0 {
 		return nil
 	}
+	exceptLoopID = strings.TrimSpace(exceptLoopID)
+	if exceptLoopID == "" {
+		return nil
+	}
 	all, err := repos.Loops.List(ctx)
 	if err != nil {
 		return err
 	}
+	var except *storage.LoopRecord
+	for i := range all {
+		if strings.TrimSpace(all[i].ID) == exceptLoopID {
+			except = &all[i]
+			break
+		}
+	}
+	if except == nil {
+		return nil
+	}
 	repo = strings.TrimSpace(repo)
 	projectID = strings.TrimSpace(projectID)
-	exceptLoopID = strings.TrimSpace(exceptLoopID)
-	for _, loop := range all {
-		if strings.TrimSpace(loop.ID) == exceptLoopID {
+	for _, loop := range loops.FindSiblingReviewFixLoops(all, *except) {
+		if projectID != "" && strings.TrimSpace(loop.ProjectID) != projectID {
 			continue
 		}
-		if strings.TrimSpace(loop.ProjectID) != projectID {
+		if repo != "" && derefLoopRepo(loop) != repo {
 			continue
 		}
-		if derefLoopRepo(loop) != repo || derefLoopPRNumber(loop) != prNumber {
+		if derefLoopPRNumber(loop) != prNumber {
 			continue
 		}
 		if strings.TrimSpace(loop.Status) != "awaiting_human" {
 			continue
 		}
 		ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
-		if !ok || !strings.EqualFold(strings.TrimSpace(ask.Transport), "github") || ask.PRNumber != prNumber {
+		if !ok || !strings.EqualFold(strings.TrimSpace(ask.Transport), "github") {
+			continue
+		}
+		if ask.PRNumber != 0 && ask.PRNumber != prNumber {
 			continue
 		}
 		if ask.AskCommentID >= commentID {
@@ -485,10 +505,11 @@ func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage
 
 func githubHITLDecisionPairKey(loop githubHITLAwaitingLoop) string {
 	repo := strings.TrimSpace(loop.Repo)
-	if repo == "" || loop.PRNumber == 0 {
+	lane := strings.TrimSpace(loop.Lane)
+	if repo == "" || loop.PRNumber == 0 || lane == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s#%d", repo, loop.PRNumber)
+	return fmt.Sprintf("%s#%d:%s", repo, loop.PRNumber, lane)
 }
 
 func githubHITLPRHasRemainingAwaiting(ctx context.Context, repos *storage.Repositories, projectID, repo string, prNumber int64) bool {
@@ -805,6 +826,7 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 			// with budget asks so unrelated PR chatter does not poison the
 			// decision. Overlay siblings keep a preserved agent ask kind.
 			BudgetAsk: githubHITLDecisionOnlyAsk(l, ask),
+			Lane:      loops.ReviewFixBudgetLane(l),
 		})
 	}
 	if len(awaiting) == 0 {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -424,7 +424,10 @@ func githubHITLPRHasRemainingAwaiting(ctx context.Context, repos *storage.Reposi
 	}
 	all, err := repos.Loops.List(ctx)
 	if err != nil {
-		return false
+		// Unknown remaining state must keep looper:awaiting-human. A transient
+		// List error after one delivery must not clear the label while another
+		// GitHub-backed ask may still be open on the PR.
+		return true
 	}
 	repo = strings.TrimSpace(repo)
 	for _, loop := range all {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -314,6 +314,16 @@ func githubHITLDecisionOnlyAsk(loop storage.LoopRecord, ask loops.HITLAsk) bool 
 	return loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewScopeHumanHold(loop)
 }
 
+// githubHITLResidualOrdinaryAsk reports a preserved agent HITL ask that is not
+// itself a pair Continue/Stop question. Overlay siblings keep this ask while
+// the pair hold is the decision authority.
+func githubHITLResidualOrdinaryAsk(ask loops.HITLAsk) bool {
+	if loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(ask.Status), "awaiting")
+}
+
 func drainScopeHoldOnStop(ctx context.Context, repos *storage.Repositories, loopID, answer string, drain func(context.Context, storage.LoopRecord) error) error {
 	if drain == nil || repos == nil || repos.Loops == nil || !loops.IsReviewFixBudgetStop(answer) {
 		return nil
@@ -363,9 +373,10 @@ func drainReviewFixPairExecutions(ctx context.Context, repos *storage.Repositori
 // waiting on a GitHub HITL answer, it looks for a human's reply after the ask and
 // delivers it. It is idempotent — a loop that leaves awaiting_human on delivery
 // simply won't be passed in again. A Continue/Stop consumed by a decision-only
-// pair member is persisted onto remaining sibling GitHub asks in that same
-// review-fix lane so the next poll cannot treat that comment as an ordinary
-// answer after the overlay is gone.
+// pair member is remembered in-process for this poll. Residual ordinary sibling
+// asks keep their original AskCommentID so earlier free-text replies stay
+// visible after the overlay is released; those asks also ignore Continue/Stop
+// so the pair decision cannot become their answer.
 func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoop, deps githubHITLPollDeps) int {
 	delivered := 0
 	consumedDecisionPairs := make(map[string]struct{})
@@ -402,6 +413,10 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 			accept = func(body string) bool {
 				return loops.IsReviewFixBudgetContinue(body) || loops.IsReviewFixBudgetStop(body)
 			}
+		} else {
+			accept = func(body string) bool {
+				return !loops.IsReviewFixBudgetContinue(body) && !loops.IsReviewFixBudgetStop(body)
+			}
 		}
 		answer, commentID := detectGitHubHITLAnswerMatchingWithID(comments, loop.AskCommentID, deps.answerAuthors, accept)
 		if answer == "" {
@@ -418,6 +433,9 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 			}
 			for j := range awaiting {
 				if j == i || githubHITLDecisionPairKey(awaiting[j]) != pairKey {
+					continue
+				}
+				if !awaiting[j].BudgetAsk {
 					continue
 				}
 				if awaiting[j].AskCommentID < commentID {
@@ -487,6 +505,9 @@ func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage
 			continue
 		}
 		if ask.AskCommentID >= commentID {
+			continue
+		}
+		if githubHITLResidualOrdinaryAsk(ask) {
 			continue
 		}
 		ask.AskCommentID = commentID

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -274,6 +274,9 @@ type githubHITLPollDeps struct {
 	deliverAnswer func(ctx contextType, loopID, answer string) error
 	// clearAwaiting removes the awaiting-human label from the PR after delivery.
 	clearAwaiting func(ctx contextType, repo string, prNumber int64, cwd string)
+	// remainingAwaiting, when set, is consulted after a successful delivery.
+	// clearAwaiting is skipped when another awaiting GitHub ask remains on the PR.
+	remainingAwaiting func(ctx contextType, repo string, prNumber int64) bool
 	// projectCWD returns the local repo path for a project (gh runs there).
 	projectCWD    func(projectID string) string
 	answerAuthors []string
@@ -399,7 +402,7 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 		if loop.BudgetAsk && pairKey != "" && (loops.IsReviewFixBudgetContinue(answer) || loops.IsReviewFixBudgetStop(answer)) {
 			consumedDecisionPairs[pairKey] = struct{}{}
 		}
-		if deps.clearAwaiting != nil {
+		if deps.clearAwaiting != nil && (deps.remainingAwaiting == nil || !deps.remainingAwaiting(ctx, repo, loop.PRNumber)) {
 			deps.clearAwaiting(ctx, repo, loop.PRNumber, cwd)
 		}
 		delivered++
@@ -413,6 +416,51 @@ func githubHITLDecisionPairKey(loop githubHITLAwaitingLoop) string {
 		return ""
 	}
 	return fmt.Sprintf("%s#%d", repo, loop.PRNumber)
+}
+
+func githubHITLPRHasRemainingAwaiting(ctx context.Context, repos *storage.Repositories, projectID, repo string, prNumber int64) bool {
+	if repos == nil || repos.Loops == nil || prNumber == 0 {
+		return false
+	}
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return false
+	}
+	repo = strings.TrimSpace(repo)
+	for _, loop := range all {
+		if strings.TrimSpace(projectID) != "" && loop.ProjectID != projectID {
+			continue
+		}
+		if loop.Status != "awaiting_human" {
+			continue
+		}
+		ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
+		if !ok {
+			continue
+		}
+		if s := strings.TrimSpace(ask.Status); s != "" && s != "awaiting" {
+			continue
+		}
+		askPR := ask.PRNumber
+		if askPR == 0 {
+			askPR = derefLoopPRNumber(loop)
+		}
+		if askPR != prNumber {
+			continue
+		}
+		if repo != "" {
+			loopRepo := derefLoopRepo(loop)
+			if loopRepo != "" && !strings.EqualFold(loopRepo, repo) {
+				continue
+			}
+		}
+		transport := strings.TrimSpace(ask.Transport)
+		if transport != "" && !strings.EqualFold(transport, "github") {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // deliverHITLAnswerToLoop is the runtime-side equivalent of the api
@@ -709,6 +757,9 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 		},
 		clearAwaiting: func(ctx contextType, repo string, pr int64, cwd string) {
 			_ = gw.RemovePullRequestLabels(ctx, githubinfra.PullRequestLabelsInput{Repo: repo, PRNumber: pr, Labels: []string{awaitingLabel}, CWD: cwd})
+		},
+		remainingAwaiting: func(ctx contextType, repo string, pr int64) bool {
+			return githubHITLPRHasRemainingAwaiting(ctx, input.Repos, project.ID, repo, pr)
 		},
 		projectCWD:    func(string) string { return project.RepoPath },
 		answerAuthors: answerAuthors,

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -437,7 +437,7 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 					continue
 				}
 				if !awaiting[j].BudgetAsk {
-					if residualOrdinaryHasEarlierAnswer(comments, awaiting[j].AskCommentID, commentID) {
+					if residualOrdinaryHasEarlierAnswer(comments, awaiting[j].AskCommentID, commentID, deps.answerAuthors) {
 						continue
 					}
 				}
@@ -464,17 +464,17 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 	return delivered
 }
 
-func residualOrdinaryHasEarlierAnswer(comments []githubAnswerComment, askCommentID, consumedID int64) bool {
+func residualOrdinaryHasEarlierAnswer(comments []githubAnswerComment, askCommentID, consumedID int64, answerAuthors []string) bool {
 	if consumedID == 0 {
 		return false
 	}
-	_, id := detectGitHubHITLAnswerMatchingWithID(comments, askCommentID, nil, func(body string) bool {
+	_, id := detectGitHubHITLAnswerMatchingWithID(comments, askCommentID, answerAuthors, func(body string) bool {
 		return !loops.IsReviewFixBudgetContinue(body) && !loops.IsReviewFixBudgetStop(body)
 	}, map[int64]struct{}{consumedID: {}})
 	return id != 0 && id < consumedID
 }
 
-func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage.Repositories, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error {
+func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage.Repositories, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment, answerAuthors []string) error {
 	if repos == nil || repos.Loops == nil || commentID == 0 || prNumber == 0 {
 		return nil
 	}
@@ -521,7 +521,7 @@ func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage
 		if ask.AskCommentID >= commentID {
 			continue
 		}
-		if githubHITLResidualOrdinaryAsk(ask) && residualOrdinaryHasEarlierAnswer(comments, ask.AskCommentID, commentID) {
+		if githubHITLResidualOrdinaryAsk(ask) && residualOrdinaryHasEarlierAnswer(comments, ask.AskCommentID, commentID, answerAuthors) {
 			continue
 		}
 		ask.AskCommentID = commentID
@@ -895,7 +895,7 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 			return githubHITLPRHasRemainingAwaiting(ctx, input.Repos, project.ID, repo, pr)
 		},
 		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error {
-			return advanceSiblingGitHubHITLAsksPastComment(ctx, input.Repos, projectID, repo, prNumber, exceptLoopID, commentID, comments)
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, input.Repos, projectID, repo, prNumber, exceptLoopID, commentID, comments, answerAuthors)
 		},
 		projectCWD:    func(string) string { return project.RepoPath },
 		answerAuthors: answerAuthors,

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -41,6 +41,11 @@ func detectGitHubHITLAnswer(comments []githubAnswerComment, askCommentID int64, 
 }
 
 func detectGitHubHITLAnswerMatching(comments []githubAnswerComment, askCommentID int64, answerAuthors []string, accept func(string) bool) string {
+	answer, _ := detectGitHubHITLAnswerMatchingWithID(comments, askCommentID, answerAuthors, accept)
+	return answer
+}
+
+func detectGitHubHITLAnswerMatchingWithID(comments []githubAnswerComment, askCommentID int64, answerAuthors []string, accept func(string) bool) (string, int64) {
 	allow := make(map[string]bool, len(answerAuthors))
 	for _, a := range answerAuthors {
 		if a = strings.TrimSpace(a); a != "" {
@@ -75,7 +80,7 @@ func detectGitHubHITLAnswerMatching(comments []githubAnswerComment, askCommentID
 			answer = body
 		}
 	}
-	return answer
+	return answer, bestID
 }
 
 // githubHITLDeliveryDeps are the injected dependencies for posting an undelivered
@@ -277,6 +282,10 @@ type githubHITLPollDeps struct {
 	// remainingAwaiting, when set, is consulted after a successful delivery.
 	// clearAwaiting is skipped when another awaiting GitHub ask remains on the PR.
 	remainingAwaiting func(ctx contextType, repo string, prNumber int64) bool
+	// advanceAskPastComment moves remaining GitHub asks on the same repo#PR
+	// past a consumed Continue/Stop so a later poll cannot treat that comment
+	// as an ordinary answer after a scope overlay is released.
+	advanceAskPastComment func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64) error
 	// projectCWD returns the local repo path for a project (gh runs there).
 	projectCWD    func(projectID string) string
 	answerAuthors []string
@@ -351,11 +360,12 @@ func drainReviewFixPairExecutions(ctx context.Context, repos *storage.Repositori
 // waiting on a GitHub HITL answer, it looks for a human's reply after the ask and
 // delivers it. It is idempotent — a loop that leaves awaiting_human on delivery
 // simply won't be passed in again. A Continue/Stop consumed by a decision-only
-// pair member is not delivered again to the overlaid sibling in the same pass.
+// pair member is persisted onto remaining sibling GitHub asks so the next poll
+// cannot treat that comment as an ordinary answer after the overlay is gone.
 func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoop, deps githubHITLPollDeps) int {
 	delivered := 0
 	consumedDecisionPairs := make(map[string]struct{})
-	for _, loop := range awaiting {
+	for i, loop := range awaiting {
 		if !strings.EqualFold(strings.TrimSpace(loop.Transport), "github") || loop.PRNumber == 0 {
 			continue
 		}
@@ -389,9 +399,27 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 				return loops.IsReviewFixBudgetContinue(body) || loops.IsReviewFixBudgetStop(body)
 			}
 		}
-		answer := detectGitHubHITLAnswerMatching(comments, loop.AskCommentID, deps.answerAuthors, accept)
+		answer, commentID := detectGitHubHITLAnswerMatchingWithID(comments, loop.AskCommentID, deps.answerAuthors, accept)
 		if answer == "" {
 			continue
+		}
+		if loop.BudgetAsk && pairKey != "" && commentID != 0 && (loops.IsReviewFixBudgetContinue(answer) || loops.IsReviewFixBudgetStop(answer)) {
+			if deps.advanceAskPastComment != nil {
+				if err := deps.advanceAskPastComment(ctx, loop.ProjectID, repo, loop.PRNumber, loop.ID, commentID); err != nil {
+					if deps.logWarn != nil {
+						deps.logWarn("hitl github poll: advance consumed decision failed", map[string]any{"loopId": loop.ID, "error": err.Error()})
+					}
+					continue
+				}
+			}
+			for j := range awaiting {
+				if j == i || githubHITLDecisionPairKey(awaiting[j]) != pairKey {
+					continue
+				}
+				if awaiting[j].AskCommentID < commentID {
+					awaiting[j].AskCommentID = commentID
+				}
+			}
 		}
 		if err := deps.deliverAnswer(ctx, loop.ID, answer); err != nil {
 			if deps.logWarn != nil {
@@ -408,6 +436,51 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 		delivered++
 	}
 	return delivered
+}
+
+func advanceSiblingGitHubHITLAsksPastComment(ctx context.Context, repos *storage.Repositories, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64) error {
+	if repos == nil || repos.Loops == nil || commentID == 0 || prNumber == 0 {
+		return nil
+	}
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	repo = strings.TrimSpace(repo)
+	projectID = strings.TrimSpace(projectID)
+	exceptLoopID = strings.TrimSpace(exceptLoopID)
+	for _, loop := range all {
+		if strings.TrimSpace(loop.ID) == exceptLoopID {
+			continue
+		}
+		if strings.TrimSpace(loop.ProjectID) != projectID {
+			continue
+		}
+		if derefLoopRepo(loop) != repo || derefLoopPRNumber(loop) != prNumber {
+			continue
+		}
+		if strings.TrimSpace(loop.Status) != "awaiting_human" {
+			continue
+		}
+		ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
+		if !ok || !strings.EqualFold(strings.TrimSpace(ask.Transport), "github") || ask.PRNumber != prNumber {
+			continue
+		}
+		if ask.AskCommentID >= commentID {
+			continue
+		}
+		ask.AskCommentID = commentID
+		meta, err := loops.WriteHITLAsk(loop.MetadataJSON, ask)
+		if err != nil {
+			return err
+		}
+		updated := loop
+		updated.MetadataJSON = &meta
+		if err := repos.Loops.Upsert(ctx, updated); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func githubHITLDecisionPairKey(loop githubHITLAwaitingLoop) string {
@@ -763,6 +836,9 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 		},
 		remainingAwaiting: func(ctx contextType, repo string, pr int64) bool {
 			return githubHITLPRHasRemainingAwaiting(ctx, input.Repos, project.ID, repo, pr)
+		},
+		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64) error {
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, input.Repos, projectID, repo, prNumber, exceptLoopID, commentID)
 		},
 		projectCWD:    func(string) string { return project.RepoPath },
 		answerAuthors: answerAuthors,

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -299,6 +299,51 @@ func githubHITLDecisionOnlyAsk(loop storage.LoopRecord, ask loops.HITLAsk) bool 
 	return loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewScopeHumanHold(loop)
 }
 
+func drainScopeHoldOnStop(ctx context.Context, repos *storage.Repositories, loopID, answer string, drain func(context.Context, storage.LoopRecord) error) error {
+	if drain == nil || repos == nil || repos.Loops == nil || !loops.IsReviewFixBudgetStop(answer) {
+		return nil
+	}
+	loop, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil {
+		return err
+	}
+	if loop == nil || !loops.IsReviewScopeHumanHold(*loop) {
+		return nil
+	}
+	return drain(ctx, *loop)
+}
+
+func drainReviewFixPairExecutions(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, executions *ActiveExecutionRegistry) error {
+	if repos == nil || repos.Loops == nil {
+		return nil
+	}
+	all, err := repos.Loops.List(ctx)
+	if err != nil {
+		return err
+	}
+	members := append(loops.FindSiblingReviewFixLoops(all, loop), loop)
+	seen := make(map[string]struct{}, len(members))
+	for _, member := range members {
+		if _, ok := seen[member.ID]; ok {
+			continue
+		}
+		seen[member.ID] = struct{}{}
+		if member.ID != loop.ID && !loops.IsReviewFixPairHold(member) {
+			continue
+		}
+		switch strings.TrimSpace(member.Status) {
+		case "terminated", "stopped", "completed":
+			continue
+		}
+		if executions != nil {
+			if _, err := executions.BeginLoopStop(member.ID, "Stopped by review-fix scope pair"); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // pollGitHubHITLAnswersOnce runs one pass of the answer-poll lane: for each loop
 // waiting on a GitHub HITL answer, it looks for a human's reply after the ask and
 // delivers it. It is idempotent — a loop that leaves awaiting_human on delivery
@@ -638,6 +683,9 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 			return out, nil
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			if err := drainScopeHoldOnStop(ctx, input.Repos, loopID, answer, input.DrainHITLPair); err != nil {
+				return err
+			}
 			return deliverHITLAnswerToLoopWithCaps(ctx, input.Repos, input.DB, nowISO, loopID, answer, reviewFixBudgetLiveCaps(input.Config, project.ID))
 		},
 		clearAwaiting: func(ctx contextType, repo string, pr int64, cwd string) {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -670,6 +670,17 @@ func enqueueHumanMessageToLoopWithCaps(ctx context.Context, repos *storage.Repos
 		if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
 			return applyReviewScopeHumanAnswerAndReopen(ctx, db, repos, executions, *loop, text, nowISO)
 		}
+		if feishuOverlayResidualCardIsNotPairDecision(*loop, text) {
+			write := func(writeRepos *storage.Repositories) error {
+				return persistOverlayResidualAskAnswer(ctx, writeRepos, loopID, text, nowISO)
+			}
+			if db != nil {
+				return storage.WithTransaction(ctx, db, nil, func(tx *sql.Tx) error {
+					return write(storage.NewRepositories(tx))
+				})
+			}
+			return write(repos)
+		}
 		return nil
 	}
 

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -347,9 +347,11 @@ func drainReviewFixPairExecutions(ctx context.Context, repos *storage.Repositori
 // pollGitHubHITLAnswersOnce runs one pass of the answer-poll lane: for each loop
 // waiting on a GitHub HITL answer, it looks for a human's reply after the ask and
 // delivers it. It is idempotent — a loop that leaves awaiting_human on delivery
-// simply won't be passed in again.
+// simply won't be passed in again. A Continue/Stop consumed by a decision-only
+// pair member is not delivered again to the overlaid sibling in the same pass.
 func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoop, deps githubHITLPollDeps) int {
 	delivered := 0
+	consumedDecisionPairs := make(map[string]struct{})
 	for _, loop := range awaiting {
 		if !strings.EqualFold(strings.TrimSpace(loop.Transport), "github") || loop.PRNumber == 0 {
 			continue
@@ -360,6 +362,12 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 		repo := strings.TrimSpace(loop.Repo)
 		if repo == "" {
 			continue
+		}
+		pairKey := githubHITLDecisionPairKey(loop)
+		if loop.BudgetAsk && pairKey != "" {
+			if _, consumed := consumedDecisionPairs[pairKey]; consumed {
+				continue
+			}
 		}
 		cwd := ""
 		if deps.projectCWD != nil {
@@ -388,12 +396,23 @@ func pollGitHubHITLAnswersOnce(ctx contextType, awaiting []githubHITLAwaitingLoo
 			}
 			continue
 		}
+		if loop.BudgetAsk && pairKey != "" && (loops.IsReviewFixBudgetContinue(answer) || loops.IsReviewFixBudgetStop(answer)) {
+			consumedDecisionPairs[pairKey] = struct{}{}
+		}
 		if deps.clearAwaiting != nil {
 			deps.clearAwaiting(ctx, repo, loop.PRNumber, cwd)
 		}
 		delivered++
 	}
 	return delivered
+}
+
+func githubHITLDecisionPairKey(loop githubHITLAwaitingLoop) string {
+	repo := strings.TrimSpace(loop.Repo)
+	if repo == "" || loop.PRNumber == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s#%d", repo, loop.PRNumber)
 }
 
 // deliverHITLAnswerToLoop is the runtime-side equivalent of the api

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -292,6 +292,13 @@ type githubHITLAwaitingLoop struct {
 	BudgetAsk    bool
 }
 
+// githubHITLDecisionOnlyAsk reports Continue/Stop-only GitHub answer filtering.
+// Scope overlays keep a preserved agent ask; the overlay, not the ask kind, is
+// the authority that later Continue/Stop must resolve.
+func githubHITLDecisionOnlyAsk(loop storage.LoopRecord, ask loops.HITLAsk) bool {
+	return loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewScopeHumanHold(loop)
+}
+
 // pollGitHubHITLAnswersOnce runs one pass of the answer-poll lane: for each loop
 // waiting on a GitHub HITL answer, it looks for a human's reply after the ask and
 // delivers it. It is idempotent — a loop that leaves awaiting_human on delivery
@@ -606,9 +613,10 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 		awaiting = append(awaiting, githubHITLAwaitingLoop{
 			ID: l.ID, ProjectID: l.ProjectID, Repo: repo,
 			Transport: ask.Transport, AskStatus: ask.Status, PRNumber: ask.PRNumber, AskCommentID: ask.AskCommentID,
-			// Scope asks share Continue/Stop-only filtering with budget asks so
-			// unrelated PR chatter does not poison the decision.
-			BudgetAsk: loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask),
+			// Scope asks and scope overlays share Continue/Stop-only filtering
+			// with budget asks so unrelated PR chatter does not poison the
+			// decision. Overlay siblings keep a preserved agent ask kind.
+			BudgetAsk: githubHITLDecisionOnlyAsk(l, ask),
 		})
 	}
 	if len(awaiting) == 0 {

--- a/internal/runtime/hitl_github_poll.go
+++ b/internal/runtime/hitl_github_poll.go
@@ -328,18 +328,42 @@ func githubHITLResidualOrdinaryAsk(ask loops.HITLAsk) bool {
 	return strings.EqualFold(strings.TrimSpace(ask.Status), "awaiting")
 }
 
-func drainScopeHoldOnStop(ctx context.Context, repos *storage.Repositories, loopID, answer string, drain func(context.Context, storage.LoopRecord) error) error {
+// afterDrainScopeStopHook is test-only: runs after a scope Stop drain and before
+// the caller applies the answer, so tests can commit a racing Continue.
+var afterDrainScopeStopHook func()
+
+func drainScopeHoldOnStop(ctx context.Context, repos *storage.Repositories, loopID, answer string, drain func(context.Context, storage.LoopRecord) error) (bool, error) {
 	if drain == nil || repos == nil || repos.Loops == nil || !loops.IsReviewFixBudgetStop(answer) {
-		return nil
+		return false, nil
 	}
 	loop, err := repos.Loops.GetByID(ctx, loopID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if loop == nil || !loops.IsReviewScopeHumanHold(*loop) {
-		return nil
+		return false, nil
 	}
-	return drain(ctx, *loop)
+	if err := drain(ctx, *loop); err != nil {
+		return false, err
+	}
+	if afterDrainScopeStopHook != nil {
+		afterDrainScopeStopHook()
+	}
+	return true, nil
+}
+
+// deliverHITLAnswerAfterScopeDrain drains a live scope pair before applying Stop,
+// then reopens sticky spawn gates if that Stop did not remain applied.
+func deliverHITLAnswerAfterScopeDrain(ctx context.Context, repos *storage.Repositories, db *sql.DB, nowISO, loopID, answer string, caps loops.ReviewFixBudgetLiveCaps, drain func(context.Context, storage.LoopRecord) error, executions *ActiveExecutionRegistry) error {
+	drained, err := drainScopeHoldOnStop(ctx, repos, loopID, answer, drain)
+	if err != nil {
+		return err
+	}
+	deliverErr := deliverHITLAnswerToLoopWithCaps(ctx, repos, db, nowISO, loopID, answer, caps, executions)
+	if drained {
+		ReopenUnappliedScopeStopGates(ctx, repos, executions, loopID)
+	}
+	return deliverErr
 }
 
 func drainReviewFixPairExecutions(ctx context.Context, repos *storage.Repositories, loop storage.LoopRecord, executions *ActiveExecutionRegistry) error {
@@ -609,10 +633,10 @@ func githubHITLPRHasRemainingAwaiting(ctx context.Context, repos *storage.Reposi
 // is the exception: only Continue/Stop may unpark, and they apply the budget
 // decision instead of enqueueing conversational text.
 func enqueueHumanMessageToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, text string) error {
-	return enqueueHumanMessageToLoopWithCaps(ctx, repos, nil, nowISO, loopID, text, reviewFixBudgetLiveCaps(nil, ""))
+	return enqueueHumanMessageToLoopWithCaps(ctx, repos, nil, nowISO, loopID, text, reviewFixBudgetLiveCaps(nil, ""), nil)
 }
 
-func enqueueHumanMessageToLoopWithCaps(ctx context.Context, repos *storage.Repositories, db *sql.DB, nowISO, loopID, text string, caps loops.ReviewFixBudgetLiveCaps) error {
+func enqueueHumanMessageToLoopWithCaps(ctx context.Context, repos *storage.Repositories, db *sql.DB, nowISO, loopID, text string, caps loops.ReviewFixBudgetLiveCaps, executions *ActiveExecutionRegistry) error {
 	// Share process-wide requeue exclusion with API discard+retry so free-text
 	// inbox delivery cannot requeue paused/waiting/manual_intervention loops
 	// between discard preflight and git reset (see LockLoopRequeue).
@@ -644,7 +668,7 @@ func enqueueHumanMessageToLoopWithCaps(ctx context.Context, repos *storage.Repos
 	}
 	if loops.IsReviewScopeHumanHold(*loop) {
 		if loops.IsReviewFixBudgetContinue(text) || loops.IsReviewFixBudgetStop(text) {
-			return applyReviewScopeHumanAnswerTX(ctx, db, repos, *loop, text, nowISO)
+			return applyReviewScopeHumanAnswerAndReopen(ctx, db, repos, executions, *loop, text, nowISO)
 		}
 		return nil
 	}
@@ -705,9 +729,10 @@ func applyReviewFixBudgetAnswerTX(ctx context.Context, db *sql.DB, repos *storag
 	return err
 }
 
-func applyReviewScopeHumanAnswerTX(ctx context.Context, db *sql.DB, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string) error {
+func applyReviewScopeHumanAnswerTX(ctx context.Context, db *sql.DB, repos *storage.Repositories, loop storage.LoopRecord, answer, nowISO string) (loops.ReviewScopeHumanAnswerResult, error) {
 	if db != nil {
-		return storage.WithTransaction(ctx, db, nil, func(tx *sql.Tx) error {
+		var result loops.ReviewScopeHumanAnswerResult
+		err := storage.WithTransaction(ctx, db, nil, func(tx *sql.Tx) error {
 			txRepos := storage.NewRepositories(tx)
 			fresh, err := txRepos.Loops.GetByID(ctx, loop.ID)
 			if err != nil {
@@ -716,19 +741,62 @@ func applyReviewScopeHumanAnswerTX(ctx context.Context, db *sql.DB, repos *stora
 			if fresh == nil {
 				return nil
 			}
-			_, err = loops.ApplyReviewScopeHumanAnswer(ctx, txRepos, *fresh, answer, nowISO)
+			result, err = loops.ApplyReviewScopeHumanAnswer(ctx, txRepos, *fresh, answer, nowISO)
 			return err
 		})
+		return result, err
 	}
-	_, err := loops.ApplyReviewScopeHumanAnswer(ctx, repos, loop, answer, nowISO)
-	return err
+	return loops.ApplyReviewScopeHumanAnswer(ctx, repos, loop, answer, nowISO)
+}
+
+func applyReviewScopeHumanAnswerAndReopen(ctx context.Context, db *sql.DB, repos *storage.Repositories, executions *ActiveExecutionRegistry, loop storage.LoopRecord, answer, nowISO string) error {
+	result, err := applyReviewScopeHumanAnswerTX(ctx, db, repos, loop, answer, nowISO)
+	if err != nil {
+		return err
+	}
+	if loops.IsReviewFixBudgetStop(answer) && !result.Applied {
+		ReopenUnappliedScopeStopGates(ctx, repos, executions, loop.ID)
+	}
+	return nil
+}
+
+// ReopenUnappliedScopeStopGates clears sticky pair spawn gates left by a Stop
+// drain when ApplyReviewScopeHumanAnswer did not apply (Continue already
+// released the hold). Terminal members stay gated.
+func ReopenUnappliedScopeStopGates(ctx context.Context, repos *storage.Repositories, executions *ActiveExecutionRegistry, loopID string) {
+	if executions == nil || repos == nil || repos.Loops == nil || strings.TrimSpace(loopID) == "" {
+		return
+	}
+	loop, err := repos.Loops.GetByID(ctx, loopID)
+	if err != nil || loop == nil {
+		return
+	}
+	if loops.IsReviewScopeHumanHold(*loop) {
+		return
+	}
+	members := []storage.LoopRecord{*loop}
+	if all, listErr := repos.Loops.List(ctx); listErr == nil {
+		members = append(loops.FindSiblingReviewFixLoops(all, *loop), *loop)
+	}
+	seen := make(map[string]struct{}, len(members))
+	for _, member := range members {
+		if _, ok := seen[member.ID]; ok {
+			continue
+		}
+		seen[member.ID] = struct{}{}
+		switch strings.TrimSpace(member.Status) {
+		case "terminated", "stopped", "completed":
+			continue
+		}
+		executions.ClearLoopStop(member.ID)
+	}
 }
 
 func deliverHITLAnswerToLoop(ctx context.Context, repos *storage.Repositories, nowISO, loopID, answer string) error {
-	return deliverHITLAnswerToLoopWithCaps(ctx, repos, nil, nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""))
+	return deliverHITLAnswerToLoopWithCaps(ctx, repos, nil, nowISO, loopID, answer, reviewFixBudgetLiveCaps(nil, ""), nil)
 }
 
-func deliverHITLAnswerToLoopWithCaps(ctx context.Context, repos *storage.Repositories, db *sql.DB, nowISO, loopID, answer string, caps loops.ReviewFixBudgetLiveCaps) error {
+func deliverHITLAnswerToLoopWithCaps(ctx context.Context, repos *storage.Repositories, db *sql.DB, nowISO, loopID, answer string, caps loops.ReviewFixBudgetLiveCaps, executions *ActiveExecutionRegistry) error {
 	// Same requeue + target exclusion as free-text enqueue / API discard+retry.
 	unlock := LockLoopRequeue(loopID)
 	defer unlock()
@@ -747,7 +815,7 @@ func deliverHITLAnswerToLoopWithCaps(ctx context.Context, repos *storage.Reposit
 		return applyReviewFixBudgetAnswerTX(ctx, db, repos, *loop, answer, nowISO, caps)
 	}
 	if loops.IsReviewScopeHumanHold(*loop) {
-		return applyReviewScopeHumanAnswerTX(ctx, db, repos, *loop, answer, nowISO)
+		return applyReviewScopeHumanAnswerAndReopen(ctx, db, repos, executions, *loop, answer, nowISO)
 	}
 	if loop.Status != "awaiting_human" {
 		return nil
@@ -883,10 +951,7 @@ func runGitHubHITLPoll(ctx context.Context, input defaultSchedulerTickInput, pro
 			return out, nil
 		},
 		deliverAnswer: func(ctx contextType, loopID, answer string) error {
-			if err := drainScopeHoldOnStop(ctx, input.Repos, loopID, answer, input.DrainHITLPair); err != nil {
-				return err
-			}
-			return deliverHITLAnswerToLoopWithCaps(ctx, input.Repos, input.DB, nowISO, loopID, answer, reviewFixBudgetLiveCaps(input.Config, project.ID))
+			return deliverHITLAnswerAfterScopeDrain(ctx, input.Repos, input.DB, nowISO, loopID, answer, reviewFixBudgetLiveCaps(input.Config, project.ID), input.DrainHITLPair, input.ActiveExecutions)
 		},
 		clearAwaiting: func(ctx contextType, repo string, pr int64, cwd string) {
 			_ = gw.RemovePullRequestLabels(ctx, githubinfra.PullRequestLabelsInput{Repo: repo, PRNumber: pr, Labels: []string{awaitingLabel}, CWD: cwd})

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -1738,6 +1738,113 @@ func TestScopeStopReopensGatesWhenContinueWinsAfterDrain(t *testing.T) {
 	}
 }
 
+func TestGitHubScopeAskDeliveryDoesNotClobberContinueOrStop(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		race          string
+		wantDelivered int
+		wantStatus    string
+		wantHold      bool
+		wantCommentID int64
+	}{
+		{name: "no_race", wantDelivered: 1, wantStatus: "awaiting_human", wantHold: true, wantCommentID: 9201},
+		{name: "continue", race: loops.ReviewFixBudgetAnswerContinue, wantDelivered: 0, wantStatus: "queued", wantHold: false},
+		{name: "stop", race: loops.ReviewFixBudgetAnswerStop, wantDelivered: 0, wantStatus: "terminated", wantHold: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+			nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+			coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+				Now: func() time.Time { return now },
+			})
+			if err != nil {
+				t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+			}
+			t.Cleanup(func() { _ = coordinator.Close() })
+			if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+				t.Fatalf("RunPending() error = %v", err)
+			}
+			repos := storage.NewRepositories(coordinator.DB())
+			projectID := "project_scope_github_delivery_" + tc.name
+			if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+				ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}); err != nil {
+				t.Fatalf("Projects.Upsert() error = %v", err)
+			}
+			repo := "acme/looper"
+			pr := int64(42)
+			target := "pr:acme/looper:42"
+			reviewer := storage.LoopRecord{
+				ID: "loop_scope_gh_delivery_rev_" + tc.name, Seq: 301, ProjectID: projectID, Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			fixer := storage.LoopRecord{
+				ID: "loop_scope_gh_delivery_fix_" + tc.name, Seq: 302, ProjectID: projectID, Type: "fixer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "queued", CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+				t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+			}
+			if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+				t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+			}
+			seedPollBudgetQueue(t, repos, nowISO, projectID, "queue_scope_gh_rev_"+tc.name, reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+			seedPollBudgetQueue(t, repos, nowISO, projectID, "queue_scope_gh_fix_"+tc.name, fixer.ID, "fixer", storage.QueuePriorityFixer)
+			if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+				Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+				Question: "Clarify AGENTS.md rule X before unpause",
+			}); err != nil {
+				t.Fatalf("ParkReviewScopeHuman: %v", err)
+			}
+			all, err := repos.Loops.List(context.Background())
+			if err != nil {
+				t.Fatalf("Loops.List() error = %v", err)
+			}
+			delivered := deliverUndeliveredGitHubBudgetAsks(context.Background(), projectID, all, repos, githubHITLDeliveryDeps{
+				createComment: func(ctx contextType, _ string, _ int64, _ string, _ string) (int64, error) {
+					if tc.race != "" {
+						fresh, err := repos.Loops.GetByID(ctx, reviewer.ID)
+						if err != nil || fresh == nil {
+							t.Fatalf("GetByID during createComment = (%#v, %v)", fresh, err)
+						}
+						if _, err := loops.ApplyReviewScopeHumanAnswer(ctx, repos, *fresh, tc.race, nowISO); err != nil {
+							t.Fatalf("ApplyReviewScopeHumanAnswer(%s): %v", tc.race, err)
+						}
+					}
+					return 9201, nil
+				},
+				nowISO: nowISO,
+			})
+			if delivered != tc.wantDelivered {
+				t.Fatalf("deliverUndeliveredGitHubBudgetAsks() = %d, want %d", delivered, tc.wantDelivered)
+			}
+			fresh, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+			if err != nil || fresh == nil {
+				t.Fatalf("Loops.GetByID(reviewer) = (%#v, %v)", fresh, err)
+			}
+			if fresh.Status != tc.wantStatus {
+				t.Fatalf("reviewer status = %s, want %s meta=%s", fresh.Status, tc.wantStatus, derefString(fresh.MetadataJSON))
+			}
+			if loops.IsReviewScopeHumanHold(*fresh) != tc.wantHold {
+				t.Fatalf("reviewer hold = %v, want %v meta=%s", loops.IsReviewScopeHumanHold(*fresh), tc.wantHold, derefString(fresh.MetadataJSON))
+			}
+			ask, ok := loops.ReadHITLAsk(fresh.MetadataJSON)
+			if tc.wantHold {
+				if !ok || !loops.IsReviewScopeHumanAsk(ask) || ask.Transport != "github" || ask.AskCommentID != tc.wantCommentID {
+					t.Fatalf("delivered scope ask = (%#v, %v), want github comment %d", ask, ok, tc.wantCommentID)
+				}
+				return
+			}
+			if ok && loops.IsReviewScopeHumanAsk(ask) {
+				t.Fatalf("stale persist restored scope ask after %s: %#v", tc.race, ask)
+			}
+		})
+	}
+}
+
 func seedPollBudgetQueue(t *testing.T, repos *storage.Repositories, nowISO, projectID, id, loopID, queueType string, priority int64) {
 	t.Helper()
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -119,6 +119,119 @@ func TestGitHubHITLDecisionOnlyAskIncludesScopeOverlay(t *testing.T) {
 	}
 }
 
+func TestPollGitHubHITLAnswersOnceScopeOverlaySkipsUnrelatedComments(t *testing.T) {
+	comments := []githubAnswerComment{
+		{ID: 8001, Author: "looper", Body: "<!-- looper:hitl:ask --> Which approach?"},
+		{ID: 8002, Author: "operator", Body: "unrelated discussion about the PR"},
+		{ID: 8003, Author: "operator", Body: "Continue"},
+	}
+	agentAsk := loops.HITLAsk{
+		Status: "awaiting", Transport: "github", PRNumber: 42, AskCommentID: 8001,
+		Question: "unrelated agent question on the sibling",
+	}
+	meta, err := loops.WriteHITLAsk(nil, agentAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk: %v", err)
+	}
+	meta, err = loops.WriteReviewScopeHumanState(&meta, loops.ReviewScopeHumanState{
+		HeldBy: "reviewer", PauseReason: loops.ReviewScopeHumanSiblingPauseReason,
+		Question: "Clarify AGENTS.md vs PR non-goals before continue.",
+	})
+	if err != nil {
+		t.Fatalf("WriteReviewScopeHumanState: %v", err)
+	}
+	loop := storage.LoopRecord{ID: "loop_overlay_poll", Status: "awaiting_human", MetadataJSON: &meta}
+	ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
+	if !ok {
+		t.Fatal("want preserved agent ask")
+	}
+	var delivered []string
+	deps := githubHITLPollDeps{
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return comments, nil
+		},
+		deliverAnswer: func(_ contextType, loopID, answer string) error {
+			delivered = append(delivered, loopID+"="+answer)
+			return nil
+		},
+	}
+	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		{ID: loop.ID, Repo: "acme/x", Transport: "github", AskStatus: "awaiting", PRNumber: 42, AskCommentID: 8001, BudgetAsk: githubHITLDecisionOnlyAsk(loop, ask)},
+	}, deps)
+	if n != 1 || len(delivered) != 1 || delivered[0] != loop.ID+"=Continue" {
+		t.Fatalf("delivered = %#v n=%d, want Continue after skipping overlay chatter", delivered, n)
+	}
+}
+
+func TestDrainScopeHoldOnStopDrainsPairBeforeScopeStop(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_stop_drain"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_scope_drain_reviewer", Seq: 21, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_scope_drain_fixer", Seq: 22, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	parked, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	reg := NewActiveExecutionRegistry()
+	var drained []string
+	drain := func(ctx context.Context, loop storage.LoopRecord) error {
+		drained = append(drained, loop.ID)
+		return drainReviewFixPairExecutions(ctx, repos, loop, reg)
+	}
+	if err := drainScopeHoldOnStop(context.Background(), repos, parked.ID, "Continue", drain); err != nil {
+		t.Fatalf("Continue drain: %v", err)
+	}
+	if len(drained) != 0 {
+		t.Fatalf("Continue drained = %v, want none", drained)
+	}
+	if err := drainScopeHoldOnStop(context.Background(), repos, parked.ID, "Stop", drain); err != nil {
+		t.Fatalf("Stop drain: %v", err)
+	}
+	if len(drained) != 1 || drained[0] != parked.ID {
+		t.Fatalf("Stop drained = %v, want [%s]", drained, parked.ID)
+	}
+	if !reg.LoopStopActive(reviewer.ID) || !reg.LoopStopActive(fixer.ID) {
+		t.Fatal("pair stop gates not closed after scope Stop drain")
+	}
+}
 
 func TestPollGitHubHITLAnswersOnce(t *testing.T) {
 	commentsByPR := map[int64][]githubAnswerComment{

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -91,6 +91,34 @@ func TestPollGitHubHITLAnswersOnceScopeAskSkipsUnrelatedComments(t *testing.T) {
 	}
 }
 
+func TestPollGitHubHITLAnswersOnceAcceptsContinueAndStopForOrdinaryAsk(t *testing.T) {
+	t.Parallel()
+	for _, answer := range []string{"Continue", "Stop"} {
+		t.Run(answer, func(t *testing.T) {
+			comments := []githubAnswerComment{
+				{ID: 9001, Author: "looper", Body: "<!-- looper:hitl:ask --> Which approach should we take?"},
+				{ID: 9002, Author: "operator", Body: answer},
+			}
+			var delivered []string
+			deps := githubHITLPollDeps{
+				listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+					return comments, nil
+				},
+				deliverAnswer: func(_ contextType, loopID, got string) error {
+					delivered = append(delivered, loopID+"="+got)
+					return nil
+				},
+			}
+			n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+				{ID: "loop-ordinary", Repo: "acme/x", Transport: "github", AskStatus: "awaiting", PRNumber: 42, AskCommentID: 9001, BudgetAsk: false},
+			}, deps)
+			if n != 1 || len(delivered) != 1 || delivered[0] != "loop-ordinary="+answer {
+				t.Fatalf("delivered = %#v n=%d, want %s for ordinary GitHub ask", delivered, n, answer)
+			}
+		})
+	}
+}
+
 func TestGitHubHITLDecisionOnlyAskIncludesScopeOverlay(t *testing.T) {
 	t.Parallel()
 	agentAsk := loops.HITLAsk{
@@ -383,8 +411,8 @@ func TestPollGitHubHITLAnswersOnceDoesNotReuseScopeContinueOnSecondPass(t *testi
 			delivered = append(delivered, loopID+"="+answer)
 			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
 		},
-		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64) error {
-			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID)
+		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error {
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID, comments)
 		},
 		remainingAwaiting: func(ctx contextType, repo string, pr int64) bool {
 			return githubHITLPRHasRemainingAwaiting(ctx, repos, projectID, repo, pr)
@@ -415,6 +443,124 @@ func TestPollGitHubHITLAnswersOnceDoesNotReuseScopeContinueOnSecondPass(t *testi
 	}, deps)
 	if second != 1 || len(delivered) != 2 || delivered[1] != fixer.ID+"=use approach A" {
 		t.Fatalf("second pass delivered = %#v n=%d, want earlier agent answer not Continue", delivered, second)
+	}
+}
+
+func TestPollGitHubHITLAnswersOnceDoesNotReuseConsumedContinueWithoutEarlierText(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_continue_only"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_scope_continue_only_reviewer", Seq: 51, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_scope_continue_only_fixer", Seq: 52, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	agentAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+		Transport: "github", PRNumber: pr, AskCommentID: 8002,
+	}
+	fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(fixer): %v", err)
+	}
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md vs PR non-goals before continue.",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	reviewer = stampGitHubHITLAsk(t, repos, reviewer.ID, 8001)
+	fixer = stampGitHubHITLAsk(t, repos, fixer.ID, 8002)
+	reviewerAsk, ok := loops.ReadHITLAsk(reviewer.MetadataJSON)
+	if !ok || !loops.IsReviewScopeHumanAsk(reviewerAsk) {
+		t.Fatalf("reviewer ask = (%#v, %v), want scope ask", reviewerAsk, ok)
+	}
+	fixerAsk, ok := loops.ReadHITLAsk(fixer.MetadataJSON)
+	if !ok || loops.IsReviewScopeHumanAsk(fixerAsk) {
+		t.Fatalf("fixer ask = (%#v, %v), want preserved agent ask", fixerAsk, ok)
+	}
+
+	comments := []githubAnswerComment{
+		{ID: 8001, Author: "looper", Body: "<!-- looper:hitl:ask --> Clarify AGENTS.md?"},
+		{ID: 8002, Author: "looper", Body: "<!-- looper:hitl:ask --> Which approach?"},
+		{ID: 8004, Author: "operator", Body: "Continue"},
+	}
+	var delivered []string
+	deps := githubHITLPollDeps{
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return comments, nil
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			delivered = append(delivered, loopID+"="+answer)
+			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+		},
+		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error {
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID, comments)
+		},
+		remainingAwaiting: func(ctx contextType, repo string, pr int64) bool {
+			return githubHITLPRHasRemainingAwaiting(ctx, repos, projectID, repo, pr)
+		},
+	}
+	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		githubHITLAwaitingFrom(reviewer, reviewerAsk),
+		githubHITLAwaitingFrom(fixer, fixerAsk),
+	}, deps)
+	if n != 1 || len(delivered) != 1 || delivered[0] != reviewer.ID+"=Continue" {
+		t.Fatalf("first pass delivered = %#v n=%d, want reviewer Continue", delivered, n)
+	}
+
+	freshFixer, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || freshFixer == nil || freshFixer.Status != "awaiting_human" || loops.IsReviewScopeHumanHold(*freshFixer) {
+		t.Fatalf("fixer after first pass = (%#v, %v), want awaiting preserved ask", freshFixer, err)
+	}
+	remaining, ok := loops.ReadHITLAsk(freshFixer.MetadataJSON)
+	if !ok || remaining.Status != "awaiting" || remaining.Question != agentAsk.Question || remaining.Answer != "" {
+		t.Fatalf("fixer ask after first pass = (%#v, %v), want unanswered agent question", remaining, ok)
+	}
+	if remaining.AskCommentID != 8004 {
+		t.Fatalf("fixer AskCommentID = %d, want consumed Continue 8004 so it cannot answer the ordinary ask", remaining.AskCommentID)
+	}
+
+	second := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		githubHITLAwaitingFrom(*freshFixer, remaining),
+	}, deps)
+	if second != 0 || len(delivered) != 1 {
+		t.Fatalf("second pass delivered = %#v n=%d, want no reuse of consumed Continue", delivered, second)
 	}
 }
 
@@ -561,8 +707,8 @@ func TestPollGitHubHITLAnswersOnceLimitsConsumedDecisionToPairLane(t *testing.T)
 			delivered = append(delivered, loopID+"="+answer)
 			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
 		},
-		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64) error {
-			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID)
+		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error {
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID, comments)
 		},
 	})
 	if n != 3 {

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -56,6 +56,39 @@ func TestDetectGitHubHITLAnswerSkipsUnrelatedBudgetComments(t *testing.T) {
 	}
 }
 
+func TestPollGitHubHITLAnswersOnceScopeAskSkipsUnrelatedComments(t *testing.T) {
+	// Scope asks must use Continue/Stop-only filtering (same as budget asks).
+	comments := []githubAnswerComment{
+		{ID: 8001, Author: "looper", Body: "<!-- looper:hitl:ask --> Clarify AGENTS.md before unpause"},
+		{ID: 8002, Author: "operator", Body: "unrelated discussion about the PR"},
+		{ID: 8003, Author: "operator", Body: "Continue"},
+	}
+	var delivered []string
+	deps := githubHITLPollDeps{
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return comments, nil
+		},
+		deliverAnswer: func(_ contextType, loopID, answer string) error {
+			delivered = append(delivered, loopID+"="+answer)
+			return nil
+		},
+	}
+	// BudgetAsk=true is set for scope asks at the poll assembly site.
+	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		{ID: "loop-scope", Repo: "acme/x", Transport: "github", AskStatus: "awaiting", PRNumber: 42, AskCommentID: 8001, BudgetAsk: true},
+	}, deps)
+	if n != 1 || len(delivered) != 1 || delivered[0] != "loop-scope=Continue" {
+		t.Fatalf("delivered = %#v n=%d, want only Continue for scope ask", delivered, n)
+	}
+	// Without BudgetAsk filtering, the unrelated comment would win.
+	n = pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		{ID: "loop-scope-open", Repo: "acme/x", Transport: "github", AskStatus: "awaiting", PRNumber: 42, AskCommentID: 8001, BudgetAsk: false},
+	}, deps)
+	if n != 1 || len(delivered) != 2 || delivered[1] != "loop-scope-open=unrelated discussion about the PR" {
+		t.Fatalf("open ask delivered = %#v n=%d, want earliest unrelated comment", delivered, n)
+	}
+}
+
 func TestPollGitHubHITLAnswersOnce(t *testing.T) {
 	commentsByPR := map[int64][]githubAnswerComment{
 		42: {{ID: 500, Author: "lefarcen", Body: "<!-- looper:hitl:ask --> ask"}, {ID: 501, Author: "lefarcen", Body: "go with A"}},

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -1845,6 +1845,139 @@ func TestGitHubScopeAskDeliveryDoesNotClobberContinueOrStop(t *testing.T) {
 	}
 }
 
+func TestAdvanceSiblingGitHubHITLAskDoesNotRestoreReleasedOverlay(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		race       string
+		wantStatus string
+		wantHold   bool
+		wantCursor int64
+	}{
+		{name: "no_race", wantStatus: "awaiting_human", wantHold: true, wantCursor: 8004},
+		{name: "api_continue", race: loops.ReviewFixBudgetAnswerContinue, wantStatus: "awaiting_human", wantHold: false, wantCursor: 8004},
+		{name: "feishu_stop", race: loops.ReviewFixBudgetAnswerStop, wantStatus: "terminated", wantHold: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+			nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+			coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+				Now: func() time.Time { return now },
+			})
+			if err != nil {
+				t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+			}
+			t.Cleanup(func() { _ = coordinator.Close() })
+			if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+				t.Fatalf("RunPending() error = %v", err)
+			}
+			repos := storage.NewRepositories(coordinator.DB())
+			projectID := "project_scope_gh_cursor_" + tc.name
+			if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+				ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}); err != nil {
+				t.Fatalf("Projects.Upsert() error = %v", err)
+			}
+			repo := "acme/looper"
+			pr := int64(42)
+			target := "pr:acme/looper:42"
+			reviewer := storage.LoopRecord{
+				ID: "loop_scope_gh_cursor_rev_" + tc.name, Seq: 311, ProjectID: projectID, Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			fixer := storage.LoopRecord{
+				ID: "loop_scope_gh_cursor_fix_" + tc.name, Seq: 312, ProjectID: projectID, Type: "fixer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			agentAsk := loops.HITLAsk{
+				Kind: "agent_question", Question: "Which approach should Fixer take?",
+				Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+				Transport: "github", PRNumber: pr, AskCommentID: 8002,
+			}
+			fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+			if err != nil {
+				t.Fatalf("WriteHITLAsk(fixer): %v", err)
+			}
+			fixer.MetadataJSON = &fixerMeta
+			if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+				t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+			}
+			if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+				t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+			}
+			seedPollBudgetQueue(t, repos, nowISO, projectID, "queue_scope_gh_cursor_rev_"+tc.name, reviewer.ID, "reviewer", storage.QueuePriorityReviewer)
+			if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+				Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr,
+				NowISO: nowISO, HITLEnabled: true,
+				Question: "Clarify AGENTS.md vs PR non-goals before continue.",
+			}); err != nil {
+				t.Fatalf("ParkReviewScopeHuman: %v", err)
+			}
+			reviewer = stampGitHubHITLAsk(t, repos, reviewer.ID, 8001)
+			fixer = stampGitHubHITLAsk(t, repos, fixer.ID, 8002)
+			if !loops.IsReviewScopeHumanHold(fixer) {
+				t.Fatal("precondition: fixer must carry scope overlay")
+			}
+			comments := []githubAnswerComment{
+				{ID: 8001, Author: "looper", Body: "<!-- looper:hitl:ask --> Clarify AGENTS.md?"},
+				{ID: 8002, Author: "looper", Body: "<!-- looper:hitl:ask --> Which approach?"},
+				{ID: 8004, Author: "operator", Body: "Continue"},
+			}
+			afterAdvanceSiblingGitHubAskListHook = func() {
+				if tc.race == "" {
+					return
+				}
+				fresh, getErr := repos.Loops.GetByID(context.Background(), reviewer.ID)
+				if getErr != nil || fresh == nil {
+					t.Errorf("hook GetByID = (%v, %v)", fresh, getErr)
+					return
+				}
+				if tc.name == "feishu_stop" {
+					if err := deliverHITLAnswerToLoopWithCaps(context.Background(), repos, coordinator.DB(), nowISO, fresh.ID, tc.race, reviewFixBudgetLiveCaps(nil, ""), nil); err != nil {
+						t.Errorf("racing Feishu Stop: %v", err)
+					}
+					return
+				}
+				if _, err := loops.ApplyReviewScopeHumanAnswer(context.Background(), repos, *fresh, tc.race, nowISO); err != nil {
+					t.Errorf("racing API Continue: %v", err)
+				}
+			}
+			t.Cleanup(func() { afterAdvanceSiblingGitHubAskListHook = nil })
+			if err := advanceSiblingGitHubHITLAsksPastComment(context.Background(), repos, projectID, repo, pr, reviewer.ID, 8004, comments, nil); err != nil {
+				t.Fatalf("advanceSiblingGitHubHITLAsksPastComment: %v", err)
+			}
+			freshFixer, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+			if err != nil || freshFixer == nil {
+				t.Fatalf("Loops.GetByID(fixer) = (%#v, %v)", freshFixer, err)
+			}
+			if freshFixer.Status != tc.wantStatus {
+				t.Fatalf("fixer status = %s, want %s meta=%s", freshFixer.Status, tc.wantStatus, derefString(freshFixer.MetadataJSON))
+			}
+			if loops.IsReviewScopeHumanHold(*freshFixer) != tc.wantHold {
+				t.Fatalf("fixer hold = %v, want %v meta=%s", loops.IsReviewScopeHumanHold(*freshFixer), tc.wantHold, derefString(freshFixer.MetadataJSON))
+			}
+			ask, ok := loops.ReadHITLAsk(freshFixer.MetadataJSON)
+			if tc.wantHold {
+				if !ok || ask.Question != agentAsk.Question || ask.AskCommentID != tc.wantCursor {
+					t.Fatalf("overlay ask = (%#v, %v), want cursor %d", ask, ok, tc.wantCursor)
+				}
+				return
+			}
+			if tc.wantStatus == "terminated" {
+				if ok {
+					t.Fatalf("terminated fixer still has HITL ask after Stop: %#v", ask)
+				}
+				return
+			}
+			if !ok || ask.Question != agentAsk.Question || ask.Answer != "" || ask.AskCommentID != tc.wantCursor {
+				t.Fatalf("released overlay ask = (%#v, %v), want unanswered agent cursor %d", ask, ok, tc.wantCursor)
+			}
+		})
+	}
+}
+
 func seedPollBudgetQueue(t *testing.T, repos *storage.Repositories, nowISO, projectID, id, loopID, queueType string, priority int64) {
 	t.Helper()
 	if err := repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nexu-io/looper/internal/agent"
 	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 )
@@ -1093,13 +1094,13 @@ func TestDrainScopeHoldOnStopDrainsPairBeforeScopeStop(t *testing.T) {
 		drained = append(drained, loop.ID)
 		return drainReviewFixPairExecutions(ctx, repos, loop, reg)
 	}
-	if err := drainScopeHoldOnStop(context.Background(), repos, parked.ID, "Continue", drain); err != nil {
+	if _, err := drainScopeHoldOnStop(context.Background(), repos, parked.ID, "Continue", drain); err != nil {
 		t.Fatalf("Continue drain: %v", err)
 	}
 	if len(drained) != 0 {
 		t.Fatalf("Continue drained = %v, want none", drained)
 	}
-	if err := drainScopeHoldOnStop(context.Background(), repos, parked.ID, "Stop", drain); err != nil {
+	if _, err := drainScopeHoldOnStop(context.Background(), repos, parked.ID, "Stop", drain); err != nil {
 		t.Fatalf("Stop drain: %v", err)
 	}
 	if len(drained) != 1 || drained[0] != parked.ID {
@@ -1641,6 +1642,99 @@ func TestGitHubHITLPollDeliversAndStopsReviewFixBudget(t *testing.T) {
 	sibling, err := repos.Loops.GetByID(context.Background(), fixer.ID)
 	if err != nil || sibling == nil || sibling.Status != "terminated" {
 		t.Fatalf("fixer after stop = (%#v, %v), want terminated", sibling, err)
+	}
+}
+
+func TestScopeStopReopensGatesWhenContinueWinsAfterDrain(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_stop_continue_race"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_scope_race_reviewer", Seq: 31, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_scope_race_fixer", Seq: 32, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	parked, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr, NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md rule X before unpause",
+	})
+	if err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	reg := NewActiveExecutionRegistry()
+	drain := func(ctx context.Context, loop storage.LoopRecord) error {
+		return drainReviewFixPairExecutions(ctx, repos, loop, reg)
+	}
+	afterDrainScopeStopHook = func() {
+		fresh, getErr := repos.Loops.GetByID(context.Background(), parked.ID)
+		if getErr != nil || fresh == nil {
+			t.Errorf("hook GetByID: (%v, %v)", fresh, getErr)
+			return
+		}
+		if _, applyErr := loops.ApplyReviewScopeHumanAnswer(context.Background(), repos, *fresh, "Continue", nowISO); applyErr != nil {
+			t.Errorf("racing Continue: %v", applyErr)
+			return
+		}
+		if !reg.LoopStopActive(reviewer.ID) || !reg.LoopStopActive(fixer.ID) {
+			t.Error("pair stop gates not closed after drain and racing Continue")
+		}
+	}
+	t.Cleanup(func() { afterDrainScopeStopHook = nil })
+
+	if err := deliverHITLAnswerAfterScopeDrain(context.Background(), repos, coordinator.DB(), nowISO, parked.ID, "Stop", reviewFixBudgetLiveCaps(nil, ""), drain, reg); err != nil {
+		t.Fatalf("unapplied Stop deliver: %v", err)
+	}
+	if reg.LoopStopActive(reviewer.ID) || reg.LoopStopActive(fixer.ID) {
+		t.Fatal("pair stop gates still closed after unapplied Stop")
+	}
+	if _, err := reg.AdmitSpawn(context.Background(), agent.SpawnMeta{
+		LoopID: reviewer.ID, RunID: "run_scope_continue", ExecutionID: "exec_scope_continue_rev",
+	}); err != nil {
+		t.Fatalf("AdmitSpawn reviewer after unapplied Stop: %v", err)
+	}
+	if _, err := reg.AdmitSpawn(context.Background(), agent.SpawnMeta{
+		LoopID: fixer.ID, RunID: "run_scope_continue", ExecutionID: "exec_scope_continue_fix",
+	}); err != nil {
+		t.Fatalf("AdmitSpawn fixer after unapplied Stop: %v", err)
+	}
+	freshReviewer, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+	if err != nil || freshReviewer == nil || freshReviewer.Status != "queued" || loops.IsReviewScopeHumanHold(*freshReviewer) {
+		t.Fatalf("reviewer after Continue-wins Stop = (%#v, %v), want queued without hold", freshReviewer, err)
+	}
+	freshFixer, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || freshFixer == nil || freshFixer.Status == "terminated" || loops.IsReviewScopeHumanHold(*freshFixer) {
+		t.Fatalf("fixer after Continue-wins Stop = (%#v, %v), want released pair member", freshFixer, err)
 	}
 }
 

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -248,16 +248,8 @@ func TestPollGitHubHITLAnswersOnceConsumesOneScopeDecisionPerPair(t *testing.T) 
 				t.Fatal("both pair members must snapshot as decision-only")
 			}
 
-			primary := githubHITLAwaitingLoop{
-				ID: reviewer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
-				AskStatus: reviewerAsk.Status, PRNumber: pr, AskCommentID: reviewerAsk.AskCommentID,
-				BudgetAsk: githubHITLDecisionOnlyAsk(reviewer, reviewerAsk),
-			}
-			overlay := githubHITLAwaitingLoop{
-				ID: fixer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
-				AskStatus: fixerAsk.Status, PRNumber: pr, AskCommentID: fixerAsk.AskCommentID,
-				BudgetAsk: githubHITLDecisionOnlyAsk(fixer, fixerAsk),
-			}
+			primary := githubHITLAwaitingFrom(reviewer, reviewerAsk)
+			overlay := githubHITLAwaitingFrom(fixer, fixerAsk)
 			awaiting := []githubHITLAwaitingLoop{primary, overlay}
 			if tc.siblingFirst {
 				awaiting = []githubHITLAwaitingLoop{overlay, primary}
@@ -398,16 +390,8 @@ func TestPollGitHubHITLAnswersOnceDoesNotReuseScopeContinueOnSecondPass(t *testi
 		},
 	}
 	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
-		{
-			ID: reviewer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
-			AskStatus: reviewerAsk.Status, PRNumber: pr, AskCommentID: reviewerAsk.AskCommentID,
-			BudgetAsk: githubHITLDecisionOnlyAsk(reviewer, reviewerAsk),
-		},
-		{
-			ID: fixer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
-			AskStatus: fixerAsk.Status, PRNumber: pr, AskCommentID: fixerAsk.AskCommentID,
-			BudgetAsk: githubHITLDecisionOnlyAsk(fixer, fixerAsk),
-		},
+		githubHITLAwaitingFrom(reviewer, reviewerAsk),
+		githubHITLAwaitingFrom(fixer, fixerAsk),
 	}, deps)
 	if n != 1 || len(delivered) != 1 || delivered[0] != reviewer.ID+"=Continue" {
 		t.Fatalf("first pass delivered = %#v n=%d, want reviewer Continue", delivered, n)
@@ -425,23 +409,199 @@ func TestPollGitHubHITLAnswersOnceDoesNotReuseScopeContinueOnSecondPass(t *testi
 		t.Fatalf("fixer AskCommentID = %d, want advanced past Continue comment 8003", remaining.AskCommentID)
 	}
 
-	second := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{{
-		ID: freshFixer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
-		AskStatus: remaining.Status, PRNumber: pr, AskCommentID: remaining.AskCommentID,
-		BudgetAsk: githubHITLDecisionOnlyAsk(*freshFixer, remaining),
-	}}, deps)
+	second := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		githubHITLAwaitingFrom(*freshFixer, remaining),
+	}, deps)
 	if second != 0 || len(delivered) != 1 {
 		t.Fatalf("second pass delivered = %#v n=%d, want no reuse of Continue", delivered, second)
 	}
 
 	comments = append(comments, githubAnswerComment{ID: 8004, Author: "operator", Body: "use approach A"})
-	third := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{{
-		ID: freshFixer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
-		AskStatus: remaining.Status, PRNumber: pr, AskCommentID: remaining.AskCommentID,
-		BudgetAsk: githubHITLDecisionOnlyAsk(*freshFixer, remaining),
-	}}, deps)
+	third := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		githubHITLAwaitingFrom(*freshFixer, remaining),
+	}, deps)
 	if third != 1 || len(delivered) != 2 || delivered[1] != fixer.ID+"=use approach A" {
 		t.Fatalf("third pass delivered = %#v n=%d, want later agent answer", delivered, third)
+	}
+}
+
+func TestPollGitHubHITLAnswersOnceLimitsConsumedDecisionToPairLane(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_multi_lane"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	autoReviewer := storage.LoopRecord{
+		ID: "loop_multi_lane_auto_rev", Seq: 51, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	autoFixer := storage.LoopRecord{
+		ID: "loop_multi_lane_auto_fix", Seq: 52, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	autoAgentAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which automatic approach?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+		Transport: "github", PRNumber: pr, AskCommentID: 8002,
+	}
+	autoFixerMeta, err := loops.WriteHITLAsk(nil, autoAgentAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(auto fixer): %v", err)
+	}
+	autoFixer.MetadataJSON = &autoFixerMeta
+	contMeta := `{"manual":true,"followUpdates":true}`
+	contAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which continuous-manual approach?",
+		Options: []string{"C", "D"}, Status: "awaiting", AskedAt: nowISO,
+		Transport: "github", PRNumber: pr, AskCommentID: 8003,
+	}
+	contAskMeta, err := loops.WriteHITLAsk(&contMeta, contAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(continuous fixer): %v", err)
+	}
+	contFixer := storage.LoopRecord{
+		ID: "loop_multi_lane_cont_fix", Seq: 53, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &contAskMeta,
+	}
+	oneShotMeta := `{"manual":true,"followUpdates":false}`
+	oneShotAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which one-shot approach?",
+		Options: []string{"E", "F"}, Status: "awaiting", AskedAt: nowISO,
+		Transport: "github", PRNumber: pr, AskCommentID: 8005,
+	}
+	oneShotAskMeta, err := loops.WriteHITLAsk(&oneShotMeta, oneShotAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(one-shot fixer): %v", err)
+	}
+	oneShotFixer := storage.LoopRecord{
+		ID: "loop_multi_lane_oneshot_fix", Seq: 54, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO, MetadataJSON: &oneShotAskMeta,
+	}
+	for _, loop := range []storage.LoopRecord{autoReviewer, autoFixer, contFixer, oneShotFixer} {
+		if err := repos.Loops.Upsert(context.Background(), loop); err != nil {
+			t.Fatalf("Loops.Upsert(%s) error = %v", loop.ID, err)
+		}
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: autoReviewer, Role: "reviewer", Repo: repo, PRNumber: pr,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md vs PR non-goals before continue.",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	autoReviewer = stampGitHubHITLAsk(t, repos, autoReviewer.ID, 8001)
+	autoFixer = stampGitHubHITLAsk(t, repos, autoFixer.ID, 8002)
+	contFixer = stampGitHubHITLAsk(t, repos, contFixer.ID, 8003)
+	oneShotFixer = stampGitHubHITLAsk(t, repos, oneShotFixer.ID, 8005)
+	autoReviewerAsk, ok := loops.ReadHITLAsk(autoReviewer.MetadataJSON)
+	if !ok || !loops.IsReviewScopeHumanAsk(autoReviewerAsk) {
+		t.Fatalf("auto reviewer ask = (%#v, %v), want scope ask", autoReviewerAsk, ok)
+	}
+	autoFixerAsk, ok := loops.ReadHITLAsk(autoFixer.MetadataJSON)
+	if !ok || loops.IsReviewScopeHumanAsk(autoFixerAsk) {
+		t.Fatalf("auto fixer ask = (%#v, %v), want preserved agent ask", autoFixerAsk, ok)
+	}
+	contAsk, ok = loops.ReadHITLAsk(contFixer.MetadataJSON)
+	if !ok || contAsk.Question != "Which continuous-manual approach?" {
+		t.Fatalf("continuous ask = (%#v, %v)", contAsk, ok)
+	}
+	oneShotAsk, ok = loops.ReadHITLAsk(oneShotFixer.MetadataJSON)
+	if !ok || oneShotAsk.Question != "Which one-shot approach?" {
+		t.Fatalf("one-shot ask = (%#v, %v)", oneShotAsk, ok)
+	}
+	if loops.ReviewFixBudgetLane(autoReviewer) == loops.ReviewFixBudgetLane(contFixer) {
+		t.Fatal("automatic and continuous-manual must be different pairing lanes")
+	}
+	if loops.ReviewFixBudgetLane(oneShotFixer) != "" {
+		t.Fatal("one-shot manual must not pair")
+	}
+	overlaid, err := repos.Loops.GetByID(context.Background(), autoFixer.ID)
+	if err != nil || overlaid == nil || !loops.IsReviewScopeHumanHold(*overlaid) {
+		t.Fatalf("auto fixer overlay = (%#v, %v), want scope hold", overlaid, err)
+	}
+	if loops.IsReviewScopeHumanHold(contFixer) || loops.IsReviewScopeHumanHold(oneShotFixer) {
+		t.Fatal("other-lane asks must not be overlaid by the automatic scope hold")
+	}
+
+	var delivered []string
+	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		githubHITLAwaitingFrom(autoReviewer, autoReviewerAsk),
+		githubHITLAwaitingFrom(autoFixer, autoFixerAsk),
+		githubHITLAwaitingFrom(contFixer, contAsk),
+		githubHITLAwaitingFrom(oneShotFixer, oneShotAsk),
+	}, githubHITLPollDeps{
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return []githubAnswerComment{
+				{ID: 8001, Author: "looper", Body: "<!-- looper:hitl:ask --> Clarify AGENTS.md?"},
+				{ID: 8002, Author: "looper", Body: "<!-- looper:hitl:ask --> Which automatic approach?"},
+				{ID: 8003, Author: "looper", Body: "<!-- looper:hitl:ask --> Which continuous-manual approach?"},
+				{ID: 8004, Author: "operator", Body: "use approach B"},
+				{ID: 8005, Author: "looper", Body: "<!-- looper:hitl:ask --> Which one-shot approach?"},
+				{ID: 8006, Author: "operator", Body: "oneshot yes"},
+				{ID: 8007, Author: "operator", Body: "Continue"},
+			}, nil
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			delivered = append(delivered, loopID+"="+answer)
+			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+		},
+		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64) error {
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID)
+		},
+	})
+	if n != 3 {
+		t.Fatalf("delivered = %#v n=%d, want automatic Continue plus other-lane answers", delivered, n)
+	}
+	if len(delivered) != 3 || delivered[0] != autoReviewer.ID+"=Continue" || delivered[1] != contFixer.ID+"=use approach B" || delivered[2] != oneShotFixer.ID+"=oneshot yes" {
+		t.Fatalf("delivered = %#v, want Continue then other-lane answers, not skipped replies", delivered)
+	}
+
+	freshCont, err := repos.Loops.GetByID(context.Background(), contFixer.ID)
+	if err != nil || freshCont == nil {
+		t.Fatalf("continuous fixer get = (%#v, %v)", freshCont, err)
+	}
+	remainingCont, ok := loops.ReadHITLAsk(freshCont.MetadataJSON)
+	if ok && remainingCont.AskCommentID >= 8007 {
+		t.Fatalf("continuous AskCommentID = %d, must not advance past other-lane Continue 8007", remainingCont.AskCommentID)
+	}
+	freshOneShot, err := repos.Loops.GetByID(context.Background(), oneShotFixer.ID)
+	if err != nil || freshOneShot == nil {
+		t.Fatalf("one-shot fixer get = (%#v, %v)", freshOneShot, err)
+	}
+	remainingOneShot, ok := loops.ReadHITLAsk(freshOneShot.MetadataJSON)
+	if ok && remainingOneShot.AskCommentID >= 8007 {
+		t.Fatalf("one-shot AskCommentID = %d, must not advance past other-lane Continue 8007", remainingOneShot.AskCommentID)
+	}
+	freshAutoFixer, err := repos.Loops.GetByID(context.Background(), autoFixer.ID)
+	if err != nil || freshAutoFixer == nil || freshAutoFixer.Status != "awaiting_human" {
+		t.Fatalf("auto fixer after Continue = (%#v, %v), want awaiting preserved ask", freshAutoFixer, err)
+	}
+	remainingAuto, ok := loops.ReadHITLAsk(freshAutoFixer.MetadataJSON)
+	if !ok || remainingAuto.AskCommentID < 8007 {
+		t.Fatalf("auto fixer AskCommentID = (%#v, %v), want advanced past pair Continue 8007", remainingAuto, ok)
 	}
 }
 
@@ -521,16 +681,8 @@ func TestPollGitHubHITLAnswersOnceKeepsLabelWhenRemainingLookupFails(t *testing.
 
 	var cleared []int64
 	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
-		{
-			ID: reviewer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
-			AskStatus: reviewerAsk.Status, PRNumber: pr, AskCommentID: reviewerAsk.AskCommentID,
-			BudgetAsk: githubHITLDecisionOnlyAsk(reviewer, reviewerAsk),
-		},
-		{
-			ID: fixer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
-			AskStatus: fixerAsk.Status, PRNumber: pr, AskCommentID: fixerAsk.AskCommentID,
-			BudgetAsk: githubHITLDecisionOnlyAsk(fixer, fixerAsk),
-		},
+		githubHITLAwaitingFrom(reviewer, reviewerAsk),
+		githubHITLAwaitingFrom(fixer, fixerAsk),
 	}, githubHITLPollDeps{
 		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
 			return []githubAnswerComment{
@@ -604,6 +756,28 @@ func stampGitHubHITLAsk(t *testing.T, repos *storage.Repositories, loopID string
 		t.Fatalf("Loops.Upsert(%s): %v", loopID, err)
 	}
 	return *fresh
+}
+
+func githubHITLAwaitingFrom(loop storage.LoopRecord, ask loops.HITLAsk) githubHITLAwaitingLoop {
+	repo := ""
+	if loop.Repo != nil {
+		repo = *loop.Repo
+	}
+	pr := ask.PRNumber
+	if pr == 0 && loop.PRNumber != nil {
+		pr = *loop.PRNumber
+	}
+	return githubHITLAwaitingLoop{
+		ID:           loop.ID,
+		ProjectID:    loop.ProjectID,
+		Repo:         repo,
+		Transport:    ask.Transport,
+		AskStatus:    ask.Status,
+		PRNumber:     pr,
+		AskCommentID: ask.AskCommentID,
+		BudgetAsk:    githubHITLDecisionOnlyAsk(loop, ask),
+		Lane:         loops.ReviewFixBudgetLane(loop),
+	}
 }
 
 func TestDrainScopeHoldOnStopDrainsPairBeforeScopeStop(t *testing.T) {

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -307,6 +307,144 @@ func TestPollGitHubHITLAnswersOnceConsumesOneScopeDecisionPerPair(t *testing.T) 
 	}
 }
 
+func TestPollGitHubHITLAnswersOnceDoesNotReuseScopeContinueOnSecondPass(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_second_pass"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_scope_second_pass_reviewer", Seq: 41, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_scope_second_pass_fixer", Seq: 42, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	agentAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+		Transport: "github", PRNumber: pr, AskCommentID: 8002,
+	}
+	fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(fixer): %v", err)
+	}
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md vs PR non-goals before continue.",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	reviewer = stampGitHubHITLAsk(t, repos, reviewer.ID, 8001)
+	fixer = stampGitHubHITLAsk(t, repos, fixer.ID, 8002)
+	reviewerAsk, ok := loops.ReadHITLAsk(reviewer.MetadataJSON)
+	if !ok || !loops.IsReviewScopeHumanAsk(reviewerAsk) {
+		t.Fatalf("reviewer ask = (%#v, %v), want scope ask", reviewerAsk, ok)
+	}
+	fixerAsk, ok := loops.ReadHITLAsk(fixer.MetadataJSON)
+	if !ok || loops.IsReviewScopeHumanAsk(fixerAsk) {
+		t.Fatalf("fixer ask = (%#v, %v), want preserved agent ask", fixerAsk, ok)
+	}
+
+	comments := []githubAnswerComment{
+		{ID: 8001, Author: "looper", Body: "<!-- looper:hitl:ask --> Clarify AGENTS.md?"},
+		{ID: 8002, Author: "looper", Body: "<!-- looper:hitl:ask --> Which approach?"},
+		{ID: 8003, Author: "operator", Body: "Continue"},
+	}
+	var delivered []string
+	deps := githubHITLPollDeps{
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return comments, nil
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			delivered = append(delivered, loopID+"="+answer)
+			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+		},
+		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64) error {
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID)
+		},
+		remainingAwaiting: func(ctx contextType, repo string, pr int64) bool {
+			return githubHITLPRHasRemainingAwaiting(ctx, repos, projectID, repo, pr)
+		},
+	}
+	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		{
+			ID: reviewer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
+			AskStatus: reviewerAsk.Status, PRNumber: pr, AskCommentID: reviewerAsk.AskCommentID,
+			BudgetAsk: githubHITLDecisionOnlyAsk(reviewer, reviewerAsk),
+		},
+		{
+			ID: fixer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
+			AskStatus: fixerAsk.Status, PRNumber: pr, AskCommentID: fixerAsk.AskCommentID,
+			BudgetAsk: githubHITLDecisionOnlyAsk(fixer, fixerAsk),
+		},
+	}, deps)
+	if n != 1 || len(delivered) != 1 || delivered[0] != reviewer.ID+"=Continue" {
+		t.Fatalf("first pass delivered = %#v n=%d, want reviewer Continue", delivered, n)
+	}
+
+	freshFixer, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || freshFixer == nil || freshFixer.Status != "awaiting_human" || loops.IsReviewScopeHumanHold(*freshFixer) {
+		t.Fatalf("fixer after first pass = (%#v, %v), want awaiting preserved ask", freshFixer, err)
+	}
+	remaining, ok := loops.ReadHITLAsk(freshFixer.MetadataJSON)
+	if !ok || remaining.Status != "awaiting" || remaining.Question != agentAsk.Question || remaining.Answer != "" {
+		t.Fatalf("fixer ask after first pass = (%#v, %v), want unanswered agent question", remaining, ok)
+	}
+	if remaining.AskCommentID < 8003 {
+		t.Fatalf("fixer AskCommentID = %d, want advanced past Continue comment 8003", remaining.AskCommentID)
+	}
+
+	second := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{{
+		ID: freshFixer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
+		AskStatus: remaining.Status, PRNumber: pr, AskCommentID: remaining.AskCommentID,
+		BudgetAsk: githubHITLDecisionOnlyAsk(*freshFixer, remaining),
+	}}, deps)
+	if second != 0 || len(delivered) != 1 {
+		t.Fatalf("second pass delivered = %#v n=%d, want no reuse of Continue", delivered, second)
+	}
+
+	comments = append(comments, githubAnswerComment{ID: 8004, Author: "operator", Body: "use approach A"})
+	third := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{{
+		ID: freshFixer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
+		AskStatus: remaining.Status, PRNumber: pr, AskCommentID: remaining.AskCommentID,
+		BudgetAsk: githubHITLDecisionOnlyAsk(*freshFixer, remaining),
+	}}, deps)
+	if third != 1 || len(delivered) != 2 || delivered[1] != fixer.ID+"=use approach A" {
+		t.Fatalf("third pass delivered = %#v n=%d, want later agent answer", delivered, third)
+	}
+}
+
 func TestPollGitHubHITLAnswersOnceKeepsLabelWhenRemainingLookupFails(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -2,6 +2,8 @@ package runtime
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -303,6 +305,141 @@ func TestPollGitHubHITLAnswersOnceConsumesOneScopeDecisionPerPair(t *testing.T) 
 			}
 		})
 	}
+}
+
+func TestPollGitHubHITLAnswersOnceKeepsLabelWhenRemainingLookupFails(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_remaining_list_fail"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_remaining_list_fail_rev", Seq: 41, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_remaining_list_fail_fix", Seq: 42, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	agentAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+		Transport: "github", PRNumber: pr, AskCommentID: 8002,
+	}
+	fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(fixer): %v", err)
+	}
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md vs PR non-goals before continue.",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	reviewer = stampGitHubHITLAsk(t, repos, reviewer.ID, 8001)
+	fixer = stampGitHubHITLAsk(t, repos, fixer.ID, 8002)
+	reviewerAsk, ok := loops.ReadHITLAsk(reviewer.MetadataJSON)
+	if !ok {
+		t.Fatal("reviewer missing scope ask")
+	}
+	fixerAsk, ok := loops.ReadHITLAsk(fixer.MetadataJSON)
+	if !ok {
+		t.Fatal("fixer missing preserved agent ask")
+	}
+
+	failingRepos := storage.NewRepositories(failLoopsListQuerier{db: coordinator.DB()})
+	if githubHITLPRHasRemainingAwaiting(context.Background(), failingRepos, projectID, repo, pr) != true {
+		t.Fatal("remaining lookup must treat a List error as remaining")
+	}
+
+	var cleared []int64
+	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		{
+			ID: reviewer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
+			AskStatus: reviewerAsk.Status, PRNumber: pr, AskCommentID: reviewerAsk.AskCommentID,
+			BudgetAsk: githubHITLDecisionOnlyAsk(reviewer, reviewerAsk),
+		},
+		{
+			ID: fixer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
+			AskStatus: fixerAsk.Status, PRNumber: pr, AskCommentID: fixerAsk.AskCommentID,
+			BudgetAsk: githubHITLDecisionOnlyAsk(fixer, fixerAsk),
+		},
+	}, githubHITLPollDeps{
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return []githubAnswerComment{
+				{ID: 8001, Author: "looper", Body: "<!-- looper:hitl:ask --> Clarify AGENTS.md?"},
+				{ID: 8002, Author: "looper", Body: "<!-- looper:hitl:ask --> Which approach?"},
+				{ID: 8003, Author: "operator", Body: "Continue"},
+			}, nil
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+		},
+		clearAwaiting: func(_ contextType, _ string, gotPR int64, _ string) {
+			cleared = append(cleared, gotPR)
+		},
+		remainingAwaiting: func(ctx contextType, gotRepo string, gotPR int64) bool {
+			return githubHITLPRHasRemainingAwaiting(ctx, failingRepos, projectID, gotRepo, gotPR)
+		},
+	})
+	if n != 1 {
+		t.Fatalf("delivered = %d, want one pair-level Continue", n)
+	}
+	freshFixer, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || freshFixer == nil || freshFixer.Status != "awaiting_human" {
+		t.Fatalf("fixer after Continue = (%#v, %v), want awaiting preserved agent ask", freshFixer, err)
+	}
+	if len(cleared) != 0 {
+		t.Fatalf("cleared = %v, want empty when remaining-ask List fails", cleared)
+	}
+}
+
+type failLoopsListQuerier struct {
+	db *sql.DB
+}
+
+func (q failLoopsListQuerier) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return q.db.ExecContext(ctx, query, args...)
+}
+
+func (q failLoopsListQuerier) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	if strings.Contains(query, "SELECT * FROM loops") && !strings.Contains(query, "WHERE") {
+		return nil, errors.New("database is locked")
+	}
+	return q.db.QueryContext(ctx, query, args...)
+}
+
+func (q failLoopsListQuerier) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return q.db.QueryRowContext(ctx, query, args...)
 }
 
 func stampGitHubHITLAsk(t *testing.T, repos *storage.Repositories, loopID string, commentID int64) storage.LoopRecord {

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -89,6 +89,37 @@ func TestPollGitHubHITLAnswersOnceScopeAskSkipsUnrelatedComments(t *testing.T) {
 	}
 }
 
+func TestGitHubHITLDecisionOnlyAskIncludesScopeOverlay(t *testing.T) {
+	t.Parallel()
+	agentAsk := loops.HITLAsk{
+		Status: "awaiting", Transport: "github", PRNumber: 42, AskCommentID: 8001,
+		Question: "unrelated agent question on the sibling",
+	}
+	meta, err := loops.WriteHITLAsk(nil, agentAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk: %v", err)
+	}
+	meta, err = loops.WriteReviewScopeHumanState(&meta, loops.ReviewScopeHumanState{
+		HeldBy: "reviewer", PauseReason: loops.ReviewScopeHumanSiblingPauseReason,
+		Question: "Clarify AGENTS.md vs PR non-goals before continue.",
+	})
+	if err != nil {
+		t.Fatalf("WriteReviewScopeHumanState: %v", err)
+	}
+	loop := storage.LoopRecord{ID: "loop_fix", Status: "awaiting_human", MetadataJSON: &meta}
+	ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
+	if !ok || loops.IsReviewScopeHumanAsk(ask) || loops.IsReviewFixBudgetAsk(ask) {
+		t.Fatalf("ask = (%#v, %v), want preserved agent ask", ask, ok)
+	}
+	if !loops.IsReviewScopeHumanHold(loop) {
+		t.Fatal("want scope overlay hold")
+	}
+	if !githubHITLDecisionOnlyAsk(loop, ask) {
+		t.Fatal("scope overlay must force Continue/Stop-only GitHub filtering")
+	}
+}
+
+
 func TestPollGitHubHITLAnswersOnce(t *testing.T) {
 	commentsByPR := map[int64][]githubAnswerComment{
 		42: {{ID: 500, Author: "lefarcen", Body: "<!-- looper:hitl:ask --> ask"}, {ID: 501, Author: "lefarcen", Body: "go with A"}},

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -412,7 +412,7 @@ func TestPollGitHubHITLAnswersOnceDoesNotReuseScopeContinueOnSecondPass(t *testi
 			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
 		},
 		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error {
-			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID, comments)
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID, comments, nil)
 		},
 		remainingAwaiting: func(ctx contextType, repo string, pr int64) bool {
 			return githubHITLPRHasRemainingAwaiting(ctx, repos, projectID, repo, pr)
@@ -530,7 +530,7 @@ func TestPollGitHubHITLAnswersOnceDoesNotReuseConsumedContinueWithoutEarlierText
 			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
 		},
 		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error {
-			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID, comments)
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID, comments, nil)
 		},
 		remainingAwaiting: func(ctx contextType, repo string, pr int64) bool {
 			return githubHITLPRHasRemainingAwaiting(ctx, repos, projectID, repo, pr)
@@ -554,6 +554,127 @@ func TestPollGitHubHITLAnswersOnceDoesNotReuseConsumedContinueWithoutEarlierText
 	}
 	if remaining.AskCommentID != 8004 {
 		t.Fatalf("fixer AskCommentID = %d, want consumed Continue 8004 so it cannot answer the ordinary ask", remaining.AskCommentID)
+	}
+
+	second := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		githubHITLAwaitingFrom(*freshFixer, remaining),
+	}, deps)
+	if second != 0 || len(delivered) != 1 {
+		t.Fatalf("second pass delivered = %#v n=%d, want no reuse of consumed Continue", delivered, second)
+	}
+}
+
+func TestPollGitHubHITLAnswersOnceIgnoresUnauthorizedEarlierSiblingText(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+	nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+	coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+		t.Fatalf("RunPending() error = %v", err)
+	}
+	repos := storage.NewRepositories(coordinator.DB())
+	const projectID = "project_scope_unauthorized_earlier"
+	if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+		ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewer := storage.LoopRecord{
+		ID: "loop_scope_unauth_earlier_reviewer", Seq: 61, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	fixer := storage.LoopRecord{
+		ID: "loop_scope_unauth_earlier_fixer", Seq: 62, ProjectID: projectID, Type: "fixer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	agentAsk := loops.HITLAsk{
+		Kind: "agent_question", Question: "Which approach should Fixer take?",
+		Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+		Transport: "github", PRNumber: pr, AskCommentID: 8002,
+	}
+	fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(fixer): %v", err)
+	}
+	fixer.MetadataJSON = &fixerMeta
+	if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr,
+		NowISO: nowISO, HITLEnabled: true,
+		Question: "Clarify AGENTS.md vs PR non-goals before continue.",
+	}); err != nil {
+		t.Fatalf("ParkReviewScopeHuman: %v", err)
+	}
+	reviewer = stampGitHubHITLAsk(t, repos, reviewer.ID, 8001)
+	fixer = stampGitHubHITLAsk(t, repos, fixer.ID, 8002)
+	reviewerAsk, ok := loops.ReadHITLAsk(reviewer.MetadataJSON)
+	if !ok || !loops.IsReviewScopeHumanAsk(reviewerAsk) {
+		t.Fatalf("reviewer ask = (%#v, %v), want scope ask", reviewerAsk, ok)
+	}
+	fixerAsk, ok := loops.ReadHITLAsk(fixer.MetadataJSON)
+	if !ok || loops.IsReviewScopeHumanAsk(fixerAsk) {
+		t.Fatalf("fixer ask = (%#v, %v), want preserved agent ask", fixerAsk, ok)
+	}
+
+	allowed := []string{"operator"}
+	comments := []githubAnswerComment{
+		{ID: 8001, Author: "looper", Body: "<!-- looper:hitl:ask --> Clarify AGENTS.md?"},
+		{ID: 8002, Author: "looper", Body: "<!-- looper:hitl:ask --> Which approach?"},
+		{ID: 8003, Author: "outsider", Body: "use approach A"},
+		{ID: 8004, Author: "operator", Body: "Continue"},
+	}
+	var delivered []string
+	deps := githubHITLPollDeps{
+		listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+			return comments, nil
+		},
+		deliverAnswer: func(ctx contextType, loopID, answer string) error {
+			delivered = append(delivered, loopID+"="+answer)
+			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+		},
+		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error {
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID, comments, allowed)
+		},
+		remainingAwaiting: func(ctx contextType, repo string, pr int64) bool {
+			return githubHITLPRHasRemainingAwaiting(ctx, repos, projectID, repo, pr)
+		},
+		answerAuthors: allowed,
+	}
+	n := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
+		githubHITLAwaitingFrom(reviewer, reviewerAsk),
+		githubHITLAwaitingFrom(fixer, fixerAsk),
+	}, deps)
+	if n != 1 || len(delivered) != 1 || delivered[0] != reviewer.ID+"=Continue" {
+		t.Fatalf("first pass delivered = %#v n=%d, want reviewer Continue", delivered, n)
+	}
+
+	freshFixer, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || freshFixer == nil || freshFixer.Status != "awaiting_human" || loops.IsReviewScopeHumanHold(*freshFixer) {
+		t.Fatalf("fixer after first pass = (%#v, %v), want awaiting preserved ask", freshFixer, err)
+	}
+	remaining, ok := loops.ReadHITLAsk(freshFixer.MetadataJSON)
+	if !ok || remaining.Status != "awaiting" || remaining.Question != agentAsk.Question || remaining.Answer != "" {
+		t.Fatalf("fixer ask after first pass = (%#v, %v), want unanswered agent question", remaining, ok)
+	}
+	if remaining.AskCommentID != 8004 {
+		t.Fatalf("fixer AskCommentID = %d, want consumed Continue 8004; unauthorized earlier text is not a preserved answer", remaining.AskCommentID)
 	}
 
 	second := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
@@ -708,7 +829,7 @@ func TestPollGitHubHITLAnswersOnceLimitsConsumedDecisionToPairLane(t *testing.T)
 			return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
 		},
 		advanceAskPastComment: func(ctx contextType, projectID, repo string, prNumber int64, exceptLoopID string, commentID int64, comments []githubAnswerComment) error {
-			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID, comments)
+			return advanceSiblingGitHubHITLAsksPastComment(ctx, repos, projectID, repo, prNumber, exceptLoopID, commentID, comments, nil)
 		},
 	})
 	if n != 3 {

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -163,6 +163,165 @@ func TestPollGitHubHITLAnswersOnceScopeOverlaySkipsUnrelatedComments(t *testing.
 	}
 }
 
+func TestPollGitHubHITLAnswersOnceConsumesOneScopeDecisionPerPair(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name         string
+		siblingFirst bool
+	}{
+		{name: "primary_first"},
+		{name: "sibling_first", siblingFirst: true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)
+			nowISO := now.UTC().Format("2006-01-02T15:04:05.000Z")
+			coordinator, err := storage.OpenSQLiteCoordinator(context.Background(), filepath.Join(root, "looper.sqlite"), storage.SQLiteCoordinatorOptions{
+				Now: func() time.Time { return now },
+			})
+			if err != nil {
+				t.Fatalf("OpenSQLiteCoordinator() error = %v", err)
+			}
+			t.Cleanup(func() { _ = coordinator.Close() })
+			if _, err := coordinator.MigrationRunner().RunPending(context.Background(), storage.RunPendingOptions{}); err != nil {
+				t.Fatalf("RunPending() error = %v", err)
+			}
+			repos := storage.NewRepositories(coordinator.DB())
+			projectID := "project_scope_pair_" + tc.name
+			if err := repos.Projects.Upsert(context.Background(), storage.ProjectRecord{
+				ID: projectID, Name: "Scope", RepoPath: root, CreatedAt: nowISO, UpdatedAt: nowISO,
+			}); err != nil {
+				t.Fatalf("Projects.Upsert() error = %v", err)
+			}
+			repo := "acme/looper"
+			pr := int64(42)
+			target := "pr:acme/looper:42"
+			reviewer := storage.LoopRecord{
+				ID: "loop_scope_pair_reviewer_" + tc.name, Seq: 31, ProjectID: projectID, Type: "reviewer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "running", CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			fixer := storage.LoopRecord{
+				ID: "loop_scope_pair_fixer_" + tc.name, Seq: 32, ProjectID: projectID, Type: "fixer",
+				TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+				Status: "awaiting_human", CreatedAt: nowISO, UpdatedAt: nowISO,
+			}
+			agentAsk := loops.HITLAsk{
+				Kind: "agent_question", Question: "Which approach should Fixer take?",
+				Options: []string{"A", "B"}, Status: "awaiting", AskedAt: nowISO,
+				Transport: "github", PRNumber: pr, AskCommentID: 8002,
+			}
+			fixerMeta, err := loops.WriteHITLAsk(nil, agentAsk)
+			if err != nil {
+				t.Fatalf("WriteHITLAsk(fixer): %v", err)
+			}
+			fixer.MetadataJSON = &fixerMeta
+			if err := repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+				t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+			}
+			if err := repos.Loops.Upsert(context.Background(), fixer); err != nil {
+				t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+			}
+
+			if _, err := loops.ParkReviewScopeHuman(context.Background(), repos, loops.ParkReviewScopeHumanInput{
+				Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr,
+				NowISO: nowISO, HITLEnabled: true,
+				Question: "Clarify AGENTS.md vs PR non-goals before continue.",
+			}); err != nil {
+				t.Fatalf("ParkReviewScopeHuman: %v", err)
+			}
+			reviewer = stampGitHubHITLAsk(t, repos, reviewer.ID, 8001)
+			fixer = stampGitHubHITLAsk(t, repos, fixer.ID, 8002)
+			reviewerAsk, ok := loops.ReadHITLAsk(reviewer.MetadataJSON)
+			if !ok || !loops.IsReviewScopeHumanAsk(reviewerAsk) {
+				t.Fatalf("reviewer ask = (%#v, %v), want scope ask", reviewerAsk, ok)
+			}
+			fixerAsk, ok := loops.ReadHITLAsk(fixer.MetadataJSON)
+			if !ok || loops.IsReviewScopeHumanAsk(fixerAsk) || fixerAsk.Question != agentAsk.Question {
+				t.Fatalf("fixer ask = (%#v, %v), want preserved agent ask", fixerAsk, ok)
+			}
+			if !githubHITLDecisionOnlyAsk(reviewer, reviewerAsk) || !githubHITLDecisionOnlyAsk(fixer, fixerAsk) {
+				t.Fatal("both pair members must snapshot as decision-only")
+			}
+
+			primary := githubHITLAwaitingLoop{
+				ID: reviewer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
+				AskStatus: reviewerAsk.Status, PRNumber: pr, AskCommentID: reviewerAsk.AskCommentID,
+				BudgetAsk: githubHITLDecisionOnlyAsk(reviewer, reviewerAsk),
+			}
+			overlay := githubHITLAwaitingLoop{
+				ID: fixer.ID, ProjectID: projectID, Repo: repo, Transport: "github",
+				AskStatus: fixerAsk.Status, PRNumber: pr, AskCommentID: fixerAsk.AskCommentID,
+				BudgetAsk: githubHITLDecisionOnlyAsk(fixer, fixerAsk),
+			}
+			awaiting := []githubHITLAwaitingLoop{primary, overlay}
+			if tc.siblingFirst {
+				awaiting = []githubHITLAwaitingLoop{overlay, primary}
+			}
+			n := pollGitHubHITLAnswersOnce(context.Background(), awaiting, githubHITLPollDeps{
+				listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
+					return []githubAnswerComment{
+						{ID: 8001, Author: "looper", Body: "<!-- looper:hitl:ask --> Clarify AGENTS.md?"},
+						{ID: 8002, Author: "looper", Body: "<!-- looper:hitl:ask --> Which approach?"},
+						{ID: 8003, Author: "operator", Body: "Continue"},
+					}, nil
+				},
+				deliverAnswer: func(ctx contextType, loopID, answer string) error {
+					return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
+				},
+				clearAwaiting: func(_ contextType, _ string, _ int64, _ string) {},
+			})
+			if n != 1 {
+				t.Fatalf("delivered = %d, want one pair-level Continue", n)
+			}
+
+			freshReviewer, err := repos.Loops.GetByID(context.Background(), reviewer.ID)
+			if err != nil || freshReviewer == nil || freshReviewer.Status != "queued" || loops.IsReviewScopeHumanHold(*freshReviewer) {
+				t.Fatalf("reviewer after Continue = (%#v, %v), want queued and released", freshReviewer, err)
+			}
+			if _, stillAsked := loops.ReadHITLAsk(freshReviewer.MetadataJSON); stillAsked {
+				t.Fatal("reviewer still has a HITL ask after pair Continue")
+			}
+			freshFixer, err := repos.Loops.GetByID(context.Background(), fixer.ID)
+			if err != nil || freshFixer == nil || freshFixer.Status != "awaiting_human" || loops.IsReviewScopeHumanHold(*freshFixer) {
+				t.Fatalf("fixer after Continue = (%#v, %v), want awaiting preserved agent ask without overlay", freshFixer, err)
+			}
+			remaining, ok := loops.ReadHITLAsk(freshFixer.MetadataJSON)
+			if !ok || remaining.Status != "awaiting" || remaining.Question != agentAsk.Question || remaining.Answer != "" {
+				t.Fatalf("fixer ask after Continue = (%#v, %v), want unanswered agent question", remaining, ok)
+			}
+		})
+	}
+}
+
+func stampGitHubHITLAsk(t *testing.T, repos *storage.Repositories, loopID string, commentID int64) storage.LoopRecord {
+	t.Helper()
+	fresh, err := repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || fresh == nil {
+		t.Fatalf("Loops.GetByID(%s) = (%#v, %v)", loopID, fresh, err)
+	}
+	ask, ok := loops.ReadHITLAsk(fresh.MetadataJSON)
+	if !ok {
+		t.Fatalf("loop %s missing HITL ask", loopID)
+	}
+	ask.Transport = "github"
+	ask.AskCommentID = commentID
+	if ask.PRNumber == 0 {
+		ask.PRNumber = 42
+	}
+	meta, err := loops.WriteHITLAsk(fresh.MetadataJSON, ask)
+	if err != nil {
+		t.Fatalf("WriteHITLAsk(%s): %v", loopID, err)
+	}
+	fresh.MetadataJSON = &meta
+	if err := repos.Loops.Upsert(context.Background(), *fresh); err != nil {
+		t.Fatalf("Loops.Upsert(%s): %v", loopID, err)
+	}
+	return *fresh
+}
+
 func TestDrainScopeHoldOnStopDrainsPairBeforeScopeStop(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, time.April, 17, 12, 34, 56, 0, time.UTC)

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -260,6 +260,7 @@ func TestPollGitHubHITLAnswersOnceConsumesOneScopeDecisionPerPair(t *testing.T) 
 			if tc.siblingFirst {
 				awaiting = []githubHITLAwaitingLoop{overlay, primary}
 			}
+			var cleared []int64
 			n := pollGitHubHITLAnswersOnce(context.Background(), awaiting, githubHITLPollDeps{
 				listComments: func(_ contextType, _ string, _ int64, _ string) ([]githubAnswerComment, error) {
 					return []githubAnswerComment{
@@ -271,7 +272,12 @@ func TestPollGitHubHITLAnswersOnceConsumesOneScopeDecisionPerPair(t *testing.T) 
 				deliverAnswer: func(ctx contextType, loopID, answer string) error {
 					return deliverHITLAnswerToLoop(ctx, repos, nowISO, loopID, answer)
 				},
-				clearAwaiting: func(_ contextType, _ string, _ int64, _ string) {},
+				clearAwaiting: func(_ contextType, _ string, pr int64, _ string) {
+					cleared = append(cleared, pr)
+				},
+				remainingAwaiting: func(ctx contextType, repo string, pr int64) bool {
+					return githubHITLPRHasRemainingAwaiting(ctx, repos, projectID, repo, pr)
+				},
 			})
 			if n != 1 {
 				t.Fatalf("delivered = %d, want one pair-level Continue", n)
@@ -291,6 +297,9 @@ func TestPollGitHubHITLAnswersOnceConsumesOneScopeDecisionPerPair(t *testing.T) 
 			remaining, ok := loops.ReadHITLAsk(freshFixer.MetadataJSON)
 			if !ok || remaining.Status != "awaiting" || remaining.Question != agentAsk.Question || remaining.Answer != "" {
 				t.Fatalf("fixer ask after Continue = (%#v, %v), want unanswered agent question", remaining, ok)
+			}
+			if len(cleared) != 0 {
+				t.Fatalf("cleared = %v, want empty while sibling agent ask remains", cleared)
 			}
 		})
 	}

--- a/internal/runtime/hitl_github_poll_test.go
+++ b/internal/runtime/hitl_github_poll_test.go
@@ -371,7 +371,8 @@ func TestPollGitHubHITLAnswersOnceDoesNotReuseScopeContinueOnSecondPass(t *testi
 	comments := []githubAnswerComment{
 		{ID: 8001, Author: "looper", Body: "<!-- looper:hitl:ask --> Clarify AGENTS.md?"},
 		{ID: 8002, Author: "looper", Body: "<!-- looper:hitl:ask --> Which approach?"},
-		{ID: 8003, Author: "operator", Body: "Continue"},
+		{ID: 8003, Author: "operator", Body: "use approach A"},
+		{ID: 8004, Author: "operator", Body: "Continue"},
 	}
 	var delivered []string
 	deps := githubHITLPollDeps{
@@ -405,23 +406,15 @@ func TestPollGitHubHITLAnswersOnceDoesNotReuseScopeContinueOnSecondPass(t *testi
 	if !ok || remaining.Status != "awaiting" || remaining.Question != agentAsk.Question || remaining.Answer != "" {
 		t.Fatalf("fixer ask after first pass = (%#v, %v), want unanswered agent question", remaining, ok)
 	}
-	if remaining.AskCommentID < 8003 {
-		t.Fatalf("fixer AskCommentID = %d, want advanced past Continue comment 8003", remaining.AskCommentID)
+	if remaining.AskCommentID != 8002 {
+		t.Fatalf("fixer AskCommentID = %d, want original ordinary ask 8002 (not Continue 8004)", remaining.AskCommentID)
 	}
 
 	second := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
 		githubHITLAwaitingFrom(*freshFixer, remaining),
 	}, deps)
-	if second != 0 || len(delivered) != 1 {
-		t.Fatalf("second pass delivered = %#v n=%d, want no reuse of Continue", delivered, second)
-	}
-
-	comments = append(comments, githubAnswerComment{ID: 8004, Author: "operator", Body: "use approach A"})
-	third := pollGitHubHITLAnswersOnce(context.Background(), []githubHITLAwaitingLoop{
-		githubHITLAwaitingFrom(*freshFixer, remaining),
-	}, deps)
-	if third != 1 || len(delivered) != 2 || delivered[1] != fixer.ID+"=use approach A" {
-		t.Fatalf("third pass delivered = %#v n=%d, want later agent answer", delivered, third)
+	if second != 1 || len(delivered) != 2 || delivered[1] != fixer.ID+"=use approach A" {
+		t.Fatalf("second pass delivered = %#v n=%d, want earlier agent answer not Continue", delivered, second)
 	}
 }
 
@@ -600,8 +593,8 @@ func TestPollGitHubHITLAnswersOnceLimitsConsumedDecisionToPairLane(t *testing.T)
 		t.Fatalf("auto fixer after Continue = (%#v, %v), want awaiting preserved ask", freshAutoFixer, err)
 	}
 	remainingAuto, ok := loops.ReadHITLAsk(freshAutoFixer.MetadataJSON)
-	if !ok || remainingAuto.AskCommentID < 8007 {
-		t.Fatalf("auto fixer AskCommentID = (%#v, %v), want advanced past pair Continue 8007", remainingAuto, ok)
+	if !ok || remainingAuto.AskCommentID != 8002 {
+		t.Fatalf("auto fixer AskCommentID = (%#v, %v), want original ordinary ask 8002", remainingAuto, ok)
 	}
 }
 

--- a/internal/runtime/human_attention.go
+++ b/internal/runtime/human_attention.go
@@ -33,6 +33,20 @@ func (r *Runtime) notifyHumanAttentionBestEffort(ctx context.Context, repos *sto
 	notifyDurableHumanAttention(ctx, gateway, repos, loopID)
 }
 
+// NotifyHumanAttention observes durable loop state after a non-claim park
+// (budget Continue → no-HITL scope promotion). Best-effort; never changes
+// loop/queue/run control flow.
+func (r *Runtime) NotifyHumanAttention(ctx context.Context, loopID string) {
+	if r == nil {
+		return
+	}
+	services := r.Services()
+	if services.Repositories == nil {
+		return
+	}
+	r.notifyHumanAttentionBestEffort(ctx, services.Repositories, loopID)
+}
+
 // ensureHumanAttentionNotifyCtx returns the shared cancelable parent for
 // human-attention delivery. Refuses to arm after Stop or while admission is
 // stopping so a post-claim race cannot outlive BeginShutdown's cancel snapshot.

--- a/internal/runtime/human_attention.go
+++ b/internal/runtime/human_attention.go
@@ -408,6 +408,7 @@ func notifyDurableHumanAttention(ctx context.Context, gateway *notify.Gateway, r
 		if entryKey == "" {
 			return
 		}
+		state := loops.ReadReviewScopeHumanState(loop.MetadataJSON)
 		gateway.NotifyHumanAttention(ctx, notify.HumanAttentionInput{
 			ProjectID:  loop.ProjectID,
 			LoopID:     loop.ID,
@@ -417,6 +418,8 @@ func notifyDurableHumanAttention(ctx context.Context, gateway *notify.Gateway, r
 			Reason:     notify.HumanAttentionReviewScopeHuman,
 			EntryKey:   entryKey,
 			Subtitle:   humanAttentionSubtitle(*loop),
+			Question:   state.Question,
+			Evidence:   state.Evidence,
 			EntityType: "loop",
 			EntityID:   loop.ID,
 		})

--- a/internal/runtime/human_attention.go
+++ b/internal/runtime/human_attention.go
@@ -278,9 +278,10 @@ func (r *Runtime) isStopped() bool {
 
 // collectHumanAttentionLoopIDs returns loop IDs that may need human-attention
 // observation after recovery: durable awaiting_human loop status, no-HITL
-// review-fix budget exhausted pauses, and latest queue rows parked as
-// manual_intervention. notifyDurableHumanAttention applies the hard-condition
-// filter and permanent entry dedupe.
+// review-fix budget exhausted pauses, no-HITL review-scope required pauses,
+// and latest queue rows parked as manual_intervention.
+// notifyDurableHumanAttention applies the hard-condition filter and permanent
+// entry dedupe.
 func collectHumanAttentionLoopIDs(ctx context.Context, repos *storage.Repositories) []string {
 	if repos == nil {
 		return nil
@@ -305,11 +306,11 @@ func collectHumanAttentionLoopIDs(ctx context.Context, repos *storage.Repositori
 				add(loop.ID)
 			}
 		}
-		// No-HITL budget exhausted holds are paused (not awaiting_human).
+		// No-HITL budget exhausted / scope-required holds are paused (not awaiting_human).
 		paused, err := repos.Loops.ListByStatuses(ctx, []string{string(domain.LoopStatusPaused)})
 		if err == nil {
 			for _, loop := range paused {
-				if loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) {
+				if loops.IsReviewFixBudgetExhaustedPause(loop.MetadataJSON) || loops.IsReviewScopeHumanRequiredPause(loop.MetadataJSON) {
 					add(loop.ID)
 				}
 			}
@@ -378,6 +379,28 @@ func notifyDurableHumanAttention(ctx context.Context, gateway *notify.Gateway, r
 			RunID:      latestRunID(ctx, repos, loop.ID),
 			LoopType:   loop.Type,
 			Reason:     notify.HumanAttentionReviewFixBudget,
+			EntryKey:   entryKey,
+			Subtitle:   humanAttentionSubtitle(*loop),
+			EntityType: "loop",
+			EntityID:   loop.ID,
+		})
+		return
+	}
+
+	// No-HITL needs_human scope hold: paused + review_scope_human_required.
+	// Sibling-only pause does not notify separately (held role notifies).
+	if loop.Status == string(domain.LoopStatusPaused) && loops.IsReviewScopeHumanRequiredPause(loop.MetadataJSON) {
+		entryKey := humanAttentionEntryKeyForReviewScopeHuman(*loop)
+		if entryKey == "" {
+			return
+		}
+		gateway.NotifyHumanAttention(ctx, notify.HumanAttentionInput{
+			ProjectID:  loop.ProjectID,
+			LoopID:     loop.ID,
+			LoopSeq:    loop.Seq,
+			RunID:      latestRunID(ctx, repos, loop.ID),
+			LoopType:   loop.Type,
+			Reason:     notify.HumanAttentionReviewScopeHuman,
 			EntryKey:   entryKey,
 			Subtitle:   humanAttentionSubtitle(*loop),
 			EntityType: "loop",
@@ -460,6 +483,17 @@ func humanAttentionEntryKeyForReviewFixBudget(loop storage.LoopRecord) string {
 		return "budget:" + loop.ID + ":" + updated
 	}
 	return "budget:" + loop.ID
+}
+
+func humanAttentionEntryKeyForReviewScopeHuman(loop storage.LoopRecord) string {
+	state := loops.ReadReviewScopeHumanState(loop.MetadataJSON)
+	if at := strings.TrimSpace(state.HandoffEventAt); at != "" {
+		return "scope:" + loop.ID + ":" + at
+	}
+	if updated := strings.TrimSpace(loop.UpdatedAt); updated != "" {
+		return "scope:" + loop.ID + ":" + updated
+	}
+	return "scope:" + loop.ID
 }
 
 func humanAttentionEntryKeyForManualIntervention(queue storage.QueueItemRecord) string {

--- a/internal/runtime/human_attention_contract_helpers_test.go
+++ b/internal/runtime/human_attention_contract_helpers_test.go
@@ -44,6 +44,30 @@ func assertHumanAttentionInAppCount(t *testing.T, repos *storage.Repositories, l
 	}
 }
 
+func assertHumanAttentionInAppBodyContains(t *testing.T, repos *storage.Repositories, loopID, want string) {
+	t.Helper()
+	notifications, err := repos.Notifications.List(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("Notifications.List() error = %v", err)
+	}
+	for _, n := range notifications {
+		if n.LoopID == nil || *n.LoopID != loopID {
+			continue
+		}
+		if n.Channel != "in_app" || n.Level != "action_required" {
+			continue
+		}
+		if n.DedupeKey == nil || !strings.HasPrefix(*n.DedupeKey, "human_attention:") {
+			continue
+		}
+		if strings.Contains(n.Body, want) {
+			return
+		}
+		t.Fatalf("human_attention in_app body for %s = %q, want substring %q", loopID, n.Body, want)
+	}
+	t.Fatalf("human_attention in_app row for %s not found", loopID)
+}
+
 func assertOsascriptContains(t *testing.T, path, want string) {
 	t.Helper()
 	body, err := os.ReadFile(path)

--- a/internal/runtime/human_attention_scope_contract_test.go
+++ b/internal/runtime/human_attention_scope_contract_test.go
@@ -1,0 +1,97 @@
+package runtime
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/infra/notify"
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// No-HITL needs_human scope hold must produce action-required human attention.
+func TestHumanAttentionContract_ReviewScopeHumanRequired(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	capturePath := filepath.Join(root, "osascript.log")
+	scriptPath := filepath.Join(root, "osascript")
+	writeHumanAttentionOsascript(t, scriptPath, capturePath, false)
+
+	coordinator := openMigratedCoordinator(t, filepath.Join(root, "scope-attention.sqlite"), filepath.Join(root, "backups"))
+	repos := storage.NewRepositories(coordinator.DB())
+	now := time.Date(2026, time.July, 29, 12, 0, 0, 0, time.UTC)
+	nowISO := eventlog.FormatJavaScriptISOString(now)
+
+	projectID := "project_scope_attention"
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{
+		ID: projectID, Name: "Scope Attention", RepoPath: filepath.Join(root, "repo"),
+		CreatedAt: nowISO, UpdatedAt: nowISO,
+	}); err != nil {
+		t.Fatalf("Projects.Upsert() error = %v", err)
+	}
+
+	repo := "acme/looper"
+	pr := int64(42)
+	target := "pr:acme/looper:42"
+	reviewerMeta := `{"loop":{"iterationCount":1}}`
+	reviewer := storage.LoopRecord{
+		ID: "loop_scope_attention", Seq: 718, ProjectID: projectID, Type: "reviewer",
+		TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &pr,
+		Status: "running", MetadataJSON: &reviewerMeta, CreatedAt: nowISO, UpdatedAt: nowISO,
+	}
+	if err := repos.Loops.Upsert(ctx, reviewer); err != nil {
+		t.Fatalf("Loops.Upsert: %v", err)
+	}
+	parked, err := loops.ParkReviewScopeHuman(ctx, repos, loops.ParkReviewScopeHumanInput{
+		Held: reviewer, Role: "reviewer", Repo: repo, PRNumber: pr,
+		NowISO: nowISO, HITLEnabled: false,
+		Question: "Clarify AGENTS.md rule X before unpause",
+		Evidence: "PR non-goals exclude API expansion",
+	})
+	if err != nil {
+		t.Fatalf("Park: %v", err)
+	}
+	if parked.Status != "paused" || !loops.IsReviewScopeHumanRequiredPause(parked.MetadataJSON) {
+		t.Fatalf("parked = %#v, want no-HITL scope pause", parked)
+	}
+
+	ids := collectHumanAttentionLoopIDs(ctx, repos)
+	found := false
+	for _, id := range ids {
+		if id == reviewer.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("collectHumanAttentionLoopIDs() = %v, want scope hold %s", ids, reviewer.ID)
+	}
+
+	gateway := notify.NewGateway(notify.Options{
+		Config: config.NotificationConfig{
+			InApp: true,
+			Osascript: config.OsascriptNotificationConfig{
+				Enabled:               true,
+				SoundForLevels:        []config.NotificationSoundLevel{config.NotificationSoundLevelActionRequired},
+				ThrottleWindowSeconds: 1,
+			},
+		},
+		OsascriptPath: scriptPath,
+		Repositories:  repos,
+		Now:           func() time.Time { return now },
+	})
+
+	notifyDurableHumanAttention(ctx, gateway, repos, reviewer.ID)
+	assertHumanAttentionInAppCount(t, repos, reviewer.ID, 1)
+	assertOsascriptContains(t, capturePath, "display notification")
+
+	// Re-observe must not resend.
+	notifyDurableHumanAttention(ctx, gateway, repos, reviewer.ID)
+	assertHumanAttentionInAppCount(t, repos, reviewer.ID, 1)
+}

--- a/internal/runtime/human_attention_scope_contract_test.go
+++ b/internal/runtime/human_attention_scope_contract_test.go
@@ -89,8 +89,9 @@ func TestHumanAttentionContract_ReviewScopeHumanRequired(t *testing.T) {
 
 	notifyDurableHumanAttention(ctx, gateway, repos, reviewer.ID)
 	assertHumanAttentionInAppCount(t, repos, reviewer.ID, 1)
+	assertHumanAttentionInAppBodyContains(t, repos, reviewer.ID, "Clarify AGENTS.md rule X before unpause")
+	assertHumanAttentionInAppBodyContains(t, repos, reviewer.ID, "PR non-goals exclude API expansion")
 	assertOsascriptContains(t, capturePath, "display notification")
-
 	// Re-observe must not resend.
 	notifyDurableHumanAttention(ctx, gateway, repos, reviewer.ID)
 	assertHumanAttentionInAppCount(t, repos, reviewer.ID, 1)

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -130,6 +130,9 @@ type defaultSchedulerTickInput struct {
 	// DrainHITLPair stops live pair agents before a scope Stop answer is
 	// applied by GitHub/Feishu poll. Optional; tests may inject a recorder.
 	DrainHITLPair func(context.Context, storage.LoopRecord) error
+	// ActiveExecutions reopens sticky pair spawn gates when a scope Stop drain
+	// loses to a concurrent Continue.
+	ActiveExecutions *ActiveExecutionRegistry
 }
 
 type defaultSchedulerHandlers struct {
@@ -3672,6 +3675,7 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 			DrainHITLPair: func(ctx context.Context, loop storage.LoopRecord) error {
 				return drainReviewFixPairExecutions(ctx, services.Repositories, loop, services.ActiveExecutions)
 			},
+			ActiveExecutions: services.ActiveExecutions,
 		}
 	}
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -127,6 +127,9 @@ type defaultSchedulerTickInput struct {
 	// claim finishes and emits a best-effort action_required notification when
 	// the loop newly entered awaiting_human or manual_intervention.
 	NotifyHumanAttention func(context.Context, string)
+	// DrainHITLPair stops live pair agents before a scope Stop answer is
+	// applied by GitHub/Feishu poll. Optional; tests may inject a recorder.
+	DrainHITLPair func(context.Context, storage.LoopRecord) error
 }
 
 type defaultSchedulerHandlers struct {
@@ -3666,6 +3669,9 @@ func buildDefaultSchedulerHandlersWithOptions(cfg config.Config, configPath stri
 			OnHITLAsk:                notifyHITLAsk,
 			OnHITLAnswerDelivered:    notificationGateway.MarkAskAnswered,
 			NotifyHumanAttention:     notifyHumanAttention,
+			DrainHITLPair: func(ctx context.Context, loop storage.LoopRecord) error {
+				return drainReviewFixPairExecutions(ctx, services.Repositories, loop, services.ActiveExecutions)
+			},
 		}
 	}
 


### PR DESCRIPTION
# Summary

- Stack 2/4. Base is the budget slice, not `main`.
- Every finding is `must_fix` / `follow_up` / `needs_human`. Only `must_fix` becomes remote review feedback.
- Trusted review-submit rejects missing disposition fields and rejects `follow_up`/`needs_human` in actionable comments. Provider adapters still strip Looper-only fields.
- `needs_human` parks the pair (`review_scope_human_required`) instead of dropping the finding. HITL on → ask; HITL off → no-ask pause.

Do not merge a prompt-only subset of this PR. The outbound gate is the authority seam.

# Testing

- [x] Targeted: `go test ./internal/loops/ ./internal/reviewer/ ./internal/api/ ./internal/fixer/ -count=1`
- [ ] `go test ./...`
- [x] Additional targeted checks: review-submit contract tests in this commit

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [x] Daemon boot / config / runtime path risk
- [ ] Worktree / repo isolation / lifecycle risk
- [x] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

Transient Looper fields are stripped before the existing provider call.

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [x] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- Spec slice 2: `specs/2026-08-24-review-fix-convergence/spec.md`

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied
