### PR TITLE
fix: restore missing GitHub webhook tunnel secrets on reconcile

### DIFF
--- a/internal/runtime/webhook_tunnel.go
+++ b/internal/runtime/webhook_tunnel.go
@@ -39,6 +39,7 @@ type webhookTunnelGitHubHook struct {
 		URL         string `json:"url"`
 		ContentType string `json:"content_type"`
 		InsecureSSL string `json:"insecure_ssl"`
+		Secret      string `json:"secret"`
 	} `json:"config"`
 	LastResponse *struct {
 		Code int `json:"code"`
@@ -308,7 +309,7 @@ func (w *webhookRuntime) reconcileTunnelHook(ctx context.Context, store *storage
 	if record.ConsecutiveDisables >= webhookTunnelDisableLatchThreshold && !hook.Active {
 		return tunnelStateLatched(record, "remote hook disabled repeatedly; not re-enabling")
 	}
-	needPatch := !hook.Active || strings.TrimSpace(hook.Config.URL) != url || !sameWebhookEvents(hook.Events, webhookForwardEvents) || !strings.EqualFold(strings.TrimSpace(hook.Config.ContentType), "json") || strings.TrimSpace(hook.Config.InsecureSSL) != "0"
+	needPatch := !hook.Active || strings.TrimSpace(hook.Config.URL) != url || !sameWebhookEvents(hook.Events, webhookForwardEvents) || !strings.EqualFold(strings.TrimSpace(hook.Config.ContentType), "json") || strings.TrimSpace(hook.Config.InsecureSSL) != "0" || strings.TrimSpace(hook.Config.Secret) == ""
 	if needPatch {
 		if !hook.Active {
 			record.ConsecutiveDisables++

--- a/internal/runtime/webhook_tunnel_adoption_test.go
+++ b/internal/runtime/webhook_tunnel_adoption_test.go
@@ -313,6 +313,7 @@ func TestReconcileTunnelHookTreatsDesiredURLAsManagedInsteadOfOrphaning(t *testi
 	hook.Config.URL = desiredURL
 	hook.Config.ContentType = "json"
 	hook.Config.InsecureSSL = "0"
+	hook.Config.Secret = "********"
 	client := &fakeWebhookTunnelGitHubClient{getHook: hook, getFound: true}
 	rt := newWebhookRuntime(cfg, &testLogger{}, func() time.Time { return time.Unix(10, 0) })
 	rt.tunnelClient = client

--- a/internal/runtime/webhook_tunnel_reconcile_test.go
+++ b/internal/runtime/webhook_tunnel_reconcile_test.go
@@ -67,6 +67,76 @@ func TestReconcileTunnelHookEmptySecretDegradesWithoutMutation(t *testing.T) {
 	}
 }
 
+func TestReconcileTunnelHookMissingRemoteSecretRepatchesHook(t *testing.T) {
+	t.Parallel()
+
+	ctx, repos, cfg := setupWebhookTunnelTestRepos(t)
+	record := storage.WebhookTunnelHookRecord{Repo: "acme/looper", HookID: 42, ManagedURL: webhookTunnelManagedURL(cfg, "acme/looper"), SecretRef: webhookTunnelSecretRef("acme/looper"), CreatedAt: 1, UpdatedAt: 1}
+	if err := repos.WebhookTunnelHooks.Upsert(ctx, record); err != nil {
+		t.Fatalf("WebhookTunnelHooks.Upsert() error = %v", err)
+	}
+	secretPath := webhookTunnelSecretPath(cfg.Storage.DBPath, record.SecretRef)
+	if err := os.MkdirAll(filepath.Dir(secretPath), 0o700); err != nil {
+		t.Fatalf("os.MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(secretPath, []byte("top-secret"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	hook := webhookTunnelGitHubHook{ID: 42, Active: true, Events: webhookForwardEvents}
+	hook.Config.URL = record.ManagedURL
+	hook.Config.ContentType = "json"
+	hook.Config.InsecureSSL = "0"
+	client := &fakeWebhookTunnelGitHubClient{getHook: hook, getFound: true}
+	rt := newWebhookRuntime(cfg, &testLogger{}, func() time.Time { return time.Unix(10, 0) })
+	rt.tunnelClient = client
+
+	state := rt.reconcileTunnelHook(ctx, repos.WebhookTunnelHooks, cfg, record.Repo, record, true, time.Now().UnixNano())
+
+	if state.LastError != "" {
+		t.Fatalf("state.LastError = %q, want empty", state.LastError)
+	}
+	if client.updateCalls != 1 {
+		t.Fatalf("UpdateHook calls = %d, want 1 to restore missing remote secret", client.updateCalls)
+	}
+	if client.lastUpdate.secret != "top-secret" {
+		t.Fatalf("UpdateHook secret = %q, want local secret", client.lastUpdate.secret)
+	}
+}
+
+func TestReconcileTunnelHookRedactedRemoteSecretDoesNotRepatch(t *testing.T) {
+	t.Parallel()
+
+	ctx, repos, cfg := setupWebhookTunnelTestRepos(t)
+	record := storage.WebhookTunnelHookRecord{Repo: "acme/looper", HookID: 42, ManagedURL: webhookTunnelManagedURL(cfg, "acme/looper"), SecretRef: webhookTunnelSecretRef("acme/looper"), CreatedAt: 1, UpdatedAt: 1}
+	if err := repos.WebhookTunnelHooks.Upsert(ctx, record); err != nil {
+		t.Fatalf("WebhookTunnelHooks.Upsert() error = %v", err)
+	}
+	secretPath := webhookTunnelSecretPath(cfg.Storage.DBPath, record.SecretRef)
+	if err := os.MkdirAll(filepath.Dir(secretPath), 0o700); err != nil {
+		t.Fatalf("os.MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(secretPath, []byte("top-secret"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	hook := webhookTunnelGitHubHook{ID: 42, Active: true, Events: webhookForwardEvents}
+	hook.Config.URL = record.ManagedURL
+	hook.Config.ContentType = "json"
+	hook.Config.InsecureSSL = "0"
+	hook.Config.Secret = "********"
+	client := &fakeWebhookTunnelGitHubClient{getHook: hook, getFound: true}
+	rt := newWebhookRuntime(cfg, &testLogger{}, func() time.Time { return time.Unix(10, 0) })
+	rt.tunnelClient = client
+
+	state := rt.reconcileTunnelHook(ctx, repos.WebhookTunnelHooks, cfg, record.Repo, record, true, time.Now().UnixNano())
+
+	if state.LastError != "" {
+		t.Fatalf("state.LastError = %q, want empty", state.LastError)
+	}
+	if client.updateCalls != 0 {
+		t.Fatalf("UpdateHook calls = %d, want 0 when GitHub reports a secret is set", client.updateCalls)
+	}
+}
+
 func TestReconcileTunnelHooksMarksExistingRecordsOrphanedWhenRepoSetBecomesEmpty(t *testing.T) {
 	t.Parallel()
 
@@ -111,6 +181,7 @@ func TestReconcileTunnelHooksReactivatesOrphanedRecordWhenRepoIsReadded(t *testi
 	hook.Config.URL = record.ManagedURL
 	hook.Config.ContentType = "json"
 	hook.Config.InsecureSSL = "0"
+	hook.Config.Secret = "********"
 	client := &fakeWebhookTunnelGitHubClient{getHook: hook, getFound: true}
 	rt := newWebhookRuntime(cfg, &testLogger{}, func() time.Time { return time.Unix(10, 0) })
 	rt.ghPath = "/usr/bin/gh"


### PR DESCRIPTION
# Summary

- Tunnel webhook reconcile treated a GitHub hook as healthy when URL, events, and content-type matched, even if `config.secret` was missing.
- GitHub replaces hook `config` as a whole, so a PATCH that omits `secret` clears it. Deliveries then fail HMAC verification (`webhook.tunnel.signature_failed` / HTTP 401) and never recover.
- Reconcile now treats an empty remote `config.secret` as `needPatch` and re-PATCHes the locally stored secret.

# Testing

- [x] Targeted: `go test ./internal/runtime -run 'TestReconcileTunnelHookMissingRemoteSecretRepatchesHook|TestReconcileTunnelHookRedactedRemoteSecretDoesNotRepatch|TestReconcileTunnelHookPatchPreservesWebhookSecret|TestReconcileTunnelHookTreatsDesiredURLAsManagedInsteadOfOrphaning|TestReconcileTunnelHooksReactivatesOrphanedRecordWhenRepoIsReadded' -count=1`
- [ ] `go test ./...` (CI)
- [x] Additional targeted checks:
  - Live repro on `powerformer/apps` hook 631584525: GitHub ping 401, `config` omitted `secret`; local signed POST 200.
  - After `looper webhook rotate powerformer/apps`, GitHub ping 200 and `has_secret: true`.

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [ ] Daemon boot / config / runtime path risk
- [ ] Worktree / repo isolation / lifecycle risk
- [x] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

Reconcile may PATCH an existing managed hook when GitHub omits `config.secret`. Fake GitHub client covers the contract; no new sandbox E2E.

# Regression Policy

- [ ] This is not a P0/P1 bug fix
- [x] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [ ] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

`TestReconcileTunnelHookMissingRemoteSecretRepatchesHook` failed with `UpdateHook calls = 0` before the `needPatch` change and passes after.

# Regression Mapping

- PR / issue links for regression coverage:
  - This PR: missing remote webhook secret never re-PATCHed

# Reviewer Checklist

- [ ] Tests validate user-visible invariants, not only implementation details
- [ ] P0/P1 regression policy requirements above are satisfied