### PR TITLE
docs: show review-fix hold reason and unpause/stop commands

### DIFF
--- a/docs/GUIDE-hitl-setup.md
+++ b/docs/GUIDE-hitl-setup.md
@@ -13,7 +13,8 @@ Review-fix budget and scope holds still fire when HITL is off. They pause the
 pair with no ask. `looper unpause <seq>` releases the hold: a budget hold
 refills only exhausted meters, while other holds may still prevent the pair
 from running; a scope hold clears only the overlay and leaves independent
-blockers such as failed, interrupted, human takeover, or a manual pause. `looper stop <seq>` terminates both roles.
+blockers such as unanswered agent/HITL asks, failed or interrupted runs, human
+takeover, or a manual pause. `looper stop <seq>` terminates both roles.
 Enabling HITL only changes presentation (Continue/Stop card), not whether the
 pair halts.
 

--- a/docs/GUIDE-hitl-setup.md
+++ b/docs/GUIDE-hitl-setup.md
@@ -11,9 +11,9 @@ exactly as before. Turn them on one at a time.
 
 Review-fix budget and scope holds still fire when HITL is off. They pause the
 pair with no ask. `looper unpause <seq>` releases the hold: a budget hold
-resumes the pair and refills only exhausted meters; a scope hold clears only
-the overlay and leaves independent blockers such as failed, interrupted, human
-takeover, or a manual pause. `looper stop <seq>` terminates both roles.
+refills only exhausted meters, while other holds may still prevent the pair
+from running; a scope hold clears only the overlay and leaves independent
+blockers such as failed, interrupted, human takeover, or a manual pause. `looper stop <seq>` terminates both roles.
 Enabling HITL only changes presentation (Continue/Stop card), not whether the
 pair halts.
 

--- a/docs/GUIDE-hitl-setup.md
+++ b/docs/GUIDE-hitl-setup.md
@@ -9,6 +9,14 @@ milestones), and one-command local takeover. For the design rationale see
 **Everything here is off by default** — a looper with none of these flags behaves
 exactly as before. Turn them on one at a time.
 
+Review-fix budget and scope holds still fire when HITL is off. They pause the
+pair with no ask. `looper unpause <seq>` releases the hold: a budget hold
+resumes the pair and refills only exhausted meters; a scope hold clears only
+the overlay and leaves independent blockers such as failed, interrupted, human
+takeover, or a manual pause. `looper stop <seq>` terminates both roles.
+Enabling HITL only changes presentation (Continue/Stop card), not whether the
+pair halts.
+
 ---
 
 ## What each capability needs (at a glance)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -689,6 +689,8 @@ Unlimited reviewer ⇄ fixer ping-pong is a cost and quality problem: each side 
 
 Continue / no-HITL `unpause` refills only meters currently at/over their live cap and releases the pair. Stop / no-HITL `looper stop` terminates both roles. Product terminals (ready label, identical output, closed PR) still win and do not open a budget ask. Budget exhaustion never approves, resolves, or merges. Event: `loop.review_fix_budget.exhausted` (`level: action_required`). A `needs_human` scope dispute with HITL off pauses the pair with reason `review_scope_human_required` and the same `unpause`/`stop` pair; `unpause` resumes against current evidence without refilling a meter unless one is also exhausted.
 
+`looper describe <seq>` / `looper loop inspect <seq>` and the dashboard loop page show the current hold reason and the exact `looper unpause <seq>` / `looper stop <seq>` commands. Live caps, current head, last reviewed signal, exhausted-role meters, unresolved findings, pending decisions, late blockers, and outcome/progress are not rebuilt on those surfaces (park-time `loop.review_fix_budget.exhausted` / `loop.review_scope_human.required` events still snapshot decision-time evidence).
+
 **Failure prevented:** expanding-scope review/fix that never converges, including on default HITL-off installs. **Cost:** paired pause/unpause/stop plus an action-required event. **Why not reuse the old knobs:** those were reviewer-only infra counters that stranded long PRs and were explicitly demoted in #209.
 
 ### Same-head disposition (always on for GitHub)

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -537,12 +537,12 @@ looper run reconcile-stale
 Typical usage:
 
 - `looper ps`: see which loops are currently running (includes a truncated failure reason when present)
-- `looper describe <id>`: show why a loop is blocked (manual intervention reason, diagnosis); same as `looper loop inspect`
+- `looper describe <id>`: show why a loop is blocked (manual intervention reason, diagnosis); same as `looper loop inspect`. For a review-fix budget or scope hold, also names the hold reason and the next command (`looper unpause <seq>` / `looper stop <seq>`).
 - `looper logs <id> --follow`: stream logs live
 - `looper jump <id>`: print the shell command for the loop's worktree; use `eval "$(looper jump 12)"` to actually change directories, or pass `--print-path` to print just the path
 - `looper worktree cleanup`: inspect Looper-managed worktree cleanup candidates without deleting anything; add `--confirm` for one immediate cleanup pass or `--json` for structured output
-- `looper unpause <id>`: on a review-fix budget or `needs_human` hold, Continue the pair (refill exhausted meters only); otherwise resume that one paused loop
-- `looper stop <id>`: stop an active loop; on a review-fix hold, terminate both roles in the lane
+- `looper unpause <id>`: on a review-fix budget hold, Continue the pair (refill exhausted meters only); on a `needs_human` scope hold, release only the overlay and leave independent blockers; otherwise resume that one paused loop
+- `looper stop <id>`: stop an active loop, or terminate a budget/scope-held pair
 - `looper run reconcile-stale`: interrupt stale running runs, repair blocked queue state, and requeue eligible loops after sleep/wake or other local process loss; `looper daemon restart` is still a reasonable fallback if you want a full daemon restart
 
 ## 15. Minimal end-to-end example

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -598,7 +598,12 @@ func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storag
 		diagnosis.RecommendedAction = recommendedActionForState(state)
 	}
 	if associateQueue && loops.IsReviewFixPairHold(loop) {
-		diagnosis.RecommendedAction = reviewFixInspectResume(loop)
+		release := reviewFixInspectResume(loop)
+		if loops.IsReviewScopeHumanHold(loop) && !loops.IsReviewFixBudgetHold(loop) {
+			diagnosis.RecommendedAction = release + "; unpause releases only the scope hold; then " + diagnosis.RecommendedAction
+		} else {
+			diagnosis.RecommendedAction = release
+		}
 	}
 	// Expand <seq> before emitting JSON/human output so operators and scripts
 	// never see the literal placeholder outside writeHumanLoopInspect.
@@ -995,12 +1000,13 @@ func writeHumanLoopInspect(w io.Writer, output loopInspectOutput) error {
 		}
 	}
 	if output.Handoff != nil {
-		label := "Resume"
-		if output.Handoff.Kind == loops.HITLKindReviewScopeHuman {
-			label = "Release"
-		}
-		if _, err := fmt.Fprintf(w, "%s: %s\n", label, output.Handoff.Resume); err != nil {
+		if _, err := fmt.Fprintf(w, "Release: %s\n", output.Handoff.Resume); err != nil {
 			return err
+		}
+		if output.Handoff.Kind == loops.HITLKindReviewFixBudget {
+			if _, err := fmt.Fprintln(w, "unpause releases the budget hold and refills only exhausted meters; other holds, including scope holds, may still prevent the pair from running."); err != nil {
+				return err
+			}
 		}
 		if output.Handoff.Kind == loops.HITLKindReviewScopeHuman {
 			if _, err := fmt.Fprintln(w, "unpause releases the scope hold; failed, interrupted, human takeover, or a manual pause remain."); err != nil {

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -1009,7 +1009,7 @@ func writeHumanLoopInspect(w io.Writer, output loopInspectOutput) error {
 			}
 		}
 		if output.Handoff.Kind == loops.HITLKindReviewScopeHuman {
-			if _, err := fmt.Fprintln(w, "unpause releases the scope hold; failed, interrupted, human takeover, or a manual pause remain."); err != nil {
+			if _, err := fmt.Fprintln(w, "unpause releases the scope hold; other blockers remain, such as unanswered agent/HITL asks, failed or interrupted runs, human takeover, or a manual pause."); err != nil {
 				return err
 			}
 		}

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nexu-io/looper/internal/eventlog"
+	"github.com/nexu-io/looper/internal/loops"
 	"github.com/nexu-io/looper/internal/storage"
 	"github.com/spf13/cobra"
 )
@@ -22,10 +23,17 @@ type loopInspectOutput struct {
 	SelectorKind    string                  `json:"selectorKind"`
 	Loop            loopDiagnosticLoop      `json:"loop"`
 	Metadata        loopDiagnosticMetadata  `json:"metadata"`
+	Handoff         *loopInspectHandoff     `json:"handoff,omitempty"`
 	Run             *loopDiagnosticRun      `json:"run,omitempty"`
 	LatestQueueItem *queueItemCommandOutput `json:"latestQueueItem,omitempty"`
 	Agent           *loopDiagnosticAgent    `json:"agent,omitempty"`
 	Diagnosis       loopDiagnosis           `json:"diagnosis"`
+}
+
+type loopInspectHandoff struct {
+	Kind        string  `json:"kind"`
+	PauseReason *string `json:"pauseReason,omitempty"`
+	Resume      string  `json:"resume"`
 }
 
 type loopFailuresOutput struct {
@@ -79,6 +87,7 @@ type loopDiagnosticMetadata struct {
 	LastPublishedHeadSHA *string                     `json:"lastPublishedHeadSha,omitempty"`
 	LastReviewEvent      *string                     `json:"lastReviewEvent,omitempty"`
 	LastReviewSummary    *string                     `json:"lastReviewSummary,omitempty"`
+	PauseReason          *string                     `json:"pauseReason,omitempty"`
 	LastFilterSkip       map[string]any              `json:"lastFilterSkip,omitempty"`
 	Loop                 *loopDiagnosticLoopMetadata `json:"loop,omitempty"`
 }
@@ -388,6 +397,9 @@ func buildLoopInspectOutput(ctx context.Context, repos *storage.Repositories, se
 		agentOutput := diagnosticAgentOutput(*agent, now)
 		output.Agent = &agentOutput
 	}
+	if handoff := reviewFixInspectHandoff(resolved.Loop, metadata); handoff != nil {
+		output.Handoff = handoff
+	}
 	return output, nil
 }
 
@@ -433,6 +445,7 @@ func parseLoopDiagnosticMetadata(raw *string) loopDiagnosticMetadata {
 		LastPublishedHeadSHA: stringPtrFromMap(doc, "lastPublishedHeadSha"),
 		LastReviewEvent:      stringPtrFromMap(doc, "lastReviewEvent"),
 		LastReviewSummary:    stringPtrFromMap(doc, "lastReviewSummary"),
+		PauseReason:          stringPtrFromMap(doc, "pauseReason"),
 	}
 	if skip, ok := doc["lastFilterSkip"].(map[string]any); ok {
 		output.LastFilterSkip = skip
@@ -583,6 +596,9 @@ func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storag
 	}
 	if diagnosis.RecommendedAction == "" {
 		diagnosis.RecommendedAction = recommendedActionForState(state)
+	}
+	if associateQueue && loops.IsReviewFixPairHold(loop) {
+		diagnosis.RecommendedAction = reviewFixInspectResume(loop)
 	}
 	// Expand <seq> before emitting JSON/human output so operators and scripts
 	// never see the literal placeholder outside writeHumanLoopInspect.
@@ -806,6 +822,65 @@ func formatActionWithSeq(action string, seq int64) string {
 	return strings.ReplaceAll(action, "<seq>", strconv.FormatInt(seq, 10))
 }
 
+func reviewFixInspectHandoff(loop storage.LoopRecord, metadata loopDiagnosticMetadata) *loopInspectHandoff {
+	if !loops.IsReviewFixPairHold(loop) {
+		return nil
+	}
+	kind := loops.HITLKindReviewFixBudget
+	if loops.IsReviewScopeHumanHold(loop) && !loops.IsReviewFixBudgetHold(loop) {
+		kind = loops.HITLKindReviewScopeHuman
+	}
+	return &loopInspectHandoff{
+		Kind:        kind,
+		PauseReason: reviewFixInspectPauseReason(metadata, loop, kind),
+		Resume:      reviewFixInspectResume(loop),
+	}
+}
+
+func reviewFixInspectResume(loop storage.LoopRecord) string {
+	selector := strings.TrimSpace(loop.ID)
+	if loop.Seq > 0 {
+		selector = strconv.FormatInt(loop.Seq, 10)
+	}
+	cli := fmt.Sprintf("looper unpause %s / looper stop %s", selector, selector)
+	ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
+	if ok && strings.EqualFold(strings.TrimSpace(ask.Status), "awaiting") &&
+		(loops.IsReviewFixBudgetAsk(ask) || loops.IsReviewScopeHumanAsk(ask)) {
+		return "Continue / Stop; " + cli
+	}
+	return cli
+}
+
+func reviewFixInspectPauseReason(metadata loopDiagnosticMetadata, loop storage.LoopRecord, kind string) *string {
+	if metadata.PauseReason != nil {
+		if reason := strings.TrimSpace(*metadata.PauseReason); reason != "" {
+			return &reason
+		}
+	}
+	nested := ""
+	if kind == loops.HITLKindReviewScopeHuman {
+		nested = strings.TrimSpace(loops.ReadReviewScopeHumanState(loop.MetadataJSON).PauseReason)
+	} else {
+		nested = strings.TrimSpace(loops.ReadReviewFixBudgetState(loop.MetadataJSON).PauseReason)
+	}
+	if nested == "" {
+		return nil
+	}
+	return &nested
+}
+
+func humanInspectHoldReason(output loopInspectOutput) string {
+	if output.Metadata.PauseReason != nil {
+		if reason := strings.TrimSpace(*output.Metadata.PauseReason); reason != "" {
+			return reason
+		}
+	}
+	if output.Handoff != nil && output.Handoff.PauseReason != nil {
+		return strings.TrimSpace(*output.Handoff.PauseReason)
+	}
+	return ""
+}
+
 func requiresOperatorHold(output loopInspectOutput) bool {
 	if output.Diagnosis.FailureClass == "manual_intervention" {
 		return true
@@ -914,12 +989,31 @@ func writeHumanLoopInspect(w io.Writer, output loopInspectOutput) error {
 			}
 		}
 	}
+	if reason := humanInspectHoldReason(output); reason != "" {
+		if _, err := fmt.Fprintf(w, "Hold: %s\n", reason); err != nil {
+			return err
+		}
+	}
+	if output.Handoff != nil {
+		label := "Resume"
+		if output.Handoff.Kind == loops.HITLKindReviewScopeHuman {
+			label = "Release"
+		}
+		if _, err := fmt.Fprintf(w, "%s: %s\n", label, output.Handoff.Resume); err != nil {
+			return err
+		}
+		if output.Handoff.Kind == loops.HITLKindReviewScopeHuman {
+			if _, err := fmt.Fprintln(w, "unpause releases the scope hold; failed, interrupted, human takeover, or a manual pause remain."); err != nil {
+				return err
+			}
+		}
+	}
 	if output.Diagnosis.RecommendedAction != "" {
 		if _, err := fmt.Fprintf(w, "Action: %s\n", formatActionWithSeq(output.Diagnosis.RecommendedAction, output.Loop.Seq)); err != nil {
 			return err
 		}
 	}
-	if requiresOperatorHold(output) {
+	if requiresOperatorHold(output) && output.Handoff == nil {
 		if _, err := fmt.Fprintf(w, "Next: after resolving the blocker, looper retry %d (see also looper logs %d)\n", output.Loop.Seq, output.Loop.Seq); err != nil {
 			return err
 		}

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -444,8 +444,8 @@ func TestDiagnoseLoopBudgetHoldRecommendsUnpauseStop(t *testing.T) {
 	if !strings.Contains(got, "Hold: review_fix_budget_exhausted") {
 		t.Fatalf("human inspect = %q, want Hold reason", got)
 	}
-	if !strings.Contains(got, "Resume: looper unpause 12 / looper stop 12") {
-		t.Fatalf("human inspect = %q, want Resume commands", got)
+	if !strings.Contains(got, "Release: looper unpause 12 / looper stop 12") {
+		t.Fatalf("human inspect = %q, want Release commands", got)
 	}
 	if strings.Contains(got, "looper retry 12") {
 		t.Fatalf("human inspect = %q, must not suggest retry", got)

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -478,7 +478,7 @@ func TestWriteHumanLoopInspectScopeHoldUsesRelease(t *testing.T) {
 	if !strings.Contains(got, "Release: looper unpause 9 / looper stop 9") {
 		t.Fatalf("human inspect = %q, want Release commands", got)
 	}
-	if !strings.Contains(got, "unpause releases the scope hold; failed, interrupted, human takeover, or a manual pause remain.") {
+	if !strings.Contains(got, "unpause releases the scope hold; other blockers remain, such as unanswered agent/HITL asks, failed or interrupted runs, human takeover, or a manual pause.") {
 		t.Fatalf("human inspect = %q, want independent-blocker note", got)
 	}
 	if strings.Contains(got, "Resume:") {

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -1,6 +1,7 @@
 package cliapp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -408,6 +409,123 @@ func TestRecommendedActionForPausedIsNotAlwaysRetry(t *testing.T) {
 	}
 	if !strings.Contains(got, "unpause") {
 		t.Fatalf("paused action = %q, want unpause guidance", got)
+	}
+}
+
+func TestDiagnoseLoopBudgetHoldRecommendsUnpauseStop(t *testing.T) {
+	t.Parallel()
+	meta := `{"pauseReason":"review_fix_budget_exhausted","reviewFixBudget":{"exhaustedBy":"reviewer","pauseReason":"review_fix_budget_exhausted"}}`
+	loop := storage.LoopRecord{ID: "loop_budget", Seq: 12, Type: "reviewer", Status: "paused", MetadataJSON: &meta}
+	parsed := parseLoopDiagnosticMetadata(loop.MetadataJSON)
+	if parsed.PauseReason == nil || *parsed.PauseReason != "review_fix_budget_exhausted" {
+		t.Fatalf("PauseReason = %#v, want review_fix_budget_exhausted", parsed.PauseReason)
+	}
+	diagnosis := diagnoseLoop(loop, nil, nil, parsed, true)
+	if !strings.Contains(diagnosis.RecommendedAction, "looper unpause 12") || !strings.Contains(diagnosis.RecommendedAction, "looper stop 12") {
+		t.Fatalf("RecommendedAction = %q, want unpause/stop", diagnosis.RecommendedAction)
+	}
+	if strings.Contains(diagnosis.RecommendedAction, "retry") {
+		t.Fatalf("RecommendedAction = %q, must not recommend retry for budget hold", diagnosis.RecommendedAction)
+	}
+	handoff := reviewFixInspectHandoff(loop, parsed)
+	if handoff == nil || handoff.Kind != "review_fix_budget" {
+		t.Fatalf("handoff = %#v, want review_fix_budget", handoff)
+	}
+	var buf bytes.Buffer
+	if err := writeHumanLoopInspect(&buf, loopInspectOutput{
+		Loop:      diagnosticLoopOutput(loop),
+		Metadata:  parsed,
+		Handoff:   handoff,
+		Diagnosis: diagnosis,
+	}); err != nil {
+		t.Fatalf("writeHumanLoopInspect: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "Hold: review_fix_budget_exhausted") {
+		t.Fatalf("human inspect = %q, want Hold reason", got)
+	}
+	if !strings.Contains(got, "Resume: looper unpause 12 / looper stop 12") {
+		t.Fatalf("human inspect = %q, want Resume commands", got)
+	}
+	if strings.Contains(got, "looper retry 12") {
+		t.Fatalf("human inspect = %q, must not suggest retry", got)
+	}
+}
+
+func TestWriteHumanLoopInspectScopeHoldUsesRelease(t *testing.T) {
+	t.Parallel()
+	meta := `{"pauseReason":"review_scope_human_required","reviewScopeHuman":{"heldBy":"reviewer","pauseReason":"review_scope_human_required"}}`
+	loop := storage.LoopRecord{ID: "loop_scope", Seq: 9, Type: "reviewer", Status: "paused", MetadataJSON: &meta}
+	parsed := parseLoopDiagnosticMetadata(loop.MetadataJSON)
+	diagnosis := diagnoseLoop(loop, nil, nil, parsed, true)
+	handoff := reviewFixInspectHandoff(loop, parsed)
+	if handoff == nil || handoff.Kind != "review_scope_human" {
+		t.Fatalf("handoff = %#v, want review_scope_human", handoff)
+	}
+	var buf bytes.Buffer
+	if err := writeHumanLoopInspect(&buf, loopInspectOutput{
+		Loop:      diagnosticLoopOutput(loop),
+		Metadata:  parsed,
+		Handoff:   handoff,
+		Diagnosis: diagnosis,
+	}); err != nil {
+		t.Fatalf("writeHumanLoopInspect: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "Hold: review_scope_human_required") {
+		t.Fatalf("human inspect = %q, want Hold reason", got)
+	}
+	if !strings.Contains(got, "Release: looper unpause 9 / looper stop 9") {
+		t.Fatalf("human inspect = %q, want Release commands", got)
+	}
+	if !strings.Contains(got, "unpause releases the scope hold; failed, interrupted, human takeover, or a manual pause remain.") {
+		t.Fatalf("human inspect = %q, want independent-blocker note", got)
+	}
+	if strings.Contains(got, "Resume:") {
+		t.Fatalf("human inspect = %q, must use Release not Resume", got)
+	}
+}
+
+func TestDiagnoseLoopHITLBudgetAskPrefixesContinueStop(t *testing.T) {
+	t.Parallel()
+	meta := `{"hitl":{"kind":"review_fix_budget","status":"awaiting","options":["Continue","Stop"]}}`
+	loop := storage.LoopRecord{ID: "loop_hitl", Seq: 15, Type: "reviewer", Status: "awaiting_human", MetadataJSON: &meta}
+	got := diagnoseLoop(loop, nil, nil, parseLoopDiagnosticMetadata(loop.MetadataJSON), true)
+	if !strings.Contains(got.RecommendedAction, "Continue / Stop") {
+		t.Fatalf("RecommendedAction = %q, want Continue/Stop prefix", got.RecommendedAction)
+	}
+	if !strings.Contains(got.RecommendedAction, "looper unpause 15") || !strings.Contains(got.RecommendedAction, "looper stop 15") {
+		t.Fatalf("RecommendedAction = %q, want unpause/stop commands", got.RecommendedAction)
+	}
+}
+
+func TestDiagnoseLoopOrdinaryPauseIsNotPairStop(t *testing.T) {
+	t.Parallel()
+	loop := storage.LoopRecord{ID: "loop_paused", Seq: 4, Type: "worker", Status: "paused"}
+	got := diagnoseLoop(loop, nil, nil, loopDiagnosticMetadata{}, true)
+	if !strings.Contains(got.RecommendedAction, "looper unpause 4") || !strings.Contains(got.RecommendedAction, "looper describe 4") {
+		t.Fatalf("RecommendedAction = %q, want unpause/describe", got.RecommendedAction)
+	}
+	if strings.Contains(got.RecommendedAction, "looper stop") {
+		t.Fatalf("RecommendedAction = %q, must not use pair stop", got.RecommendedAction)
+	}
+	if reviewFixInspectHandoff(loop, loopDiagnosticMetadata{}) != nil {
+		t.Fatal("handoff must be nil for ordinary pause")
+	}
+}
+
+func TestDiagnoseLoopRunSelectorDoesNotRewritePairHoldAction(t *testing.T) {
+	t.Parallel()
+	meta := `{"pauseReason":"review_fix_budget_exhausted","reviewFixBudget":{"exhaustedBy":"reviewer","pauseReason":"review_fix_budget_exhausted"}}`
+	loop := storage.LoopRecord{ID: "loop_budget", Seq: 12, Type: "reviewer", Status: "paused", MetadataJSON: &meta}
+	runMsg := `Post "https://api.github.com/graphql": EOF`
+	run := &storage.RunRecord{Status: "failed", ErrorMessage: &runMsg}
+	got := diagnoseLoop(loop, run, nil, parseLoopDiagnosticMetadata(loop.MetadataJSON), false)
+	if got.FailureClass != "github_transient" {
+		t.Fatalf("FailureClass = %q, want github_transient from historical run", got.FailureClass)
+	}
+	if strings.Contains(got.RecommendedAction, "unpause") || strings.Contains(got.RecommendedAction, "looper stop") {
+		t.Fatalf("RecommendedAction = %q, must not rewrite historical-run action", got.RecommendedAction)
 	}
 }
 

--- a/internal/cliapp/loop_handoff_lifecycle_test.go
+++ b/internal/cliapp/loop_handoff_lifecycle_test.go
@@ -1,0 +1,114 @@
+package cliapp
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// Exercise persisted holds and their Continue transitions, then check the
+// operator output against the lifecycle that actually remains.
+func TestHandoffGuidancePreservesUnderlyingLifecycle(t *testing.T) {
+	for _, initial := range []string{"failed", "budget"} {
+		t.Run(initial, func(t *testing.T) {
+			ctx := context.Background()
+			_, repos := writeEmptyRunStatsCommandFixtureWithRepos(t)
+			now := "2026-09-06T00:00:00.000Z"
+			project := storage.ProjectRecord{ID: "handoff_project", Name: "Handoff", RepoPath: t.TempDir(), CreatedAt: now, UpdatedAt: now}
+			if err := repos.Projects.Upsert(ctx, project); err != nil {
+				t.Fatal(err)
+			}
+			pr := int64(646)
+			reviewer := storage.LoopRecord{ID: "handoff_reviewer", Seq: 1, ProjectID: project.ID, Type: "reviewer", TargetType: "pull_request", Repo: stringPtr("nexu-io/looper"), PRNumber: &pr, Status: "running", CreatedAt: now, UpdatedAt: now}
+			fixer := reviewer
+			fixer.ID, fixer.Seq, fixer.Type, fixer.Status = "handoff_fixer", 2, "fixer", "failed"
+			if initial == "budget" {
+				fixer.Status = "queued"
+			}
+			for _, loop := range []storage.LoopRecord{reviewer, fixer} {
+				if err := repos.Loops.Upsert(ctx, loop); err != nil {
+					t.Fatal(err)
+				}
+			}
+			getFixer := func() storage.LoopRecord {
+				t.Helper()
+				got, err := repos.Loops.GetByID(ctx, fixer.ID)
+				if err != nil || got == nil {
+					t.Fatalf("fixer: %v, %v", got, err)
+				}
+				return *got
+			}
+			if initial == "budget" {
+				if _, err := loops.ParkReviewFixBudget(ctx, repos, loops.ParkReviewFixBudgetInput{Exhausted: fixer, Role: "fixer", Repo: "nexu-io/looper", PRNumber: pr, Count: 3, Cap: 3, NowISO: now}); err != nil {
+					t.Fatal(err)
+				}
+				fresh, err := repos.Loops.GetByID(ctx, reviewer.ID)
+				if err != nil || fresh == nil {
+					t.Fatalf("reviewer: %v, %v", fresh, err)
+				}
+				reviewer = *fresh
+			}
+			parked, err := loops.ParkReviewScopeHuman(ctx, repos, loops.ParkReviewScopeHumanInput{Held: reviewer, Role: "reviewer", Repo: "nexu-io/looper", PRNumber: pr, NowISO: now, Question: "Clarify scope"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			held := getFixer()
+			if !loops.IsReviewScopeHumanHold(held) {
+				t.Fatal("missing scope overlay")
+			}
+			parsed := parseLoopDiagnosticMetadata(held.MetadataJSON)
+			message := "unusable worktree path preserved"
+			run := &storage.RunRecord{Status: "failed", ErrorMessage: &message}
+			if initial == "budget" {
+				run = nil
+			}
+			diagnosis := diagnoseLoop(held, run, nil, parsed, true)
+			output := loopInspectOutput{Loop: diagnosticLoopOutput(held), Metadata: parsed, Handoff: reviewFixInspectHandoff(held, parsed), Diagnosis: diagnosis}
+			var buf bytes.Buffer
+			if initial == "budget" {
+				if !loops.IsReviewFixBudgetHold(held) {
+					t.Fatal("missing budget hold")
+				}
+				if err := writeHumanLoopInspect(&buf, output); err != nil {
+					t.Fatal(err)
+				}
+				if !strings.Contains(buf.String(), "other holds, including scope holds") || strings.Contains(buf.String(), "Resume:") {
+					t.Fatalf("misleading output: %s", &buf)
+				}
+				result, err := loops.ApplyReviewFixBudgetAnswer(ctx, repos, held, "Continue", now, loops.ReviewFixBudgetLiveCaps{ReviewerMaxPublishes: 3, FixerMaxPushes: 3})
+				if err != nil || !result.Applied {
+					t.Fatalf("budget Continue: %v, %v", result, err)
+				}
+				after := getFixer()
+				if after.Status != "paused" || !loops.IsReviewScopeHumanHold(after) || loops.IsReviewFixBudgetHold(after) {
+					t.Fatalf("expected remaining scope hold: %+v", after)
+				}
+			} else {
+				baseline := diagnoseLoop(fixer, run, nil, loopDiagnosticMetadata{}, true).RecommendedAction
+				if err := writeHumanLoopFailures(&buf, loopFailuresOutput{Items: []loopInspectOutput{output}}); err != nil {
+					t.Fatal(err)
+				}
+				for _, want := range []string{baseline, "looper unpause 2", "releases only the scope hold"} {
+					if !strings.Contains(buf.String(), want) {
+						t.Fatalf("failures output %q missing %q", buf.String(), want)
+					}
+				}
+				result, err := loops.ApplyReviewScopeHumanAnswer(ctx, repos, parked, "Continue", now)
+				if err != nil || !result.Applied {
+					t.Fatalf("scope Continue: %v, %v", result, err)
+				}
+				after := getFixer()
+				if after.Status != "failed" || loops.IsReviewScopeHumanHold(after) {
+					t.Fatalf("expected independent failure: %+v", after)
+				}
+				if got := diagnoseLoop(after, run, nil, parseLoopDiagnosticMetadata(after.MetadataJSON), true).RecommendedAction; got != baseline {
+					t.Fatalf("recovery after release = %q, want %q", got, baseline)
+				}
+			}
+		})
+	}
+}

--- a/internal/cliapp/loop_handoff_lifecycle_test.go
+++ b/internal/cliapp/loop_handoff_lifecycle_test.go
@@ -13,7 +13,7 @@ import (
 // Exercise persisted holds and their Continue transitions, then check the
 // operator output against the lifecycle that actually remains.
 func TestHandoffGuidancePreservesUnderlyingLifecycle(t *testing.T) {
-	for _, initial := range []string{"failed", "budget"} {
+	for _, initial := range []string{"failed", "budget", "awaiting_human"} {
 		t.Run(initial, func(t *testing.T) {
 			ctx := context.Background()
 			_, repos := writeEmptyRunStatsCommandFixtureWithRepos(t)
@@ -28,6 +28,14 @@ func TestHandoffGuidancePreservesUnderlyingLifecycle(t *testing.T) {
 			fixer.ID, fixer.Seq, fixer.Type, fixer.Status = "handoff_fixer", 2, "fixer", "failed"
 			if initial == "budget" {
 				fixer.Status = "queued"
+			}
+			if initial == "awaiting_human" {
+				fixer.Status = initial
+				meta, err := loops.WriteHITLAsk(nil, loops.HITLAsk{Kind: "agent_question", Status: "awaiting", Question: "Which approach should Fixer take?", AskedAt: now})
+				if err != nil {
+					t.Fatal(err)
+				}
+				fixer.MetadataJSON = &meta
 			}
 			for _, loop := range []storage.LoopRecord{reviewer, fixer} {
 				if err := repos.Loops.Upsert(ctx, loop); err != nil {
@@ -63,7 +71,7 @@ func TestHandoffGuidancePreservesUnderlyingLifecycle(t *testing.T) {
 			parsed := parseLoopDiagnosticMetadata(held.MetadataJSON)
 			message := "unusable worktree path preserved"
 			run := &storage.RunRecord{Status: "failed", ErrorMessage: &message}
-			if initial == "budget" {
+			if initial != "failed" {
 				run = nil
 			}
 			diagnosis := diagnoseLoop(held, run, nil, parsed, true)
@@ -86,6 +94,27 @@ func TestHandoffGuidancePreservesUnderlyingLifecycle(t *testing.T) {
 				after := getFixer()
 				if after.Status != "paused" || !loops.IsReviewScopeHumanHold(after) || loops.IsReviewFixBudgetHold(after) {
 					t.Fatalf("expected remaining scope hold: %+v", after)
+				}
+			} else if initial == "awaiting_human" {
+				if err := writeHumanLoopInspect(&buf, output); err != nil {
+					t.Fatal(err)
+				}
+				if !strings.Contains(buf.String(), "unanswered agent/HITL asks") || !strings.Contains(buf.String(), "such as") {
+					t.Fatalf("missing remaining-ask guidance: %s", &buf)
+				}
+				result, err := loops.ApplyReviewScopeHumanAnswer(ctx, repos, parked, "Continue", now)
+				if err != nil || !result.Applied {
+					t.Fatalf("scope Continue: %v, %v", result, err)
+				}
+				after := getFixer()
+				if after.Status != "awaiting_human" || loops.IsReviewScopeHumanHold(after) || after.NextRunAt != nil {
+					t.Fatalf("expected unanswered ask to keep loop blocked: %+v", after)
+				}
+				for _, loop := range []storage.LoopRecord{held, after} {
+					ask, ok := loops.ReadHITLAsk(loop.MetadataJSON)
+					if !ok || ask.Kind != "agent_question" || ask.Status != "awaiting" || ask.Question != "Which approach should Fixer take?" {
+						t.Fatalf("agent ask was not preserved: %+v", ask)
+					}
 				}
 			} else {
 				baseline := diagnoseLoop(fixer, run, nil, loopDiagnosticMetadata{}, true).RecommendedAction

--- a/internal/config/value_sources_test.go
+++ b/internal/config/value_sources_test.go
@@ -39,10 +39,10 @@ func TestLoadFileMetadataReportsCanonicalFieldSources(t *testing.T) {
 	}
 
 	want := map[string]ValueSource{
-		"agent.model":                   ValueSourceConfigFile,
-		"agent.env":                     ValueSourceConfigFile,
-		"agent.env.TOKEN":               ValueSourceConfigFile,
-		"agent.timeouts.plannerSeconds": ValueSourceCLI,
+		"agent.model":                             ValueSourceConfigFile,
+		"agent.env":                               ValueSourceConfigFile,
+		"agent.env.TOKEN":                         ValueSourceConfigFile,
+		"agent.timeouts.plannerSeconds":           ValueSourceCLI,
 		"agent.timeouts.plannerMaxRuntimeSeconds": ValueSourceCLI,
 		"defaults.allowAutoPush":                  ValueSourceEnv,
 		"notifications.webhook.mentionOpenIds":    ValueSourceConfigFile,

--- a/internal/config/value_sources_test.go
+++ b/internal/config/value_sources_test.go
@@ -39,10 +39,10 @@ func TestLoadFileMetadataReportsCanonicalFieldSources(t *testing.T) {
 	}
 
 	want := map[string]ValueSource{
-		"agent.model":                             ValueSourceConfigFile,
-		"agent.env":                               ValueSourceConfigFile,
-		"agent.env.TOKEN":                         ValueSourceConfigFile,
-		"agent.timeouts.plannerSeconds":           ValueSourceCLI,
+		"agent.model":                   ValueSourceConfigFile,
+		"agent.env":                     ValueSourceConfigFile,
+		"agent.env.TOKEN":               ValueSourceConfigFile,
+		"agent.timeouts.plannerSeconds": ValueSourceCLI,
 		"agent.timeouts.plannerMaxRuntimeSeconds": ValueSourceCLI,
 		"defaults.allowAutoPush":                  ValueSourceEnv,
 		"notifications.webhook.mentionOpenIds":    ValueSourceConfigFile,

--- a/specs/2026-08-24-review-fix-convergence/spec.md
+++ b/specs/2026-08-24-review-fix-convergence/spec.md
@@ -656,6 +656,15 @@ counters/reason; CLI/dashboard may refresh thread links and PR state from the
 provider. This keeps historical evidence without another state copy to
 reconcile.
 
+Operator CLI and dashboard currently show the inspected loop's hold reason
+and exact unpause/stop commands only. The rest of this evidence list (PR,
+lane, current head, last reviewed signal, count/live cap meters, exhausted
+roles, unresolved `must_fix` links, pending `wontfix`/decline reasons,
+late-discovery blockers, last outcome/progress, provider-refreshed thread
+state) is deferred to a later bounded implementation: one backend-computed
+brief, CLI/dashboard display the same result, no TypeScript inference, no
+full-project polling, no persisted handoff record.
+
 ## 10. Module design
 
 ### 10.1 Reviewer convergence Module
@@ -943,8 +952,9 @@ go build ./...
 4. **Thread signal:** narrow feature gate, fingerprint, stable queue coalescing,
    same-head polling/webhook trigger, extended decisions, post-mutation signal
    commit, and stale-mutation guard tests.
-5. **Docs/observability:** configuration guide, user guide, dashboard/CLI handoff
-   detail, metrics/events for disposition and budget outcomes.
+5. **Docs/observability:** configuration guide, user guide, and the reduced
+   operator surface (docs plus inspected-loop hold reason and exact unpause/stop
+   commands). The full §9.5 handoff brief is not in this slice.
 
 Each slice must leave existing authority and lifecycle invariants intact. Do not
 merge a prompt-only partial that publishes new disposition words without the

--- a/web/dashboard/src/lib/reviewFixHandoff.test.ts
+++ b/web/dashboard/src/lib/reviewFixHandoff.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { readReviewFixHandoff } from "@/lib/reviewFixHandoff";
+
+describe("readReviewFixHandoff", () => {
+  it("builds current-loop no-HITL budget commands", () => {
+    const handoff = readReviewFixHandoff({
+      seq: 12,
+      status: "paused",
+      metadataJson: JSON.stringify({
+        pauseReason: "review_fix_budget_exhausted",
+        reviewFixBudget: {
+          exhaustedBy: "reviewer",
+          pauseReason: "review_fix_budget_exhausted",
+        },
+      }),
+    });
+    expect(handoff).toMatchObject({
+      kind: "review_fix_budget",
+      pauseReason: "review_fix_budget_exhausted",
+      unpauseCommand: "looper unpause 12",
+      stopCommand: "looper stop 12",
+      title: "Review-fix budget exhausted",
+    });
+  });
+
+  it("shows HITL budget unpause/stop without requiring Continue/Stop on the card", () => {
+    const handoff = readReviewFixHandoff({
+      seq: 4,
+      status: "awaiting_human",
+      metadataJson: JSON.stringify({
+        hitl: {
+          kind: "review_fix_budget",
+          status: "awaiting",
+          question: "reviewer hit its review-fix budget on acme/looper#42 (3/3).",
+        },
+      }),
+    });
+    expect(handoff?.kind).toBe("review_fix_budget");
+    expect(handoff?.unpauseCommand).toBe("looper unpause 4");
+    expect(handoff?.stopCommand).toBe("looper stop 4");
+    expect(handoff?.unpauseCommand).not.toContain("Continue");
+    expect(handoff?.stopCommand).not.toContain("Stop");
+  });
+
+  it("surfaces current-loop scope hold reason", () => {
+    const handoff = readReviewFixHandoff({
+      seq: 9,
+      status: "paused",
+      metadataJson: JSON.stringify({
+        pauseReason: "review_scope_human_required",
+        reviewScopeHuman: {
+          heldBy: "reviewer",
+          question: "Clarify AGENTS.md vs PR non-goals before unpause.",
+          evidence: "thread PRRT_1 conflicts with stated non-goal",
+          pauseReason: "review_scope_human_required",
+        },
+      }),
+    });
+    expect(handoff).toMatchObject({
+      kind: "review_scope_human",
+      pauseReason: "review_scope_human_required",
+      unpauseCommand: "looper unpause 9",
+      stopCommand: "looper stop 9",
+      title: "Human scope decision required",
+    });
+  });
+
+  it("ignores ordinary paused loops", () => {
+    expect(
+      readReviewFixHandoff({
+        seq: 1,
+        status: "paused",
+        metadataJson: JSON.stringify({ pauseReason: "manual" }),
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores pending-only scope evidence", () => {
+    expect(
+      readReviewFixHandoff({
+        seq: 9,
+        status: "paused",
+        metadataJson: JSON.stringify({
+          reviewScopeHuman: {
+            pending: true,
+            question: "Clarify AGENTS.md vs PR non-goals before unpause.",
+            evidence: "thread PRRT_1 conflicts with stated non-goal",
+          },
+        }),
+      }),
+    ).toBeNull();
+  });
+
+  it("uses distinct lead text for budget vs scope", () => {
+    const budget = readReviewFixHandoff({
+      seq: 12,
+      status: "paused",
+      metadataJson: JSON.stringify({
+        pauseReason: "review_fix_budget_exhausted",
+        reviewFixBudget: { pauseReason: "review_fix_budget_exhausted" },
+      }),
+    });
+    expect(budget?.lead).toContain("refills only exhausted meters");
+    expect(budget?.lead).toContain("resumes the pair");
+    expect(budget?.lead).toContain("exhaustion is not approval");
+    expect(budget?.lead).not.toContain("releases the scope hold");
+
+    const scope = readReviewFixHandoff({
+      seq: 9,
+      status: "paused",
+      metadataJson: JSON.stringify({
+        pauseReason: "review_scope_human_required",
+        reviewScopeHuman: { pauseReason: "review_scope_human_required" },
+      }),
+    });
+    expect(scope?.lead).toContain("releases the scope hold");
+    expect(scope?.lead).toContain("failed");
+    expect(scope?.lead).toContain("interrupted");
+    expect(scope?.lead).toContain("human takeover");
+    expect(scope?.lead).toContain("manual pause");
+    expect(scope?.lead).not.toContain("resumes the pair");
+  });
+});

--- a/web/dashboard/src/lib/reviewFixHandoff.test.ts
+++ b/web/dashboard/src/lib/reviewFixHandoff.test.ts
@@ -83,6 +83,20 @@ describe("readReviewFixHandoff", () => {
     expect(handoff?.lead).not.toContain("resumes the pair");
   });
 
+  it("explains that an unrelated agent ask survives scope release", () => {
+    const handoff = readReviewFixHandoff({
+      seq: 12,
+      status: "awaiting_human",
+      metadataJson: JSON.stringify({
+        hitl: { kind: "agent_question", status: "awaiting" },
+        reviewScopeHuman: { heldBy: "reviewer" },
+      }),
+    });
+    expect(handoff?.kind).toBe("review_scope_human");
+    expect(handoff?.lead).toContain("unanswered agent/HITL asks");
+    expect(handoff?.lead).toContain("such as");
+  });
+
   it("ignores ordinary paused loops", () => {
     expect(
       readReviewFixHandoff({

--- a/web/dashboard/src/lib/reviewFixHandoff.test.ts
+++ b/web/dashboard/src/lib/reviewFixHandoff.test.ts
@@ -65,6 +65,24 @@ describe("readReviewFixHandoff", () => {
     });
   });
 
+  it("does not promise resume when budget and scope holds coexist", () => {
+    const handoff = readReviewFixHandoff({
+      seq: 12,
+      status: "paused",
+      metadataJson: JSON.stringify({
+        pauseReason: "sibling_review_fix_budget",
+        reviewFixBudget: { pauseReason: "sibling_review_fix_budget" },
+        reviewScopeHuman: {
+          heldBy: "reviewer",
+          pauseReason: "sibling_review_scope_human",
+        },
+      }),
+    });
+    expect(handoff?.lead).toContain("releases the budget hold");
+    expect(handoff?.lead).toContain("other holds, including scope holds");
+    expect(handoff?.lead).not.toContain("resumes the pair");
+  });
+
   it("ignores ordinary paused loops", () => {
     expect(
       readReviewFixHandoff({
@@ -101,7 +119,8 @@ describe("readReviewFixHandoff", () => {
       }),
     });
     expect(budget?.lead).toContain("refills only exhausted meters");
-    expect(budget?.lead).toContain("resumes the pair");
+    expect(budget?.lead).toContain("other holds, including scope holds");
+    expect(budget?.lead).not.toContain("resumes the pair");
     expect(budget?.lead).toContain("exhaustion is not approval");
     expect(budget?.lead).not.toContain("releases the scope hold");
 

--- a/web/dashboard/src/lib/reviewFixHandoff.ts
+++ b/web/dashboard/src/lib/reviewFixHandoff.ts
@@ -1,0 +1,103 @@
+export type ReviewFixHandoffKind = "review_fix_budget" | "review_scope_human";
+
+export type ReviewFixHandoff = {
+  kind: ReviewFixHandoffKind;
+  pauseReason: string;
+  unpauseCommand: string;
+  stopCommand: string;
+  title: string;
+  lead: string;
+};
+
+type LoopLike = {
+  seq: number;
+  id?: string;
+  status?: string | null;
+  metadataJson?: string | null;
+};
+
+type LoopMetadata = {
+  hitl?: { kind?: string; status?: string };
+  pauseReason?: string;
+  reviewFixBudget?: { pauseReason?: string; exhaustedBy?: string };
+  reviewScopeHuman?: { pauseReason?: string; heldBy?: string };
+};
+
+const BUDGET_REASONS: Record<string, true> = {
+  sibling_review_fix_budget: true,
+  review_fix_budget_exhausted: true,
+};
+
+const SCOPE_REASONS: Record<string, true> = {
+  sibling_review_scope_human: true,
+  review_scope_human_required: true,
+};
+
+const BUDGET_LEAD =
+  "Continue/Unpause refills only exhausted meters and resumes the pair; Stop terminates both; exhaustion is not approval.";
+
+const SCOPE_LEAD =
+  "Continue/Unpause releases the scope hold; independent blockers (failed, interrupted, human takeover, or a manual pause) remain; Stop terminates both.";
+
+function parseMetadata(raw?: string | null): LoopMetadata {
+  if (!raw?.trim()) return {};
+  try {
+    return JSON.parse(raw) as LoopMetadata;
+  } catch {
+    return {};
+  }
+}
+
+function isReviewFixBudgetHold(status: string, meta: LoopMetadata): boolean {
+  if (status === "awaiting_human") {
+    return (meta.hitl?.kind ?? "").trim() === "review_fix_budget";
+  }
+  if (status !== "paused") return false;
+  const top = (meta.pauseReason ?? "").trim();
+  const nested = (meta.reviewFixBudget?.pauseReason ?? "").trim();
+  return (
+    BUDGET_REASONS[top] === true ||
+    BUDGET_REASONS[nested] === true ||
+    (meta.reviewFixBudget?.exhaustedBy ?? "").trim() !== ""
+  );
+}
+
+function isReviewScopeHumanHold(status: string, meta: LoopMetadata): boolean {
+  if (status === "terminated" || status === "stopped" || status === "completed") {
+    return false;
+  }
+  if ((meta.reviewScopeHuman?.heldBy ?? "").trim()) return true;
+  const nested = (meta.reviewScopeHuman?.pauseReason ?? "").trim();
+  const top = (meta.pauseReason ?? "").trim();
+  if (SCOPE_REASONS[nested] === true || SCOPE_REASONS[top] === true) return true;
+  return (
+    status === "awaiting_human" &&
+    (meta.hitl?.kind ?? "").trim() === "review_scope_human"
+  );
+}
+
+export function readReviewFixHandoff(loop: LoopLike): ReviewFixHandoff | null {
+  const meta = parseMetadata(loop.metadataJson);
+  const status = (loop.status ?? "").trim();
+  const budget = isReviewFixBudgetHold(status, meta);
+  if (!budget && !isReviewScopeHumanHold(status, meta)) return null;
+  const kind: ReviewFixHandoffKind = budget
+    ? "review_fix_budget"
+    : "review_scope_human";
+  const selector =
+    loop.seq !== 0 ? String(loop.seq) : (loop.id ?? "").trim() || "0";
+  return {
+    kind,
+    pauseReason:
+      (meta.pauseReason ?? "").trim() ||
+      (meta.reviewFixBudget?.pauseReason ?? "").trim() ||
+      (meta.reviewScopeHuman?.pauseReason ?? "").trim(),
+    unpauseCommand: `looper unpause ${selector}`,
+    stopCommand: `looper stop ${selector}`,
+    title:
+      kind === "review_fix_budget"
+        ? "Review-fix budget exhausted"
+        : "Human scope decision required",
+    lead: kind === "review_fix_budget" ? BUDGET_LEAD : SCOPE_LEAD,
+  };
+}

--- a/web/dashboard/src/lib/reviewFixHandoff.ts
+++ b/web/dashboard/src/lib/reviewFixHandoff.ts
@@ -37,7 +37,7 @@ const BUDGET_LEAD =
   "Continue/Unpause releases the budget hold and refills only exhausted meters; other holds, including scope holds, may still prevent the pair from running. Stop terminates both; exhaustion is not approval.";
 
 const SCOPE_LEAD =
-  "Continue/Unpause releases the scope hold; independent blockers (failed, interrupted, human takeover, or a manual pause) remain; Stop terminates both.";
+  "Continue/Unpause releases the scope hold; other blockers remain, such as unanswered agent/HITL asks, failed or interrupted runs, human takeover, or a manual pause; Stop terminates both.";
 
 function parseMetadata(raw?: string | null): LoopMetadata {
   if (!raw?.trim()) return {};

--- a/web/dashboard/src/lib/reviewFixHandoff.ts
+++ b/web/dashboard/src/lib/reviewFixHandoff.ts
@@ -34,7 +34,7 @@ const SCOPE_REASONS: Record<string, true> = {
 };
 
 const BUDGET_LEAD =
-  "Continue/Unpause refills only exhausted meters and resumes the pair; Stop terminates both; exhaustion is not approval.";
+  "Continue/Unpause releases the budget hold and refills only exhausted meters; other holds, including scope holds, may still prevent the pair from running. Stop terminates both; exhaustion is not approval.";
 
 const SCOPE_LEAD =
   "Continue/Unpause releases the scope hold; independent blockers (failed, interrupted, human takeover, or a manual pause) remain; Stop terminates both.";

--- a/web/dashboard/src/pages/LoopDetail.tsx
+++ b/web/dashboard/src/pages/LoopDetail.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode,
 } from "react";
 import { Link, useParams } from "react-router-dom";
+import { CopyButton } from "@/components/CopyButton";
 import { LoopActionBar } from "@/components/LoopActionBar";
 import { LoopTypeBadge } from "@/components/LoopTypeBadge";
 import { PanelError } from "@/components/PanelError";
@@ -43,6 +44,7 @@ import {
   resolveLogsStreamStatus,
   stderrGapFromSecondarySnapshot,
 } from "@/lib/logsStream";
+import { readReviewFixHandoff } from "@/lib/reviewFixHandoff";
 import { consumeSSE } from "@/lib/sse";
 import { usePolling } from "@/lib/usePolling";
 
@@ -260,6 +262,31 @@ function HITLDecisionCard({
         </Button>
       </form>
       {error ? <p className="mb-0 text-[12px] text-red-500">{error}</p> : null}
+    </Card>
+  );
+}
+
+function ReviewFixHandoffCard({ loop }: { loop: Loop }) {
+  const handoff = readReviewFixHandoff(loop);
+  if (!handoff) return null;
+  return (
+    <Card title={handoff.title}>
+      <p className="mt-0 text-[13px]">{handoff.lead}</p>
+      {handoff.pauseReason ? (
+        <dl className="m-0">
+          <Kv label="Pause reason" value={handoff.pauseReason} />
+        </dl>
+      ) : null}
+      <div className="mt-2 flex flex-wrap gap-2">
+        <code className="mono rounded border border-[var(--border)] px-2 py-1 text-[12px]">
+          {handoff.unpauseCommand}
+        </code>
+        <CopyButton text={handoff.unpauseCommand} label="Copy unpause" />
+        <code className="mono rounded border border-[var(--border)] px-2 py-1 text-[12px]">
+          {handoff.stopCommand}
+        </code>
+        <CopyButton text={handoff.stopCommand} label="Copy stop" />
+      </div>
     </Card>
   );
 }
@@ -819,6 +846,7 @@ export function LoopDetailPage() {
       ) : null}
 
       {data ? <HITLDecisionCard loop={data} onMutated={onMutated} /> : null}
+      {data ? <ReviewFixHandoffCard loop={data} /> : null}
 
       {data ? (
         <Card title="Actions">


### PR DESCRIPTION
# Summary

- Rebuilt on current `main` (no longer stacked on `feat/review-fix-convergence-same-head`).
- Operator surface only: current-loop hold reason plus exact `looper unpause <seq>` / `looper stop <seq>`.
- Deleted the Go/TS cross-loop handoff reconstruction (pair aggregation, meters, heads, exhausted roles, sibling List/poll, historical ranking).
- Budget exhaustion is not approval. Budget unpause releases only its hold; a scope hold may still prevent execution. Scope unpause releases the overlay only, and failure-specific recovery guidance remains visible.

## Deferred (§9.5)

Not in this PR. Later bounded implementation should compute one backend brief that CLI/dashboard display; no TypeScript inference, no full-project polling, no persisted handoff record:

- PR/lane/current head/last reviewed signal
- Reviewer/Fixer `count / live cap`
- which role(s) are exhausted
- unresolved `must_fix` links, pending `wontfix`/decline reasons, late blockers, last outcome/progress
- provider-refreshed thread state

Park-time events (`loop.review_fix_budget.exhausted`, `loop.review_scope_human.required`) still snapshot decision-time evidence.

# Testing

- [x] `go test -p 1 ./...` (full suite passed; the initial parallel run hit the previously observed 2-second worker E2E HTTP timeout)
- [x] `go vet ./...` and `go build ./...`
- [x] Dashboard `pnpm test` (194 passed) and `pnpm build`
- [x] `TestHandoffGuidancePreservesUnderlyingLifecycle`: real scope/budget park and Continue transitions connected to CLI inspect/failures output. Covers remaining scope holds, failed siblings, and preserved unanswered agent/HITL asks; regression cases fail before their corresponding guidance fixes.
- [x] Dashboard combined budget/scope hold guidance regression.

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [ ] Daemon boot / config / runtime path risk
- [x] Worktree / repo isolation / lifecycle risk (operator guidance only; persisted lifecycle-to-output integration coverage)
- [ ] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

# Regression Policy

- [x] This is not a P0/P1 bug fix

# Regression Mapping

- Spec slice 5 (reduced): `specs/2026-08-24-review-fix-convergence/spec.md` §9.5 deferred note

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied

