### PR TITLE
feat: complete native Forgejo review and fix loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The loops compose: planner hands off to reviewer↔fixer, reviewer↔fixer hands
 ## Features
 
 - 🚢 **Start from an issue, not a prompt.** Label an issue `looper:plan`, assign it to yourself, and a spec PR shows up. Once it reaches `looper:spec-ready`, implementation begins.
-- 🐙 **The forge is the source of truth.** Issues, PRs, labels, reviews, and assignees *are* the workflow — no external task tracker, no YAML pipeline. GitHub is fully supported; Forgejo supports planner, worker, native reviewer requests/reviews, and summary-comment compatibility flows.
+- 🐙 **The forge is the source of truth.** Issues, PRs, labels, reviews, and assignees *are* the workflow — no external task tracker, no YAML pipeline. GitHub is fully supported; Forgejo supports planner, worker, native reviewer/fixer loops, summary-comment compatibility, and opt-in reviewer auto-merge.
 - 🛰️ **Many repos, one daemon.** Register your projects once — Looper watches them together and runs loops across repos in parallel.
 - 🌳 **Parallel-safe by design.** Every loop runs in its own git worktree, so agents work across issues and repos without stepping on each other.
 - 🤖 **Bring your own agent.** Pluggable vendor layer (`opencode`, `claude-code`, `codex`, `cursor-cli`, `grok-build`, `pi`, `omp`) so you're not locked into one model or CLI.
@@ -72,7 +72,7 @@ looper project add .
 
 Add each repo you want Looper to watch after bootstrap. Full install, upgrade, uninstall, and from-source instructions: **[docs/installation.md](docs/installation.md)**.
 
-Once `looper status` succeeds and your forge credentials are configured (`gh auth status` for GitHub, or a configured Forgejo token environment variable), drive loops manually:
+Once `looper status` succeeds and your forge credentials are configured (`gh auth status` for GitHub, or a configured Forgejo token environment variable or tea login), drive loops manually:
 
 ```bash
 # plan a spec from an issue
@@ -295,6 +295,10 @@ go test ./internal/e2e -run 'Forgejo|Smoke|FailsFast|GitHubSandboxRepoEnv' -coun
 ```
 
 Forgejo live sandbox e2e is local/manual only and skipped unless explicitly enabled. Use a dedicated existing sandbox repo; tests create and clean run-scoped issues, branches, PRs, labels, and comments:
+
+For a real Codex Reviewer → Fixer → Reviewer cycle with an existing tea login, run `python3 scripts/forgejo-review-fix-smoke.py --base-url https://code.example.com --repo owner/looper-sandbox --tea-login sandbox`. It verifies the pushed repair, common message templates, and restart stability in an isolated runtime, then cleans its own resources. See [Forgejo live checks](docs/configuration.md#forgejo-live-sandbox-e2e) for the provider conflict/status/guarded-merge check and [implementation notes](docs/DESIGN-forgejo-reviewer-fixer.md) for configuration and acceptance results.
+
+The token-backed provider suite remains available:
 
 ```bash
 LOOPER_E2E_FORGEJO=1 \

--- a/docs/DESIGN-forgejo-reviewer-fixer.md
+++ b/docs/DESIGN-forgejo-reviewer-fixer.md
@@ -36,6 +36,8 @@ Forgejo 拒绝在自己创建的 PR 上提交 REQUEST_CHANGES；已获准的自�
 
 优先删除“无法 resolve 就不允许修复”的能力门槛。复用已有 fixer evidence 的 `ResolveState=fixed_unresolved`，明确表示“代码已处理、远端仍未关闭”，不引入第二套 receipt / ledger 或数据库迁移。repair checkpoint 增加 agent 当时看到的评论指纹，防止 resolve 重试时把旧决定套给已编辑评论；缺少指纹的旧 checkpoint 重新采集，不从新快照补猜。成本是保留新状态值与旧 checkpoint 的兼容路径，并让发现、重试与展示保持同一含义。仅忽略所有远端未解决评论会丢失新评论、编辑和 deferred 结果；仅删除能力门槛则会在重启后重复修复。
 
+真实验收发现，普通 push 后 Forgejo 会改变评论的 `updated_at`，而正文和其他返回字段完全不变。因此删除以该时间戳代表内容版本的假设，已有指纹改为 comment ID 加原始正文的 SHA-256，不新增持久化字段。定位投影和时间戳不参与计算；实际正文编辑即使没有更晚的时间戳也能被发现。成本是旧时间戳格式的 checkpoint / evidence 不再匹配，需要安全地重新评估一次，以及正文变化会触发重新处理。直接去掉漂移判断会让旧 agent 决定作用于新内容；直接把全文重复塞入指纹则增加 prompt 与 checkpoint 体积，均不采用。哈希只检测输入变化，fixed 的权威仍是 agent 的结构化结果。
+
 原生评论没有远端 resolve/reply 结果时，公共修复说明是该轮唯一的远端处理反馈，不能沿用 GitHub 补充总结的 best-effort 语义。先在已有 run checkpoint 保存 agent 决定，说明发布成功或按同一 marker 查回后，再写入用于 discovery 去重的 evidence；发布失败仅重放已有步骤，不重复 agent 或推送。这个顺序避免增加“等待消息”的队列状态和额外 discovery 门禁。HTTP 结果只表示消息是否送达，不改变 agent 对代码是否 fixed 的决定。
 
 混合旧 summary 与原生评论时，同一条公共回评先保存本轮成功结果，再重新采集新增或编辑的反馈。复用 checkpoint 中 agent 已观察的旧 reviewer round，避免新 round 借用旧决定；发布时仍刷新 fixer 评论以恢复响应丢失后的同一条消息。发现与 recheck 直接读取最新 reviewer round，因此手动循环关闭 autoDiscovery 后也能看到新反馈。没有增加快照字段或消息层；旧协议仍以 round 版本为边界，不扩展支持人工在同一 round 内改写隐藏协议内容。
@@ -56,6 +58,41 @@ go build -o dist/looperd ./cmd/looperd
 
 既有 Forgejo 项目不需要迁移数据库。原生流程使用 `roles.reviewer.behavior.publishMode=single_review`，并启用 reviewer/fixer 的 autoDiscovery。同一账号同时创建和评审 PR 时，需要显式允许 self-review；可以使用配置的 reviewer label 触发，不依赖自请求评审。保留 `threadResolution.enabled=false`。这些设置均可放在目标项目的 `projects[].roles` 下；具体结构见 [配置说明](configuration.md#provider-support)。兼容 `summary_comment` 的旧项目可以继续运行，也使用相同的可见模板。
 
+例如，对已在配置文件中声明的 Forgejo 项目，将以下 `roles` 合并到对应 `projects[]` 条目，可通过 `needs-review` 标签运行同账号 reviewer / fixer。先在仓库创建该标签，并添加到要处理的 PR；保留项目已有的 provider、repo、repoPath 和其他角色设置。不要为 CLI/API 管理的项目另建同 ID 配置条目；项目归属规则见 [项目配置来源](configuration.md#project-authority-and-import)。
+
+```json
+{
+  "roles": {
+    "reviewer": {
+      "discovery": {
+        "autoDiscovery": true,
+        "triggers": {
+          "enableSelfReview": true,
+          "requireReviewRequest": false,
+          "labels": ["needs-review"]
+        }
+      },
+      "behavior": {
+        "publishMode": "single_review",
+        "loop": {"enabledByDefault": true},
+        "threadResolution": {"enabled": false}
+      },
+      "autoMerge": {"enabled": false}
+    },
+    "fixer": {
+      "autoDiscovery": true,
+      "triggers": {"labels": ["needs-review"]}
+    }
+  }
+}
+```
+
+修改目标配置后，用新构建的 CLI 做离线校验，再按既有服务部署方式切换到新 `looperd` 二进制。配置若使用 TOML，请替换下面路径；本次实现没有安装二进制或重启日常 daemon。
+
+```sh
+./dist/looper config validate --config "$HOME/.looper/config.json"
+```
+
 自动合并单独显式开启，仍要求既有 Looper scope / linked issue / acceptance criteria / 分支保护。等待 CI 使用现有有界重试，达到队列重试或连续失败上限后，需要在 CI 就绪后继续或重新检查；不是无限期后台排队。自审降级为 COMMENT 不授予合并权限。
 
 完整源码检查：
@@ -69,7 +106,27 @@ go build ./...
 
 Sandbox 使用 `core/looper-sandbox`、独立配置 / 数据库 / worktree / 端口及专属分支和标签。测试结束关闭本轮 PR 并删除本轮测试分支、标签；不合并到 sandbox 默认分支，不操作现有 looperd。远端请求同时校验 HTTP 状态，不能只依赖 tea 退出码。
 
-实际验证结果与最终配置步骤在验收阶段补齐。
+## 实际验收结果（2026-09-06）
+
+实例版本为 `16.0.3+gitea-1.22.0`，使用 `core/looper-sandbox` 和已有 tea 登录 `powerformer-code`。
+
+| 验收 | 结果 |
+| --- | --- |
+| [PR #28](https://code.powerformer.net/core/looper-sandbox/pulls/28)：真实 Codex 原生闭环 | Reviewer 找到折扣计算错误 → 自动 Fixer 推送 `151738696dce05c524c861e335db3b8f345d6034` 并回评 → 新 head Reviewer 发布 clean；共 3 次 agent 执行、2 条 native review、1 条 fixer 回评 |
+| 同一数据库重启 | 执行数仍为 3，无新增 run、push、review 或修复消息；队列为空闲状态 |
+| 修复与消息 | 远端提交通过最初的 3 个 unittest（另存于 agent 工作区外）；comment `2446` 保持未解决，fixer 回评明确写明 `code fixed; comment remains open`；reviewer/fixer 均使用公共 Powered by Looper 署名，无专用 Summary 标题 |
+| [PR #26](https://code.powerformer.net/core/looper-sandbox/pulls/26) / [#27](https://code.powerformer.net/core/looper-sandbox/pulls/27)：真实 provider 合约 | 两个角色正确区分真实冲突与干净 PR；当前提交 status failure → success 去重、URL/描述映射通过；脏工作区、refs、index、FETCH_HEAD 保持不变 |
+| 受保护的临时 base | CI 失败拒绝合并（405），错误 SHA 和推送后过期 SHA 拒绝合并（409）；正确新 SHA 只合入临时 base，真实 Git 祖先关系验证通过 |
+| 清理 | PR #24 / #25 / #26 / #28 已关闭未合并，#27 仅合入临时 base；本轮分支、标签、保护规则全部删除，自有测试进程停止。main 前后均为 `ef6a1f22b225a7ae990d2773b825ffeb072b0dc1` |
+| Go 检查 | gofmt、vet、build 与完整 test 通过。并行检查时一条未修改的 worker E2E 触发既有 2 秒本机 HTTP 超时，单独重跑完整测试通过；没有修改阈值或断言 |
+
+验收期间发现并修复了生产代码的时间戳指纹问题。另修正了测试采集器对不分页评论接口的假设，统一按实际 `X-Total-Pages` / `Link` 读取；最终重启校验复用了已成功的三次真实执行，没有额外调用 agent。原始执行器因采集器修正而中断，续验通过后由其原有 finally 路径完成清理；不将该执行器的退出码冒充整段脚本零退出。
+
+本机证据分别保存在 `dist/forgejo-acceptance-20260906-native-v3/`（远端快照、SQLite、原始测试、续验代码/日志、result.json、cleanup.json）和 `dist/forgejo-completion-20260906/`（provider 日志与 Go 检查）。之前的 native 尝试保留在相邻目录，便于核对已修复问题。
+
+真实验收覆盖原生主闭环、commit status、冲突和即时合并接口。503 / 响应丢失 / SQLite 重放、编辑与新 finding、force-push、混合旧协议、外部 reviewer、HITL 和合并授权策略由自动化合约测试覆盖。未声称真实运行 Forgejo Actions workflow；其读取、映射和失败状态通过 provider 合约验证。
+
+仍不支持远端 review-thread resolve、Forgejo coordinator、routed network/webhook 和 GitHub 的同 head decline adjudication。自动合并继续默认关闭、有界重试；不会使用 Forgejo 未保留审核 SHA 的 scheduled merge。
 
 已有 `tea` 登录和 Codex 登录时，可执行隔离的真实 agent 验收：
 
@@ -81,3 +138,16 @@ python3 scripts/forgejo-review-fix-smoke.py \
 ```
 
 脚本从当前源码构建二进制，手动发起第一轮原生 reviewer（不使用 force），随后自动执行 fixer 与新 head 的 reviewer，并重启同一隔离数据库验证不会重复推送或发布 review。最后运行远端修复 commit 的 fixture 测试、检查公共署名与可见消息格式，并关闭自身 PR、删除自身分支和标签。真实 Codex 调用使用当前账号，会消耗模型额度。证据保存在 `dist/looper-smoke-<run>/`，包括远端快照、run/checkpoint、fixture 测试结果与 cleanup 结果。
+
+不调用 agent 的真实 provider 合约验收：
+
+```sh
+LOOPER_FORGEJO_LIVE_CONTRACTS=1 \
+LOOPER_FORGEJO_LIVE_BASE_URL=https://code.powerformer.net \
+LOOPER_FORGEJO_LIVE_REPO=core/looper-sandbox \
+LOOPER_FORGEJO_LIVE_TEA_LOGIN=powerformer-code \
+LOOPER_FORGEJO_LIVE_MERGE=1 \
+go test ./internal/runtime -run '^TestForgejoLiveProviderContracts$' -v -count=1 -timeout=15m
+```
+
+该测试建立自己的 base 和两个 head 分支，验证真实冲突、当前提交的 status 映射、脏工作区不被改变，以及受保护分支上 CI / SHA 的合并约束。第二个开关才允许修改自有 base 的保护并合并到该分支；省略它则只检查冲突和状态。它验证传输与 adapter 行为，reviewer 的 clean / criteria / scope 授权另由生命周期合约覆盖。清理结果与默认分支前后 SHA 输出到测试日志。

--- a/docs/DESIGN-forgejo-reviewer-fixer.md
+++ b/docs/DESIGN-forgejo-reviewer-fixer.md
@@ -34,9 +34,31 @@ Forgejo 拒绝在自己创建的 PR 上提交 REQUEST_CHANGES；已获准的自�
 
 `mergeable=false` 不能直接表示冲突：Forgejo 还用它表示计算中、计算失败及 WIP。provider 保留原始三态；运行时只在明确为 false 时，使用 `git merge-tree --write-tree` 检查准确的 base/head commit。代价是一次本地 Git 计算以及必要时获取缺失对象，不新增持久化状态，不变更分支、index、工作区或 FETCH_HEAD；简单映射布尔值会把正常 PR 错判为冲突，因此不足以满足 F2。该路径要求 Git 支持 `merge-tree --write-tree`（2.38+）。依据：[Forgejo 16.0.3 Mergeable 实现](https://codeberg.org/forgejo/forgejo/src/tag/v16.0.3/models/issues/pull.go#L881)。
 
-优先删除“无法 resolve 就不允许修复”的能力门槛。已有 checkpoint 与 fixer evidence 可承载本地处理结果，不引入第二套 receipt / ledger 或数据库迁移。新增本地处理结果如果需要状态值，必须明确表示“代码已处理、远端仍未关闭”，并在发现、重试与展示路径保持同一含义；这是避免无 resolve 平台重复修复的必要成本。不能仅忽略远端未解决评论，否则新评论、修改后的评论和 deferred 结果会丢失。
+优先删除“无法 resolve 就不允许修复”的能力门槛。复用已有 fixer evidence 的 `ResolveState=fixed_unresolved`，明确表示“代码已处理、远端仍未关闭”，不引入第二套 receipt / ledger 或数据库迁移。repair checkpoint 增加 agent 当时看到的评论指纹，防止 resolve 重试时把旧决定套给已编辑评论；缺少指纹的旧 checkpoint 重新采集，不从新快照补猜。成本是保留新状态值与旧 checkpoint 的兼容路径，并让发现、重试与展示保持同一含义。仅忽略所有远端未解决评论会丢失新评论、编辑和 deferred 结果；仅删除能力门槛则会在重启后重复修复。
+
+原生评论没有远端 resolve/reply 结果时，公共修复说明是该轮唯一的远端处理反馈，不能沿用 GitHub 补充总结的 best-effort 语义。先在已有 run checkpoint 保存 agent 决定，说明发布成功或按同一 marker 查回后，再写入用于 discovery 去重的 evidence；发布失败仅重放已有步骤，不重复 agent 或推送。这个顺序避免增加“等待消息”的队列状态和额外 discovery 门禁。HTTP 结果只表示消息是否送达，不改变 agent 对代码是否 fixed 的决定。
+
+混合旧 summary 与原生评论时，同一条公共回评先保存本轮成功结果，再重新采集新增或编辑的反馈。复用 checkpoint 中 agent 已观察的旧 reviewer round，避免新 round 借用旧决定；发布时仍刷新 fixer 评论以恢复响应丢失后的同一条消息。发现与 recheck 直接读取最新 reviewer round，因此手动循环关闭 autoDiscovery 后也能看到新反馈。没有增加快照字段或消息层；旧协议仍以 round 版本为边界，不扩展支持人工在同一 round 内改写隐藏协议内容。
+
+Forgejo Compare API 只返回 commits/files/total_commits，没有 GitHub 的 status/ahead_by/behind_by。已处理 finding 是否仍包含在当前 head，使用准确 commit 的 Git ancestry 判断，复用冲突检查的对象获取逻辑。代价是本地 Git 查询和必要的对象获取；不能从比较结果的 commit 数量推断祖先关系。浅克隆中如果两个方向都查不到祖先，明确报错，避免把截断历史误判为分叉；先补全本地历史后可继续。
+
+自动合并复用现有策略和 provider dispatch，不新增授权状态或重试账本。授权来自既有 clean review 结果、显式配置及 Looper 范围策略，提交 SHA 仅约束该决定不能作用于漂移后的代码。独立审查发现 Forgejo 16.0.3 的 scheduled merge 会在 `head_commit_id` 校验前返回，后台任务也不保存该 SHA，因此不能靠携带这个字段声称排队合并受保护。删除对服务器合并队列的依赖，使用 `merge_when_checks_succeed=false` 的即时合并与既有 Reviewer publish checkpoint 重试；CI 拒绝后复用已完成的评审，不重新调用 agent。成本是维护 settings / protection 的字段映射，并保留 review request 被审批消费后的同一 checkpoint 恢复路径。默认关闭，不 force merge、不自动删分支，不放宽标签、linked issue / criteria 或自审 COMMENT 限制。依据：[API 的排队与即时分支](https://codeberg.org/forgejo/forgejo/src/tag/v16.0.3/routers/api/v1/repo/pull.go#L1004)、[后台合并执行](https://codeberg.org/forgejo/forgejo/src/tag/v16.0.3/services/automerge/automerge.go#L231)。
 
 ## 验收命令
+
+在本次实现分支的工作区构建可执行文件：
+
+```sh
+mkdir -p dist
+go build -o dist/looper ./cmd/looper
+go build -o dist/looperd ./cmd/looperd
+```
+
+既有 Forgejo 项目不需要迁移数据库。原生流程使用 `roles.reviewer.behavior.publishMode=single_review`，并启用 reviewer/fixer 的 autoDiscovery。同一账号同时创建和评审 PR 时，需要显式允许 self-review；可以使用配置的 reviewer label 触发，不依赖自请求评审。保留 `threadResolution.enabled=false`。这些设置均可放在目标项目的 `projects[].roles` 下；具体结构见 [配置说明](configuration.md#provider-support)。兼容 `summary_comment` 的旧项目可以继续运行，也使用相同的可见模板。
+
+自动合并单独显式开启，仍要求既有 Looper scope / linked issue / acceptance criteria / 分支保护。等待 CI 使用现有有界重试，达到队列重试或连续失败上限后，需要在 CI 就绪后继续或重新检查；不是无限期后台排队。自审降级为 COMMENT 不授予合并权限。
+
+完整源码检查：
 
 ```sh
 gofmt -l .
@@ -48,3 +70,14 @@ go build ./...
 Sandbox 使用 `core/looper-sandbox`、独立配置 / 数据库 / worktree / 端口及专属分支和标签。测试结束关闭本轮 PR 并删除本轮测试分支、标签；不合并到 sandbox 默认分支，不操作现有 looperd。远端请求同时校验 HTTP 状态，不能只依赖 tea 退出码。
 
 实际验证结果与最终配置步骤在验收阶段补齐。
+
+已有 `tea` 登录和 Codex 登录时，可执行隔离的真实 agent 验收：
+
+```sh
+python3 scripts/forgejo-review-fix-smoke.py \
+  --base-url https://code.powerformer.net \
+  --repo core/looper-sandbox \
+  --tea-login powerformer-code
+```
+
+脚本从当前源码构建二进制，手动发起第一轮原生 reviewer（不使用 force），随后自动执行 fixer 与新 head 的 reviewer，并重启同一隔离数据库验证不会重复推送或发布 review。最后运行远端修复 commit 的 fixture 测试、检查公共署名与可见消息格式，并关闭自身 PR、删除自身分支和标签。真实 Codex 调用使用当前账号，会消耗模型额度。证据保存在 `dist/looper-smoke-<run>/`，包括远端快照、run/checkpoint、fixture 测试结果与 cleanup 结果。

--- a/docs/DESIGN-forgejo-reviewer-fixer.md
+++ b/docs/DESIGN-forgejo-reviewer-fixer.md
@@ -1,0 +1,50 @@
+# Forgejo reviewer / fixer 改造与验收
+
+目标是让原生 Forgejo review → fixer → 再次 review 持续运行。远端没有 resolve 接口时，修复、验证、推送和回评继续执行；评论仍然保留未解决状态。可见消息使用与 GitHub 相同的正文与 disclosure 模板，不展示 Reviewer Summary / Looper Forgejo Fixer Summary 专用标题或轮次协议。
+
+本文是本次改造的实施记录。既有 hold、作者过滤、自审开关和自动合并授权规则继续生效。
+
+## 行为与验证
+
+| 编号 | 预期行为 | 主要验证 |
+| --- | --- | --- |
+| F1 | 手动创建 reviewer / fixer 按项目 provider 读取 PR 和 hold，包括动态注册的项目；不误调用 gh | API provider 合约 |
+| F2 | Forgejo 的真实冲突、当前 head 的失败 CI 能进入公共 reviewer / fixer 数据结构 | REST / runtime 合约与 sandbox |
+| F3 | 原生 inline finding 可自动触发 fixer，同一账号的 Looper reviewer finding 不被当成 fixer 自言自语过滤 | discovery 与跨步骤集成 |
+| F4 | 无 resolve 接口不阻止代码修复；agent 明确 fixed、验证与推送完成后记录本地处理结果，不伪造远端 resolved | fixer 生命周期集成 |
+| F5 | 未改变且已处理的 finding 不因轮询或重启反复修复；新评论、被编辑的 finding 和发生分歧的 head 重新评估 | 持久状态 / 漂移集成 |
+| F6 | 修复后的 head 可以再次 review；repair deferred / declined 不被记录成 fixed | reviewer / fixer 交接与 sandbox |
+| F7 | 原生和兼容评论模式都复用 GitHub 署名，协议元数据不可见，修复反馈说明实际处理结果 | 渲染合约与远端正文检查 |
+| F8 | agent 获取正确的 Forgejo PR URL、API 与 CI 日志上下文 | prompt / runtime 合约 |
+| F9 | 显式启用自动合并后沿用现有范围、策略与分支保护规则，并绑定已审核 head | config / provider 合约与隔离分支验收 |
+
+## 实施顺序
+
+1. 补齐 provider 数据和手动入口。保留原有公共结构，提供真实 mergeability、commit status、Actions 和 review 数据；修正遗漏的 provider dispatch。
+2. 打通原生 review / fix 状态流转。移除修复前的 resolve 能力阻断，将代码处理结果与远端评论状态分开，接入已有重试、回评和消息发布路径。
+3. 运行完整 Go 检查和隔离 sandbox 验收，更新配置说明、迁移步骤和实际限制。
+
+每个阶段在相关测试通过后进行独立代码审查。源码修改在独立 worktree 分支完成，不更改当前运行的 looperd 配置或进程。
+
+## 权威与成本
+
+对 finding 的处理决策以 agent 的结构化 `repair_results` 为权威；推送、head 和评论指纹只用于检测执行结果或输入漂移，不能从“发生了 commit”推断“所有评论已修复”。
+
+Forgejo 拒绝在自己创建的 PR 上提交 REQUEST_CHANGES；已获准的自审因此保留结构化 blocking outcome，以 COMMENT 作为传输形式。marker 验证和历史恢复共用一个非持久化的显式兼容参数，其成本是两处事件匹配调用需要保持一致；直接放宽所有 COMMENT 会改变其他作者及 GitHub 的既有策略，因此不采用。自审是否允许仍由现有配置与手动入口决定。
+
+`mergeable=false` 不能直接表示冲突：Forgejo 还用它表示计算中、计算失败及 WIP。provider 保留原始三态；运行时只在明确为 false 时，使用 `git merge-tree --write-tree` 检查准确的 base/head commit。代价是一次本地 Git 计算以及必要时获取缺失对象，不新增持久化状态，不变更分支、index、工作区或 FETCH_HEAD；简单映射布尔值会把正常 PR 错判为冲突，因此不足以满足 F2。该路径要求 Git 支持 `merge-tree --write-tree`（2.38+）。依据：[Forgejo 16.0.3 Mergeable 实现](https://codeberg.org/forgejo/forgejo/src/tag/v16.0.3/models/issues/pull.go#L881)。
+
+优先删除“无法 resolve 就不允许修复”的能力门槛。已有 checkpoint 与 fixer evidence 可承载本地处理结果，不引入第二套 receipt / ledger 或数据库迁移。新增本地处理结果如果需要状态值，必须明确表示“代码已处理、远端仍未关闭”，并在发现、重试与展示路径保持同一含义；这是避免无 resolve 平台重复修复的必要成本。不能仅忽略远端未解决评论，否则新评论、修改后的评论和 deferred 结果会丢失。
+
+## 验收命令
+
+```sh
+gofmt -l .
+go vet ./...
+go test ./...
+go build ./...
+```
+
+Sandbox 使用 `core/looper-sandbox`、独立配置 / 数据库 / worktree / 端口及专属分支和标签。测试结束关闭本轮 PR 并删除本轮测试分支、标签；不合并到 sandbox 默认分支，不操作现有 looperd。远端请求同时校验 HTTP 状态，不能只依赖 tea 退出码。
+
+实际验证结果与最终配置步骤在验收阶段补齐。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -404,7 +404,7 @@ Oh My Pi support is fresh-run only. Daemon native resume and interactive takeove
 Looper supports three provider kinds:
 
 - `github` — existing default behavior, backed by `gh`. Projects without `provider` keep the legacy GitHub autodetection/metadata path.
-- `forgejo` — REST-backed planner, worker, native reviewer-request/review flows, summary-comment compatibility, and manual/direct native-review-comment fixer runs. Forgejo projects are config-driven and do not require `gh` in Forgejo-only installs.
+- `forgejo` — REST-backed planner, worker, native reviewer/fixer loops, summary-comment compatibility, and opt-in reviewer auto-merge. Forgejo projects are config-driven and do not require `gh` in Forgejo-only installs.
 - `plane` — a **task-source** provider: issues (work-items) are read from a [Plane](https://plane.so) project, while pull requests, diffs, and reviews stay on the project's GitHub code repo. Use this to let Looper consume Plane work-items directly as its issue source without creating a redundant GitHub issue. See [Plane provider + Feishu HITL setup](plane-provider.md) for the full guide, including the one-command `looper bootstrap --provider plane …` flow.
 
 Forgejo provider example:
@@ -476,11 +476,17 @@ Forgejo rules:
 - Forgejo projects require a `provider` and repo (`owner/name`). They can be written in config, persisted by `looper project add --provider <id>`, or created with `--forgejo-url` plus either `--forgejo-token-env` or `--auth tea --tea-login`. The repo may be detected only from an origin matching that provider. CLI/API-added provider bindings become active immediately through the atomic Project Catalog; already-started work retains its previous snapshot.
 - Config validation rejects duplicate configured `repo` values case-insensitively, even across different providers, because current runtime records are still keyed by bare repo.
 - Forgejo uses polling only. Omit `projects[].webhook.mode` and keep `projects[].network.mode` unset or `off`.
-- Forgejo projects get a provider profile that makes minimal config safe: planner and worker stay enabled, worker only processes issues already assigned to the current provider user, reviewer uses native review-request discovery and native review publication, fixer supports the manual native-comment + summary protocol described below, and coordinator/auto-merge/thread resolution stay disabled.
+- Forgejo projects get a provider profile that makes minimal config safe: planner and worker stay enabled, worker only processes issues already assigned to the current provider user, reviewer uses native review-request discovery and native review publication, and fixer automatically consumes native findings and legacy summary items. Auto-merge defaults to disabled and can be enabled explicitly; coordinator and thread resolution remain unsupported.
 - Explicitly re-enabling unsupported Forgejo behavior fails config validation instead of silently downgrading behavior.
 - `looper status` reads the Forgejo version, identity, repository permissions, and OpenAPI document with a bounded timeout and no mutations. Capability output separates Looper's configured support from the server-observed contract; missing or disabled OpenAPI is `unknown`. The probe is fresh for each status request and is not persisted or used as a daemon startup gate.
 
-Forgejo reviewer discovery defaults to native review requests. Configured reviewer labels remain an optional source; when labels and review requests are both enabled, Forgejo uses their union with deterministic PR-number dedupe. Native clean and blocking outcomes follow `reviewEvents` (`APPROVE`, `REQUEST_CHANGES`, or `COMMENT`). Set `roles.reviewer.behavior.publishMode = "summary_comment"` and configure reviewer labels to retain the legacy top-level Reviewer Summary compatibility flow. Native operations require the corresponding endpoint in the Forgejo OpenAPI contract; older instances fail with a provider capability error instead of silently switching modes.
+Forgejo reviewer discovery defaults to native review requests. Configured reviewer labels remain an optional source; when labels and review requests are both enabled, Forgejo uses their union with deterministic PR-number dedupe. Native clean and blocking outcomes follow `reviewEvents` (`APPROVE`, `REQUEST_CHANGES`, or `COMMENT`). An authorized self-review uses `COMMENT` when Forgejo rejects an approval or change request by the PR author; the structured clean/blocking outcome is preserved. Set `roles.reviewer.behavior.publishMode = "summary_comment"` and configure reviewer labels to retain the legacy top-level comment protocol. Both publication modes use the common GitHub message templates and disclosure, without visible protocol titles or round numbers. Native operations require the corresponding endpoint in the Forgejo OpenAPI contract; older instances fail with a provider capability error instead of silently switching modes.
+
+Forgejo Fixer automatically consumes unresolved native review comments, including findings published by the same account's Looper Reviewer. It repairs, validates, and pushes without requiring a remote resolve API. A matching structured `fixed` result records that the code was fixed while the remote comment remains open. Unchanged acknowledged findings do not repeat after polling or restart; edited comments, new findings, or a head that no longer contains the repair become eligible again. Deferred or declined findings are not acknowledged as fixed. Existing manual hold and role budgets still apply. A new PR head can trigger the next Reviewer pass; Forgejo does not support GitHub's same-head decline adjudication.
+
+Current-head commit statuses and Forgejo Actions are included in CI context. Exact local Git checks distinguish an actual merge conflict from other `mergeable=false` states, and compare acknowledged repair commits with the current head. These checks require Git 2.38+ and may fetch missing objects from the configured origin without changing the checkout.
+
+Set `roles.reviewer.autoMerge.enabled = true` explicitly to opt into Forgejo auto-merge. Existing Looper scope, criteria-verified clean review, repository strategy, branch protection, and permission checks still apply: a tracked PR needs a `looper:*` label and a closing issue reference whose issue has `triaged` or a `dispatch/*` label and explicit acceptance criteria. A self-review downgraded to `COMMENT` does not authorize auto-merge. Looper uses an immediate merge request bound to the reviewed head; blocked checks retry through the existing Reviewer publish checkpoint and retry budget. If that budget or the consecutive-failure limit is exhausted, the loop requires the existing continue/recheck flow after CI is ready. Forgejo's scheduled merge does not retain the expected head, so Looper does not use it. Looper never forces the merge or deletes the branch through this path.
 
 ### Plane task-source provider
 
@@ -494,6 +500,19 @@ Forgejo reviewer discovery defaults to native review requests. Configured review
 ### Forgejo live sandbox e2e
 
 Forgejo live sandbox e2e is a local/manual developer check, not a normal CI job. It is skipped unless explicitly enabled:
+
+For the full native Reviewer → Fixer → Reviewer flow with an authenticated Codex and an existing tea login, run:
+
+```bash
+python3 scripts/forgejo-review-fix-smoke.py \
+  --base-url https://code.example.com \
+  --repo owner/looper-sandbox \
+  --tea-login sandbox
+```
+
+This builds the current source, uses isolated runtime paths, creates one fixture PR on its own branch, checks repair and restart behavior, and closes the PR and removes its branch and label. It uses real Codex calls. Evidence is saved under `dist/looper-smoke-<run>/`. The default branch is not changed. See [implementation and acceptance notes](DESIGN-forgejo-reviewer-fixer.md).
+
+The existing token-backed provider integration suite is also available:
 
 ```bash
 LOOPER_E2E_FORGEJO=1 \
@@ -745,15 +764,15 @@ Reviewer auto-merge lives under `roles.reviewer.autoMerge.*`:
 
 | Path | Purpose | Default | Valid values | Validation |
 | --- | --- | --- | --- | --- |
-| `roles.reviewer.autoMerge.enabled` | Enables Reviewer's auto-merge opt-in flow for in-scope code PRs | `false` | `true`, `false` | When `true`, project startup fails fast unless the repo allows auto-merge, the configured merge strategy is enabled in repo settings, the repo is known, and GitHub validation is configured |
-| `roles.reviewer.autoMerge.strategy` | Merge strategy passed to `gh pr merge --auto` | `"squash"` | `"squash"`, `"merge"`, `"rebase"` | Config validation rejects any other value; when `enabled=true`, startup also fails fast if the repo disallows the chosen strategy |
-| `roles.reviewer.autoMerge.requireBranchProtection` | Requires base-branch protection with required checks before Reviewer opts in | `true` | `true`, `false` | When `true` and `enabled=true`, startup fails fast unless the default/base branch is known and GitHub reports branch protection with required checks |
+| `roles.reviewer.autoMerge.enabled` | Enables Reviewer's auto-merge opt-in flow for in-scope code PRs | `false` | `true`, `false` | When `true`, project startup fails fast unless the provider supports the merge flow, the configured strategy is enabled in repo settings, and the repo is known |
+| `roles.reviewer.autoMerge.strategy` | Merge strategy used by the selected provider | `"squash"` | `"squash"`, `"merge"`, `"rebase"` | Config validation rejects any other value; when `enabled=true`, startup also fails fast if the repo disallows the chosen strategy |
+| `roles.reviewer.autoMerge.requireBranchProtection` | Requires base-branch protection with required checks before Reviewer opts in | `true` | `true`, `false` | When `true` and `enabled=true`, startup fails fast unless the default/base branch is known and the provider reports branch protection with required checks |
 | `roles.reviewer.autoMerge.transientRetries` | Retry budget for transient merge-watch failures | `3` | positive integers | Config validation rejects values less than `1` |
 | `roles.reviewer.autoMerge.scope` | v1 scope guard for which PRs Looper may opt into auto-merge | `"looper-only"` | `"looper-only"` | Config validation rejects any other value; startup validation also rejects unsupported scopes |
 
 Project-level overrides use the same shape under `projects[].roles.reviewer.autoMerge.*`.
 
-When `roles.reviewer.autoMerge.enabled = true`, Looper performs a repo-aware startup validation pass: the project must have a known GitHub repo, GitHub auto-merge must be enabled for that repo, the configured strategy must be allowed, and — if `requireBranchProtection=true` — the effective base branch must exist with required checks enabled.
+When `roles.reviewer.autoMerge.enabled = true`, Looper performs provider-aware startup validation: the project must have a known repo, the configured strategy must be allowed, and — if `requireBranchProtection=true` — the effective base branch must exist with required checks enabled. GitHub additionally requires the repository's auto-merge setting and uses `gh pr merge --auto`. Forgejo uses head-bound immediate merge with existing Reviewer publish retries; its server-side scheduled merge is not used. Coordinator merge-watch settings do not enable a Forgejo coordinator.
 
 ## Project override rules
 
@@ -1222,8 +1241,9 @@ Forgejo provider profile differences:
 - planner discovers labeled issues through the Forgejo REST provider
 - worker discovers only issues already assigned to the current Forgejo user and does not claim work by adding itself as assignee
 - reviewer defaults to native review requests and native PR review events; configured labels can be used alone or combined, and `publishMode = "summary_comment"` retains the legacy summary flow
-- fixer auto-discovery still follows Reviewer Summary items only, while manual/direct Forgejo fixer runs also consume unresolved native Forgejo review comments and may resolve those native comments after validation + push + post-push verification
-- coordinator, auto-merge, review-thread resolution, routed network mode, and webhook modes are unsupported for Forgejo in the MVP and fail fast if explicitly enabled
+- fixer automatically consumes native review comments and legacy summary items; validated fixes are acknowledged locally and in a common PR comment while native comments remain open
+- auto-merge defaults to disabled and can be enabled explicitly under the same review, scope, and branch policies
+- coordinator, review-thread resolution, routed network mode, and webhook modes remain unsupported for Forgejo and fail fast if explicitly enabled
 
 Common fields:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -512,6 +512,19 @@ python3 scripts/forgejo-review-fix-smoke.py \
 
 This builds the current source, uses isolated runtime paths, creates one fixture PR on its own branch, checks repair and restart behavior, and closes the PR and removes its branch and label. It uses real Codex calls. Evidence is saved under `dist/looper-smoke-<run>/`. The default branch is not changed. See [implementation and acceptance notes](DESIGN-forgejo-reviewer-fixer.md).
 
+To verify the real provider adapters for conflicts, commit statuses, and head-bound merge using tea without an agent:
+
+```bash
+LOOPER_FORGEJO_LIVE_CONTRACTS=1 \
+LOOPER_FORGEJO_LIVE_BASE_URL=https://code.example.com \
+LOOPER_FORGEJO_LIVE_REPO=owner/looper-sandbox \
+LOOPER_FORGEJO_LIVE_TEA_LOGIN=sandbox \
+LOOPER_FORGEJO_LIVE_MERGE=1 \
+go test ./internal/runtime -run '^TestForgejoLiveProviderContracts$' -v -count=1 -timeout=15m
+```
+
+The extra `LOOPER_FORGEJO_LIVE_MERGE=1` permits required-check protection and immediate merge into the test's own temporary base branch. Omit it to check conflicts and statuses without merging. The test closes its PRs, removes its branches and protection rule, and verifies that the existing default branch is unchanged. Closed PRs and statuses on test commits remain as audit history. Missing prerequisites fail an explicitly enabled run; ordinary `go test ./...` skips the live test.
+
 The existing token-backed provider integration suite is also available:
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,6 +19,8 @@ For source development:
 
 `looperd` auto-detects tool paths from `PATH`, but startup validation fails if required tools cannot be resolved. `git` is always required. `gh` is required when any configured project uses the GitHub provider, but a Forgejo-only config starts without `gh` when the Forgejo provider and token environment variable are valid.
 
+Forgejo reviewer/fixer conflict checks require Git 2.38+ (`merge-tree --write-tree`). Repair ancestry checks need enough local history to distinguish a divergent head; an ambiguous shallow clone reports an error until its history is completed. Tea-backed Forgejo authentication is also supported with an explicit existing login.
+
 ## Install
 
 Looper uses Go binaries as the default supported implementation.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1,6 +1,6 @@
 # Looper Quick User Guide
 
-This guide is for everyday users. It focuses on how `coordinator`, `planner`, `reviewer`, `fixer`, and `worker` interact with forge issues and PRs. GitHub is fully supported; Forgejo support includes planner, worker, native reviewer requests/reviews, summary-comment compatibility, and the manual/direct native-review-comment fixer path.
+This guide is for everyday users. It focuses on how `coordinator`, `planner`, `reviewer`, `fixer`, and `worker` interact with forge issues and PRs. GitHub is fully supported; Forgejo support includes planner, worker, native reviewer/fixer loops, summary-comment compatibility, and opt-in reviewer auto-merge.
 
 ## 1. Prerequisites
 
@@ -109,12 +109,13 @@ If no project matches the current directory, or multiple projects match, pass `-
 | `fixer` | Fixes PR issues based on review comments; declines leave threads open for Reviewer | `looper fix <repo>#<pr>` |
 | `worker` | Implements the actual work from a spec or issue, and can reuse an existing PR | `looper work --issue <num>` or `looper work --project <id> --issue <num>` |
 
-Forgejo MVP role support:
+Forgejo role support:
 
 - Planner and Worker are supported over the Forgejo REST API.
-- Reviewer supports native review requests and native `APPROVE`, `REQUEST_CHANGES`, and `COMMENT` reviews. A configured `summary_comment` publish mode retains the top-level Reviewer Summary compatibility protocol.
-- Fixer is supported through two Forgejo-specific paths: Reviewer Summary items still flow through the top-level Fixer Summary PR comment, and manual/direct `looper fix` runs also read unresolved native Forgejo PR review comments and can resolve those native comments after validation, push, and post-push verification.
-- Coordinator, auto-merge, routed network mode, and webhook modes remain unsupported for Forgejo.
+- Reviewer supports native review requests and native `APPROVE`, `REQUEST_CHANGES`, and `COMMENT` reviews. A configured `summary_comment` publish mode retains the top-level comment protocol. Both modes use the same visible templates and disclosure as GitHub.
+- Fixer automatically consumes native inline findings and legacy summary items, repairs the code, validates, and pushes. Without a remote resolve API, it reports the fix in a PR comment and leaves the native comment open. Local acknowledgements prevent unchanged findings from repeating after a restart.
+- Reviewer auto-merge is available when explicitly enabled, subject to the existing review, scope, and branch policies. It defaults to disabled.
+- Coordinator, native thread resolution, routed network mode, and webhook modes remain unsupported for Forgejo.
 - A Forgejo-only daemon can start without `gh`; mixed or GitHub projects still require `gh`.
 
 ## 4. Recommended flow
@@ -311,7 +312,7 @@ For the default review-requested path, Looper asks GitHub for PRs requested from
 
 For spec PRs, `looper:spec-reviewing` marks the review phase, but it does not by itself authorize other users' Looper instances to run. Request review from the intended GitHub user to trigger that user's automatic reviewer.
 
-For Forgejo projects, reviewer auto-discovery defaults to review requests. Configured labels can be used independently or combined with review requests; combined results are deduplicated deterministically. Reviewer publishes native `APPROVE`, `REQUEST_CHANGES`, or `COMMENT` reviews according to configuration and preserves Looper disclosure/idempotency markers. Self-authored PRs are skipped by default; when self-review is enabled, an attempted clean approval is explicitly downgraded to `COMMENT`. Set reviewer `publishMode` to `summary_comment` to keep the legacy Reviewer Summary/Fixer Summary workflow.
+For Forgejo projects, reviewer auto-discovery defaults to review requests. Configured labels can be used independently or combined with review requests; combined results are deduplicated deterministically. Reviewer publishes native `APPROVE`, `REQUEST_CHANGES`, or `COMMENT` reviews according to configuration and preserves Looper disclosure/idempotency markers. Self-authored PRs are skipped by default; an authorized self-review uses `COMMENT` for both clean and blocking outcomes when Forgejo rejects the configured event. A clean self-comment does not authorize auto-merge. Set reviewer `publishMode` to `summary_comment` to keep the legacy comment workflow with common message templates.
 
 ### What happens after reviewer finishes
 
@@ -377,12 +378,15 @@ Fixer will:
 
 Third-party review comments (a human or Codex, not Looper) stay Fixer-eligible. If Fixer declines one of those, it still replies with evidence and leaves the thread open; Reviewer adjudicates the decline. Trusted `/looper` directives apply only on Looper-authored threads.
 
-For Forgejo projects, automatic Fixer runs are summary-only because Forgejo's public REST API does not currently expose a native review-comment resolve mutation:
+For Forgejo projects, automatic and manual Fixer runs consume native findings without requiring a review-comment resolve mutation:
 
-- reviewer-summary items still come from the top-level Reviewer Summary comment
-- native Forgejo PR review comments do not trigger automatic Fixer runs, even when their response includes a `resolver` field
-- the `resolver` response field describes state; it is not treated as proof that a resolve mutation exists
-- explicit manual Fixer runs may inspect native comments, but stop with a manual-intervention error when the provider cannot resolve them
+- native findings from other reviewers and the current account's Looper Reviewer can trigger repairs; ordinary self-comments and Fixer chatter are ignored
+- a matching structured `fixed` decision, successful validation, and current input/head checks acknowledge the code repair; the remote comment stays open and the PR receives a common Fixer message
+- unchanged acknowledged findings are suppressed across polling and restarts while the current head contains the repair; edited comments, new findings, and removal of the repair commit re-arm them
+- deferred and declined findings remain open; existing manual holds and role budgets apply, and explicit `needs_human` results suspend for intervention
+- legacy reviewer-summary items remain supported, with protocol metadata hidden from the visible message
+
+After a repair changes the head, Reviewer can review the new code. GitHub's same-head decline adjudication is not available on Forgejo. See [Forgejo configuration](configuration.md#provider-support) for opt-in auto-merge and the remaining provider limits.
 
 If the PR is still in the spec review phase and the review becomes clean, fixer can also move the labels from:
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -4913,36 +4913,62 @@ func (h *Handler) validateManualHoldBypassForLoopTarget(ctx context.Context, pro
 	if err != nil {
 		return err
 	}
-	// Hold preflight is best-effort at create time: when we cannot reliably talk to
-	// GitHub from this handler context (missing repo path, missing gh path, etc.) we
-	// skip validation rather than blocking manual creation for unrelated local setup.
-	if strings.TrimSpace(project.RepoPath) == "" {
+	if target.TargetType != domain.LoopTargetTypeIssue && target.TargetType != domain.LoopTargetTypePullRequest {
 		return nil
 	}
-	if _, err := os.Stat(project.RepoPath); err != nil {
-		return nil
+	cfg := h.effectiveConfig()
+	provider, ok := resolveProjectProviderConfig(cfg, projectID, parseJSONObject(project.MetadataJSON))
+	if !ok {
+		return apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("refresh target before manual loop create: provider for project %q is not configured", projectID)}
 	}
-	ghPath := strings.TrimSpace(derefString(h.context.Config.Tools.GHPath))
-	if ghPath == "" {
-		return nil
-	}
-	gh := githubinfra.New(githubinfra.Options{GHPath: ghPath, CWD: project.RepoPath, GHRun: shell.Run})
 	labels := []string(nil)
-	switch target.TargetType {
-	case domain.LoopTargetTypeIssue:
-		detail, err := gh.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: target.Repo, IssueNumber: target.IssueNumber, CWD: project.RepoPath})
-		if err != nil {
-			return apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("refresh target before manual loop create: %v", err)}
+	if provider.Kind == config.ProviderKindForgejo {
+		client, clientErr := forge.NewForgejoClientFromConfig(provider, target.Repo)
+		err = clientErr
+		if err == nil {
+			switch target.TargetType {
+			case domain.LoopTargetTypeIssue:
+				var detail forge.Issue
+				detail, err = client.ViewIssue(ctx, target.IssueNumber)
+				for _, label := range detail.Labels {
+					labels = append(labels, label.Name)
+				}
+			case domain.LoopTargetTypePullRequest:
+				var detail forge.PullRequest
+				detail, err = client.ViewPullRequest(ctx, target.PRNumber)
+				for _, label := range detail.Labels {
+					labels = append(labels, label.Name)
+				}
+			}
 		}
-		labels = detail.Labels
-	case domain.LoopTargetTypePullRequest:
-		detail, err := gh.ViewPullRequest(ctx, githubinfra.ViewPullRequestInput{Repo: target.Repo, PRNumber: target.PRNumber, CWD: project.RepoPath})
-		if err != nil {
-			return apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("refresh target before manual loop create: %v", err)}
+	} else {
+		// Preserve the GitHub preflight's best-effort local setup behavior.
+		// Forgejo authenticates directly through its provider and does not need gh
+		// or a local checkout to read the target's current hold labels.
+		if strings.TrimSpace(project.RepoPath) == "" {
+			return nil
 		}
-		labels = detail.Labels
-	default:
-		return nil
+		if _, err := os.Stat(project.RepoPath); err != nil {
+			return nil
+		}
+		ghPath := strings.TrimSpace(derefString(cfg.Tools.GHPath))
+		if ghPath == "" {
+			return nil
+		}
+		gh := githubinfra.New(githubinfra.Options{GHPath: ghPath, CWD: project.RepoPath, GHRun: shell.Run})
+		switch target.TargetType {
+		case domain.LoopTargetTypeIssue:
+			var detail githubinfra.IssueDetail
+			detail, err = gh.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: target.Repo, IssueNumber: target.IssueNumber, CWD: project.RepoPath})
+			labels = detail.Labels
+		case domain.LoopTargetTypePullRequest:
+			var detail githubinfra.PullRequestDetail
+			detail, err = gh.ViewPullRequest(ctx, githubinfra.ViewPullRequestInput{Repo: target.Repo, PRNumber: target.PRNumber, CWD: project.RepoPath})
+			labels = detail.Labels
+		}
+	}
+	if err != nil {
+		return apiError{code: pkgapi.ErrorCodeValidationFailed, status: http.StatusBadRequest, message: fmt.Sprintf("refresh target before manual loop create: %v", err)}
 	}
 	if !domain.IsAutoLaneHeld(loopType, labels) {
 		return nil
@@ -8109,41 +8135,45 @@ func resolveProjectProviderKind(cfg config.Config, projectID string, metadata ma
 // metadata provider id. Base URL is empty for unknown providers; GitHub defaults
 // to https://github.com when kind is github and base is unset.
 func resolveProjectProvider(cfg config.Config, projectID string, metadata map[string]any) (kind config.ProviderKind, baseURL string, ok bool) {
-	providerID := ""
+	provider, ok := resolveProjectProviderConfig(cfg, projectID, metadata)
+	if !ok {
+		return "", "", false
+	}
+	if provider.Kind == config.ProviderKindPlane {
+		// Plane remains the reported task-source provider; code hosting is GitHub.
+		return config.ProviderKindPlane, "https://github.com", true
+	}
+	kind = provider.Kind
+	if kind == "" {
+		kind = config.ProviderKindGitHub
+	}
+	base := strings.TrimRight(strings.TrimSpace(provider.BaseURL), "/")
+	if kind == config.ProviderKindGitHub && base == "" {
+		base = "https://github.com"
+	}
+	return kind, base, true
+}
+
+// The request's runtime config includes the live project catalog. Fall back to
+// record metadata for API-registered projects absent from a caller's snapshot.
+func resolveProjectProviderConfig(cfg config.Config, projectID string, metadata map[string]any) (config.ProviderConfig, bool) {
+	providerID := strings.TrimSpace(stringMetadataValue(metadata, "provider"))
 	for _, configured := range cfg.Projects {
 		if configured.ID != projectID {
 			continue
 		}
 		providerID = strings.TrimSpace(configured.Provider)
-		if providerID == "" {
-			return config.ProviderKindGitHub, "https://github.com", true
-		}
 		break
 	}
 	if providerID == "" {
-		providerID = strings.TrimSpace(stringMetadataValue(metadata, "provider"))
-	}
-	if providerID == "" {
-		return config.ProviderKindGitHub, "https://github.com", true
+		return config.ProviderConfig{Kind: config.ProviderKindGitHub, BaseURL: "https://github.com"}, true
 	}
 	for _, provider := range cfg.Providers {
-		if provider.ID != providerID {
-			continue
+		if provider.ID == providerID {
+			return provider, true
 		}
-		if provider.Kind == config.ProviderKindPlane {
-			// Plane remains the reported task-source provider; code hosting is GitHub.
-			return config.ProviderKindPlane, "https://github.com", true
-		}
-		base := strings.TrimRight(strings.TrimSpace(provider.BaseURL), "/")
-		if provider.Kind == config.ProviderKindGitHub && base == "" {
-			base = "https://github.com"
-		}
-		if provider.Kind == "" {
-			return config.ProviderKindGitHub, base, true
-		}
-		return provider.Kind, base, true
 	}
-	return "", "", false
+	return config.ProviderConfig{}, false
 }
 
 // resolveProjectRepoURL builds the forge HTML URL for owner/repo using the

--- a/internal/api/handler_forgejo_manual_test.go
+++ b/internal/api/handler_forgejo_manual_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/domain"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestHandlerCreateForgejoManualLoopsUsesProviderAndPreservesHolds(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		role           string
+		configured     bool
+		held           bool
+		force          bool
+		missingRepo    bool
+		missingGH      bool
+		issue          bool
+		providerStatus int
+	}{
+		{name: "configured reviewer", role: "reviewer", configured: true},
+		{name: "configured fixer", role: "fixer", configured: true},
+		{name: "registered reviewer without gh", role: "reviewer", missingGH: true},
+		{name: "registered fixer without checkout", role: "fixer", missingRepo: true},
+		{name: "reviewer hold", role: "reviewer", configured: true, held: true},
+		{name: "fixer hold", role: "fixer", held: true},
+		{name: "held reviewer without checkout or gh", role: "reviewer", held: true, missingRepo: true, missingGH: true},
+		{name: "force reviewer bypasses hold", role: "reviewer", held: true, force: true},
+		{name: "force fixer bypasses hold", role: "fixer", configured: true, held: true, force: true},
+		{name: "provider failure does not enqueue", role: "fixer", providerStatus: http.StatusForbidden},
+		{name: "planner issue hold", role: "planner", held: true, issue: true},
+		{name: "worker issue hold", role: "worker", held: true, issue: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newTestFixture(t)
+			var reads atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				wantPath := "/api/v1/repos/acme/looper/pulls/42"
+				if tc.issue {
+					wantPath = "/api/v1/repos/acme/looper/issues/77"
+				}
+				if r.Method != http.MethodGet || r.URL.Path != wantPath {
+					t.Errorf("unexpected provider request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				reads.Add(1)
+				if r.Header.Get("Authorization") != "token manual-loop-token" {
+					t.Errorf("provider request did not use its configured authentication")
+				}
+				if tc.providerStatus != 0 {
+					w.WriteHeader(tc.providerStatus)
+					_, _ = w.Write([]byte(`{"message":"permission denied"}`))
+					return
+				}
+				labels := []map[string]string{}
+				if tc.held {
+					labels = append(labels, map[string]string{"name": domain.HoldLabelGlobal})
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"number": 42, "state": "open", "labels": labels})
+			}))
+			defer server.Close()
+			t.Setenv("LOOPER_TEST_MANUAL_FORGEJO_TOKEN", "manual-loop-token")
+			fixture.config.Providers = []config.ProviderConfig{{ID: "forgejo", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: stringPtr("LOOPER_TEST_MANUAL_FORGEJO_TOKEN")}}
+			// Any accidental gh dispatch must fail; Forgejo should use only HTTP.
+			fixture.config.Tools.GHPath = stringPtr(filepath.Join(fixture.rootDir, "gh-must-not-run"))
+			if tc.missingGH {
+				fixture.config.Tools.GHPath = nil
+			}
+			repoPath := fixture.rootDir
+			if tc.missingRepo {
+				repoPath = filepath.Join(fixture.rootDir, "not-checked-out")
+			}
+			metadata := `{"repo":"acme/looper","provider":"forgejo","source":"api"}`
+			if tc.configured {
+				fixture.config.Projects = []config.ProjectRefConfig{{ID: "project_1", Repo: "acme/looper", RepoPath: repoPath, Provider: "forgejo"}}
+				// The coherent runtime catalog binding takes precedence over a stale
+				// record snapshot supplied by compatibility callers.
+				metadata = `{"repo":"acme/looper","provider":"stale-provider"}`
+			}
+			now := fixture.now.UTC().Format(javaScriptISOString)
+			if err := fixture.runtime.Services().Repositories.Projects.Upsert(context.Background(), storage.ProjectRecord{ID: "project_1", Name: "Looper", RepoPath: repoPath, MetadataJSON: &metadata, CreatedAt: now, UpdatedAt: now}); err != nil {
+				t.Fatal(err)
+			}
+			// Supply the binding in the current runtime snapshot, not the handler's
+			// startup config, to cover dynamically registered / reloaded providers.
+			startupConfig := fixture.config
+			startupConfig.Providers = nil
+			startupConfig.Projects = nil
+			h := NewHandler(Context{Config: startupConfig, Runtime: runtimeWithConfig(fixture.runtime, fixture.config), Now: func() time.Time { return fixture.now.Add(time.Minute) }})
+			body := fmt.Sprintf(`{"projectId":"project_1","type":%q,"targetType":"pull_request","repo":"acme/looper","prNumber":42,"force":%t}`, tc.role, tc.force)
+			path := "/api/v1/loops"
+			if tc.issue {
+				path = "/api/v1/" + tc.role + "s"
+				body = `{"projectId":"project_1","repo":"acme/looper","issueNumber":77,"baseBranch":"main"}`
+			}
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+			req.Header.Set("content-type", "application/json")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			wantStatus, wantQueue := http.StatusOK, 1
+			if (tc.held && !tc.force) || tc.providerStatus != 0 {
+				wantStatus, wantQueue = http.StatusBadRequest, 0
+			}
+			if rec.Code != wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, wantStatus, rec.Body.String())
+			}
+			if tc.held && !tc.force && !strings.Contains(rec.Body.String(), "--force") {
+				t.Fatalf("held response omitted force guidance: %s", rec.Body.String())
+			}
+			wantReads := int64(1)
+			if tc.force {
+				wantReads = 0
+			}
+			if got := reads.Load(); got != wantReads {
+				t.Fatalf("provider reads = %d, want %d", got, wantReads)
+			}
+			queued, err := fixture.runtime.Services().Repositories.Queue.List(context.Background())
+			if err != nil || len(queued) != wantQueue {
+				t.Fatalf("queue = %#v, %v; want %d items", queued, err, wantQueue)
+			}
+		})
+	}
+}

--- a/internal/cliapp/review_submit.go
+++ b/internal/cliapp/review_submit.go
@@ -689,18 +689,31 @@ func wrapReviewSubmitError(cmd *cobra.Command, repo string, prNumber int64, even
 	return fmt.Errorf("%s: %w", prefix, err)
 }
 
-func (r *commandRuntime) effectiveReviewSubmitEvent(cmd *cobra.Command, gh reviewSubmitGateway, repo string, prNumber int64, event string, authorLogin string, cwd string) (string, error) {
-	if !strings.EqualFold(strings.TrimSpace(event), "APPROVE") || strings.TrimSpace(authorLogin) == "" {
+func (r *commandRuntime) effectiveReviewSubmitEvent(cmd *cobra.Command, gateway reviewSubmitGateway, repo string, prNumber int64, event string, authorLogin string, cwd string) (string, error) {
+	_, isForgejo := gateway.(forgejoReviewSubmitGateway)
+	isApproval := strings.EqualFold(strings.TrimSpace(event), "APPROVE")
+	isForgejoChangeRequest := isForgejo && strings.EqualFold(strings.TrimSpace(event), "REQUEST_CHANGES")
+	if (!isApproval && !isForgejoChangeRequest) || strings.TrimSpace(authorLogin) == "" {
 		return event, nil
 	}
-	currentLogin, err := gh.GetCurrentUserLogin(cmd.Context(), cwd)
+	providerName := "GitHub"
+	if isForgejo {
+		providerName = "Forgejo"
+	}
+	currentLogin, err := gateway.GetCurrentUserLogin(cmd.Context(), cwd)
 	if err != nil {
-		return "", fmt.Errorf("determine authenticated GitHub user for self-approval check: %w", err)
+		return "", fmt.Errorf("determine authenticated %s user for self-review check: %w", providerName, err)
 	}
 	if !sameGitHubLogin(currentLogin, authorLogin) {
 		return event, nil
 	}
-	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "looper: downgrading APPROVE review to COMMENT for %s#%d because authenticated GitHub user %q authored the pull request and GitHub does not allow self-approval\n", repo, prNumber, strings.TrimSpace(currentLogin))
+	restriction := providerName + " does not allow self-approval"
+	if isForgejoChangeRequest {
+		restriction = "Forgejo does not allow authors to request changes on their own pull requests"
+	}
+	// This only adapts native transport. The validated outcome marker and inline
+	// findings remain unchanged, including a blocking outcome on a COMMENT review.
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "looper: downgrading %s review to COMMENT for %s#%d because authenticated %s user %q authored the pull request and %s\n", event, repo, prNumber, providerName, strings.TrimSpace(currentLogin), restriction)
 	return "COMMENT", nil
 }
 
@@ -1140,7 +1153,9 @@ func recoverReviewSubmitEngagement(ctx context.Context, gateway reviewSubmitGate
 	}
 	policyCfg := reviewSubmitConfigWithMatchedProject(cfg, matched)
 	policy := reviewengagement.Policy(loop.MetadataJSON, config.ProjectRoleConfigs(policyCfg, loop.ProjectID).Reviewer.Behavior.ReviewEvents)
-	return githubinfra.ReviewEngagementHead(detail.Reviews, loop.ID, headSHA, login, reviewengagement.AllowedEvents(policy), sameGitHubLogin(login, detail.Author)), nil
+	selfAuthored := sameGitHubLogin(login, detail.Author)
+	_, isForgejo := gateway.(forgejoReviewSubmitGateway)
+	return githubinfra.ReviewEngagementHead(detail.Reviews, loop.ID, headSHA, login, reviewengagement.AllowedEvents(policy), selfAuthored, selfAuthored && isForgejo), nil
 }
 
 func currentRunningReviewerRun(ctx context.Context, repos *storage.Repositories, repo string, prNumber int64) (*storage.RunRecord, error) {

--- a/internal/cliapp/review_submit_engagement_test.go
+++ b/internal/cliapp/review_submit_engagement_test.go
@@ -106,37 +106,50 @@ esac
 
 func TestForgejoReviewSubmitRecoversNativeEngagement(t *testing.T) {
 	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/swagger.v1.json":
-			_, _ = w.Write([]byte(`{"paths":{"/repos/{owner}/{repo}/pulls/{index}/reviews":{"get":{}},"/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments":{"get":{}}}}`))
-		case "/api/v1/user":
-			_, _ = w.Write([]byte(`{"login":"bob"}`))
-		case "/api/v1/repos/acme/looper/pulls/42":
-			_, _ = w.Write([]byte(`{"number":42,"state":"open","user":{"login":"alice"},"head":{"sha":"new"}}`))
-		case "/api/v1/repos/acme/looper/pulls/42/reviews/1/comments":
-			_, _ = w.Write([]byte(`[]`))
-		case "/api/v1/repos/acme/looper/pulls/42/reviews":
-			_, _ = w.Write([]byte(`[{"id":1,"user":{"login":"bob"},"state":"REQUEST_CHANGES","commit_id":"old","body":"<!-- looper:review id=reviewer:loop head=old outcome=blocking -->"}]`))
-		default:
-			t.Errorf("unexpected request: %s", r.URL.Path)
-			w.WriteHeader(404)
-		}
-	}))
-	defer server.Close()
-	client, err := forge.NewForgejoClient(forge.RepositoryRef{ProviderID: "forgejo", Kind: forge.ProviderKindForgejo, BaseURL: server.URL, Repo: "acme/looper"}, "token")
-	if err != nil {
-		t.Fatal(err)
-	}
-	cfg, err := config.DefaultConfig(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	cfg.Storage.DBPath = filepath.Join(t.TempDir(), "absent.sqlite")
-	meta := `{"followUpdates":true,"loop":{"enabled":true},"reviewEvents":{"blocking":"REQUEST_CHANGES"}}`
-	loop := storage.LoopRecord{ID: "loop", ProjectID: "project", MetadataJSON: &meta}
-	got, err := recoverReviewSubmitEngagement(context.Background(), forgejoReviewSubmitGateway{client: client}, cfg, loop, "acme/looper", 42, "new", t.TempDir())
-	if err != nil || got != "old" {
-		t.Fatalf("recovery = %q, %v", got, err)
+	for _, tc := range []struct {
+		name, author, reviewAuthor, state, markerHead, want string
+	}{
+		{name: "native change request", author: "alice", reviewAuthor: "bob", state: "REQUEST_CHANGES", markerHead: "old", want: "old"},
+		{name: "self blocking fallback", author: "bob", reviewAuthor: "bob", state: "COMMENT", markerHead: "old", want: "old"},
+		{name: "other author comment is not a fallback", author: "alice", reviewAuthor: "bob", state: "COMMENT", markerHead: "old"},
+		{name: "self fallback still requires review author", author: "bob", reviewAuthor: "alice", state: "COMMENT", markerHead: "old"},
+		{name: "self fallback still requires matching commit", author: "bob", reviewAuthor: "bob", state: "COMMENT", markerHead: "different"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/swagger.v1.json":
+					_, _ = w.Write([]byte(`{"paths":{"/repos/{owner}/{repo}/pulls/{index}/reviews":{"get":{}},"/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments":{"get":{}}}}`))
+				case "/api/v1/user":
+					_, _ = w.Write([]byte(`{"login":"bob"}`))
+				case "/api/v1/repos/acme/looper/pulls/42":
+					_ = json.NewEncoder(w).Encode(map[string]any{"number": 42, "state": "open", "user": map[string]any{"login": tc.author}, "head": map[string]any{"sha": "new"}})
+				case "/api/v1/repos/acme/looper/pulls/42/reviews/1/comments":
+					_, _ = w.Write([]byte(`[]`))
+				case "/api/v1/repos/acme/looper/pulls/42/reviews":
+					_ = json.NewEncoder(w).Encode([]map[string]any{{"id": 1, "user": map[string]any{"login": tc.reviewAuthor}, "state": tc.state, "commit_id": "old", "body": "<!-- looper:review id=reviewer:loop head=" + tc.markerHead + " outcome=blocking -->"}})
+				default:
+					t.Errorf("unexpected request: %s", r.URL.Path)
+					w.WriteHeader(404)
+				}
+			}))
+			defer server.Close()
+			client, err := forge.NewForgejoClient(forge.RepositoryRef{ProviderID: "forgejo", Kind: forge.ProviderKindForgejo, BaseURL: server.URL, Repo: "acme/looper"}, "token")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg.Storage.DBPath = filepath.Join(t.TempDir(), "absent.sqlite")
+			meta := `{"followUpdates":true,"loop":{"enabled":true},"reviewEvents":{"blocking":"REQUEST_CHANGES"}}`
+			loop := storage.LoopRecord{ID: "loop", ProjectID: "project", MetadataJSON: &meta}
+			got, err := recoverReviewSubmitEngagement(context.Background(), forgejoReviewSubmitGateway{client: client}, cfg, loop, "acme/looper", 42, "new", t.TempDir())
+			if err != nil || got != tc.want {
+				t.Fatalf("recovery = %q, %v; want %q", got, err, tc.want)
+			}
+		})
 	}
 }

--- a/internal/cliapp/review_submit_test.go
+++ b/internal/cliapp/review_submit_test.go
@@ -1114,6 +1114,100 @@ func TestEffectiveReviewSubmitEventDoesNotFetchUserForComment(t *testing.T) {
 	}
 }
 
+func TestForgejoSelfReviewTransportPreservesOutcomeAndDisclosure(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, event, outcome, author, wantEvent string
+	}{
+		{name: "self blocking", event: "REQUEST_CHANGES", outcome: "blocking", author: "Reviewer", wantEvent: "COMMENT"},
+		{name: "self clean", event: "APPROVE", outcome: "clean", author: "reviewer", wantEvent: "COMMENT"},
+		{name: "other author blocking", event: "REQUEST_CHANGES", outcome: "blocking", author: "alice", wantEvent: "REQUEST_CHANGES"},
+		{name: "other author clean", event: "APPROVE", outcome: "clean", author: "alice", wantEvent: "APPROVED"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var published map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/swagger.v1.json":
+					_, _ = w.Write([]byte(`{"paths":{"/repos/{owner}/{repo}/pulls/{index}/reviews":{"get":{},"post":{}},"/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments":{"get":{}}}}`))
+				case r.Method == http.MethodGet && r.URL.Path == "/api/v1/user":
+					_, _ = w.Write([]byte(`{"id":7,"login":"reviewer"}`))
+				case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/looper/pulls/42/reviews":
+					_, _ = w.Write([]byte(`[]`))
+				case r.Method == http.MethodPost && r.URL.Path == "/api/v1/repos/acme/looper/pulls/42/reviews":
+					if err := json.NewDecoder(r.Body).Decode(&published); err != nil {
+						t.Error(err)
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"id": 9, "state": published["event"], "body": published["body"], "commit_id": "head", "user": map[string]any{"login": "reviewer"}})
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+			client, err := forge.NewForgejoClient(forge.RepositoryRef{ProviderID: "forgejo", Kind: forge.ProviderKindForgejo, BaseURL: server.URL, Repo: "acme/looper"}, "token")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			vendor := config.AgentVendorCodex
+			cfg.Agent.Vendor = &vendor
+			cfg.Disclosure.Enabled = true
+			cfg.Disclosure.IncludeAgent = true
+			cfg.Disclosure.IncludeOS = false
+			cfg.Disclosure.Channels.ReviewComment = true
+			cfg.Disclosure.Channels.InlineCommentVisible = false
+			stamper := disclosure.FromConfig(cfg)
+			gateway := forgejoReviewSubmitGateway{client: client, stamper: stamper}
+			cmd := &cobra.Command{}
+			cmd.SetContext(context.Background())
+			stderr := &bytes.Buffer{}
+			cmd.SetErr(stderr)
+			event, err := (&commandRuntime{}).effectiveReviewSubmitEvent(cmd, gateway, "acme/looper", 42, tc.event, tc.author, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := "@" + tc.author + " Thanks for the implementation; I checked the changed behavior.\n\n<!-- looper:review id=reviewer:loop:head head=head outcome=" + tc.outcome + " -->"
+			input := githubinfra.SubmitReviewInput{PRNumber: 42, Event: event, Body: body, CommitID: "head"}
+			if tc.outcome == "blocking" {
+				input.Comments = []githubinfra.ReviewComment{{Body: "Return the discounted total.", Path: "app.go", Line: 1, Side: "RIGHT"}}
+			}
+			if err := gateway.SubmitReview(context.Background(), input); err != nil {
+				t.Fatal(err)
+			}
+			if published["event"] != tc.wantEvent || published["commit_id"] != "head" {
+				t.Fatalf("published transport = %#v; want %s at head", published, tc.wantEvent)
+			}
+			wantBody := stamper.Markdown(body, "reviewer", disclosure.ChannelReviewComment)
+			if published["body"] != wantBody {
+				t.Fatalf("Forgejo body differs from the shared GitHub template:\n%v\nwant:\n%s", published["body"], wantBody)
+			}
+			for _, want := range []string{"🔁 Powered by ", "runner=reviewer · agent=codex · " + disclosure.Slogan, "outcome=" + tc.outcome} {
+				if !strings.Contains(wantBody, want) {
+					t.Fatalf("body %q missing %q", wantBody, want)
+				}
+			}
+			if tc.outcome == "blocking" {
+				comments, _ := published["comments"].([]any)
+				if len(comments) != 1 {
+					t.Fatalf("published comments = %#v, want preserved blocking inline", comments)
+				}
+				comment, _ := comments[0].(map[string]any)
+				if comment["body"] != stamper.ReviewComment(input.Comments[0].Body, "reviewer") {
+					t.Fatalf("inline disclosure differs from GitHub: %#v", comment)
+				}
+			}
+			if strings.EqualFold(tc.author, "reviewer") && !strings.Contains(stderr.String(), "authenticated Forgejo user") {
+				t.Fatalf("self-review downgrade diagnostic = %q", stderr.String())
+			}
+		})
+	}
+}
+
 func TestWrapReviewSubmitErrorSurfacesContentSafetyRecoveryGuidance(t *testing.T) {
 	t.Parallel()
 	cmd := &cobra.Command{}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -363,6 +363,9 @@ func TestMinimalForgejoProviderConfigAppliesSafeProjectProfile(t *testing.T) {
 		t.Fatalf("provider baseUrl = %q, want normalized host without trailing slash", got)
 	}
 	roles := ProjectRoleConfigs(loaded.Config, "demo")
+	if roles.Reviewer.AutoMerge.Enabled {
+		t.Fatal("Forgejo auto-merge must remain disabled by default")
+	}
 	if !roles.Reviewer.Discovery.Triggers.RequireReviewRequest {
 		t.Fatalf("forgejo reviewer requireReviewRequest = false, want true")
 	}
@@ -534,8 +537,31 @@ func TestForgejoProjectRejectsUnsupportedRoleCapabilityOptIns(t *testing.T) {
 	if !errors.As(err, &validationErr) {
 		t.Fatalf("LoadFile() error = %T, want *ConfigValidationError", err)
 	}
-	assertValidationIssue(t, validationErr, "projects[0].roles.reviewer.autoMerge.enabled", "must be false for forgejo projects")
 	assertValidationIssue(t, validationErr, "projects[0].roles.reviewer.behavior.threadResolution.enabled", "must be false for forgejo projects")
+}
+
+func TestForgejoProjectAllowsExplicitAutoMergeOptIn(t *testing.T) {
+	cwd := t.TempDir()
+	configPath := filepath.Join(cwd, "config.json")
+	contents := `{
+		"notifications":{"osascript":{"enabled":false}},
+		"providers":[{"id":"fj","kind":"forgejo","baseUrl":"https://forgejo.example.test","tokenEnv":"FORGEJO_TOKEN"}],
+		"projects":[{"id":"demo","name":"Demo","provider":"fj","repo":"owner/repo","repoPath":"/tmp/repo","roles":{"reviewer":{"autoMerge":{"enabled":true,"strategy":"rebase"}}}}]
+	}`
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadFile(LoadFileOptions{CWD: cwd, ConfigPath: configPath, LookupEnv: emptyEnvLookup, LookPath: fakeLookPath(map[string]string{"git": "/git"})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	autoMerge := ProjectRoleConfigs(loaded.Config, "demo").Reviewer.AutoMerge
+	if !autoMerge.Enabled || autoMerge.Strategy != ReviewerAutoMergeStrategyRebase || autoMerge.Scope != ReviewerAutoMergeScopeLooperOnly || !autoMerge.RequireBranchProtection {
+		t.Fatalf("auto-merge opt-in changed policy = %#v", autoMerge)
+	}
+	if loaded.Config.Roles.Reviewer.AutoMerge.Enabled {
+		t.Fatal("project opt-in changed the global default")
+	}
 }
 
 func TestForgejoProviderAuthTeaAllowsMissingTokenEnv(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -564,6 +564,40 @@ func TestForgejoProjectAllowsExplicitAutoMergeOptIn(t *testing.T) {
 	}
 }
 
+func TestForgejoProjectRejectsAutoMergeWithSummaryComment(t *testing.T) {
+	cwd := t.TempDir()
+	configPath := filepath.Join(cwd, "config.json")
+	contents := `{
+		"notifications": {"osascript": {"enabled": false}},
+		"providers": [{"id":"fj","kind":"forgejo","baseUrl":"https://forgejo.example.test","tokenEnv":"FORGEJO_TOKEN"}],
+		"projects": [{
+			"id":"demo",
+			"name":"Demo",
+			"provider":"fj",
+			"repo":"owner/repo",
+			"repoPath":"/tmp/repo",
+			"roles": {
+				"reviewer": {
+					"autoMerge": {"enabled": true},
+					"behavior": {"publishMode": "summary_comment"}
+				}
+			}
+		}]
+	}`
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	_, err := LoadFile(LoadFileOptions{CWD: cwd, ConfigPath: configPath, LookupEnv: emptyEnvLookup, LookPath: fakeLookPath(map[string]string{"git": "/git"})})
+	if err == nil {
+		t.Fatal("LoadFile() error = nil, want summary_comment auto-merge validation error")
+	}
+	var validationErr *ConfigValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("LoadFile() error = %T, want *ConfigValidationError", err)
+	}
+	assertValidationIssue(t, validationErr, "projects[0].roles.reviewer.autoMerge.enabled", "must be false when publishMode is summary_comment")
+}
+
 func TestForgejoProviderAuthTeaAllowsMissingTokenEnv(t *testing.T) {
 	auth := ProviderAuthTea
 	cfg, err := Normalize(t.TempDir(), PartialConfig{

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -521,9 +521,6 @@ func isAbsoluteHTTPURL(value string) bool {
 }
 
 func validateForgejoRoleCapabilities(roles RoleConfigs, prefix string, issues *[]ValidationIssue) {
-	if roles.Reviewer.AutoMerge.Enabled {
-		*issues = append(*issues, ValidationIssue{Path: prefix + ".roles.reviewer.autoMerge.enabled", Message: "must be false for forgejo projects"})
-	}
 	if roles.Reviewer.Behavior.ThreadResolution.Enabled {
 		*issues = append(*issues, ValidationIssue{Path: prefix + ".roles.reviewer.behavior.threadResolution.enabled", Message: "must be false for forgejo projects"})
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -527,6 +527,9 @@ func validateForgejoRoleCapabilities(roles RoleConfigs, prefix string, issues *[
 	if roles.Coordinator.Enabled {
 		*issues = append(*issues, ValidationIssue{Path: prefix + ".roles.coordinator.enabled", Message: "must be false for forgejo projects"})
 	}
+	if roles.Reviewer.AutoMerge.Enabled && roles.Reviewer.Behavior.PublishMode == ReviewerPublishModeSummaryComment {
+		*issues = append(*issues, ValidationIssue{Path: prefix + ".roles.reviewer.autoMerge.enabled", Message: "must be false when publishMode is summary_comment"})
+	}
 }
 
 // ValidateForgejoRoleCapabilities rejects role settings that require GitHub-only

--- a/internal/config/value_sources_test.go
+++ b/internal/config/value_sources_test.go
@@ -39,10 +39,10 @@ func TestLoadFileMetadataReportsCanonicalFieldSources(t *testing.T) {
 	}
 
 	want := map[string]ValueSource{
-		"agent.model":                   ValueSourceConfigFile,
-		"agent.env":                     ValueSourceConfigFile,
-		"agent.env.TOKEN":               ValueSourceConfigFile,
-		"agent.timeouts.plannerSeconds": ValueSourceCLI,
+		"agent.model":                             ValueSourceConfigFile,
+		"agent.env":                               ValueSourceConfigFile,
+		"agent.env.TOKEN":                         ValueSourceConfigFile,
+		"agent.timeouts.plannerSeconds":           ValueSourceCLI,
 		"agent.timeouts.plannerMaxRuntimeSeconds": ValueSourceCLI,
 		"defaults.allowAutoPush":                  ValueSourceEnv,
 		"notifications.webhook.mentionOpenIds":    ValueSourceConfigFile,

--- a/internal/config/value_sources_test.go
+++ b/internal/config/value_sources_test.go
@@ -39,10 +39,10 @@ func TestLoadFileMetadataReportsCanonicalFieldSources(t *testing.T) {
 	}
 
 	want := map[string]ValueSource{
-		"agent.model":                             ValueSourceConfigFile,
-		"agent.env":                               ValueSourceConfigFile,
-		"agent.env.TOKEN":                         ValueSourceConfigFile,
-		"agent.timeouts.plannerSeconds":           ValueSourceCLI,
+		"agent.model":                   ValueSourceConfigFile,
+		"agent.env":                     ValueSourceConfigFile,
+		"agent.env.TOKEN":               ValueSourceConfigFile,
+		"agent.timeouts.plannerSeconds": ValueSourceCLI,
 		"agent.timeouts.plannerMaxRuntimeSeconds": ValueSourceCLI,
 		"defaults.allowAutoPush":                  ValueSourceEnv,
 		"notifications.webhook.mentionOpenIds":    ValueSourceConfigFile,

--- a/internal/fixer/hitl.go
+++ b/internal/fixer/hitl.go
@@ -14,14 +14,13 @@ import (
 	"github.com/nexu-io/looper/internal/storage"
 )
 
-const fixerHITLInstruction = `HUMAN-IN-THE-LOOP: This mechanism applies only to non-native comment fix items represented in review_thread_replies. Classify every listed item before editing. Use "needs_human" when PR scope or product intent is materially ambiguous, repository rules conflict with the request, the request reverses an intentional design or an earlier fixer decision, the same behavior needs a second repair, satisfying it appears to require a new concept or subsystem, or a high-stakes sign-off is required. Do not use it for routine, reversible implementation choices that are clearly inside the documented PR intent. Never use "needs_human" in Forgejo repair_results; follow that contract's fixed, declined, or deferred actions.
+const fixerHITLInstruction = `HUMAN-IN-THE-LOOP: This mechanism applies to listed review comments, including Forgejo native comments. Classify every listed item before editing. Use "needs_human" when PR scope or product intent is materially ambiguous, repository rules conflict with the request, the request reverses an intentional design or an earlier fixer decision, the same behavior needs a second repair, satisfying it appears to require a new concept or subsystem, or a high-stakes sign-off is required. Do not use it for routine, reversible implementation choices that are clearly inside the documented PR intent. For Forgejo native comments, use "needs_human" in repair_results with the exact source, providerCommentId, observedFingerprint, and explanation.
 
-If any item needs human direction, set that fix item's review_thread_replies action to "needs_human", put the concrete conflict and decision needed in "explanation", and STOP THE ENTIRE TURN BEFORE MAKING EDITS. Do not commit, push, dismiss reviews, post replies, resolve threads, or otherwise mutate remote state. Looper will pause and resume you after an operator answers through its existing control plane. Choosing "needs_human" for a genuine authority or scope decision is a correct result, not a failure.`
+If any item needs human direction, set that fix item's review_thread_replies action (or Forgejo repair_results action) to "needs_human", put the concrete conflict and decision needed in "explanation", and STOP THE ENTIRE TURN BEFORE MAKING EDITS. Do not commit, push, dismiss reviews, post replies, resolve threads, or otherwise mutate remote state. Looper will pause and resume you after an operator answers through its existing control plane. Choosing "needs_human" for a genuine authority or scope decision is a correct result, not a failure.`
 
 func fixerHITLPromptFor(fixItems []FixItem) string {
 	for _, item := range fixItems {
-		if item.Type == "comment" && item.Source != NativeReviewCommentSource &&
-			strings.TrimSpace(item.ID) != "" && strings.TrimSpace(item.ThreadID) != "" {
+		if item.Type == "comment" && strings.TrimSpace(item.ID) != "" && (item.ThreadID != "" || item.ProviderCommentID > 0) {
 			return fixerHITLInstruction
 		}
 	}
@@ -78,6 +77,7 @@ func validateNeedsHumanReplies(stdout, stderr string, fixItems []FixItem, accept
 			Action      string `json:"action"`
 			Explanation string `json:"explanation"`
 		} `json:"review_thread_replies"`
+		Native []nativeRepairResultEntry `json:"repair_results"`
 	}
 	if err := json.Unmarshal([]byte(payload), &result); err != nil {
 		if strings.Contains(strings.ToLower(payload), `"`+string(replyActionNeedsHuman)+`"`) {
@@ -110,6 +110,24 @@ func validateNeedsHumanReplies(stdout, stderr string, fixItems []FixItem, accept
 			strings.TrimSpace(reply.ThreadID) != item.ThreadID ||
 			sanitizeReplyExplanation(reply.Explanation) == "" {
 			return fmt.Errorf("invalid needs_human decision for fix item %q", reply.FixItemID)
+		}
+		seen[item.ID] = struct{}{}
+	}
+	nativeItems := map[int64]FixItem{}
+	for _, item := range fixItems {
+		if item.Source == NativeReviewCommentSource && item.ProviderCommentID > 0 {
+			nativeItems[item.ProviderCommentID] = item
+		}
+	}
+	for _, reply := range result.Native {
+		if normalizeReplyAction(reply.Action) != string(replyActionNeedsHuman) {
+			continue
+		}
+		rawCount++
+		item, ok := nativeItems[reply.ProviderCommentID]
+		_, duplicate := seen[item.ID]
+		if !ok || duplicate || reply.Source != NativeReviewCommentSource || reply.ObservedFingerprint == "" || reply.ObservedFingerprint != item.ObservedFingerprint || sanitizeReplyExplanation(reply.Explanation) == "" {
+			return fmt.Errorf("invalid needs_human decision for native review comment %d", reply.ProviderCommentID)
 		}
 		seen[item.ID] = struct{}{}
 	}

--- a/internal/fixer/hitl_test.go
+++ b/internal/fixer/hitl_test.go
@@ -227,16 +227,16 @@ func TestFixerHITLParksResumesAndConsumesAnswer(t *testing.T) {
 	}
 }
 
-func TestFixerHITLPromptIsLimitedToNonNativeReviewThreads(t *testing.T) {
+func TestFixerHITLPromptIncludesExplicitNativeDecisionContract(t *testing.T) {
 	t.Parallel()
 	native := []FixItem{{Type: "comment", ID: "native-1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101}}
-	if instruction := fixerHITLPromptFor(native); instruction != "" {
-		t.Fatalf("native-only HITL instruction = %q, want empty", instruction)
+	if instruction := fixerHITLPromptFor(native); !strings.Contains(instruction, "repair_results") {
+		t.Fatalf("native HITL instruction = %q, want structured native contract", instruction)
 	}
 	regular := []FixItem{{Type: "comment", ID: "c1", ThreadID: "t1"}}
 	instruction := fixerHITLPromptFor(regular)
-	if !strings.Contains(instruction, "only to non-native comment fix items") ||
-		!strings.Contains(instruction, "Never use \"needs_human\" in Forgejo repair_results") ||
+	if !strings.Contains(instruction, "including Forgejo native comments") ||
+		!strings.Contains(instruction, "For Forgejo native comments") ||
 		!strings.Contains(instruction, "Classify every listed item before editing") ||
 		!strings.Contains(instruction, "the same behavior needs a second repair") ||
 		!strings.Contains(instruction, "STOP THE ENTIRE TURN BEFORE MAKING EDITS") ||

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -278,8 +278,12 @@ type NativeReviewComment struct {
 	ReviewAuthor        string
 }
 
-func NativeReviewCommentFingerprint(commentID int64, updatedAt string) string {
-	return fmt.Sprintf("%s:%d:%s", NativeReviewCommentSource, commentID, strings.TrimSpace(updatedAt))
+// NativeReviewCommentFingerprint binds an observed decision to the comment's
+// identity and exact feedback. Forgejo may change updated_at after a push even
+// when the feedback is unchanged, so timestamps are not content revisions.
+func NativeReviewCommentFingerprint(commentID int64, body string) string {
+	digest := sha256.Sum256([]byte(body))
+	return fmt.Sprintf("%s:%d:sha256:%x", NativeReviewCommentSource, commentID, digest)
 }
 
 func NativeReviewCommentFixItemID(commentID int64) string {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -1861,6 +1861,13 @@ func (r *Runner) isForgejoProject(projectID string) bool {
 	return r.projectRoleConfig != nil && config.ProjectProviderKind(*r.projectRoleConfig, projectID) == config.ProviderKindForgejo
 }
 
+func (r *Runner) forgejoSummaryCommentMode(projectID string) bool {
+	if r.projectRoleConfig == nil {
+		return false
+	}
+	return r.isForgejoProject(projectID) && config.ProjectRoleConfigs(*r.projectRoleConfig, projectID).Reviewer.Behavior.PublishMode == config.ReviewerPublishModeSummaryComment
+}
+
 func defaultDiscoveryLimit(limit int) int {
 	if limit <= 0 {
 		return 30
@@ -2047,11 +2054,13 @@ func (r *Runner) prepareForgejoDiscoveryDetail(ctx context.Context, project stor
 		return detail, err
 	}
 	sanitizeForgejoSummaryAuthority(&detail, currentUser)
-	native, err := r.github.ListNativeReviewComments(ctx, ListNativeReviewCommentsInput{Repo: repo, PRNumber: detail.Number, CWD: project.RepoPath})
-	if err != nil {
-		return detail, classifyForgejoNativeDiscoveryError(err)
+	if !r.forgejoSummaryCommentMode(project.ID) {
+		native, err := r.github.ListNativeReviewComments(ctx, ListNativeReviewCommentsInput{Repo: repo, PRNumber: detail.Number, CWD: project.RepoPath})
+		if err != nil {
+			return detail, classifyForgejoNativeDiscoveryError(err)
+		}
+		detail.Comments = append(nativeReviewCommentsToMaps(actionableNativeReviewComments(native, currentUser)), nonNativeComments(detail.Comments)...)
 	}
-	detail.Comments = append(nativeReviewCommentsToMaps(actionableNativeReviewComments(native, currentUser)), nonNativeComments(detail.Comments)...)
 	checkpoint := fixerCheckpoint{Detail: pullRequestCheckpointDetail(detail)}
 	if _, _, err := reviewerSummaryFromCheckpointDetail(checkpoint.Detail); err != nil {
 		return detail, err
@@ -2873,7 +2882,7 @@ func (r *Runner) runCollectFixesStep(ctx context.Context, input stepInput) (fixe
 		checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because it is not eligible", input.Repo, input.PRNumber)
 		return checkpoint, nil
 	}
-	if r.isForgejoProject(input.Project.ID) || isManualFixerLoop(input.Loop) {
+	if !r.forgejoSummaryCommentMode(input.Project.ID) && (r.isForgejoProject(input.Project.ID) || isManualFixerLoop(input.Loop)) {
 		if err := r.attachForgejoNativeComments(ctx, input, &checkpoint); err != nil {
 			return checkpoint, err
 		}
@@ -3815,7 +3824,7 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		}
 	}
 	var liveNativeComments []NativeReviewComment
-	if hasNativeForgejoItems || r.isForgejoProject(input.Project.ID) || isManualFixerLoop(input.Loop) {
+	if hasNativeForgejoItems || (!r.forgejoSummaryCommentMode(input.Project.ID) && (r.isForgejoProject(input.Project.ID) || isManualFixerLoop(input.Loop))) {
 		liveNativeComments, err = r.github.ListNativeReviewComments(ctx, ListNativeReviewCommentsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 		if err != nil {
 			return checkpoint, classifyForgejoNativeResolveError(err)

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -160,6 +160,7 @@ type PullRequestSummary struct {
 
 type PullRequestDetail struct {
 	Number         int64
+	URL            string
 	State          string
 	IsDraft        bool
 	Labels         []string
@@ -270,6 +271,10 @@ type NativeReviewComment struct {
 	IsResolved          bool
 	Author              string
 	UpdatedAt           string
+	ReviewBody          string
+	ReviewState         string
+	ReviewCommitID      string
+	ReviewAuthor        string
 }
 
 func NativeReviewCommentFingerprint(commentID int64, updatedAt string) string {

--- a/internal/fixer/runner.go
+++ b/internal/fixer/runner.go
@@ -146,6 +146,7 @@ type FixItem struct {
 	URL                 string   `json:"url,omitempty"`
 	Path                string   `json:"path,omitempty"`
 	Line                int64    `json:"line,omitempty"`
+	ActionRunID         int64    `json:"actionRunId,omitempty"`
 }
 
 type PullRequestSummary struct {
@@ -768,6 +769,7 @@ const (
 )
 
 type checkpointDetail struct {
+	URL            string           `json:"url,omitempty"`
 	State          string           `json:"state,omitempty"`
 	IsDraft        bool             `json:"isDraft,omitempty"`
 	Labels         []string         `json:"labels,omitempty"`
@@ -835,6 +837,7 @@ type replyExplanationEntry struct {
 	Action                 string `json:"action,omitempty"`
 	Explanation            string `json:"explanation"`
 	ThreadCommentsObserved string `json:"threadCommentsObserved,omitempty"`
+	ObservedFingerprint    string `json:"observedFingerprint,omitempty"`
 }
 
 type nativeRepairResultEntry struct {
@@ -1142,6 +1145,8 @@ func normalizeNativeRepairAction(raw string) string {
 		return "declined"
 	case "deferred":
 		return "deferred"
+	case "needs_human":
+		return "needs_human"
 	default:
 		return ""
 	}
@@ -1212,7 +1217,7 @@ func parseNativeRepairResults(stdout, stderr string, fixItems []FixItem) []reply
 	out := make([]replyExplanationEntry, 0, len(results))
 	for _, result := range results {
 		item := itemsByProviderID[result.ProviderCommentID]
-		out = append(out, replyExplanationEntry{FixItemID: item.ID, ThreadID: item.ThreadID, Action: result.Action, Explanation: result.Explanation})
+		out = append(out, replyExplanationEntry{FixItemID: item.ID, ThreadID: item.ThreadID, Action: result.Action, Explanation: result.Explanation, ObservedFingerprint: result.ObservedFingerprint})
 	}
 	return out
 }
@@ -1930,7 +1935,7 @@ func (r *Runner) discoverPullRequestFromDetail(ctx context.Context, project stor
 		result.Skipped++
 		return nil
 	}
-	detail, err = r.prepareForgejoDiscoveryDetail(ctx, project, detail)
+	detail, err = r.prepareForgejoDiscoveryDetail(ctx, project, repo, detail)
 	if err != nil {
 		return err
 	}
@@ -1958,8 +1963,19 @@ func (r *Runner) discoverPullRequestFromDetail(ctx context.Context, project stor
 		result.Skipped++
 		return nil
 	}
-	allFixItemsStateHash := hashFixItemsState(allFixItems)
-	fixItems := suppressDeclinedFixItems(loopMetadataForPR(ctx, r, project.ID, repo, detail.Number), detail.HeadSHA, allFixItems)
+	actionableFixItems, err = r.suppressFixedForgejoNativeItems(ctx, project, repo, detail.Number, detail.HeadSHA, loop, actionableFixItems)
+	if err != nil {
+		return err
+	}
+	if len(actionableFixItems) == 0 {
+		if err := r.clearFixerFollowupStateForPR(ctx, project.ID, repo, detail.Number); err != nil {
+			return err
+		}
+		result.Skipped++
+		return nil
+	}
+	allFixItemsStateHash := hashFixItemsState(actionableFixItems)
+	fixItems := suppressDeclinedFixItems(loopMetadataForPR(ctx, r, project.ID, repo, detail.Number), detail.HeadSHA, actionableFixItems)
 	fixItems, err = r.suppressWithheldDispositionFixItems(ctx, project, repo, detail, fixItems)
 	if err != nil {
 		return err
@@ -2015,10 +2031,10 @@ func (r *Runner) discoverPullRequestFromDetail(ctx context.Context, project stor
 }
 
 func pullRequestCheckpointDetail(detail PullRequestDetail) *checkpointDetail {
-	return &checkpointDetail{State: detail.State, IsDraft: detail.IsDraft, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, BaseSHA: detail.BaseSHA, ReviewDecision: detail.ReviewDecision, Comments: cloneObjectSlice(detail.Comments), IssueComments: cloneObjectSlice(detail.IssueComments), Checks: cloneObjectSlice(detail.Checks), HasConflicts: detail.HasConflicts}
+	return &checkpointDetail{URL: detail.URL, State: detail.State, IsDraft: detail.IsDraft, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, BaseSHA: detail.BaseSHA, ReviewDecision: detail.ReviewDecision, Comments: cloneObjectSlice(detail.Comments), IssueComments: cloneObjectSlice(detail.IssueComments), Checks: cloneObjectSlice(detail.Checks), HasConflicts: detail.HasConflicts}
 }
 
-func (r *Runner) prepareForgejoDiscoveryDetail(ctx context.Context, project storage.ProjectRecord, detail PullRequestDetail) (PullRequestDetail, error) {
+func (r *Runner) prepareForgejoDiscoveryDetail(ctx context.Context, project storage.ProjectRecord, repo string, detail PullRequestDetail) (PullRequestDetail, error) {
 	if !r.isForgejoProject(project.ID) {
 		return detail, nil
 	}
@@ -2027,6 +2043,11 @@ func (r *Runner) prepareForgejoDiscoveryDetail(ctx context.Context, project stor
 		return detail, err
 	}
 	sanitizeForgejoSummaryAuthority(&detail, currentUser)
+	native, err := r.github.ListNativeReviewComments(ctx, ListNativeReviewCommentsInput{Repo: repo, PRNumber: detail.Number, CWD: project.RepoPath})
+	if err != nil {
+		return detail, classifyForgejoNativeDiscoveryError(err)
+	}
+	detail.Comments = append(nativeReviewCommentsToMaps(actionableNativeReviewComments(native, currentUser)), nonNativeComments(detail.Comments)...)
 	checkpoint := fixerCheckpoint{Detail: pullRequestCheckpointDetail(detail)}
 	if _, _, err := reviewerSummaryFromCheckpointDetail(checkpoint.Detail); err != nil {
 		return detail, err
@@ -2684,7 +2705,7 @@ func (r *Runner) runDiscoverPRStep(ctx context.Context, input stepInput) (fixerC
 	if !isManualFixerLoop(input.Loop) && len(prQueryLabels(policy.Labels)) > 0 && !labelsMatch(detail.Labels, policy.Labels, policy.LabelMode) {
 		return checkpoint, &labelMismatchSkipError{summary: fmt.Sprintf("Paused fixer run for %s#%d because PR labels no longer match fixer trigger policy", input.Repo, input.PRNumber)}
 	}
-	checkpoint.Detail = &checkpointDetail{State: detail.State, IsDraft: detail.IsDraft, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, BaseSHA: detail.BaseSHA, ReviewDecision: detail.ReviewDecision, Comments: cloneObjectSlice(detail.Comments), IssueComments: cloneObjectSlice(detail.IssueComments), Checks: cloneObjectSlice(detail.Checks), HasConflicts: detail.HasConflicts}
+	checkpoint.Detail = &checkpointDetail{URL: detail.URL, State: detail.State, IsDraft: detail.IsDraft, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, BaseSHA: detail.BaseSHA, ReviewDecision: detail.ReviewDecision, Comments: cloneObjectSlice(detail.Comments), IssueComments: cloneObjectSlice(detail.IssueComments), Checks: cloneObjectSlice(detail.Checks), HasConflicts: detail.HasConflicts}
 	checkpoint.ResumePolicy = "replay_step"
 	return checkpoint, nil
 }
@@ -2848,8 +2869,8 @@ func (r *Runner) runCollectFixesStep(ctx context.Context, input stepInput) (fixe
 		checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because it is not eligible", input.Repo, input.PRNumber)
 		return checkpoint, nil
 	}
-	if isManualFixerLoop(input.Loop) {
-		if err := r.attachManualForgejoNativeComments(ctx, input, &checkpoint); err != nil {
+	if r.isForgejoProject(input.Project.ID) || isManualFixerLoop(input.Loop) {
+		if err := r.attachForgejoNativeComments(ctx, input, &checkpoint); err != nil {
 			return checkpoint, err
 		}
 	}
@@ -2868,19 +2889,12 @@ func (r *Runner) runCollectFixesStep(ctx context.Context, input stepInput) (fixe
 	if err != nil {
 		return checkpoint, err
 	}
+	fixItems, err = r.suppressFixedForgejoNativeItems(ctx, input.Project, input.Repo, input.PRNumber, detailHeadSHA(checkpoint.Detail), &input.Loop, fixItems)
+	if err != nil {
+		return checkpoint, err
+	}
 	checkpoint.FixItems = fixItems
 	checkpoint.FixItemsHash = hashFixItems(fixItems)
-	if hasForgejoNativeReviewComments(fixItems) {
-		state, probeErr := r.github.ProbeNativeReviewCommentResolution(ctx, ListNativeReviewCommentsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
-		if probeErr != nil || state != forge.ProbeStateSupported {
-			return checkpoint, &loopError{message: fmt.Sprintf("Forgejo native review comment resolution is %s; manual intervention required", firstNonEmpty(string(state), "unknown")), kind: FailureManualIntervention}
-		}
-	}
-	for _, item := range fixItems {
-		if item.Type == "comment" && item.Source == NativeReviewCommentSource && !item.ResolverPresent {
-			return checkpoint, &loopError{message: fmt.Sprintf("Forgejo native review comment resolution is unsupported for comment %d; manual intervention required", item.ProviderCommentID), kind: FailureManualIntervention}
-		}
-	}
 	if len(fixItems) == 0 {
 		checkpoint.SkipReason = fmt.Sprintf("Skipped %s#%d because no fix items remain", input.Repo, input.PRNumber)
 		return checkpoint, nil
@@ -2899,7 +2913,7 @@ func hasForgejoNativeReviewComments(items []FixItem) bool {
 	return false
 }
 
-func (r *Runner) attachManualForgejoNativeComments(ctx context.Context, input stepInput, checkpoint *fixerCheckpoint) error {
+func (r *Runner) attachForgejoNativeComments(ctx context.Context, input stepInput, checkpoint *fixerCheckpoint) error {
 	if checkpoint == nil || checkpoint.Detail == nil {
 		return nil
 	}
@@ -2913,9 +2927,6 @@ func (r *Runner) attachManualForgejoNativeComments(ctx context.Context, input st
 	nativeComments, err := r.github.ListNativeReviewComments(ctx, ListNativeReviewCommentsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 	if err != nil {
 		return classifyForgejoNativeDiscoveryError(err)
-	}
-	if len(nativeComments) == 0 {
-		return nil
 	}
 	nativeComments = actionableNativeReviewComments(nativeComments, currentUser)
 	comments := make([]map[string]any, 0, len(nativeComments)+len(checkpoint.Detail.Comments))
@@ -3338,6 +3349,7 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 		return checkpoint, &holdSkipError{summary: summary}
 	}
 	replies := normalizeReplyExplanationActions(parseReplyExplanations(result.Stdout, result.Stderr, checkpoint.FixItems))
+	replies = append(replies, parseNativeRepairResults(result.Stdout, result.Stderr, checkpoint.FixItems)...)
 	if err := validateNeedsHumanReplies(result.Stdout, result.Stderr, checkpoint.FixItems, replies); err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureManualIntervention}
 	}
@@ -3349,7 +3361,6 @@ func (r *Runner) runRepairStep(ctx context.Context, input stepInput) (fixerCheck
 	}
 	checkpoint.Repair = checkpointRepairFromAgentResult(executionID, detailHeadSHA(checkpoint.Detail), result, r.nowISO())
 	checkpoint.Repair.ReplyExplanations = replies
-	checkpoint.Repair.ReplyExplanations = append(checkpoint.Repair.ReplyExplanations, parseNativeRepairResults(result.Stdout, result.Stderr, checkpoint.FixItems)...)
 	checkpoint.ensureLifecycle("fixer", worktree.Branch, detailBaseRefName(checkpoint.Detail), false)
 	if result.Lifecycle != nil {
 		checkpoint.Lifecycle.MergeAgent(result.Lifecycle, r.nowISO())
@@ -3739,8 +3750,13 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	hasReviewerSummary := false
 	if _, ok, err := reviewerSummaryFromCheckpointDetail(checkpoint.Detail); err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureNonRetryable}
-	} else {
-		hasReviewerSummary = ok
+	} else if ok {
+		for _, item := range checkpoint.FixItems {
+			if item.Source == "forgejo-reviewer-summary" {
+				hasReviewerSummary = true
+				break
+			}
+		}
 	}
 	if checkpoint.Validation == nil || !checkpoint.Validation.Passed {
 		return checkpoint, &loopError{message: "resolve-comments requires successful validation", kind: FailureRetryableAfterResume}
@@ -3748,16 +3764,17 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	if checkpoint.Push == nil {
 		return checkpoint, &loopError{message: "resolve-comments requires push step to complete", kind: FailureRetryableAfterResume}
 	}
+	if hasForgejoNativeReviewComments(checkpoint.FixItems) {
+		// Persisted agent decisions can replay publication after interruption;
+		// live head and comment checks below still restart on actual drift.
+		checkpoint.ResumePolicy = loops.ResumePolicyReplayStep
+	}
 	liveDetail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 	if err != nil {
 		return checkpoint, err
 	}
 	if !isManualFixerLoop(input.Loop) && domain.IsAutoLaneHeld(domain.LoopTypeFixer, liveDetail.Labels) {
 		return checkpoint, &holdSkipError{summary: fmt.Sprintf("Fixer stopped because %s#%d is currently held", input.Repo, input.PRNumber)}
-	}
-	liveDetail, err = r.prepareForgejoDiscoveryDetail(ctx, input.Project, liveDetail)
-	if err != nil {
-		return checkpoint, err
 	}
 	// Ancestor guard: if we previously pushed a fix commit, make sure the
 	// live PR head still descends from it. If a collaborator force-pushed or
@@ -3786,32 +3803,57 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		}
 	}
 	priorNativeCommentItems := make([]FixItem, 0)
-	priorNativeCommentItemsByProviderID := map[int64]FixItem{}
 	hasNativeForgejoItems := false
 	for _, item := range checkpoint.FixItems {
 		if item.Type == "comment" && item.Source == NativeReviewCommentSource && item.ProviderCommentID > 0 {
 			hasNativeForgejoItems = true
 			priorNativeCommentItems = append(priorNativeCommentItems, item)
-			priorNativeCommentItemsByProviderID[item.ProviderCommentID] = item
 		}
 	}
 	var liveNativeComments []NativeReviewComment
-	if hasNativeForgejoItems || isManualFixerLoop(input.Loop) {
+	if hasNativeForgejoItems || r.isForgejoProject(input.Project.ID) || isManualFixerLoop(input.Loop) {
 		liveNativeComments, err = r.github.ListNativeReviewComments(ctx, ListNativeReviewCommentsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
 		if err != nil {
 			return checkpoint, classifyForgejoNativeResolveError(err)
 		}
-		if len(liveNativeComments) > 0 {
-			currentUser, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
-			if err != nil {
-				return checkpoint, err
-			}
-			liveNativeComments = nonSelfNativeReviewComments(liveNativeComments, currentUser)
-			liveDetail.Comments = append(nativeReviewCommentsToMaps(liveNativeComments), nonNativeComments(liveDetail.Comments)...)
+		currentUser, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath)
+		if err != nil {
+			return checkpoint, err
 		}
+		sanitizeForgejoSummaryAuthority(&liveDetail, currentUser)
+		liveNativeComments = eligibleNativeReviewComments(liveNativeComments, currentUser)
+		liveDetail.Comments = append(nativeReviewCommentsToMaps(liveNativeComments), nonNativeComments(liveDetail.Comments)...)
 	}
 	checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, liveDetail)
-	fixItems := collectFixItems(liveDetail)
+	fixItems, err := collectFixItemsFromCheckpointForStep(checkpoint)
+	if err != nil {
+		return checkpoint, err
+	}
+	fixItems, err = r.unsatisfiedForgejoSummaryItems(input.Project.ID, checkpoint.Detail, fixItems)
+	if err != nil {
+		return checkpoint, err
+	}
+	fixItems, err = r.suppressFixedForgejoNativeItems(ctx, input.Project, input.Repo, input.PRNumber, liveDetail.HeadSHA, &input.Loop, fixItems)
+	if err != nil {
+		return checkpoint, err
+	}
+	// Retain the round's original items for truthful reporting and retry. Newly
+	// arrived comments are still checked below and cannot borrow old decisions.
+	for _, prior := range checkpoint.FixItems {
+		if prior.Source != NativeReviewCommentSource && prior.Source != "forgejo-reviewer-summary" {
+			continue
+		}
+		found := false
+		for _, item := range fixItems {
+			if item.ID == prior.ID && item.Type == prior.Type && item.Name == prior.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			fixItems = append(fixItems, prior)
+		}
+	}
 	checkpoint.FixItems = fixItems
 	checkpoint.FixItemsHash = hashFixItems(fixItems)
 	if checkpoint.ResolvedComments == nil {
@@ -3853,7 +3895,6 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 	}
 	driftCount := 0
 	mutationFailureCount := 0
-	nativeMutationFailureCount := 0
 	var nativeMutationErr error
 	// Drift detection must be anchored to when the agent recorded the
 	// reply explanations, not when the current (possibly retried) run
@@ -3983,62 +4024,11 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		}
 	}
 	if len(nativeCommentItems) > 0 {
-		repliesByFixItemID := agentResolveRepliesByFixItemID(checkpoint)
-		liveByProviderID := map[int64]NativeReviewComment{}
-		for _, live := range liveNativeComments {
-			liveByProviderID[live.ProviderCommentID] = live
-		}
-		for _, item := range nativeCommentItems {
-			if alreadyResolved(checkpoint.ResolvedComments.Items, item) {
-				continue
-			}
-			decision, hasDecision := repliesByFixItemID[item.ID]
-			live, liveOK := liveByProviderID[item.ProviderCommentID]
-			if !liveOK {
-				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: decision.Action, Status: "deleted", UpdatedAt: r.nowISO()})
-				continue
-			}
-			if live.IsResolved {
-				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: decision.Action, Status: "already_resolved", UpdatedAt: r.nowISO()})
-				continue
-			}
-			if !hasDecision {
-				contractViolationCount++
-				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Status: "skipped_missing_agent_decision", Message: agentMissingThreadDecisionExplanation, UpdatedAt: r.nowISO()})
-				continue
-			}
-			if strings.TrimSpace(decision.Action) != "fixed" {
-				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: decision.Action, Status: "skipped_noop", UpdatedAt: r.nowISO()})
-				continue
-			}
-			if !checkpoint.Push.Pushed {
-				return checkpoint, &loopError{message: "resolve-comments requires an actual push before resolving fixed Forgejo native review comments", kind: FailureManualIntervention}
-			}
-			priorItem := priorNativeCommentItemsByProviderID[item.ProviderCommentID]
-			if strings.TrimSpace(priorItem.ObservedFingerprint) == "" || priorItem.ObservedFingerprint != strings.TrimSpace(live.ObservedFingerprint) {
-				driftCount++
-				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: decision.Action, Status: "skipped_thread_drift", Message: "Forgejo native review comment changed since the fixer inspected it", UpdatedAt: r.nowISO()})
-				continue
-			}
-			if err := r.github.ResolveNativeReviewComment(ctx, ResolveNativeReviewCommentInput{Repo: input.Repo, PRNumber: input.PRNumber, ProviderCommentID: item.ProviderCommentID, CWD: input.Project.RepoPath}); err != nil {
-				if isForgejoNativeResolveUnsupported(err) {
-					nativeMutationFailureCount++
-					if nativeMutationErr == nil {
-						nativeMutationErr = err
-					}
-					upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: decision.Action, Status: "unsupported_remote_resolution", Message: err.Error(), UpdatedAt: r.nowISO()})
-					continue
-				}
-				nativeMutationFailureCount++
-				if nativeMutationErr == nil {
-					nativeMutationErr = err
-				}
-				upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: decision.Action, Status: "failed_mutation_retry", Message: err.Error(), UpdatedAt: r.nowISO()})
-				continue
-			}
-			resolvedCount++
-			upsertResolvedComment(&checkpoint.ResolvedComments.Items, checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: decision.Action, Status: "resolved", UpdatedAt: r.nowISO()})
-		}
+		finished, missing, drift, finishErr := r.finishForgejoNativeComments(ctx, input, &checkpoint, nativeCommentItems, liveNativeComments)
+		resolvedCount += finished
+		contractViolationCount += missing
+		driftCount += drift
+		nativeMutationErr = finishErr
 	}
 	if contractViolationCount > 0 {
 		if _, err := r.incrementContractViolationCount(ctx, input.Loop, contractViolationCount); err != nil {
@@ -4046,8 +4036,25 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		}
 	}
 	r.appendEvent(ctx, eventInput{eventType: "fixer.comments.resolved", projectID: input.Project.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"items": checkpoint.ResolvedComments.Items}})
-	if resolvedCount > 0 {
-		r.publishRoundSummaryComment(ctx, input, &checkpoint, fixItems, commitSHA, lookupReplyExplanations(checkpoint))
+	// Publish this round's confirmed results before rediscovering any newer
+	// feedback. Mixed native/legacy rounds use the same comment and checkpoint
+	// as legacy-only rounds; publication must succeed before local suppression.
+	if hasReviewerSummary {
+		checkpoint, err = r.runForgejoFixerSummaryStep(ctx, stepInput{Project: input.Project, Loop: input.Loop, Run: input.Run, QueueItem: input.QueueItem, Repo: input.Repo, PRNumber: input.PRNumber, Checkpoint: checkpoint})
+		if err != nil {
+			return checkpoint, err
+		}
+		if err := r.recordPublishedForgejoNativeResults(ctx, input, checkpoint); err != nil {
+			return checkpoint, err
+		}
+	} else if resolvedCount > 0 || len(nativeCommentItems) > 0 || (r.isForgejoProject(input.Project.ID) && roundProducedNewCommits(&checkpoint)) {
+		if err := r.publishRoundSummaryComment(ctx, input, &checkpoint, fixItems, commitSHA, lookupReplyExplanations(checkpoint)); err != nil && len(nativeCommentItems) > 0 {
+			checkpoint.ResumePolicy = loops.ResumePolicyReplayStep
+			return checkpoint, &loopError{message: fmt.Sprintf("Failed to publish Forgejo fixer acknowledgement; will retry: %v", err), kind: FailureRetryableAfterResume}
+		}
+		if err := r.recordPublishedForgejoNativeResults(ctx, input, checkpoint); err != nil {
+			return checkpoint, err
+		}
 	}
 	if driftCount > 0 {
 		checkpoint.ResumePolicy = loops.ResumePolicyRestartFromDiscover
@@ -4061,15 +4068,12 @@ func (r *Runner) runResolveCommentsStep(ctx context.Context, input stepInput) (f
 		checkpoint.ResumePolicy = loops.ResumePolicyReplayStep
 		return checkpoint, &loopError{message: fmt.Sprintf("Failed to resolve %d review thread(s); will retry on next run", mutationFailureCount), kind: FailureRetryableAfterResume}
 	}
-	if nativeMutationFailureCount > 0 {
+	if nativeMutationErr != nil {
 		checkpoint.ResumePolicy = loops.ResumePolicyReplayStep
 		return checkpoint, classifyForgejoNativeResolveError(nativeMutationErr)
 	}
 	if _, err := r.clearFixerFollowupMetadata(ctx, input.Loop); err != nil {
 		return checkpoint, err
-	}
-	if hasReviewerSummary {
-		return r.runForgejoFixerSummaryStep(ctx, stepInput{Project: input.Project, Loop: input.Loop, Run: input.Run, QueueItem: input.QueueItem, Repo: input.Repo, PRNumber: input.PRNumber, Checkpoint: checkpoint})
 	}
 	checkpoint.ResumePolicy = "advance_from_checkpoint"
 	return checkpoint, nil
@@ -4152,18 +4156,11 @@ func (r *Runner) runForgejoFixerSummaryStep(ctx context.Context, input stepInput
 	if err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
-	liveDetail, err = r.prepareForgejoDiscoveryDetail(ctx, input.Project, liveDetail)
+	liveDetail, err = r.prepareForgejoDiscoveryDetail(ctx, input.Project, input.Repo, liveDetail)
 	if err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
 	checkpoint.Detail = mergeCheckpointDetailPreservingLabels(checkpoint.Detail, liveDetail)
-	reviewerSummary, ok, err = reviewerSummaryFromCheckpointDetail(checkpoint.Detail)
-	if err != nil {
-		return checkpoint, &loopError{message: err.Error(), kind: FailureNonRetryable}
-	}
-	if !ok {
-		return checkpoint, &loopError{message: "forgejo fixer requires reviewer summary comment", kind: FailureNonRetryable}
-	}
 	summary, err := buildForgejoFixerSummary(checkpoint, reviewerSummary, lookupReplyExplanations(checkpoint))
 	if err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
@@ -4171,7 +4168,7 @@ func (r *Runner) runForgejoFixerSummaryStep(ctx context.Context, input stepInput
 	if err := forge.ValidateFixerResultsForReviewerSummary(reviewerSummary, summary); err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
-	body, err := renderForgejoFixerSummaryComment(summary)
+	body, err := renderForgejoFixerRoundComment(summary, input.Repo, input.PRNumber, checkpoint)
 	if err != nil {
 		return checkpoint, err
 	}
@@ -4261,19 +4258,39 @@ func nextForgejoFixRoundID(detail *checkpointDetail) int {
 }
 
 func renderForgejoFixerSummaryComment(summary forge.FixerSummary) (string, error) {
+	checkpoint := fixerCheckpoint{}
+	for _, result := range summary.Results {
+		checkpoint.FixItems = append(checkpoint.FixItems, FixItem{Type: "comment", Source: "forgejo-reviewer-summary", ID: result.ReviewItemID})
+	}
+	return renderForgejoFixerRoundComment(summary, "", 0, checkpoint)
+}
+
+func renderForgejoFixerRoundComment(summary forge.FixerSummary, repo string, prNumber int64, checkpoint fixerCheckpoint) (string, error) {
 	marker, err := forge.RenderFixerSummary(summary)
 	if err != nil {
 		return "", err
 	}
-	var b strings.Builder
-	b.WriteString("**Looper Forgejo Fixer Summary**\n\n")
-	b.WriteString(fmt.Sprintf("Consumed Reviewer Summary round `%d`; Fixer Summary round `%d`.\n\n", summary.ConsumedReviewRoundID, summary.FixRoundID))
-	for _, result := range summary.Results {
-		b.WriteString(fmt.Sprintf("- `%s`: `%s` — %s\n", result.ReviewItemID, result.Result, strings.ReplaceAll(strings.TrimSpace(result.Explanation), "\n", " ")))
+	items := summaryCommentItems(checkpoint.FixItems, &checkpoint, lookupReplyExplanations(checkpoint))
+	for index := range items {
+		if items[index].FixItem.Source != "forgejo-reviewer-summary" {
+			continue
+		}
+		for _, result := range summary.Results {
+			if result.ReviewItemID != items[index].FixItem.ID {
+				continue
+			}
+			items[index].Explanation = result.Explanation
+			switch result.Result {
+			case forge.FixerItemResultFixed:
+				items[index].Status = "resolved"
+			case forge.FixerItemResultDeclined:
+				items[index].Status = "agent_declined"
+			default:
+				items[index].Status = "pending"
+			}
+		}
 	}
-	b.WriteString("\n")
-	b.WriteString(marker)
-	return strings.TrimSpace(b.String()), nil
+	return buildFixerSummaryCommentBody(repo, prNumber, summary.ObservedHeadSHA, resolveCommentCommitSHA(checkpoint, nil, false), items) + "\n\n" + marker, nil
 }
 
 // replyToFixedComment posts a reply on the review thread acknowledging the fix
@@ -4424,7 +4441,7 @@ func (r *Runner) refreshResolveCommentState(ctx context.Context, input stepInput
 	if err != nil {
 		return "", PullRequestDetail{}, err
 	}
-	liveDetail, err = r.prepareForgejoDiscoveryDetail(ctx, input.Project, liveDetail)
+	liveDetail, err = r.prepareForgejoDiscoveryDetail(ctx, input.Project, input.Repo, liveDetail)
 	if err != nil {
 		return "", PullRequestDetail{}, err
 	}
@@ -4776,9 +4793,10 @@ func fixerRoundSummaryMarker(headSHA string) string {
 
 // publishRoundSummaryComment posts (or edits) a single PR conversation comment
 // summarizing this fixer round: the commit, every fix item with its outcome,
-// agent explanations when present, and links to each thread. The summary is
-// best-effort and never blocks the resolve step.
-func (r *Runner) publishRoundSummaryComment(ctx context.Context, input stepInput, checkpoint *fixerCheckpoint, fixItems []FixItem, commitSHA string, explanationByID map[string]string) {
+// agent explanations when present, and links to each thread. GitHub keeps its
+// best-effort behavior; native Forgejo results require this acknowledgement.
+func (r *Runner) publishRoundSummaryComment(ctx context.Context, input stepInput, checkpoint *fixerCheckpoint, fixItems []FixItem, commitSHA string, explanationByID map[string]string) error {
+	native := hasForgejoNativeReviewComments(fixItems)
 	headSHA := commitSHA
 	if headSHA == "" && checkpoint.ReconcileCommits != nil {
 		headSHA = checkpoint.ReconcileCommits.FinalHeadSHA
@@ -4787,19 +4805,21 @@ func (r *Runner) publishRoundSummaryComment(ctx context.Context, input stepInput
 		headSHA = detailHeadSHA(checkpoint.Detail)
 	}
 	if headSHA == "" {
-		return
+		return fmt.Errorf("fixer acknowledgement requires a head commit")
 	}
-	evidence := resolveFixEvidence(*checkpoint, input.Loop.MetadataJSON, checkpoint.FixItemsHash)
-	if evidence == nil || !evidence.Valid || evidence.HeadSHA == "" {
-		return
+	if !native {
+		evidence := resolveFixEvidence(*checkpoint, input.Loop.MetadataJSON, checkpoint.FixItemsHash)
+		if evidence == nil || !evidence.Valid || evidence.HeadSHA == "" {
+			return nil
+		}
+		if !roundProducedNewCommits(checkpoint) && (checkpoint.ReconcileCommits == nil || evidence.HeadSHA == reconcileBaseHeadSHA(checkpoint.ReconcileCommits)) {
+			return nil
+		}
+		headSHA = evidence.HeadSHA
 	}
-	if !roundProducedNewCommits(checkpoint) && (checkpoint.ReconcileCommits == nil || evidence.HeadSHA == reconcileBaseHeadSHA(checkpoint.ReconcileCommits)) {
-		return
-	}
-	headSHA = evidence.HeadSHA
 	commentItems := summaryCommentItems(fixItems, checkpoint, explanationByID)
 	if len(commentItems) == 0 {
-		return
+		return nil
 	}
 	body := buildFixerSummaryCommentBody(input.Repo, input.PRNumber, headSHA, commitSHA, commentItems)
 	disclosureAgent, disclosureModel := r.disclosureIdentity(input.Run)
@@ -4808,33 +4828,37 @@ func (r *Runner) publishRoundSummaryComment(ctx context.Context, input stepInput
 			checkpoint.SummaryComment.State = "update_failed"
 			checkpoint.SummaryComment.Error = err.Error()
 			checkpoint.SummaryComment.UpdatedAt = r.nowISO()
-			return
+			return err
 		}
 		checkpoint.SummaryComment.State = "updated"
 		checkpoint.SummaryComment.Error = ""
 		checkpoint.SummaryComment.FixItemsHash = checkpoint.FixItemsHash
 		checkpoint.SummaryComment.UpdatedAt = r.nowISO()
-		return
+		return nil
 	}
 	trustedLogin := ""
 	if login, err := r.github.GetCurrentUserLogin(ctx, input.Project.RepoPath); err == nil {
 		trustedLogin = login
+	} else if native {
+		checkpoint.SummaryComment = &checkpointSummaryComment{HeadSHA: headSHA, FixItemsHash: checkpoint.FixItemsHash, State: "create_failed", Error: err.Error(), UpdatedAt: r.nowISO()}
+		return err
 	}
 	if existingID, existingURL := findExistingFixerSummaryCommentID(checkpoint.Detail, headSHA, trustedLogin); existingID != 0 {
 		if err := r.github.UpdateIssueComment(ctx, UpdateIssueCommentInput{Repo: input.Repo, CommentID: existingID, Body: body, CWD: input.Project.RepoPath, DisclosureAgent: disclosureAgent, DisclosureModel: disclosureModel}); err != nil {
 			checkpoint.SummaryComment = &checkpointSummaryComment{CommentID: existingID, URL: existingURL, HeadSHA: headSHA, FixItemsHash: checkpoint.FixItemsHash, State: "update_failed", Error: err.Error(), UpdatedAt: r.nowISO()}
-			return
+			return err
 		}
 		checkpoint.SummaryComment = &checkpointSummaryComment{CommentID: existingID, URL: existingURL, HeadSHA: headSHA, FixItemsHash: checkpoint.FixItemsHash, State: "updated", UpdatedAt: r.nowISO()}
-		return
+		return nil
 	}
 	created, err := r.github.CreateIssueComment(ctx, IssueCommentInput{Repo: input.Repo, IssueNumber: input.PRNumber, Body: body, CWD: input.Project.RepoPath, DisclosureAgent: disclosureAgent, DisclosureModel: disclosureModel})
 	if err != nil {
 		checkpoint.SummaryComment = &checkpointSummaryComment{HeadSHA: headSHA, FixItemsHash: checkpoint.FixItemsHash, State: "create_failed", Error: err.Error(), UpdatedAt: r.nowISO()}
-		return
+		return err
 	}
 	checkpoint.SummaryComment = &checkpointSummaryComment{CommentID: created.ID, URL: created.URL, HeadSHA: headSHA, FixItemsHash: checkpoint.FixItemsHash, State: "created", UpdatedAt: r.nowISO()}
 	r.appendEvent(ctx, eventInput{eventType: "fixer.summary.posted", projectID: input.Project.ID, entityType: "pull_request", entityID: buildPullRequestTargetID(input.Repo, input.PRNumber), payload: map[string]any{"commentId": created.ID, "url": created.URL, "headSha": headSHA, "items": len(commentItems)}})
+	return nil
 }
 
 // roundProducedNewCommits returns true when the current fixer round actually
@@ -4947,6 +4971,20 @@ func formatFixerSummaryBullet(item fixerSummaryItem) string {
 		b.WriteString(threadURL)
 		b.WriteString(")")
 	}
+	if item.FixItem.Source == NativeReviewCommentSource {
+		switch item.Status {
+		case forgejoFixedUnresolvedStatus:
+			b.WriteString(" — code fixed; comment remains open")
+		case "resolved", "already_resolved":
+			b.WriteString(" — comment closed")
+		case "skipped_noop":
+			b.WriteString(" — left open; no repair claimed")
+		case "deleted":
+			b.WriteString(" — comment removed")
+		default:
+			b.WriteString(" — comment remains open")
+		}
+	}
 	if explanation := strings.TrimSpace(item.Explanation); explanation != "" {
 		b.WriteString("\n  - ")
 		b.WriteString(strings.ReplaceAll(explanation, "\n", "\n    "))
@@ -4996,7 +5034,7 @@ func summaryItemLabel(item FixItem) string {
 
 func summaryStatusIcon(status string) string {
 	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "resolved", "already_resolved":
+	case "resolved", "already_resolved", forgejoFixedUnresolvedStatus:
 		return "✅"
 	case "agent_declined", declinePendingAdjudicationStatus:
 		return "⏸️"
@@ -5027,6 +5065,12 @@ func findExistingFixerSummaryCommentID(detail *checkpointDetail, headSHA, truste
 	for _, comment := range detail.IssueComments {
 		body, _ := stringFromAny(comment["body"])
 		if !strings.Contains(body, marker) {
+			continue
+		}
+		// Compatibility comments also use the shared visible round template,
+		// but retain a separate hidden handoff. A native-only update must not
+		// erase that handoff and make an already consumed legacy round reappear.
+		if strings.Contains(body, "<!-- "+forge.FixerSummaryMarker) {
 			continue
 		}
 		if !isTrustedFixerSummaryComment(comment, trustedLogin, body) {
@@ -5105,6 +5149,10 @@ func (r *Runner) runRecheckStep(ctx context.Context, input stepInput) (fixerChec
 	if err != nil {
 		return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 	}
+	detail, err = r.prepareForgejoDiscoveryDetail(ctx, input.Project, input.Repo, detail)
+	if err != nil {
+		return checkpoint, err
+	}
 	checkpointHadSpecReviewing := specpr.HasLabel(detailLabels(checkpoint.Detail), specpr.ReviewingLabel)
 	if (specpr.HasLabel(detail.Labels, specpr.ReviewingLabel) || checkpointHadSpecReviewing) && isSpecReviewClean(detail) {
 		if specpr.HasLabel(detail.Labels, specpr.ReviewingLabel) {
@@ -5118,7 +5166,20 @@ func (r *Runner) runRecheckStep(ctx context.Context, input stepInput) (fixerChec
 			}
 		}
 	}
-	checkpoint.Recheck = &checkpointRecheck{RemainingFixItems: collectFixItems(detail)}
+	remaining, err := r.unsatisfiedForgejoSummaryItems(input.Project.ID, pullRequestCheckpointDetail(detail), collectFixItems(detail))
+	if err != nil {
+		return checkpoint, err
+	}
+	remaining, err = r.suppressFixedForgejoNativeItems(ctx, input.Project, input.Repo, input.PRNumber, detail.HeadSHA, &input.Loop, remaining)
+	if err != nil {
+		return checkpoint, err
+	}
+	checkpoint.Recheck = &checkpointRecheck{RemainingFixItems: remaining}
+	if r.isForgejoProject(input.Project.ID) && len(remaining) == 0 {
+		if _, err := r.clearPendingFixerRediscovery(ctx, input.Loop); err != nil {
+			return checkpoint, err
+		}
+	}
 	verifiedNoPushHead := resolveCommentsVerifiedNoPushHeadSHA(checkpoint.Push, input.Loop.MetadataJSON, checkpoint.FixItemsHash)
 	hasVerifiedNoPushHead := verifiedNoPushHead != "" && strings.TrimSpace(detail.HeadSHA) == verifiedNoPushHead
 	if shouldBlockResolveWithoutFix(checkpoint, checkpoint.Recheck.RemainingFixItems, hasVerifiedNoPushHead) {
@@ -5160,6 +5221,9 @@ func (r *Runner) createRunContext(ctx context.Context, loop storage.LoopRecord) 
 		failureSummary := firstNonEmpty(derefString(latestRun.Summary), derefString(latestRun.ErrorMessage))
 		pause, _ := classifyFixerPause(latestRun, checkpoint, loop.MetadataJSON)
 		restartFromDiscover = shouldRestartFromDiscover(latestRun.Status, failedStep, pause, failureSummary) || loops.ShouldRestartFromDiscover(latestRun.Status, checkpoint.ResumePolicy)
+		if failedStep == stepResolveComments && hasForgejoNativeReviewComments(checkpoint.FixItems) && checkpoint.ResumePolicy == loops.ResumePolicyReplayStep {
+			restartFromDiscover = false
+		}
 		resumeFromPrepare = shouldResumeFromPrepare(latestRun.Status, failedStep, checkpoint) &&
 			!shouldResumeHITLRepair(loop.MetadataJSON, latestRun.Status, failedStep, checkpoint)
 	}
@@ -5795,7 +5859,18 @@ func (r *Runner) recoverLegacyNoopFollowupLoops(ctx context.Context, project sto
 			seenTargets[targetKey] = struct{}{}
 			continue
 		}
-		fixItems := collectFixItems(detail)
+		detail, err = r.prepareForgejoDiscoveryDetail(ctx, project, repo, detail)
+		if err != nil {
+			return nil, err
+		}
+		fixItems, err := r.unsatisfiedForgejoSummaryItems(project.ID, pullRequestCheckpointDetail(detail), collectFixItems(detail))
+		if err != nil {
+			return nil, err
+		}
+		fixItems, err = r.suppressFixedForgejoNativeItems(ctx, project, repo, *loop.PRNumber, detail.HeadSHA, &loop, fixItems)
+		if err != nil {
+			return nil, err
+		}
 		threadIDs := unresolvedThreadIDs(fixItems)
 		if len(threadIDs) == 0 {
 			seenTargets[targetKey] = struct{}{}
@@ -7229,7 +7304,7 @@ func nonNativeComments(comments []map[string]any) []map[string]any {
 func actionableNativeReviewComments(comments []NativeReviewComment, currentUser string) []NativeReviewComment {
 	filtered := make([]NativeReviewComment, 0, len(comments))
 	for _, comment := range comments {
-		if comment.IsResolved || sameGitHubLogin(comment.Author, currentUser) {
+		if comment.IsResolved || !eligibleNativeReviewComment(comment, currentUser) {
 			continue
 		}
 		filtered = append(filtered, comment)
@@ -7237,10 +7312,10 @@ func actionableNativeReviewComments(comments []NativeReviewComment, currentUser 
 	return filtered
 }
 
-func nonSelfNativeReviewComments(comments []NativeReviewComment, currentUser string) []NativeReviewComment {
+func eligibleNativeReviewComments(comments []NativeReviewComment, currentUser string) []NativeReviewComment {
 	filtered := make([]NativeReviewComment, 0, len(comments))
 	for _, comment := range comments {
-		if sameGitHubLogin(comment.Author, currentUser) {
+		if !eligibleNativeReviewComment(comment, currentUser) {
 			continue
 		}
 		filtered = append(filtered, comment)
@@ -7426,7 +7501,12 @@ func normalizeFixItems(comments []map[string]any, checks []map[string]any, hasCo
 		if summary == "" {
 			summary = "Failing check"
 		}
-		result = append(result, FixItem{Type: "check", Name: name, Summary: summary})
+		description, _ := stringFromAny(check["description"])
+		checkURL, _ := stringFromAny(check["url"])
+		if checkURL == "" {
+			checkURL, _ = stringFromAny(check["detailsUrl"])
+		}
+		result = append(result, FixItem{Type: "check", Name: name, Summary: summary, Body: description, URL: checkURL, ActionRunID: int64FromAny(check["actionRunId"])})
 	}
 	if hasConflicts {
 		result = append(result, FixItem{Type: "conflict", Files: []string{}})
@@ -7649,6 +7729,9 @@ func buildFixerMinimalPRSeed(repo string, prNumber int64, detail *checkpointDeta
 }
 
 func seededPullRequestURL(repo string, prNumber int64, detail *checkpointDetail, fixItems []FixItem) string {
+	if detail != nil && strings.TrimSpace(detail.URL) != "" {
+		return strings.TrimSpace(detail.URL)
+	}
 	if inferred := inferSeededPullRequestURL(prNumber, detail, fixItems); inferred != "" {
 		return inferred
 	}
@@ -7758,7 +7841,18 @@ func fixerAgentSideFetchContract(repo string, prNumber int64, detail *checkpoint
 }
 
 func buildFixerPrompt(projectID string, instructionConfig config.Config, repo string, prNumber int64, detail *checkpointDetail, fixItems []FixItem, allowAutoPush bool, disclosureCfg config.DisclosureConfig, agentRuntime string, agentModel string) (string, config.CustomInstructionBlock) {
+	if providerURL := forge.ConfiguredPullRequestURL(instructionConfig, projectID, repo, prNumber); providerURL != "" && (detail == nil || detail.URL == "") {
+		copy := checkpointDetail{}
+		if detail != nil {
+			copy = *detail
+		}
+		copy.URL = providerURL
+		detail = &copy
+	}
 	parts := []string{fmt.Sprintf("Fix pull request %s#%d.", repo, prNumber), buildFixerMinimalPRSeed(repo, prNumber, detail, fixItems), fixerAgentSideFetchContract(repo, prNumber, detail, fixItems)}
+	if providerContext := forge.ForgejoAgentContext(instructionConfig, projectID, repo, prNumber); providerContext != "" {
+		parts = append(parts, providerContext)
+	}
 	if headSHA := detailHeadSHA(detail); headSHA != "" {
 		parts = append(parts, "Head SHA: "+headSHA)
 	}
@@ -7859,7 +7953,8 @@ func buildFixerReplyExplanationInstruction(fixItems []FixItem) string {
 	if hasNativeForgejoComment {
 		parts = append(parts,
 			"For EVERY Forgejo native review comment fix item (`source: \"forgejo_review_comment\"`), also include exactly one entry in a top-level `repair_results` array on the final "+agent.CompletionMarker+" JSON line.",
-			"Each `repair_results` entry for a Forgejo native review comment must include: `source` = `forgejo_review_comment`, the exact `providerCommentId`, `action` = `fixed`, `declined`, or `deferred`, a concrete `explanation`, and the exact `observedFingerprint` from the fix item.",
+			"Each `repair_results` entry for a Forgejo native review comment must include: `source` = `forgejo_review_comment`, the exact `providerCommentId`, `action` = `fixed`, `declined`, or `deferred` (a later HUMAN-IN-THE-LOOP instruction may also enable `needs_human`), a concrete `explanation`, and the exact `observedFingerprint` from the fix item.",
+			"Do not post replies, resolve comments, submit reviews, edit PR metadata, or perform other mutating Forgejo API actions; Looper publishes the structured repair results after validation. A fixed result means the branch addresses the finding, even if Forgejo cannot close the comment.",
 			"Use Forgejo comment terminology for those entries: decide whether the individual review comment is fixed, declined, or deferred. Do not refer to Forgejo native review comments as threads in `repair_results`.",
 			"Create structured `repair_results` entries only for listed Forgejo native review comment fix items, never for collateral-only changes. Briefly mention material collateral in the explanation for the listed item it supports.",
 		)
@@ -8425,9 +8520,31 @@ func detailLabels(detail *checkpointDetail) []string {
 }
 
 func mergeCheckpointDetailPreservingLabels(existing *checkpointDetail, live PullRequestDetail) *checkpointDetail {
-	merged := &checkpointDetail{State: live.State, IsDraft: live.IsDraft, Labels: cloneStrings(live.Labels), HeadSHA: live.HeadSHA, HeadRefName: live.HeadRefName, BaseRefName: live.BaseRefName, BaseSHA: live.BaseSHA, ReviewDecision: live.ReviewDecision, Comments: cloneObjectSlice(live.Comments), IssueComments: cloneObjectSlice(live.IssueComments), Checks: cloneObjectSlice(live.Checks), HasConflicts: live.HasConflicts}
+	merged := &checkpointDetail{URL: live.URL, State: live.State, IsDraft: live.IsDraft, Labels: cloneStrings(live.Labels), HeadSHA: live.HeadSHA, HeadRefName: live.HeadRefName, BaseRefName: live.BaseRefName, BaseSHA: live.BaseSHA, ReviewDecision: live.ReviewDecision, Comments: cloneObjectSlice(live.Comments), IssueComments: cloneObjectSlice(live.IssueComments), Checks: cloneObjectSlice(live.Checks), HasConflicts: live.HasConflicts}
 	if existing != nil {
 		merged.Labels = cloneStrings(existing.Labels)
+		// Keep the legacy review round that supplied the agent's fix items.
+		// Refreshes during push/resolve may update head and fixer comments, but
+		// cannot grant old decisions authority over a newer reviewer round.
+		// Discovery and recheck read live detail directly, so new rounds remain
+		// actionable even when this checkpoint replays publication after restart.
+		var reviewerComments []map[string]any
+		for _, comment := range existing.IssueComments {
+			body, _ := stringFromAny(comment["body"])
+			if strings.Contains(body, "<!-- "+forge.ReviewerSummaryMarker) {
+				reviewerComments = append(reviewerComments, comment)
+			}
+		}
+		if len(reviewerComments) > 0 {
+			comments := merged.IssueComments[:0]
+			for _, comment := range merged.IssueComments {
+				body, _ := stringFromAny(comment["body"])
+				if !strings.Contains(body, "<!-- "+forge.ReviewerSummaryMarker) {
+					comments = append(comments, comment)
+				}
+			}
+			merged.IssueComments = append(comments, cloneObjectSlice(reviewerComments)...)
+		}
 	}
 	return merged
 }
@@ -8595,10 +8712,15 @@ func upsertThreadFixEvidence(store *fixEvidenceStoreV2, next threadFixEvidence) 
 		if entries[i].ThreadFingerprint != next.ThreadFingerprint {
 			continue
 		}
+		if next.ResolveState == "pending" && entries[i].ResolveState == forgejoFixedUnresolvedStatus && entries[i].EvidenceHeadSHA == next.EvidenceHeadSHA {
+			// A replayed push cannot replace the explicit agent decision with
+			// generic push evidence, even when it refers to the same commit.
+			return store
+		}
 		if strings.TrimSpace(next.ReplyState) == "pending" && strings.TrimSpace(entries[i].ReplyState) != "" && strings.TrimSpace(entries[i].ReplyState) != "pending" {
 			next.ReplyState = entries[i].ReplyState
 		}
-		if strings.TrimSpace(next.ResolveState) == "pending" && strings.TrimSpace(entries[i].ResolveState) != "" && strings.TrimSpace(entries[i].ResolveState) != "pending" {
+		if strings.TrimSpace(next.ResolveState) == "pending" && strings.TrimSpace(entries[i].ResolveState) != "" && strings.TrimSpace(entries[i].ResolveState) != "pending" && (entries[i].ResolveState != forgejoFixedUnresolvedStatus || entries[i].EvidenceHeadSHA == next.EvidenceHeadSHA) {
 			next.ResolveState = entries[i].ResolveState
 		}
 		if strings.TrimSpace(next.Explanation) == "" {
@@ -9064,7 +9186,7 @@ func hasRecoverableThreadEvidence(loopMetadataJSON *string, fixItems []FixItem) 
 			if strings.TrimSpace(entry.Explanation) == "" {
 				continue
 			}
-			if entry.ResolveState == "resolved" || entry.ResolveState == "already_resolved" {
+			if entry.ResolveState == "resolved" || entry.ResolveState == "already_resolved" || entry.ResolveState == forgejoFixedUnresolvedStatus {
 				continue
 			}
 			return true

--- a/internal/fixer/runner_forgejo_discovery_test.go
+++ b/internal/fixer/runner_forgejo_discovery_test.go
@@ -2,6 +2,7 @@ package fixer
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -238,6 +239,80 @@ func TestForgejoAutoDiscoveryIgnoresUntrustedSummaryMarker(t *testing.T) {
 	}
 	if len(result.QueueItems) != 0 {
 		t.Fatalf("QueueItems = %#v, label and untrusted summary must not invent repair authority", result.QueueItems)
+	}
+}
+
+func TestForgejoSummaryCommentDiscoveryIgnoresUnsupportedNativeReviews(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	detail := forgejoDiscoveryDetail(t, "head-1", 1)
+	github := &fakeGitHubGateway{
+		currentUser:   "looper",
+		listOpen:      []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}},
+		viewResponses: []PullRequestDetail{detail},
+		listNativeErr: &forge.ForgejoHTTPError{StatusCode: http.StatusNotFound, Method: "GET", Path: "/pulls/42/reviews", Message: "missing endpoint"},
+	}
+	cfg := forgejoFixerDiscoveryConfig(t, fixture)
+	cfg.Roles.Reviewer.Behavior.PublishMode = config.ReviewerPublishModeSummaryComment
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: cfg})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	if len(result.QueueItems) != 1 || len(result.CreatedLoopIDs) != 1 {
+		t.Fatalf("result = %#v, want summary_comment fixer loop from Reviewer Summary", result)
+	}
+	if github.listNativeCalls != 0 {
+		t.Fatalf("listNativeCalls = %d, summary_comment discovery must not require native review APIs", github.listNativeCalls)
+	}
+}
+
+func TestForgejoNativeDiscoveryRequiresNativeReviewAPI(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	detail := forgejoDiscoveryDetail(t, "head-1", 1)
+	github := &fakeGitHubGateway{
+		currentUser:   "looper",
+		listOpen:      []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}},
+		viewResponses: []PullRequestDetail{detail},
+		listNativeErr: &forge.ForgejoHTTPError{StatusCode: http.StatusNotFound, Method: "GET", Path: "/pulls/42/reviews", Message: "missing endpoint"},
+	}
+	cfg := forgejoFixerDiscoveryConfig(t, fixture)
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: cfg})
+
+	_, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err == nil || !strings.Contains(err.Error(), "discovery is unsupported") {
+		t.Fatalf("DiscoverPullRequests() error = %v, want native discovery manual intervention", err)
+	}
+}
+
+func TestRunCollectFixesStepSummaryCommentSkipsUnsupportedNativeDiscovery(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	detail := forgejoDiscoveryDetail(t, "head-1", 1)
+	github := &fakeGitHubGateway{
+		currentUser:   "looper",
+		listNativeErr: &forge.ForgejoHTTPError{StatusCode: http.StatusNotFound, Method: "GET", Path: "/pulls/42/reviews", Message: "missing endpoint"},
+	}
+	cfg := forgejoFixerDiscoveryConfig(t, fixture)
+	cfg.Roles.Reviewer.Behavior.PublishMode = config.ReviewerPublishModeSummaryComment
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: cfg})
+
+	checkpoint, err := runner.runCollectFixesStep(context.Background(), stepInput{
+		Project:    storage.ProjectRecord{ID: "project_1", RepoPath: fixtureProjectPath(t, fixture)},
+		Repo:       "acme/looper",
+		PRNumber:   42,
+		Checkpoint: fixerCheckpoint{Detail: pullRequestCheckpointDetail(detail)},
+	})
+	if err != nil {
+		t.Fatalf("runCollectFixesStep() error = %v", err)
+	}
+	if github.listNativeCalls != 0 {
+		t.Fatalf("listNativeCalls = %d, summary_comment collect-fixes must not require native review APIs", github.listNativeCalls)
+	}
+	if len(checkpoint.FixItems) == 0 {
+		t.Fatalf("FixItems = %#v, want Reviewer Summary items", checkpoint.FixItems)
 	}
 }
 

--- a/internal/fixer/runner_forgejo_discovery_test.go
+++ b/internal/fixer/runner_forgejo_discovery_test.go
@@ -2,7 +2,6 @@ package fixer
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 
@@ -11,7 +10,7 @@ import (
 	"github.com/nexu-io/looper/internal/storage"
 )
 
-func TestForgejoAutoDiscoveryUsesReviewerSummaryWithoutReadingNativeComments(t *testing.T) {
+func TestForgejoAutoDiscoveryUsesReviewerSummaryAndNativeComments(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	detail := forgejoDiscoveryDetail(t, "head-1", 1)
@@ -20,7 +19,6 @@ func TestForgejoAutoDiscoveryUsesReviewerSummaryWithoutReadingNativeComments(t *
 		listOpen:       []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}},
 		viewResponses:  []PullRequestDetail{detail},
 		nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "Rename this helper", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true}},
-		listNativeErr:  errors.New("native API must not be called during automatic discovery"),
 	}
 	cfg := forgejoFixerDiscoveryConfig(t, fixture)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: cfg})
@@ -92,7 +90,7 @@ func TestForgejoAutoDiscoverySuppressesConsumedReviewerRoundUntilHeadChanges(t *
 	}
 }
 
-func TestForgejoAutoDiscoveryIgnoresNativeCommentsRegardlessOfResolverField(t *testing.T) {
+func TestForgejoAutoDiscoveryAcceptsOpenNativeCommentsRegardlessOfResolverField(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name            string
@@ -111,7 +109,6 @@ func TestForgejoAutoDiscoveryIgnoresNativeCommentsRegardlessOfResolverField(t *t
 				listOpen:       []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}},
 				viewResponses:  []PullRequestDetail{detail},
 				nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "Fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: tc.resolverPresent, IsResolved: tc.resolved}},
-				listNativeErr:  errors.New("resolver response fields are not API capability authority"),
 			}
 			cfg := forgejoFixerDiscoveryConfig(t, fixture)
 			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: cfg})
@@ -120,14 +117,18 @@ func TestForgejoAutoDiscoveryIgnoresNativeCommentsRegardlessOfResolverField(t *t
 			if err != nil {
 				t.Fatalf("DiscoverPullRequests() error = %v", err)
 			}
-			if len(result.QueueItems) != 0 {
-				t.Fatalf("QueueItems = %#v, native comments must not authorize automatic Forgejo fixer work", result.QueueItems)
+			want := 1
+			if tc.resolved {
+				want = 0
+			}
+			if len(result.QueueItems) != want {
+				t.Fatalf("QueueItems = %#v, want %d for open native feedback", result.QueueItems, want)
 			}
 		})
 	}
 }
 
-func TestForgejoAutomaticCollectDoesNotAttachNativeComments(t *testing.T) {
+func TestForgejoAutomaticCollectAttachesNativeComments(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	cfg := forgejoFixerDiscoveryConfig(t, fixture)
@@ -139,7 +140,7 @@ func TestForgejoAutomaticCollectDoesNotAttachNativeComments(t *testing.T) {
 	github := &fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{
 		{ProviderCommentID: 101, Body: "Fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true},
 		{ProviderCommentID: 102, Body: "Unsupported", Author: "bob", ObservedFingerprint: NativeReviewCommentFingerprint(102, "u2"), ResolverPresent: false},
-	}, listNativeErr: errors.New("automatic collect must not read native comments")}
+	}}
 	runner := New(Options{GitHub: github, CustomInstructions: cfg})
 	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")
 	if err != nil || project == nil {
@@ -149,8 +150,8 @@ func TestForgejoAutomaticCollectDoesNotAttachNativeComments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runCollectFixesStep() error = %v", err)
 	}
-	if len(checkpoint.FixItems) != 1 || checkpoint.FixItems[0].ID != "R-001" {
-		t.Fatalf("FixItems = %#v, want only the trusted reviewer summary item", checkpoint.FixItems)
+	if len(checkpoint.FixItems) != 3 {
+		t.Fatalf("FixItems = %#v, want two native items and the trusted summary item", checkpoint.FixItems)
 	}
 }
 

--- a/internal/fixer/runner_forgejo_discovery_test.go
+++ b/internal/fixer/runner_forgejo_discovery_test.go
@@ -18,7 +18,7 @@ func TestForgejoAutoDiscoveryUsesReviewerSummaryAndNativeComments(t *testing.T) 
 		currentUser:    "looper",
 		listOpen:       []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}},
 		viewResponses:  []PullRequestDetail{detail},
-		nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "Rename this helper", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true}},
+		nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "Rename this helper", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Rename this helper"), ResolverPresent: true}},
 	}
 	cfg := forgejoFixerDiscoveryConfig(t, fixture)
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: cfg})
@@ -108,7 +108,7 @@ func TestForgejoAutoDiscoveryAcceptsOpenNativeCommentsRegardlessOfResolverField(
 				currentUser:    "looper",
 				listOpen:       []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}},
 				viewResponses:  []PullRequestDetail{detail},
-				nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "Fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: tc.resolverPresent, IsResolved: tc.resolved}},
+				nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "Fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Fix this"), ResolverPresent: tc.resolverPresent, IsResolved: tc.resolved}},
 			}
 			cfg := forgejoFixerDiscoveryConfig(t, fixture)
 			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now, CustomInstructions: cfg})
@@ -138,8 +138,8 @@ func TestForgejoAutomaticCollectAttachesNativeComments(t *testing.T) {
 	untrusted["author"] = map[string]any{"login": "mallory"}
 	detail.IssueComments = append(detail.IssueComments, untrusted)
 	github := &fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{
-		{ProviderCommentID: 101, Body: "Fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true},
-		{ProviderCommentID: 102, Body: "Unsupported", Author: "bob", ObservedFingerprint: NativeReviewCommentFingerprint(102, "u2"), ResolverPresent: false},
+		{ProviderCommentID: 101, Body: "Fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Fix this"), ResolverPresent: true},
+		{ProviderCommentID: 102, Body: "Unsupported", Author: "bob", ObservedFingerprint: NativeReviewCommentFingerprint(102, "Unsupported"), ResolverPresent: false},
 	}}
 	runner := New(Options{GitHub: github, CustomInstructions: cfg})
 	project, err := fixture.repos.Projects.GetByID(context.Background(), "project_1")

--- a/internal/fixer/runner_forgejo_lifecycle_test.go
+++ b/internal/fixer/runner_forgejo_lifecycle_test.go
@@ -68,8 +68,8 @@ func (g *nativeLifecycleGit) Push(ctx context.Context, input PushInput) error {
 	return nil
 }
 
-func ownNativeFinding(id int64, updated string) NativeReviewComment {
-	return NativeReviewComment{ProviderCommentID: id, Body: "Fix the calculation.\n<!-- looper:stamp -->", Author: "looper", ResolverPresent: true, Path: "price.go", URL: fmt.Sprintf("https://forge.example/acme/looper/pulls/42#issuecomment-%d", id), UpdatedAt: updated, ObservedFingerprint: NativeReviewCommentFingerprint(id, updated), ReviewAuthor: "looper", ReviewState: "COMMENTED", ReviewCommitID: "head-1", ReviewBody: "Please fix the calculation.\n<!-- looper:review id=reviewer:review-loop head=head-1 outcome=blocking -->"}
+func ownNativeFinding(id int64, body string) NativeReviewComment {
+	return NativeReviewComment{ProviderCommentID: id, Body: body, Author: "looper", ResolverPresent: true, Path: "price.go", URL: fmt.Sprintf("https://forge.example/acme/looper/pulls/42#issuecomment-%d", id), UpdatedAt: "2026-09-06T11:09:23Z", ObservedFingerprint: NativeReviewCommentFingerprint(id, body), ReviewAuthor: "looper", ReviewState: "COMMENTED", ReviewCommitID: "head-1", ReviewBody: "Please fix the calculation.\n<!-- looper:review id=reviewer:review-loop head=head-1 outcome=blocking -->"}
 }
 
 func nativeAgentResult(items []NativeReviewComment, action string) AgentResult {
@@ -91,9 +91,15 @@ func TestForgejoNativeLifecycleWithoutResolveSurvivesRestartAndLaterFix(t *testi
 	t.Parallel()
 	ctx := context.Background()
 	fixture := newRunnerFixture(t)
-	finding := ownNativeFinding(101, "u1")
+	finding := ownNativeFinding(101, "Fix the calculation.\n<!-- looper:stamp -->")
 	github := &nativeLifecycleGateway{probe: forge.ProbeStateUnsupported, detail: PullRequestDetail{Number: 42, URL: "https://forge.example/acme/looper/pulls/42", State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix", BaseRefName: "main", BaseSHA: "base-1", Author: "looper"}, fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}}, nativeComments: []NativeReviewComment{finding}}}
 	git := &nativeLifecycleGit{remote: github, fakeGitGateway: fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/fix", HeadSHA: "head-1"}, prepareResult: PrepareWorktreeResult{HeadSHA: "head-1", Clean: true}, inspectResults: []InspectHeadResult{{HeadSHA: "head-1"}, {HeadSHA: "fixed-head", NewCommitSHAs: []string{"fixed-head"}}, {HeadSHA: "fixed-head"}}}}
+	git.afterPush = func() {
+		// Actual Forgejo behavior: pushing changes updated_at while all comment
+		// content stays identical. The agent's original decision still applies.
+		github.nativeComments[0].UpdatedAt = "2026-09-06T11:12:03Z"
+		github.nativeComments[0].ObservedFingerprint = NativeReviewCommentFingerprint(finding.ProviderCommentID, finding.Body)
+	}
 	agent := &fakeAgentExecutor{results: []AgentResult{nativeAgentResult([]NativeReviewComment{finding}, "fixed")}}
 	runner := nativeLifecycleRunner(t, fixture, github, git, agent)
 	discovered, err := runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
@@ -116,6 +122,9 @@ func TestForgejoNativeLifecycleWithoutResolveSurvivesRestartAndLaterFix(t *testi
 	checkpoint := parseCheckpoint(run.CheckpointJSON)
 	if checkpoint.Detail.URL != github.detail.URL || checkpoint.ResolvedComments.Items[0].Status != forgejoFixedUnresolvedStatus || len(checkpoint.Recheck.RemainingFixItems) != 0 {
 		t.Fatalf("checkpoint = %#v", checkpoint)
+	}
+	if github.nativeComments[0].UpdatedAt == finding.UpdatedAt || checkpoint.Repair.ReplyExplanations[0].ObservedFingerprint != finding.ObservedFingerprint {
+		t.Fatal("timestamp refresh did not preserve the agent's original content decision")
 	}
 	if len(github.createIssueComments) != 1 || !strings.Contains(github.createIssueComments[0].Body, "code fixed; comment remains open") || strings.Contains(github.createIssueComments[0].Body, "Forgejo Fixer Summary") {
 		t.Fatalf("comments = %#v", github.createIssueComments)
@@ -144,15 +153,55 @@ func TestForgejoNativeLifecycleWithoutResolveSurvivesRestartAndLaterFix(t *testi
 	t.Cleanup(func() { _ = coordinator.Close() })
 	fixture.coordinator, fixture.repos = coordinator, storage.NewRepositories(coordinator.DB())
 	runner = nativeLifecycleRunner(t, fixture, github, git, agent)
+	github.nativeComments[0].UpdatedAt = "2026-09-06T11:15:03Z"
+	github.nativeComments[0].ObservedFingerprint = NativeReviewCommentFingerprint(finding.ProviderCommentID, finding.Body)
 	for poll := 0; poll < 3; poll++ {
 		discovered, err = runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
 		if err != nil || len(discovered.QueueItems) != 0 {
 			t.Fatalf("restart poll = %#v, %v", discovered, err)
 		}
 	}
+	// A real body edit must re-arm that same comment, even when the server
+	// reports the exact same timestamp. Complete a second agent repair to prove
+	// the old acknowledgement is not borrowed for the new feedback.
+	edited := github.nativeComments[0]
+	edited.Body = "Fix the calculation for negative values."
+	edited.ObservedFingerprint = NativeReviewCommentFingerprint(edited.ProviderCommentID, edited.Body)
+	if edited.UpdatedAt != github.nativeComments[0].UpdatedAt || edited.ObservedFingerprint == finding.ObservedFingerprint {
+		t.Fatal("body edit fixture must change only content at the same timestamp")
+	}
+	github.nativeComments = []NativeReviewComment{edited}
+	discovered, err = runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil || len(discovered.QueueItems) != 1 {
+		t.Fatalf("same-timestamp body edit discovery = %#v, %v", discovered, err)
+	}
+	git.createResult.HeadSHA, git.prepareResult.HeadSHA = "fixed-head", "fixed-head"
+	git.inspectIndex = 0
+	git.inspectResults = []InspectHeadResult{{HeadSHA: "fixed-head"}, {HeadSHA: "edited-fixed-head", NewCommitSHAs: []string{"edited-fixed-head"}}, {HeadSHA: "edited-fixed-head"}}
+	git.afterPush = func() {
+		github.detail.HeadSHA = "edited-fixed-head"
+		github.nativeComments[0].UpdatedAt = "2026-09-06T11:18:03Z"
+		github.nativeComments[0].ObservedFingerprint = NativeReviewCommentFingerprint(edited.ProviderCommentID, edited.Body)
+	}
+	agent.results = append(agent.results, nativeAgentResult([]NativeReviewComment{edited}, "fixed"))
+	fixture.advance(time.Hour)
+	claim, err = fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "test-fixer-edited", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("body edit claim = %#v, %v", claim, err)
+	}
+	result, err = runner.ProcessClaimedItem(ctx, *claim)
+	if err != nil || result.Status != "success" || len(agent.starts) != 2 || len(git.pushCalls) != 2 || len(github.resolveNativeCalls) != 0 {
+		t.Fatalf("body edit repair = %#v, %v agent/push/resolve=%d/%d/%d", result, err, len(agent.starts), len(git.pushCalls), len(github.resolveNativeCalls))
+	}
+	run, _ = fixture.repos.Runs.GetByID(ctx, result.RunID)
+	checkpoint = parseCheckpoint(run.CheckpointJSON)
+	if checkpoint.Repair.ReplyExplanations[0].ObservedFingerprint != edited.ObservedFingerprint || checkpoint.ResolvedComments.Items[0].Status != forgejoFixedUnresolvedStatus || len(checkpoint.Recheck.RemainingFixItems) != 0 {
+		t.Fatalf("edited content acknowledgement = %#v", checkpoint)
+	}
+	loop, _ = fixture.repos.Loops.GetByID(ctx, result.LoopID)
 	// A later unrelated push record must neither forget the old decision nor
 	// claim that a newly discovered finding was fixed.
-	other := ownNativeFinding(102, "u2")
+	other := ownNativeFinding(102, "Check the discount boundary.")
 	otherItem := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{other}), nil, false)[0]
 	if err := runner.persistFixEvidenceStoreV2(ctx, *loop, upsertThreadFixEvidence(nil, threadFixEvidence{ThreadID: otherItem.ThreadID, ThreadFingerprint: otherItem.ObservedFingerprint, EvidenceHeadSHA: "later-head", Source: "fallback_push", ResolveState: "pending"})); err != nil {
 		t.Fatal(err)
@@ -173,7 +222,7 @@ func TestForgejoNativeLifecycleWithoutResolveSurvivesRestartAndLaterFix(t *testi
 func TestForgejoNativeAcknowledgementOnlySuppressesExactAgentDecision(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	finding := ownNativeFinding(101, "u1")
+	finding := ownNativeFinding(101, "Fix the calculation.\n<!-- looper:stamp -->")
 	item := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{finding}), nil, false)[0]
 	for _, tc := range []struct {
 		name, state, source, head, compare, fingerprint string
@@ -182,7 +231,8 @@ func TestForgejoNativeAcknowledgementOnlySuppressesExactAgentDecision(t *testing
 		{"same head", forgejoFixedUnresolvedStatus, "agent_repair_result", "fixed-head", "", item.ObservedFingerprint, 0},
 		{"descendant", forgejoFixedUnresolvedStatus, "agent_repair_result", "later-head", "ahead", item.ObservedFingerprint, 0},
 		{"force push", forgejoFixedUnresolvedStatus, "agent_repair_result", "rewritten-head", "diverged", item.ObservedFingerprint, 1},
-		{"edited", forgejoFixedUnresolvedStatus, "agent_repair_result", "fixed-head", "", NativeReviewCommentFingerprint(101, "u2"), 1},
+		{"edited", forgejoFixedUnresolvedStatus, "agent_repair_result", "fixed-head", "", NativeReviewCommentFingerprint(101, "Fix the calculation for negative values."), 1},
+		{"legacy timestamp", forgejoFixedUnresolvedStatus, "agent_repair_result", "fixed-head", "", NativeReviewCommentSource + ":101:2026-09-06T11:09:23Z", 1},
 		{"pending push", "pending", "fallback_push", "fixed-head", "", item.ObservedFingerprint, 1},
 		{"push not agent", forgejoFixedUnresolvedStatus, "fallback_push", "fixed-head", "", item.ObservedFingerprint, 1},
 		{"declined", "declined", "agent_repair_result", "fixed-head", "", item.ObservedFingerprint, 1},
@@ -216,7 +266,7 @@ func TestForgejoNativeSummaryFailureReplaysAfterRestartWithoutRepairingAgain(t *
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			fixture := newRunnerFixture(t)
-			finding := ownNativeFinding(101, "u1")
+			finding := ownNativeFinding(101, "Fix the calculation.\n<!-- looper:stamp -->")
 			gateway := &nativeLifecycleGateway{probe: forge.ProbeStateUnsupported, acceptFailedCreate: tc.accepted, detail: PullRequestDetail{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix", BaseRefName: "main", BaseSHA: "base-1", Author: "looper"}, fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}}, nativeComments: []NativeReviewComment{finding}}}
 			outage := &forge.ForgejoHTTPError{StatusCode: 503, Method: "POST", Path: "/comments", Message: "temporary outage"}
 			if tc.update {
@@ -341,10 +391,10 @@ func TestForgejoMixedRoundPublishesBeforeRediscoveringNewFeedback(t *testing.T) 
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			fixture := newRunnerFixture(t)
-			finding := ownNativeFinding(101, "u1")
+			finding := ownNativeFinding(101, "Fix the calculation.\n<!-- looper:stamp -->")
 			original := []NativeReviewComment{finding}
 			if tc.editedNative {
-				original = append(original, ownNativeFinding(103, "u1"))
+				original = append(original, ownNativeFinding(103, "Fix negative values."))
 			}
 			gateway := &nativeLifecycleGateway{probe: forge.ProbeStateUnsupported, acceptFailedCreate: tc.responseLost, detail: forgejoDiscoveryDetail(t, "head-1", 1), fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}}, nativeComments: original}}
 			if tc.publicationFails {
@@ -353,10 +403,10 @@ func TestForgejoMixedRoundPublishesBeforeRediscoveringNewFeedback(t *testing.T) 
 			git := &nativeLifecycleGit{remote: gateway, fakeGitGateway: fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/fix", HeadSHA: "head-1"}, prepareResult: PrepareWorktreeResult{HeadSHA: "head-1", Clean: true}, inspectResults: []InspectHeadResult{{HeadSHA: "head-1"}, {HeadSHA: "fixed-head", NewCommitSHAs: []string{"fixed-head"}}, {HeadSHA: "fixed-head"}}}}
 			git.afterPush = func() {
 				if tc.newNative {
-					gateway.nativeComments = append([]NativeReviewComment{finding}, ownNativeFinding(102, "u2"))
+					gateway.nativeComments = append([]NativeReviewComment{finding}, ownNativeFinding(102, "Check the discount boundary."))
 				}
 				if tc.editedNative {
-					gateway.nativeComments = []NativeReviewComment{finding, ownNativeFinding(103, "u2")}
+					gateway.nativeComments = []NativeReviewComment{finding, ownNativeFinding(103, "Fix negative values and zero.")}
 				}
 				if tc.newLegacy {
 					live := forgejoDiscoveryDetailWithItems(t, "fixed-head", 2, []forge.ReviewItem{
@@ -571,8 +621,8 @@ func TestForgejoNativeReplayDoesNotAcknowledgeEditedComment(t *testing.T) {
 	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
 		t.Fatal(err)
 	}
-	old := ownNativeFinding(101, "u1")
-	newComment := ownNativeFinding(102, "u2")
+	old := ownNativeFinding(101, "Fix the calculation.\n<!-- looper:stamp -->")
+	newComment := ownNativeFinding(102, "Check the discount boundary.")
 	github := &nativeLifecycleGateway{probe: forge.ProbeStateUnsupported, detail: PullRequestDetail{Number: 42, State: "OPEN", HeadSHA: "fixed-head"}, fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{old, newComment}}}
 	items := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{old}), nil, false)
 	result := nativeAgentResult([]NativeReviewComment{old}, "fixed")
@@ -588,7 +638,7 @@ func TestForgejoNativeReplayDoesNotAcknowledgeEditedComment(t *testing.T) {
 	}
 	// resolve refresh has overwritten the live FixItems, but the decision still
 	// carries the old fingerprint. Editing that same ID must re-arm it.
-	github.nativeComments = []NativeReviewComment{ownNativeFinding(101, "edited")}
+	github.nativeComments = []NativeReviewComment{ownNativeFinding(101, "Fix the calculation for negative values.")}
 	input.Checkpoint = parseCheckpoint(stringPtr(mustJSON(t, updated)))
 	updated, err = runner.runResolveCommentsStep(ctx, input)
 	if err == nil || !strings.Contains(err.Error(), "changed") || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
@@ -602,9 +652,54 @@ func TestForgejoNativeReplayDoesNotAcknowledgeEditedComment(t *testing.T) {
 	}
 }
 
+func TestForgejoNativeLegacyTimestampDecisionRequiresFreshCollection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newRunnerFixture(t)
+	project, _ := fixture.repos.Projects.GetByID(ctx, "project_1")
+	loop := storage.LoopRecord{ID: "legacy-native-fingerprint", ProjectID: project.ID, Type: "fixer", TargetType: "pull_request", Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatal(err)
+	}
+	live := ownNativeFinding(101, "Fix the calculation.")
+	legacy := live
+	legacy.ObservedFingerprint = NativeReviewCommentSource + ":101:" + legacy.UpdatedAt
+	items := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{legacy}), nil, false)
+	result := nativeAgentResult([]NativeReviewComment{legacy}, "fixed")
+	checkpoint := fixerCheckpoint{
+		Detail:     &checkpointDetail{HeadSHA: "fixed-head"},
+		FixItems:   items,
+		Repair:     &checkpointRepair{ReplyExplanations: parseNativeRepairResults(result.Stdout, "", items)},
+		Validation: &ValidationResult{Passed: true, HeadSHA: "fixed-head"},
+		Push:       &checkpointPush{Pushed: true, HeadSHA: "fixed-head"},
+	}
+	gateway := &nativeLifecycleGateway{probe: forge.ProbeStateUnsupported, detail: PullRequestDetail{Number: 42, State: "OPEN", HeadSHA: "fixed-head"}, fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{live}}}
+	runner := New(Options{Repos: fixture.repos, GitHub: gateway, CustomInstructions: forgejoFixerDiscoveryConfig(t, fixture)})
+	input := stepInput{Project: *project, Loop: loop, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint}
+	updated, err := runner.runResolveCommentsStep(ctx, input)
+	if err == nil || updated.ResumePolicy != loops.ResumePolicyRestartFromDiscover || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
+		t.Fatalf("legacy fingerprint replay = %#v, %v", updated, err)
+	}
+	if updated.Repair.ReplyExplanations[0].ObservedFingerprint != legacy.ObservedFingerprint || len(gateway.resolveNativeCalls) != 0 {
+		t.Fatal("legacy decision was rewritten or applied to a content fingerprint")
+	}
+	input.Checkpoint = fixerCheckpoint{Detail: pullRequestCheckpointDetail(gateway.detail)}
+	collected, err := runner.runCollectFixesStep(ctx, input)
+	if err != nil || len(collected.FixItems) != 1 || collected.FixItems[0].ObservedFingerprint != live.ObservedFingerprint {
+		t.Fatalf("fresh content collection = %#v, %v", collected.FixItems, err)
+	}
+	if parsed := parseNativeRepairResults(result.Stdout, "", collected.FixItems); len(parsed) != 0 {
+		t.Fatalf("legacy decision granted authority after collection = %#v", parsed)
+	}
+	metadata, _ := runner.freshNativeFixMetadata(ctx, &loop)
+	if evidence, ok := findThreadFixEvidence(loadFixEvidenceStoreV2(metadata), collected.FixItems[0]); ok && evidence.ResolveState == forgejoFixedUnresolvedStatus {
+		t.Fatal("legacy timestamp decision suppressed the new content fingerprint")
+	}
+}
+
 func TestForgejoNativeProvenanceAndPushEvidenceIsolation(t *testing.T) {
 	t.Parallel()
-	base := ownNativeFinding(101, "u1")
+	base := ownNativeFinding(101, "Fix the calculation.\n<!-- looper:stamp -->")
 	for _, tc := range []struct {
 		name   string
 		mutate func(*NativeReviewComment)
@@ -647,7 +742,7 @@ func TestForgejoNativeNeedsHumanUsesSharedPreMutationSuspension(t *testing.T) {
 	ctx := context.Background()
 	fixture := newRunnerFixture(t)
 	project, _ := fixture.repos.Projects.GetByID(ctx, "project_1")
-	finding := ownNativeFinding(101, "u1")
+	finding := ownNativeFinding(101, "Fix the calculation.\n<!-- looper:stamp -->")
 	items := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{finding}), nil, false)
 	result := nativeAgentResult([]NativeReviewComment{finding}, "needs_human")
 	agent := &fakeAgentExecutor{results: []AgentResult{result}}
@@ -688,7 +783,7 @@ func TestForgejoNativeMixedCollectionKeepsOnlyUnconsumedItemsAndCIContext(t *tes
 		t.Fatal(err)
 	}
 	detail.IssueComments = append(detail.IssueComments, map[string]any{"id": int64(2), "author": map[string]any{"login": "looper"}, "body": marker})
-	github := &fakeGitHubGateway{nativeComments: []NativeReviewComment{ownNativeFinding(101, "u1")}}
+	github := &fakeGitHubGateway{nativeComments: []NativeReviewComment{ownNativeFinding(101, "Fix the calculation.\n<!-- looper:stamp -->")}}
 	cfg := forgejoFixerDiscoveryConfig(t, fixture)
 	runner := New(Options{GitHub: github, Repos: fixture.repos, CustomInstructions: cfg})
 	checkpoint, err := runner.runCollectFixesStep(ctx, stepInput{Project: *project, Loop: storage.LoopRecord{}, Repo: "acme/looper", PRNumber: 42, Checkpoint: fixerCheckpoint{Detail: pullRequestCheckpointDetail(detail)}})
@@ -743,7 +838,7 @@ func TestForgejoNativeUnfixedDecisionsRemainOpenAndReachExistingNoProgressHold(t
 			if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
 				t.Fatal(err)
 			}
-			comment := ownNativeFinding(101, "u1")
+			comment := ownNativeFinding(101, "Fix the calculation.\n<!-- looper:stamp -->")
 			github := &nativeLifecycleGateway{probe: forge.ProbeStateUnsupported, detail: PullRequestDetail{Number: 42, State: "OPEN", HeadSHA: "fixed-head"}, fakeGitHubGateway: fakeGitHubGateway{nativeComments: []NativeReviewComment{comment}}}
 			items := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{comment}), nil, false)
 			result := nativeAgentResult([]NativeReviewComment{comment}, action)

--- a/internal/fixer/runner_forgejo_lifecycle_test.go
+++ b/internal/fixer/runner_forgejo_lifecycle_test.go
@@ -1,0 +1,785 @@
+package fixer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/forge"
+	"github.com/nexu-io/looper/internal/loops"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+type nativeLifecycleGateway struct {
+	fakeGitHubGateway
+	detail             PullRequestDetail
+	probe              forge.ProbeState
+	acceptFailedCreate bool
+}
+
+func (g *nativeLifecycleGateway) ViewPullRequest(context.Context, ViewPullRequestInput) (PullRequestDetail, error) {
+	return g.detail, nil
+}
+func (g *nativeLifecycleGateway) ProbeNativeReviewCommentResolution(context.Context, ListNativeReviewCommentsInput) (forge.ProbeState, error) {
+	return g.probe, nil
+}
+func (g *nativeLifecycleGateway) CreateIssueComment(ctx context.Context, input IssueCommentInput) (IssueCommentResult, error) {
+	created, err := g.fakeGitHubGateway.CreateIssueComment(ctx, input)
+	if err == nil || g.acceptFailedCreate {
+		if created.ID == 0 {
+			created = IssueCommentResult{ID: 9000, URL: "https://example.test/c/9000"}
+		}
+		g.detail.IssueComments = append(g.detail.IssueComments, map[string]any{"id": created.ID, "url": created.URL, "body": input.Body, "author": map[string]any{"login": "looper"}})
+	}
+	return created, err
+}
+func (g *nativeLifecycleGateway) UpdateIssueComment(ctx context.Context, input UpdateIssueCommentInput) error {
+	if err := g.fakeGitHubGateway.UpdateIssueComment(ctx, input); err != nil {
+		return err
+	}
+	for _, comment := range g.detail.IssueComments {
+		if issueCommentDatabaseID(comment) == input.CommentID {
+			comment["body"] = input.Body
+		}
+	}
+	return nil
+}
+
+type nativeLifecycleGit struct {
+	fakeGitGateway
+	remote    *nativeLifecycleGateway
+	afterPush func()
+}
+
+func (g *nativeLifecycleGit) Push(ctx context.Context, input PushInput) error {
+	if err := g.fakeGitGateway.Push(ctx, input); err != nil {
+		return err
+	}
+	g.remote.detail.HeadSHA = "fixed-head"
+	if g.afterPush != nil {
+		g.afterPush()
+	}
+	return nil
+}
+
+func ownNativeFinding(id int64, updated string) NativeReviewComment {
+	return NativeReviewComment{ProviderCommentID: id, Body: "Fix the calculation.\n<!-- looper:stamp -->", Author: "looper", ResolverPresent: true, Path: "price.go", URL: fmt.Sprintf("https://forge.example/acme/looper/pulls/42#issuecomment-%d", id), UpdatedAt: updated, ObservedFingerprint: NativeReviewCommentFingerprint(id, updated), ReviewAuthor: "looper", ReviewState: "COMMENTED", ReviewCommitID: "head-1", ReviewBody: "Please fix the calculation.\n<!-- looper:review id=reviewer:review-loop head=head-1 outcome=blocking -->"}
+}
+
+func nativeAgentResult(items []NativeReviewComment, action string) AgentResult {
+	results := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		results = append(results, map[string]any{"source": NativeReviewCommentSource, "providerCommentId": item.ProviderCommentID, "action": action, "explanation": "Corrected the discount calculation and checked the boundary cases.", "observedFingerprint": item.ObservedFingerprint})
+	}
+	payload, _ := json.Marshal(map[string]any{"summary": "Evaluated the calculation feedback.", "repair_results": results})
+	return AgentResult{Status: "completed", Summary: "Evaluated the calculation feedback.", ParseStatus: "parsed", Stdout: "__LOOPER_RESULT__=" + string(payload)}
+}
+
+func nativeLifecycleRunner(t *testing.T, fixture *runnerFixture, gateway *nativeLifecycleGateway, git *nativeLifecycleGit, agent *fakeAgentExecutor) *Runner {
+	t.Helper()
+	cfg := forgejoFixerDiscoveryConfig(t, fixture)
+	return New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: gateway, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, AllowAutoCommit: true, AllowAutoPush: true, AllowRiskyFixes: true, Logger: fixture.logger, Now: fixture.now, CustomInstructions: cfg})
+}
+
+func TestForgejoNativeLifecycleWithoutResolveSurvivesRestartAndLaterFix(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newRunnerFixture(t)
+	finding := ownNativeFinding(101, "u1")
+	github := &nativeLifecycleGateway{probe: forge.ProbeStateUnsupported, detail: PullRequestDetail{Number: 42, URL: "https://forge.example/acme/looper/pulls/42", State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix", BaseRefName: "main", BaseSHA: "base-1", Author: "looper"}, fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}}, nativeComments: []NativeReviewComment{finding}}}
+	git := &nativeLifecycleGit{remote: github, fakeGitGateway: fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/fix", HeadSHA: "head-1"}, prepareResult: PrepareWorktreeResult{HeadSHA: "head-1", Clean: true}, inspectResults: []InspectHeadResult{{HeadSHA: "head-1"}, {HeadSHA: "fixed-head", NewCommitSHAs: []string{"fixed-head"}}, {HeadSHA: "fixed-head"}}}}
+	agent := &fakeAgentExecutor{results: []AgentResult{nativeAgentResult([]NativeReviewComment{finding}, "fixed")}}
+	runner := nativeLifecycleRunner(t, fixture, github, git, agent)
+	discovered, err := runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil || len(discovered.QueueItems) != 1 {
+		t.Fatalf("discover = %#v, %v", discovered, err)
+	}
+	fixture.advance(time.Hour)
+	claim, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "test-fixer", "fixer")
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, %v", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(ctx, *claim)
+	if err != nil || result.Status != "success" {
+		t.Fatalf("process = %#v, %v", result, err)
+	}
+	if len(agent.starts) != 1 || len(git.pushCalls) != 1 || len(github.resolveNativeCalls) != 0 {
+		t.Fatalf("agent/push/resolve = %d/%d/%d", len(agent.starts), len(git.pushCalls), len(github.resolveNativeCalls))
+	}
+	run, _ := fixture.repos.Runs.GetByID(ctx, result.RunID)
+	checkpoint := parseCheckpoint(run.CheckpointJSON)
+	if checkpoint.Detail.URL != github.detail.URL || checkpoint.ResolvedComments.Items[0].Status != forgejoFixedUnresolvedStatus || len(checkpoint.Recheck.RemainingFixItems) != 0 {
+		t.Fatalf("checkpoint = %#v", checkpoint)
+	}
+	if len(github.createIssueComments) != 1 || !strings.Contains(github.createIssueComments[0].Body, "code fixed; comment remains open") || strings.Contains(github.createIssueComments[0].Body, "Forgejo Fixer Summary") {
+		t.Fatalf("comments = %#v", github.createIssueComments)
+	}
+	loop, _ := fixture.repos.Loops.GetByID(ctx, result.LoopID)
+	item := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{finding}), nil, false)[0]
+	entry, ok := findThreadFixEvidence(loadFixEvidenceStoreV2(loop.MetadataJSON), item)
+	if !ok || entry.ResolveState != forgejoFixedUnresolvedStatus || entry.Source != "agent_repair_result" {
+		t.Fatalf("acknowledgement = %#v, %v", entry, ok)
+	}
+
+	// Reopen the real SQLite database: no in-memory cache or preceding run
+	// checkpoint should be needed to avoid another repair after daemon restart.
+	var sequence int
+	var name, dbPath string
+	if err := fixture.coordinator.DB().QueryRowContext(ctx, "PRAGMA database_list").Scan(&sequence, &name, &dbPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.coordinator.Close(); err != nil {
+		t.Fatal(err)
+	}
+	coordinator, err := storage.OpenSQLiteCoordinator(ctx, dbPath, storage.SQLiteCoordinatorOptions{BackupDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	fixture.coordinator, fixture.repos = coordinator, storage.NewRepositories(coordinator.DB())
+	runner = nativeLifecycleRunner(t, fixture, github, git, agent)
+	for poll := 0; poll < 3; poll++ {
+		discovered, err = runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+		if err != nil || len(discovered.QueueItems) != 0 {
+			t.Fatalf("restart poll = %#v, %v", discovered, err)
+		}
+	}
+	// A later unrelated push record must neither forget the old decision nor
+	// claim that a newly discovered finding was fixed.
+	other := ownNativeFinding(102, "u2")
+	otherItem := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{other}), nil, false)[0]
+	if err := runner.persistFixEvidenceStoreV2(ctx, *loop, upsertThreadFixEvidence(nil, threadFixEvidence{ThreadID: otherItem.ThreadID, ThreadFingerprint: otherItem.ObservedFingerprint, EvidenceHeadSHA: "later-head", Source: "fallback_push", ResolveState: "pending"})); err != nil {
+		t.Fatal(err)
+	}
+	github.detail.HeadSHA, github.compareStatus = "later-head", "ahead"
+	github.nativeComments = append(github.nativeComments, other)
+	discovered, err = runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+	if err != nil || len(discovered.QueueItems) != 1 {
+		t.Fatalf("new feedback discovery = %#v, %v", discovered, err)
+	}
+	project, _ := fixture.repos.Projects.GetByID(ctx, "project_1")
+	collected, err := runner.runCollectFixesStep(ctx, stepInput{Project: *project, Loop: *loop, Repo: "acme/looper", PRNumber: 42, Checkpoint: fixerCheckpoint{Detail: pullRequestCheckpointDetail(github.detail)}})
+	if err != nil || len(collected.FixItems) != 1 || collected.FixItems[0].ProviderCommentID != 102 {
+		t.Fatalf("later collect = %#v, %v", collected.FixItems, err)
+	}
+}
+
+func TestForgejoNativeAcknowledgementOnlySuppressesExactAgentDecision(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	finding := ownNativeFinding(101, "u1")
+	item := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{finding}), nil, false)[0]
+	for _, tc := range []struct {
+		name, state, source, head, compare, fingerprint string
+		want                                            int
+	}{
+		{"same head", forgejoFixedUnresolvedStatus, "agent_repair_result", "fixed-head", "", item.ObservedFingerprint, 0},
+		{"descendant", forgejoFixedUnresolvedStatus, "agent_repair_result", "later-head", "ahead", item.ObservedFingerprint, 0},
+		{"force push", forgejoFixedUnresolvedStatus, "agent_repair_result", "rewritten-head", "diverged", item.ObservedFingerprint, 1},
+		{"edited", forgejoFixedUnresolvedStatus, "agent_repair_result", "fixed-head", "", NativeReviewCommentFingerprint(101, "u2"), 1},
+		{"pending push", "pending", "fallback_push", "fixed-head", "", item.ObservedFingerprint, 1},
+		{"push not agent", forgejoFixedUnresolvedStatus, "fallback_push", "fixed-head", "", item.ObservedFingerprint, 1},
+		{"declined", "declined", "agent_repair_result", "fixed-head", "", item.ObservedFingerprint, 1},
+		{"deferred", "deferred", "agent_repair_result", "fixed-head", "", item.ObservedFingerprint, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := upsertThreadFixEvidence(nil, threadFixEvidence{ThreadID: item.ThreadID, ThreadFingerprint: tc.fingerprint, EvidenceHeadSHA: "fixed-head", Source: tc.source, ResolveState: tc.state, Explanation: "Fixed the calculation."})
+			metadata := mustJSON(t, map[string]any{"fixEvidenceStoreV2": store})
+			gateway := &fakeGitHubGateway{compareStatus: tc.compare}
+			runner := New(Options{GitHub: gateway})
+			got, err := runner.suppressFixedForgejoNativeItems(ctx, storage.ProjectRecord{RepoPath: t.TempDir()}, "acme/looper", 42, tc.head, &storage.LoopRecord{MetadataJSON: &metadata}, []FixItem{item})
+			if err != nil || len(got) != tc.want {
+				t.Fatalf("remaining = %#v, %v, want %d", got, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestForgejoNativeSummaryFailureReplaysAfterRestartWithoutRepairingAgain(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name                          string
+		accepted, update, interrupted bool
+		wantCreates                   int
+	}{
+		{name: "create 503", wantCreates: 2},
+		{name: "create accepted response lost", accepted: true, wantCreates: 1},
+		{name: "update 503", update: true},
+		{name: "interrupted after accepted create", accepted: true, interrupted: true, wantCreates: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			fixture := newRunnerFixture(t)
+			finding := ownNativeFinding(101, "u1")
+			gateway := &nativeLifecycleGateway{probe: forge.ProbeStateUnsupported, acceptFailedCreate: tc.accepted, detail: PullRequestDetail{Number: 42, State: "OPEN", HeadSHA: "head-1", HeadRefName: "feature/fix", BaseRefName: "main", BaseSHA: "base-1", Author: "looper"}, fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}}, nativeComments: []NativeReviewComment{finding}}}
+			outage := &forge.ForgejoHTTPError{StatusCode: 503, Method: "POST", Path: "/comments", Message: "temporary outage"}
+			if tc.update {
+				gateway.updateIssueCommentErr = outage
+				gateway.detail.IssueComments = []map[string]any{{"id": int64(9000), "author": map[string]any{"login": "looper"}, "body": fixerRoundSummaryMarker("fixed-head") + "\nPrior acknowledgement"}}
+			} else {
+				gateway.createIssueCommentErr = outage
+			}
+			git := &nativeLifecycleGit{remote: gateway, fakeGitGateway: fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/fix", HeadSHA: "head-1"}, prepareResult: PrepareWorktreeResult{HeadSHA: "head-1", Clean: true}, inspectResults: []InspectHeadResult{{HeadSHA: "head-1"}, {HeadSHA: "fixed-head", NewCommitSHAs: []string{"fixed-head"}}, {HeadSHA: "fixed-head"}}}}
+			agent := &fakeAgentExecutor{results: []AgentResult{nativeAgentResult([]NativeReviewComment{finding}, "fixed")}}
+			validations := 0
+			newRunner := func() *Runner {
+				runner := nativeLifecycleRunner(t, fixture, gateway, git, agent)
+				runner.validationRunner = func(ctx context.Context, input ValidationInput) (ValidationResult, error) {
+					validations++
+					return passValidation(ctx, input)
+				}
+				return runner
+			}
+			runner := newRunner()
+			if _, err := runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+				t.Fatal(err)
+			}
+			fixture.advance(time.Hour)
+			claim, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "test-fixer", "fixer")
+			if err != nil || claim == nil {
+				t.Fatalf("claim = %#v, %v", claim, err)
+			}
+			failed, err := runner.ProcessClaimedItem(ctx, *claim)
+			if err != nil || failed.Status != "failed" || failed.FailureKind != FailureRetryableAfterResume {
+				t.Fatalf("publication failure = %#v, %v", failed, err)
+			}
+			run, _ := fixture.repos.Runs.GetByID(ctx, failed.RunID)
+			checkpoint := parseCheckpoint(run.CheckpointJSON)
+			if checkpoint.ResumePolicy != loops.ResumePolicyReplayStep || checkpoint.ResolvedComments.Items[0].Status != forgejoFixedUnresolvedStatus || checkpoint.Repair.ReplyExplanations[0].ObservedFingerprint != finding.ObservedFingerprint {
+				t.Fatalf("pending publication lost structured decision: %#v", checkpoint)
+			}
+			loop, _ := fixture.repos.Loops.GetByID(ctx, failed.LoopID)
+			item := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{finding}), nil, false)[0]
+			if entry, ok := findThreadFixEvidence(loadFixEvidenceStoreV2(loop.MetadataJSON), item); ok && entry.ResolveState == forgejoFixedUnresolvedStatus {
+				t.Fatal("failed publication prematurely suppressed discovery")
+			}
+			if tc.interrupted {
+				// The server accepted the request, but the process exited before
+				// persisting its response. The per-item checkpoint already exists.
+				run.Status = "interrupted"
+				checkpoint.SummaryComment = nil
+				encoded := mustMarshalJSON(checkpoint)
+				run.CheckpointJSON = &encoded
+				if err := fixture.repos.Runs.Upsert(ctx, *run); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var sequence int
+			var name, dbPath string
+			if err := fixture.coordinator.DB().QueryRowContext(ctx, "PRAGMA database_list").Scan(&sequence, &name, &dbPath); err != nil {
+				t.Fatal(err)
+			}
+			if err := fixture.coordinator.Close(); err != nil {
+				t.Fatal(err)
+			}
+			coordinator, err := storage.OpenSQLiteCoordinator(ctx, dbPath, storage.SQLiteCoordinatorOptions{BackupDir: t.TempDir()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = coordinator.Close() })
+			fixture.coordinator, fixture.repos = coordinator, storage.NewRepositories(coordinator.DB())
+			gateway.createIssueCommentErr, gateway.updateIssueCommentErr = nil, nil
+			runner = newRunner()
+			// Scheduler discovery runs before the retry claim after restart.
+			if _, err := runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+				t.Fatal(err)
+			}
+			fixture.advance(time.Hour)
+			claim, err = fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "test-fixer-restarted", "fixer")
+			if err != nil || claim == nil {
+				t.Fatalf("publication retry was dropped: %#v, %v", claim, err)
+			}
+			replayed, err := runner.ProcessClaimedItem(ctx, *claim)
+			if err != nil || replayed.Status != "success" {
+				t.Fatalf("publication replay = %#v, %v", replayed, err)
+			}
+			if len(agent.starts) != 1 || validations != 1 || len(git.pushCalls) != 1 || len(gateway.resolveNativeCalls) != 0 {
+				t.Fatalf("replay repeated repair/validation/push/resolve: %d/%d/%d/%d", len(agent.starts), validations, len(git.pushCalls), len(gateway.resolveNativeCalls))
+			}
+			if len(gateway.createIssueComments) != tc.wantCreates || len(gateway.detail.IssueComments) != 1 || !strings.Contains(gateway.detail.IssueComments[0]["body"].(string), "code fixed; comment remains open") {
+				t.Fatalf("publication did not converge to one truthful comment: creates=%d comments=%#v", len(gateway.createIssueComments), gateway.detail.IssueComments)
+			}
+			loop, _ = fixture.repos.Loops.GetByID(ctx, failed.LoopID)
+			entry, ok := findThreadFixEvidence(loadFixEvidenceStoreV2(loop.MetadataJSON), item)
+			if !ok || entry.ResolveState != forgejoFixedUnresolvedStatus || entry.Source != "agent_repair_result" {
+				t.Fatalf("published decision not acknowledged: %#v", entry)
+			}
+			for poll := 0; poll < 3; poll++ {
+				discovered, err := runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+				if err != nil || len(discovered.QueueItems) != 0 {
+					t.Fatalf("completed publication rediscovered work: %#v, %v", discovered, err)
+				}
+			}
+		})
+	}
+}
+
+func TestForgejoMixedRoundPublishesBeforeRediscoveringNewFeedback(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name                                   string
+		newNative, editedNative, newLegacy     bool
+		publicationFails, responseLost, manual bool
+	}{
+		{name: "new native", newNative: true},
+		{name: "edited native", editedNative: true},
+		{name: "new legacy round", newLegacy: true},
+		{name: "manual new legacy round", newLegacy: true, manual: true},
+		{name: "new native and legacy", newNative: true, newLegacy: true},
+		{name: "503 new native", newNative: true, publicationFails: true},
+		{name: "lost response new native", newNative: true, publicationFails: true, responseLost: true},
+		{name: "503 new native and legacy", newNative: true, newLegacy: true, publicationFails: true},
+		{name: "lost response new native and legacy", newNative: true, newLegacy: true, publicationFails: true, responseLost: true},
+		{name: "503 edited native", editedNative: true, publicationFails: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			fixture := newRunnerFixture(t)
+			finding := ownNativeFinding(101, "u1")
+			original := []NativeReviewComment{finding}
+			if tc.editedNative {
+				original = append(original, ownNativeFinding(103, "u1"))
+			}
+			gateway := &nativeLifecycleGateway{probe: forge.ProbeStateUnsupported, acceptFailedCreate: tc.responseLost, detail: forgejoDiscoveryDetail(t, "head-1", 1), fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", listOpen: []PullRequestSummary{{Number: 42, State: "OPEN", HeadSHA: "head-1", Author: "looper"}}, nativeComments: original}}
+			if tc.publicationFails {
+				gateway.createIssueCommentErr = &forge.ForgejoHTTPError{StatusCode: 503, Method: "POST", Path: "/comments", Message: "temporary outage"}
+			}
+			git := &nativeLifecycleGit{remote: gateway, fakeGitGateway: fakeGitGateway{createResult: CreateWorktreeResult{WorktreePath: filepath.Join(t.TempDir(), "wt"), Branch: "feature/fix", HeadSHA: "head-1"}, prepareResult: PrepareWorktreeResult{HeadSHA: "head-1", Clean: true}, inspectResults: []InspectHeadResult{{HeadSHA: "head-1"}, {HeadSHA: "fixed-head", NewCommitSHAs: []string{"fixed-head"}}, {HeadSHA: "fixed-head"}}}}
+			git.afterPush = func() {
+				if tc.newNative {
+					gateway.nativeComments = append([]NativeReviewComment{finding}, ownNativeFinding(102, "u2"))
+				}
+				if tc.editedNative {
+					gateway.nativeComments = []NativeReviewComment{finding, ownNativeFinding(103, "u2")}
+				}
+				if tc.newLegacy {
+					live := forgejoDiscoveryDetailWithItems(t, "fixed-head", 2, []forge.ReviewItem{
+						{ReviewItemID: "R-001", Status: forge.ReviewItemStatusOpen, Title: "Different parser failure", Body: "New feedback reuses the stable ID in a new review round.", LastSeenRoundID: 2},
+						{ReviewItemID: "R-002", Status: forge.ReviewItemStatusOpen, Title: "Check overflow", Body: "Reject values outside the supported range.", LastSeenRoundID: 2},
+					})
+					gateway.detail.IssueComments = live.IssueComments
+				}
+			}
+			result := nativeAgentResult(original, "fixed")
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(extractCompletionMarkerPayload(result.Stdout)), &payload); err != nil {
+				t.Fatal(err)
+			}
+			payload["review_thread_replies"] = []map[string]any{{"fixItemId": "R-001", "action": "fixed", "explanation": "The parser now fails fast."}}
+			result.Stdout = "__LOOPER_RESULT__=" + mustMarshalJSON(payload)
+			agent := &fakeAgentExecutor{results: []AgentResult{result}}
+			validations := 0
+			newRunner := func() *Runner {
+				runner := nativeLifecycleRunner(t, fixture, gateway, git, agent)
+				runner.projectRoleConfig.Roles.Fixer.AutoDiscovery = !tc.manual
+				runner.validationRunner = func(ctx context.Context, input ValidationInput) (ValidationResult, error) {
+					validations++
+					return passValidation(ctx, input)
+				}
+				return runner
+			}
+			runner := newRunner()
+			// Seed a queue item, then exercise the same manual-loop contract as
+			// the API with automatic discovery disabled for the entire execution.
+			runner.projectRoleConfig.Roles.Fixer.AutoDiscovery = true
+			discovered, err := runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"})
+			if err != nil || len(discovered.QueueItems) != 1 {
+				t.Fatalf("initial discovery = %#v, %v", discovered, err)
+			}
+			runner.projectRoleConfig.Roles.Fixer.AutoDiscovery = !tc.manual
+			if tc.manual {
+				loop, err := fixture.repos.Loops.GetByID(ctx, *discovered.QueueItems[0].LoopID)
+				if err != nil || loop == nil {
+					t.Fatalf("manual loop = %#v, %v", loop, err)
+				}
+				if _, err := runner.mergeLoopMetadata(ctx, *loop, map[string]any{"manual": true}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			fixture.advance(time.Hour)
+			claim, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "mixed-fixer", "fixer")
+			if err != nil || claim == nil {
+				t.Fatalf("claim = %#v, %v", claim, err)
+			}
+			processed, err := runner.ProcessClaimedItem(ctx, *claim)
+			if err != nil {
+				t.Fatal(err)
+			}
+			run, _ := fixture.repos.Runs.GetByID(ctx, processed.RunID)
+			checkpoint := parseCheckpoint(run.CheckpointJSON)
+			loop, _ := fixture.repos.Loops.GetByID(ctx, processed.LoopID)
+			fixedItem := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{finding}), nil, false)[0]
+			if tc.publicationFails {
+				if processed.Status != "failed" || checkpoint.ResumePolicy != loops.ResumePolicyReplayStep {
+					t.Fatalf("publication failure = %#v, checkpoint = %#v", processed, checkpoint)
+				}
+				if evidence, ok := findThreadFixEvidence(loadFixEvidenceStoreV2(loop.MetadataJSON), fixedItem); ok && evidence.ResolveState == forgejoFixedUnresolvedStatus {
+					t.Fatal("unpublished mixed result suppressed discovery")
+				}
+			}
+			var sequence int
+			var name, dbPath string
+			if err := fixture.coordinator.DB().QueryRowContext(ctx, "PRAGMA database_list").Scan(&sequence, &name, &dbPath); err != nil {
+				t.Fatal(err)
+			}
+			if err := fixture.coordinator.Close(); err != nil {
+				t.Fatal(err)
+			}
+			coordinator, err := storage.OpenSQLiteCoordinator(ctx, dbPath, storage.SQLiteCoordinatorOptions{BackupDir: t.TempDir()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = coordinator.Close() })
+			fixture.coordinator, fixture.repos = coordinator, storage.NewRepositories(coordinator.DB())
+			runner = newRunner()
+			if tc.publicationFails {
+				gateway.createIssueCommentErr = nil
+				if _, err := runner.DiscoverPullRequests(ctx, DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+					t.Fatal(err)
+				}
+				fixture.advance(time.Hour)
+				claim, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "mixed-fixer-restarted", "fixer")
+				if err != nil || claim == nil {
+					t.Fatalf("publication retry dropped = %#v, %v", claim, err)
+				}
+				processed, err = runner.ProcessClaimedItem(ctx, *claim)
+				if err != nil {
+					t.Fatal(err)
+				}
+				run, _ = fixture.repos.Runs.GetByID(ctx, processed.RunID)
+				checkpoint = parseCheckpoint(run.CheckpointJSON)
+			}
+			if tc.newNative || tc.editedNative {
+				if processed.Status != "failed" || checkpoint.ResumePolicy != loops.ResumePolicyRestartFromDiscover {
+					t.Fatalf("new native feedback did not restart discovery = %#v, %#v", processed, checkpoint)
+				}
+			} else if processed.Status != "success" {
+				t.Fatalf("new legacy round should reach live recheck = %#v", processed)
+			}
+			if len(agent.starts) != 1 || validations != 1 || len(git.pushCalls) != 1 || len(gateway.resolveNativeCalls) != 0 {
+				t.Fatalf("replayed agent/validation/push/resolve = %d/%d/%d/%d", len(agent.starts), validations, len(git.pushCalls), len(gateway.resolveNativeCalls))
+			}
+			loop, _ = fixture.repos.Loops.GetByID(ctx, processed.LoopID)
+			if evidence, ok := findThreadFixEvidence(loadFixEvidenceStoreV2(loop.MetadataJSON), fixedItem); !ok || evidence.ResolveState != forgejoFixedUnresolvedStatus || evidence.ThreadFingerprint != finding.ObservedFingerprint {
+				t.Fatalf("confirmed native result lost before rediscovery = %#v, %v", evidence, ok)
+			}
+			comments := forgeCommentsFromCheckpointDetail(pullRequestCheckpointDetail(gateway.detail))
+			visible, summary, err := forge.ParseUniqueFixerSummaryComment(comments)
+			if err != nil || summary.ConsumedReviewRoundID != 1 || len(summary.Results) != 1 || summary.Results[0].ReviewItemID != "R-001" || !strings.Contains(visible.Body, "code fixed; comment remains open") || len(gateway.detail.IssueComments) != 2 {
+				t.Fatalf("mixed acknowledgement = %#v, %v, comments = %#v", summary, err, gateway.detail.IssueComments)
+			}
+			wantCreates := 1
+			if tc.publicationFails && !tc.responseLost {
+				wantCreates = 2
+			}
+			if len(gateway.createIssueComments) != wantCreates {
+				t.Fatalf("created %d comments, want %d attempts", len(gateway.createIssueComments), wantCreates)
+			}
+			observed, ok, err := reviewerSummaryFromCheckpointDetail(checkpoint.Detail)
+			if err != nil || !ok || observed.ReviewRoundID != 1 {
+				t.Fatalf("agent-observed review snapshot was overwritten = %#v, %v", observed, err)
+			}
+			project, _ := fixture.repos.Projects.GetByID(ctx, "project_1")
+			input := stepInput{Project: *project, Loop: *loop, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint}
+			rechecked, err := runner.runRecheckStep(ctx, input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantRemaining := map[string]bool{}
+			if tc.newNative {
+				wantRemaining[NativeReviewCommentFixItemID(102)] = true
+			}
+			if tc.editedNative {
+				wantRemaining[NativeReviewCommentFixItemID(103)] = true
+			}
+			if tc.newLegacy {
+				wantRemaining["R-001"], wantRemaining["R-002"] = true, true
+			}
+			assertRemaining := func(where string, items []FixItem) {
+				t.Helper()
+				if len(items) != len(wantRemaining) {
+					t.Fatalf("%s remaining = %#v, want IDs %#v", where, items, wantRemaining)
+				}
+				for _, item := range items {
+					if !wantRemaining[item.ID] {
+						t.Fatalf("%s rediscovered acknowledged item = %#v", where, item)
+					}
+					if item.ID == "R-001" && !strings.Contains(item.Summary, "Different parser failure") {
+						t.Fatalf("%s retained stale legacy input = %#v", where, item)
+					}
+				}
+			}
+			assertRemaining("recheck", rechecked.Recheck.RemainingFixItems)
+			input.Checkpoint = fixerCheckpoint{}
+			rediscovered, err := runner.runDiscoverPRStep(ctx, input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			input.Checkpoint = rediscovered
+			collected, err := runner.runCollectFixesStep(ctx, input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertRemaining("fresh repair input", collected.FixItems)
+		})
+	}
+}
+
+func TestForgejoNativeSummaryIdentityFailureDoesNotCreateDuplicate(t *testing.T) {
+	t.Parallel()
+	gateway := &fakeGitHubGateway{currentUserErr: errors.New("HTTP 503 identity unavailable")}
+	runner := New(Options{GitHub: gateway})
+	item := nativeFixItem(101, "u1")
+	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{HeadSHA: "fixed-head", IssueComments: []map[string]any{{"id": int64(9000), "author": map[string]any{"login": "looper"}, "body": fixerRoundSummaryMarker("fixed-head")}}}, ResolvedComments: &checkpointResolvedComments{Items: []checkpointResolvedComment{{FixItemID: item.ID, Status: forgejoFixedUnresolvedStatus}}}}
+	err := runner.publishRoundSummaryComment(context.Background(), stepInput{Repo: "acme/looper", PRNumber: 42}, &checkpoint, []FixItem{item}, "fixed-head", map[string]string{item.ID: "Fixed the calculation."})
+	if err == nil || checkpoint.SummaryComment == nil || checkpoint.SummaryComment.State != "create_failed" || len(gateway.createIssueComments) != 0 || len(gateway.updateIssueComments) != 0 {
+		t.Fatalf("identity failure publication = %#v, %v creates=%d updates=%d", checkpoint.SummaryComment, err, len(gateway.createIssueComments), len(gateway.updateIssueComments))
+	}
+}
+
+func TestGitHubSummaryFailureRemainsBestEffort(t *testing.T) {
+	t.Parallel()
+	thread := ReviewThread{ID: "thread-1", Comments: []ReviewThreadComment{{ID: "comment-1", Author: "alice", Body: "Fix the calculation."}}}
+	item := FixItem{ID: "comment-1", Type: "comment", ThreadID: "thread-1", Author: "alice"}
+	gateway := &fakeGitHubGateway{createIssueCommentErr: errors.New("HTTP 503"), threads: []ReviewThread{thread}, viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "fixed-head", Comments: []map[string]any{{"id": item.ID, "threadId": item.ThreadID, "author": item.Author}}}}}
+	checkpoint := fixerCheckpoint{
+		Detail: &checkpointDetail{HeadSHA: "fixed-head"}, FixItems: []FixItem{item},
+		Repair:           &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: item.ID, ThreadID: item.ThreadID, Action: "fixed", Explanation: "Corrected the calculation.", ThreadCommentsObserved: hashReviewThreadComments(thread)}}},
+		Validation:       &ValidationResult{Passed: true, HeadSHA: "fixed-head"},
+		Push:             &checkpointPush{Pushed: true, HeadSHA: "fixed-head", Evidence: &fixEvidence{Valid: true, HeadSHA: "fixed-head", Source: "fallback_push", ProducedNewCommits: true}},
+		ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "old-head", FinalHeadSHA: "fixed-head", NewCommitSHAs: []string{"fixed-head"}},
+	}
+	runner := New(Options{GitHub: gateway})
+	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	if err != nil || updated.SummaryComment == nil || updated.SummaryComment.State != "create_failed" || len(gateway.resolveCalls) != 1 {
+		t.Fatalf("GitHub best-effort summary changed: %#v, %v resolves=%d", updated.SummaryComment, err, len(gateway.resolveCalls))
+	}
+}
+
+func TestForgejoNativeReplayDoesNotAcknowledgeEditedComment(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newRunnerFixture(t)
+	project, _ := fixture.repos.Projects.GetByID(ctx, "project_1")
+	loop := storage.LoopRecord{ID: "native-replay", ProjectID: project.ID, Type: "fixer", TargetType: "pull_request", Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+	if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+		t.Fatal(err)
+	}
+	old := ownNativeFinding(101, "u1")
+	newComment := ownNativeFinding(102, "u2")
+	github := &nativeLifecycleGateway{probe: forge.ProbeStateUnsupported, detail: PullRequestDetail{Number: 42, State: "OPEN", HeadSHA: "fixed-head"}, fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{old, newComment}}}
+	items := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{old}), nil, false)
+	result := nativeAgentResult([]NativeReviewComment{old}, "fixed")
+	checkpoint := fixerCheckpoint{Detail: pullRequestCheckpointDetail(github.detail), FixItems: items, Repair: &checkpointRepair{ReplyExplanations: parseNativeRepairResults(result.Stdout, "", items)}, Validation: &ValidationResult{Passed: true, HeadSHA: "fixed-head"}, Push: &checkpointPush{Pushed: true, HeadSHA: "fixed-head"}}
+	runner := New(Options{Repos: fixture.repos, GitHub: github})
+	input := stepInput{Project: *project, Loop: loop, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint}
+	updated, err := runner.runResolveCommentsStep(ctx, input)
+	if err == nil || !strings.Contains(err.Error(), "omitted") {
+		t.Fatalf("first resolve = %v", err)
+	}
+	if updated.ResolvedComments.Items[0].Status != forgejoFixedUnresolvedStatus {
+		t.Fatalf("partial success = %#v", updated.ResolvedComments)
+	}
+	// resolve refresh has overwritten the live FixItems, but the decision still
+	// carries the old fingerprint. Editing that same ID must re-arm it.
+	github.nativeComments = []NativeReviewComment{ownNativeFinding(101, "edited")}
+	input.Checkpoint = parseCheckpoint(stringPtr(mustJSON(t, updated)))
+	updated, err = runner.runResolveCommentsStep(ctx, input)
+	if err == nil || !strings.Contains(err.Error(), "changed") || updated.ResolvedComments.Items[0].Status != "skipped_thread_drift" {
+		t.Fatalf("edited replay = %#v, %v", updated.ResolvedComments, err)
+	}
+	metadata, _ := runner.freshNativeFixMetadata(ctx, &loop)
+	live := normalizeFixItems(nativeReviewCommentsToMaps(github.nativeComments), nil, false)
+	remaining, err := runner.suppressFixedForgejoNativeItems(ctx, *project, input.Repo, 42, "fixed-head", &storage.LoopRecord{MetadataJSON: metadata}, live)
+	if err != nil || len(remaining) != 1 {
+		t.Fatalf("edited discovery = %#v, %v", remaining, err)
+	}
+}
+
+func TestForgejoNativeProvenanceAndPushEvidenceIsolation(t *testing.T) {
+	t.Parallel()
+	base := ownNativeFinding(101, "u1")
+	for _, tc := range []struct {
+		name   string
+		mutate func(*NativeReviewComment)
+		want   bool
+	}{
+		{"own reviewer", func(*NativeReviewComment) {}, true},
+		{"human reviewer", func(c *NativeReviewComment) { c.Author = "alice"; c.ReviewBody = "" }, true},
+		{"own chatter", func(c *NativeReviewComment) { c.ReviewBody = "Just a note.\n<!-- looper:stamp -->" }, false},
+		{"fixer reply", func(c *NativeReviewComment) { c.Author = "fix-bot"; c.Body = "<!-- looper:fixer-round head=head-1 -->" }, false},
+		{"pending", func(c *NativeReviewComment) { c.ReviewState = "PENDING" }, false},
+		{"dismissed", func(c *NativeReviewComment) { c.ReviewState = "DISMISSED" }, false},
+		{"wrong parent", func(c *NativeReviewComment) { c.ReviewAuthor = "mallory" }, false},
+		{"wrong head", func(c *NativeReviewComment) { c.ReviewCommitID = "other-head" }, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			comment := base
+			tc.mutate(&comment)
+			if got := eligibleNativeReviewComment(comment, "looper"); got != tc.want {
+				t.Fatalf("eligible = %v", got)
+			}
+		})
+	}
+	entry := threadFixEvidence{ThreadID: "comment", ThreadFingerprint: "fingerprint", EvidenceHeadSHA: "fixed-head", Source: "agent_repair_result", ResolveState: forgejoFixedUnresolvedStatus, Explanation: "Fixed."}
+	store := upsertThreadFixEvidence(nil, entry)
+	pending := entry
+	pending.Source, pending.ResolveState = "fallback_push", "pending"
+	store = upsertThreadFixEvidence(store, pending)
+	if got := store.Threads[entry.ThreadID][0]; got.Source != entry.Source || got.ResolveState != entry.ResolveState || got.EvidenceHeadSHA != entry.EvidenceHeadSHA {
+		t.Fatalf("same-head replay replaced decision: %#v", got)
+	}
+	pending.EvidenceHeadSHA = "unrelated-head"
+	store = upsertThreadFixEvidence(store, pending)
+	if got := store.Threads[entry.ThreadID][0]; got.ResolveState != "pending" {
+		t.Fatalf("old decision inherited onto new head: %#v", got)
+	}
+}
+
+func TestForgejoNativeNeedsHumanUsesSharedPreMutationSuspension(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newRunnerFixture(t)
+	project, _ := fixture.repos.Projects.GetByID(ctx, "project_1")
+	finding := ownNativeFinding(101, "u1")
+	items := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{finding}), nil, false)
+	result := nativeAgentResult([]NativeReviewComment{finding}, "needs_human")
+	agent := &fakeAgentExecutor{results: []AgentResult{result}}
+	github := &fakeGitHubGateway{}
+	git := &fakeGitGateway{prepareResult: PrepareWorktreeResult{Clean: true}}
+	runner := New(Options{Repos: fixture.repos, GitHub: github, Git: git, AgentExecutor: agent, ValidationRunner: passValidation, HITLEnabled: true, CustomInstructions: forgejoFixerDiscoveryConfig(t, fixture)})
+	root, err := config.DefaultProjectWorktreeRoot(project.ID, project.RepoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{HeadSHA: "head-1", HeadRefName: "feature/fix"}, FixItems: items, Worktree: &checkpointWorktree{Path: filepath.Join(root, "wt"), Branch: "feature/fix", HeadSHA: "head-1", BaseHeadSHA: "head-1", PreparedAt: fixture.nowISO()}}
+	_, err = runner.runRepairStep(ctx, stepInput{Project: *project, Loop: storage.LoopRecord{MetadataJSON: stringPtr(`{"manual":true}`)}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
+	var awaiting *awaitingHumanError
+	if !errors.As(err, &awaiting) {
+		t.Fatalf("repair = %v, want shared human suspension", err)
+	}
+	if len(git.pushCalls) != 0 || len(git.commitCalls) != 0 || len(github.resolveNativeCalls) != 0 || len(github.createIssueComments) != 0 || len(github.dismissedReviews) != 0 {
+		t.Fatal("needs_human mutated repository or reviews")
+	}
+	if len(agent.starts) != 1 || !strings.Contains(agent.starts[0].Prompt, "repair_results") || !strings.Contains(agent.starts[0].Prompt, "STOP THE ENTIRE TURN BEFORE MAKING EDITS") {
+		t.Fatal("native human contract missing")
+	}
+}
+
+func TestForgejoNativeMixedCollectionKeepsOnlyUnconsumedItemsAndCIContext(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newRunnerFixture(t)
+	project, _ := fixture.repos.Projects.GetByID(ctx, "project_1")
+	detail := forgejoDiscoveryDetail(t, "head-1", 1)
+	detail.URL = "https://forgejo.test/acme/looper/pulls/42"
+	detail.Checks = []map[string]any{{"name": "unit tests", "state": "FAILURE", "description": "discount boundary failed", "url": "https://forgejo.test/acme/looper/actions/runs/5", "actionRunId": int64(901)}}
+	detail.HasConflicts = true
+	summary := forge.NewFixerSummary(1, 1, []forge.FixerResult{{ReviewItemID: "R-001", Result: forge.FixerItemResultFixed, Explanation: "Already repaired."}})
+	summary.ObservedHeadSHA = "head-1"
+	marker, err := forge.RenderFixerSummary(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	detail.IssueComments = append(detail.IssueComments, map[string]any{"id": int64(2), "author": map[string]any{"login": "looper"}, "body": marker})
+	github := &fakeGitHubGateway{nativeComments: []NativeReviewComment{ownNativeFinding(101, "u1")}}
+	cfg := forgejoFixerDiscoveryConfig(t, fixture)
+	runner := New(Options{GitHub: github, Repos: fixture.repos, CustomInstructions: cfg})
+	checkpoint, err := runner.runCollectFixesStep(ctx, stepInput{Project: *project, Loop: storage.LoopRecord{}, Repo: "acme/looper", PRNumber: 42, Checkpoint: fixerCheckpoint{Detail: pullRequestCheckpointDetail(detail)}})
+	if err != nil || len(checkpoint.FixItems) != 3 {
+		t.Fatalf("collect = %#v, %v", checkpoint.FixItems, err)
+	}
+	for _, item := range checkpoint.FixItems {
+		if item.Source == "forgejo-reviewer-summary" {
+			t.Fatalf("consumed item returned: %#v", item)
+		}
+	}
+	prompt, _ := buildFixerPrompt(project.ID, *cfg, "acme/looper", 42, checkpoint.Detail, checkpoint.FixItems, true, config.DefaultDisclosureConfig(), "codex", "")
+	for _, want := range []string{detail.URL, "FORGEJO_TOKEN", "discount boundary failed", "https://forgejo.test/acme/looper/actions/runs/5", `"actionRunId":901`, "Agent-side Forgejo fetch contract"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q", want)
+		}
+	}
+	if strings.Contains(prompt, "Agent-side GitHub fetch contract") {
+		t.Fatal("Forgejo prompt uses GitHub fetch instructions")
+	}
+}
+
+func TestForgejoLegacyFixerMessageUsesCommonTemplateAndPreservesProtocol(t *testing.T) {
+	t.Parallel()
+	summary := forge.NewFixerSummary(2, 3, []forge.FixerResult{{ReviewItemID: "R-001", Result: forge.FixerItemResultFixed, Explanation: "Corrected the calculation."}})
+	summary.ObservedHeadSHA = "fixed-head"
+	body, err := renderForgejoFixerSummaryComment(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(body, "**Looper fixer round complete**") || strings.Contains(body, "Reviewer Summary") || strings.Contains(body, "Forgejo Fixer Summary") || strings.Contains(body, "Consumed") {
+		t.Fatalf("legacy body = %q", body)
+	}
+	_, parsed, err := forge.ParseUniqueFixerSummaryComment([]forge.Comment{{ID: 1, Body: body}})
+	if err != nil || parsed.ConsumedReviewRoundID != 3 || parsed.FixRoundID != 2 {
+		t.Fatalf("hidden handoff = %#v, %v", parsed, err)
+	}
+	detail := &checkpointDetail{IssueComments: []map[string]any{{"id": int64(1), "author": map[string]any{"login": "looper"}, "body": body}}}
+	if id, _ := findExistingFixerSummaryCommentID(detail, "fixed-head", "looper"); id != 0 {
+		t.Fatal("native updater may erase legacy handoff")
+	}
+}
+
+func TestForgejoNativeUnfixedDecisionsRemainOpenAndReachExistingNoProgressHold(t *testing.T) {
+	t.Parallel()
+	for _, action := range []string{"fixed", "declined", "deferred"} {
+		t.Run(action, func(t *testing.T) {
+			ctx := context.Background()
+			fixture := newRunnerFixture(t)
+			project, _ := fixture.repos.Projects.GetByID(ctx, "project_1")
+			loop := storage.LoopRecord{ID: "no-push", ProjectID: project.ID, Type: "fixer", TargetType: "pull_request", Status: "running", CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+			if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+				t.Fatal(err)
+			}
+			comment := ownNativeFinding(101, "u1")
+			github := &nativeLifecycleGateway{probe: forge.ProbeStateUnsupported, detail: PullRequestDetail{Number: 42, State: "OPEN", HeadSHA: "fixed-head"}, fakeGitHubGateway: fakeGitHubGateway{nativeComments: []NativeReviewComment{comment}}}
+			items := normalizeFixItems(nativeReviewCommentsToMaps([]NativeReviewComment{comment}), nil, false)
+			result := nativeAgentResult([]NativeReviewComment{comment}, action)
+			checkpoint := fixerCheckpoint{Detail: pullRequestCheckpointDetail(github.detail), FixItems: items, Repair: &checkpointRepair{ReplyExplanations: parseNativeRepairResults(result.Stdout, "", items)}, Validation: &ValidationResult{Passed: true, HeadSHA: "fixed-head"}, Push: &checkpointPush{Pushed: false, SkippedReason: "No new commits to push"}, ReconcileCommits: &checkpointReconcileCommits{BaseHeadSHA: "fixed-head", FinalHeadSHA: "fixed-head", WorkingTreeClean: true}}
+			runner := New(Options{Repos: fixture.repos, GitHub: github, CustomInstructions: forgejoFixerDiscoveryConfig(t, fixture)})
+			input := stepInput{Project: *project, Loop: loop, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint}
+			updated, err := runner.runResolveCommentsStep(ctx, input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			input.Checkpoint = updated
+			checked, err := runner.runRecheckStep(ctx, input)
+			if action == "fixed" {
+				if err != nil || len(checked.Recheck.RemainingFixItems) != 0 {
+					t.Fatalf("already-fixed no-push recheck = %#v, %v", checked.Recheck, err)
+				}
+			} else {
+				var hold *loopError
+				if !errors.As(err, &hold) || hold.kind != FailureManualIntervention || len(checked.Recheck.RemainingFixItems) != 1 {
+					t.Fatalf("unfixed recheck = %#v, %v", checked.Recheck, err)
+				}
+				metadata, _ := runner.freshNativeFixMetadata(ctx, &loop)
+				if entry, ok := findThreadFixEvidence(loadFixEvidenceStoreV2(metadata), items[0]); ok && entry.ResolveState == forgejoFixedUnresolvedStatus {
+					t.Fatal("unfixed decision recorded as fixed")
+				}
+			}
+			if len(github.resolveNativeCalls) != 0 || len(github.createIssueComments) != 1 {
+				t.Fatalf("resolve/comments = %d/%d", len(github.resolveNativeCalls), len(github.createIssueComments))
+			}
+			input.Checkpoint = updated
+			if _, err := runner.runResolveCommentsStep(ctx, input); err != nil {
+				t.Fatal(err)
+			}
+			if len(github.createIssueComments) != 1 {
+				t.Fatal("replay posted duplicate summary")
+			}
+		})
+	}
+}

--- a/internal/fixer/runner_forgejo_native.go
+++ b/internal/fixer/runner_forgejo_native.go
@@ -1,0 +1,215 @@
+package fixer
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/forge"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// This is the agent's fixed decision, not Forgejo's remote resolution state.
+// Reuse the existing per-comment evidence store so later runs retain that
+// decision without introducing another ledger or treating a push as authority.
+const forgejoFixedUnresolvedStatus = "fixed_unresolved"
+
+var forgejoReviewerMarker = regexp.MustCompile(`<!--\s*looper:review\s+([^>]*)-->`)
+
+func eligibleNativeReviewComment(comment NativeReviewComment, currentUser string) bool {
+	state := strings.ToUpper(strings.TrimSpace(comment.ReviewState))
+	if state == "PENDING" || state == "DISMISSED" {
+		return false
+	}
+	if isLooperFixerReplyComment(ReviewThreadComment{Body: comment.Body}) || isLooperFixerReplyComment(ReviewThreadComment{Body: comment.ReviewBody}) {
+		return false
+	}
+	if !sameGitHubLogin(comment.Author, currentUser) {
+		return true
+	}
+	// Inline comments normally carry only a generic hidden stamp. The submitted
+	// parent review's role marker distinguishes our reviewer from our own chatter.
+	if !sameGitHubLogin(comment.ReviewAuthor, currentUser) || (state != "COMMENTED" && state != "CHANGES_REQUESTED" && state != "APPROVED") {
+		return false
+	}
+	for _, match := range forgejoReviewerMarker.FindAllStringSubmatch(comment.ReviewBody, -1) {
+		fields := map[string]string{}
+		for _, raw := range strings.Fields(match[1]) {
+			if key, value, ok := strings.Cut(raw, "="); ok {
+				fields[key] = value
+			}
+		}
+		if !strings.HasPrefix(fields["id"], "reviewer:") || strings.TrimPrefix(fields["id"], "reviewer:") == "" || fields["head"] == "" || fields["head"] != comment.ReviewCommitID {
+			continue
+		}
+		switch fields["outcome"] {
+		case "blocking", "actionable", "non_blocking":
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Runner) freshNativeFixMetadata(ctx context.Context, loop *storage.LoopRecord) (*string, error) {
+	if loop == nil {
+		return nil, nil
+	}
+	if r.repos != nil && r.repos.Loops != nil && loop.ID != "" {
+		current, err := r.repos.Loops.GetByID(ctx, loop.ID)
+		if err != nil {
+			return nil, err
+		}
+		if current != nil {
+			return current.MetadataJSON, nil
+		}
+	}
+	return loop.MetadataJSON, nil
+}
+
+func (r *Runner) suppressFixedForgejoNativeItems(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64, head string, loop *storage.LoopRecord, items []FixItem) ([]FixItem, error) {
+	if !hasForgejoNativeReviewComments(items) {
+		return items, nil
+	}
+	metadata, err := r.freshNativeFixMetadata(ctx, loop)
+	if err != nil {
+		return nil, err
+	}
+	store := loadFixEvidenceStoreV2(metadata)
+	retained := make([]FixItem, 0, len(items))
+	reachable := map[string]bool{}
+	for _, item := range items {
+		entry, found := findThreadFixEvidence(store, item)
+		if item.Source != NativeReviewCommentSource || !found || entry.ResolveState != forgejoFixedUnresolvedStatus || entry.Source != "agent_repair_result" || entry.Explanation == "" || entry.EvidenceHeadSHA == "" || head == "" {
+			retained = append(retained, item)
+			continue
+		}
+		ok, checked := reachable[entry.EvidenceHeadSHA]
+		if !checked {
+			ok = strings.EqualFold(entry.EvidenceHeadSHA, head)
+			if !ok {
+				comparison, compareErr := r.github.CompareCommits(ctx, CompareCommitsInput{Repo: repo, Base: entry.EvidenceHeadSHA, Head: head, CWD: project.RepoPath})
+				if compareErr != nil {
+					return nil, compareErr
+				}
+				ok = comparison.Status == "ahead" || comparison.Status == "identical"
+			}
+			reachable[entry.EvidenceHeadSHA] = ok
+		}
+		if !ok {
+			retained = append(retained, item)
+		}
+	}
+	return retained, nil
+}
+
+func (r *Runner) recordFixedForgejoNativeItem(ctx context.Context, input stepInput, checkpoint fixerCheckpoint, item FixItem, decision replyExplanationEntry) error {
+	head := firstNonEmpty(checkpoint.Validation.HeadSHA, resolveCommentsExpectedHeadSHA(checkpoint))
+	if head == "" {
+		return fmt.Errorf("cannot retain a native repair decision without the inspected commit")
+	}
+	entry := threadFixEvidence{
+		ThreadID: item.ThreadID, ThreadFingerprint: decision.ObservedFingerprint,
+		EvidenceHeadSHA: head, ValidationHeadSHA: checkpoint.Validation.HeadSHA,
+		CommitSHA:          resolveCommentCommitSHA(checkpoint, nil, false),
+		ProducedNewCommits: roundProducedNewCommits(&checkpoint),
+		FixItemsHash:       checkpoint.FixItemsHash, Source: "agent_repair_result", RunID: input.Run.ID,
+		Explanation: decision.Explanation, ResolveState: forgejoFixedUnresolvedStatus,
+	}
+	return r.persistFixEvidenceStoreV2(ctx, input.Loop, upsertThreadFixEvidence(nil, entry))
+}
+
+// finishForgejoNativeComments keeps the agent's original decision fingerprint
+// across refresh/replay. Infrastructure only detects drift; it never invents a
+// fixed decision from commits or the presence of push evidence.
+func (r *Runner) finishForgejoNativeComments(ctx context.Context, input stepInput, checkpoint *fixerCheckpoint, items []FixItem, liveComments []NativeReviewComment) (finished, missing, drift int, mutationErr error) {
+	liveByID := map[int64]NativeReviewComment{}
+	for _, live := range liveComments {
+		liveByID[live.ProviderCommentID] = live
+	}
+	decisions := agentResolveRepliesByFixItemID(*checkpoint)
+	var resolutionState forge.ProbeState
+	var probeErr error
+	probed := false
+	for _, item := range items {
+		decision, hasDecision := decisions[item.ID]
+		live, exists := liveByID[item.ProviderCommentID]
+		result := checkpointResolvedComment{FixItemID: item.ID, ThreadID: item.ThreadID, Action: decision.Action, UpdatedAt: r.nowISO()}
+		switch {
+		case !exists:
+			result.Status = "deleted"
+		case live.IsResolved:
+			result.Status = "already_resolved"
+		case !hasDecision || normalizeNativeRepairAction(decision.Action) == "":
+			missing++
+			result.Status, result.Message = "skipped_missing_agent_decision", agentMissingThreadDecisionExplanation
+		case decision.ObservedFingerprint == "" || decision.ObservedFingerprint != live.ObservedFingerprint:
+			drift++
+			result.Status, result.Message = "skipped_thread_drift", "Forgejo review comment changed since the fixer inspected it"
+		case decision.Action != "fixed":
+			result.Status, result.Message = "skipped_noop", decision.Explanation
+		default:
+			// Missing resolver data prevents a remote mutation; it does not
+			// prevent repairing code or acknowledging the agent's fixed result.
+			if live.ResolverPresent && !probed {
+				resolutionState, probeErr = r.github.ProbeNativeReviewCommentResolution(ctx, ListNativeReviewCommentsInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.Project.RepoPath})
+				probed = true
+			}
+			unsupported := !live.ResolverPresent || resolutionState == forge.ProbeStateUnsupported
+			if !unsupported && (probeErr != nil || resolutionState != forge.ProbeStateSupported) {
+				result.Status, result.Message = "failed_mutation_retry", "Could not determine whether Forgejo can close this comment"
+				if mutationErr == nil {
+					mutationErr = fmt.Errorf("native comment resolution capability unavailable: %s: %v", resolutionState, probeErr)
+				}
+			} else {
+				if !unsupported {
+					err := r.github.ResolveNativeReviewComment(ctx, ResolveNativeReviewCommentInput{Repo: input.Repo, PRNumber: input.PRNumber, ProviderCommentID: item.ProviderCommentID, CWD: input.Project.RepoPath})
+					if isForgejoNativeResolveUnsupported(err) {
+						unsupported = true
+					} else if err != nil {
+						result.Status, result.Message = "failed_mutation_retry", err.Error()
+						if mutationErr == nil {
+							mutationErr = err
+						}
+					}
+				}
+				if result.Status == "" {
+					if unsupported {
+						result.Status, result.Message = forgejoFixedUnresolvedStatus, decision.Explanation
+					} else {
+						result.Status = "resolved"
+					}
+					finished++
+				}
+			}
+		}
+		upsertResolvedComment(&checkpoint.ResolvedComments.Items, result)
+		if err := r.persistCheckpoint(ctx, input.Run.ID, stepResolveComments, *checkpoint); err != nil {
+			return finished, missing, drift, err
+		}
+	}
+	return finished, missing, drift, mutationErr
+}
+
+// Publish before suppressing future discovery. A failed acknowledgement remains
+// replayable from the run checkpoint without treating push evidence as a fix.
+func (r *Runner) recordPublishedForgejoNativeResults(ctx context.Context, input stepInput, checkpoint fixerCheckpoint) error {
+	if checkpoint.ResolvedComments == nil {
+		return nil
+	}
+	decisions := agentResolveRepliesByFixItemID(checkpoint)
+	for _, item := range checkpoint.FixItems {
+		if item.Source != NativeReviewCommentSource {
+			continue
+		}
+		for _, result := range checkpoint.ResolvedComments.Items {
+			if result.FixItemID == item.ID && result.Status == forgejoFixedUnresolvedStatus {
+				if err := r.recordFixedForgejoNativeItem(ctx, input, checkpoint, item, decisions[item.ID]); err != nil {
+					return err
+				}
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/internal/fixer/runner_forgejo_native_resolve_test.go
+++ b/internal/fixer/runner_forgejo_native_resolve_test.go
@@ -13,32 +13,34 @@ import (
 )
 
 func nativeReply(fixItemID, action string) replyExplanationEntry {
-	updated := "u1"
-	for id, value := range map[int64]string{102: "u2", 103: "u3", 104: "u4"} {
+	commentID, _ := strconv.ParseInt(strings.TrimPrefix(fixItemID, NativeReviewCommentSource+":"), 10, 64)
+	body := "Comment one."
+	for id, value := range map[int64]string{102: "Comment two.", 103: "Comment three.", 104: "Comment four."} {
 		if fixItemID == NativeReviewCommentFixItemID(id) {
-			updated = value
+			body = value
 		}
 	}
-	return replyExplanationEntry{FixItemID: fixItemID, Action: action, Explanation: "Reviewed the Forgejo native comment.", ObservedFingerprint: fixItemID + ":" + updated}
+	return replyExplanationEntry{FixItemID: fixItemID, Action: action, Explanation: "Reviewed the Forgejo native comment.", ObservedFingerprint: NativeReviewCommentFingerprint(commentID, body)}
 }
 
-func nativeFixItem(commentID int64, updatedAt string) FixItem {
+func nativeFixItem(commentID int64, body string) FixItem {
 	return FixItem{
 		Type:                "comment",
 		Source:              NativeReviewCommentSource,
 		ID:                  NativeReviewCommentFixItemID(commentID),
 		ThreadID:            strconv.FormatInt(commentID, 10),
 		ProviderCommentID:   commentID,
-		ObservedFingerprint: NativeReviewCommentFingerprint(commentID, updatedAt),
+		Body:                body,
+		ObservedFingerprint: NativeReviewCommentFingerprint(commentID, body),
 		ResolverPresent:     true,
 	}
 }
 
 func TestRunResolveCommentsStepForgejoNativeAllowsAlreadyFixedWithoutNewPush(t *testing.T) {
 	t.Parallel()
-	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{{ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true, Author: "alice"}}}}
+	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{{ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one."), ResolverPresent: true, Author: "alice"}}}}
 	runner := New(Options{GitHub: github})
-	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "u1")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: false}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
+	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "Comment one.")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: false}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
 	_, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v, already-fixed decisions do not require a fake commit", err)
@@ -48,11 +50,11 @@ func TestRunResolveCommentsStepForgejoNativeAllowsAlreadyFixedWithoutNewPush(t *
 func TestRunResolveCommentsStepForgejoNativeNoopDoesNotRequirePush(t *testing.T) {
 	t.Parallel()
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{
-		{ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true, Author: "alice"},
-		{ProviderCommentID: 102, ObservedFingerprint: NativeReviewCommentFingerprint(102, "u2"), ResolverPresent: true, Author: "bob"},
+		{ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one."), ResolverPresent: true, Author: "alice"},
+		{ProviderCommentID: 102, Body: "Comment two.", ObservedFingerprint: NativeReviewCommentFingerprint(102, "Comment two."), ResolverPresent: true, Author: "bob"},
 	}}}
 	runner := New(Options{GitHub: github})
-	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "u1"), nativeFixItem(102, "u2")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: false}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "declined"), nativeReply(NativeReviewCommentFixItemID(102), "deferred")}}}
+	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "Comment one."), nativeFixItem(102, "Comment two.")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: false}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "declined"), nativeReply(NativeReviewCommentFixItemID(102), "deferred")}}}
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
@@ -72,11 +74,11 @@ func TestRunResolveCommentsStepForgejoNativeNoopDoesNotRequirePush(t *testing.T)
 func TestRunResolveCommentsStepForgejoNativeMissingDecisionRetriesDiscovery(t *testing.T) {
 	t.Parallel()
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{
-		{ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true, Author: "alice"},
-		{ProviderCommentID: 102, ObservedFingerprint: NativeReviewCommentFingerprint(102, "u2"), ResolverPresent: true, Author: "bob"},
+		{ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one."), ResolverPresent: true, Author: "alice"},
+		{ProviderCommentID: 102, Body: "Comment two.", ObservedFingerprint: NativeReviewCommentFingerprint(102, "Comment two."), ResolverPresent: true, Author: "bob"},
 	}}}
 	runner := New(Options{GitHub: github})
-	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "u1")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
+	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "Comment one.")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: storage.LoopRecord{}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "omitted or invalidated thread decisions") {
 		t.Fatalf("runResolveCommentsStep() error = %v, want missing-decision retry", err)
@@ -96,7 +98,7 @@ func TestRunResolveCommentsStepForgejoNativeMissingDecisionRetriesDiscovery(t *t
 func TestRunResolveCommentsStepManualForgejoRereadsNativeCommentsWithEmptyInitialSnapshot(t *testing.T) {
 	t.Parallel()
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{
-		{ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true, Author: "alice"},
+		{ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one."), ResolverPresent: true, Author: "alice"},
 	}}}
 	runner := New(Options{GitHub: github})
 	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{{Type: "comment", Source: "forgejo-reviewer-summary", ID: "summary-1", ThreadID: "summary-1"}}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{{FixItemID: "summary-1", ThreadID: "summary-1", Action: "fixed", Explanation: "Fixed the summary item."}}}}
@@ -119,11 +121,11 @@ func TestRunResolveCommentsStepManualForgejoRereadsNativeCommentsWithEmptyInitia
 func TestRunResolveCommentsStepForgejoNativeRereadSkipsLooperAuthoredComments(t *testing.T) {
 	t.Parallel()
 	github := &fakeGitHubGateway{currentUser: "looper", viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{
-		{ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true, Author: "alice"},
-		{ProviderCommentID: 102, ObservedFingerprint: NativeReviewCommentFingerprint(102, "u2"), ResolverPresent: true, Author: "looper"},
+		{ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one."), ResolverPresent: true, Author: "alice"},
+		{ProviderCommentID: 102, Body: "Comment two.", ObservedFingerprint: NativeReviewCommentFingerprint(102, "Comment two."), ResolverPresent: true, Author: "looper"},
 	}}}
 	runner := New(Options{GitHub: github})
-	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "u1")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
+	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "Comment one.")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: storage.LoopRecord{}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
@@ -146,13 +148,13 @@ func TestRunResolveCommentsStepForgejoNativeRereadSkipsLooperAuthoredComments(t 
 func TestRunResolveCommentsStepForgejoNativeResolvesFixedOnlyAndSkipsStates(t *testing.T) {
 	t.Parallel()
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{
-		{ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true, Author: "alice"},
-		{ProviderCommentID: 102, ObservedFingerprint: NativeReviewCommentFingerprint(102, "u2"), ResolverPresent: true, IsResolved: true, Author: "bob"},
-		{ProviderCommentID: 103, ObservedFingerprint: NativeReviewCommentFingerprint(103, "u3"), ResolverPresent: true, Author: "cara"},
-		{ProviderCommentID: 104, ObservedFingerprint: NativeReviewCommentFingerprint(104, "u4-new"), ResolverPresent: true, Author: "dana"},
+		{ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one."), ResolverPresent: true, Author: "alice"},
+		{ProviderCommentID: 102, Body: "Comment two.", ObservedFingerprint: NativeReviewCommentFingerprint(102, "Comment two."), ResolverPresent: true, IsResolved: true, Author: "bob"},
+		{ProviderCommentID: 103, Body: "Comment three.", ObservedFingerprint: NativeReviewCommentFingerprint(103, "Comment three."), ResolverPresent: true, Author: "cara"},
+		{ProviderCommentID: 104, Body: "Comment four has been edited.", ObservedFingerprint: NativeReviewCommentFingerprint(104, "Comment four has been edited."), ResolverPresent: true, Author: "dana"},
 	}}}
 	runner := New(Options{GitHub: github})
-	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "u1"), nativeFixItem(102, "u2"), nativeFixItem(103, "u3"), nativeFixItem(104, "u4")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed"), nativeReply(NativeReviewCommentFixItemID(102), "fixed"), nativeReply(NativeReviewCommentFixItemID(103), "declined"), nativeReply(NativeReviewCommentFixItemID(104), "fixed")}}}
+	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "Comment one."), nativeFixItem(102, "Comment two."), nativeFixItem(103, "Comment three."), nativeFixItem(104, "Comment four.")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed"), nativeReply(NativeReviewCommentFixItemID(102), "fixed"), nativeReply(NativeReviewCommentFixItemID(103), "declined"), nativeReply(NativeReviewCommentFixItemID(104), "fixed")}}}
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Loop: storage.LoopRecord{}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err == nil || !strings.Contains(err.Error(), "review thread content changed") {
 		t.Fatalf("runResolveCommentsStep() error = %v, want native thread drift retry", err)
@@ -179,7 +181,7 @@ func TestRunResolveCommentsStepForgejoNativeSkipsDeleted(t *testing.T) {
 	t.Parallel()
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}}
 	runner := New(Options{GitHub: github})
-	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "u1")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
+	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "Comment one.")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
 	updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 	if err != nil {
 		t.Fatalf("runResolveCommentsStep() error = %v", err)
@@ -200,9 +202,9 @@ func TestRunResolveCommentsStepForgejoNativeClassifiesHTTPAndTimeoutErrors(t *te
 		"timeout retry": {err: errors.New("request timed out"), kind: FailureRetryableAfterResume, text: "will retry"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{{ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true, Author: "alice"}}}, resolveNativeErr: errValue.err}
+			github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{{ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one."), ResolverPresent: true, Author: "alice"}}}, resolveNativeErr: errValue.err}
 			runner := New(Options{GitHub: github})
-			checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "u1")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
+			checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "Comment one.")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
 			_, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 			var loopErr *loopError
 			if !errors.As(err, &loopErr) || loopErr.kind != errValue.kind || !strings.Contains(loopErr.Error(), errValue.text) {
@@ -218,9 +220,9 @@ func TestRunResolveCommentsStepForgejoNativeUnsupportedResolutionRetainsFixedDec
 		&forge.ForgejoHTTPError{StatusCode: 404, Method: "POST", Path: "/resolve", Message: "missing"},
 		&forge.ForgejoHTTPError{StatusCode: 405, Method: "POST", Path: "/resolve", Message: "method"},
 	} {
-		github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{{ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true, Author: "alice"}}}, resolveNativeErr: errValue}
+		github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{{ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one."), ResolverPresent: true, Author: "alice"}}}, resolveNativeErr: errValue}
 		runner := New(Options{GitHub: github})
-		checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "u1")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
+		checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "Comment one.")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
 		updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
 		if err != nil {
 			t.Fatalf("runResolveCommentsStep() error = %v", err)
@@ -234,15 +236,15 @@ func TestRunResolveCommentsStepForgejoNativeUnsupportedResolutionRetainsFixedDec
 func TestParseNativeRepairResultsAcceptsExplicitActionsAndDefaultsMissingToDeferred(t *testing.T) {
 	t.Parallel()
 	fixItems := []FixItem{
-		{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "updated-1")},
-		{Type: "comment", ID: "c2", ThreadID: "102", Source: NativeReviewCommentSource, ProviderCommentID: 102, ObservedFingerprint: NativeReviewCommentFingerprint(102, "updated-2")},
-		{Type: "comment", ID: "c3", ThreadID: "103", Source: NativeReviewCommentSource, ProviderCommentID: 103, ObservedFingerprint: NativeReviewCommentFingerprint(103, "updated-3")},
-		{Type: "comment", ID: "c4", ThreadID: "104", Source: NativeReviewCommentSource, ProviderCommentID: 104, ObservedFingerprint: NativeReviewCommentFingerprint(104, "updated-4")},
+		{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one.")},
+		{Type: "comment", ID: "c2", ThreadID: "102", Source: NativeReviewCommentSource, ProviderCommentID: 102, Body: "Comment two.", ObservedFingerprint: NativeReviewCommentFingerprint(102, "Comment two.")},
+		{Type: "comment", ID: "c3", ThreadID: "103", Source: NativeReviewCommentSource, ProviderCommentID: 103, Body: "Comment three.", ObservedFingerprint: NativeReviewCommentFingerprint(103, "Comment three.")},
+		{Type: "comment", ID: "c4", ThreadID: "104", Source: NativeReviewCommentSource, ProviderCommentID: 104, Body: "Comment four.", ObservedFingerprint: NativeReviewCommentFingerprint(104, "Comment four.")},
 	}
 	stdout := `__LOOPER_RESULT__={"repair_results":[` +
-		`{"source":"forgejo_review_comment","providerCommentId":101,"action":"fixed","explanation":"Renamed the helper.","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "updated-1") + `"},` +
-		`{"source":"forgejo_review_comment","providerCommentId":102,"action":"declined","explanation":"Out of scope.","observedFingerprint":"` + NativeReviewCommentFingerprint(102, "updated-2") + `"},` +
-		`{"source":"forgejo_review_comment","providerCommentId":103,"action":"deferred","explanation":"Need product input.","observedFingerprint":"` + NativeReviewCommentFingerprint(103, "updated-3") + `"}` +
+		`{"source":"forgejo_review_comment","providerCommentId":101,"action":"fixed","explanation":"Renamed the helper.","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "Comment one.") + `"},` +
+		`{"source":"forgejo_review_comment","providerCommentId":102,"action":"declined","explanation":"Out of scope.","observedFingerprint":"` + NativeReviewCommentFingerprint(102, "Comment two.") + `"},` +
+		`{"source":"forgejo_review_comment","providerCommentId":103,"action":"deferred","explanation":"Need product input.","observedFingerprint":"` + NativeReviewCommentFingerprint(103, "Comment three.") + `"}` +
 		`]}`
 	got := parseNativeRepairResults(stdout, "", fixItems)
 	if len(got) != 3 {
@@ -255,7 +257,7 @@ func TestParseNativeRepairResultsAcceptsExplicitActionsAndDefaultsMissingToDefer
 
 func TestParseNativeRepairResultsMissingObservedFingerprintOmitsDecision(t *testing.T) {
 	t.Parallel()
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "updated-1")}}
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one.")}}
 	stdout := `__LOOPER_RESULT__={"repair_results":[{"source":"forgejo_review_comment","providerCommentId":101,"action":"fixed","explanation":"Renamed the helper."}]}`
 	got := parseNativeRepairResults(stdout, "", fixItems)
 	if len(got) != 0 {
@@ -265,8 +267,8 @@ func TestParseNativeRepairResultsMissingObservedFingerprintOmitsDecision(t *test
 
 func TestParseNativeRepairResultsBlankExplanationOmitsDecision(t *testing.T) {
 	t.Parallel()
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "updated-1")}}
-	stdout := `__LOOPER_RESULT__={"repair_results":[{"source":"forgejo_review_comment","providerCommentId":101,"action":"fixed","explanation":"   ","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "updated-1") + `"}]}`
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one.")}}
+	stdout := `__LOOPER_RESULT__={"repair_results":[{"source":"forgejo_review_comment","providerCommentId":101,"action":"fixed","explanation":"   ","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "Comment one.") + `"}]}`
 	got := parseNativeRepairResults(stdout, "", fixItems)
 	if len(got) != 0 {
 		t.Fatalf("parseNativeRepairResults() = %#v, want missing decision omitted", got)
@@ -275,9 +277,9 @@ func TestParseNativeRepairResultsBlankExplanationOmitsDecision(t *testing.T) {
 
 func TestParseNativeRepairResultsIgnoresUnknownExplicitEntriesWithoutFallback(t *testing.T) {
 	t.Parallel()
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "updated-1")}}
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one.")}}
 	stdout := `__LOOPER_RESULT__={"repair_results":[` +
-		`{"source":"github_review_comment","providerCommentId":101,"action":"fixed","explanation":"wrong source","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "updated-1") + `"},` +
+		`{"source":"github_review_comment","providerCommentId":101,"action":"fixed","explanation":"wrong source","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "Comment one.") + `"},` +
 		`{"source":"forgejo_review_comment","providerCommentId":999,"action":"fixed","explanation":"unknown provider","observedFingerprint":"ignored"}` +
 		`]}`
 	got := parseNativeRepairResults(stdout, "", fixItems)
@@ -288,11 +290,11 @@ func TestParseNativeRepairResultsIgnoresUnknownExplicitEntriesWithoutFallback(t 
 
 func TestParseNativeRepairResultsKeepsFirstValidDuplicate(t *testing.T) {
 	t.Parallel()
-	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "updated-1")}}
+	fixItems := []FixItem{{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, Body: "Comment one.", ObservedFingerprint: NativeReviewCommentFingerprint(101, "Comment one.")}}
 	stdout := `__LOOPER_RESULT__={"repair_results":[` +
-		`{"source":"forgejo_review_comment","providerCommentId":101,"action":"fixed","explanation":"   ","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "updated-1") + `"},` +
-		`{"source":"forgejo_review_comment","providerCommentId":101,"action":"declined","explanation":"First valid result.","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "updated-1") + `"},` +
-		`{"source":"forgejo_review_comment","providerCommentId":101,"action":"fixed","explanation":"Later duplicate should be ignored.","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "updated-1") + `"}` +
+		`{"source":"forgejo_review_comment","providerCommentId":101,"action":"fixed","explanation":"   ","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "Comment one.") + `"},` +
+		`{"source":"forgejo_review_comment","providerCommentId":101,"action":"declined","explanation":"First valid result.","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "Comment one.") + `"},` +
+		`{"source":"forgejo_review_comment","providerCommentId":101,"action":"fixed","explanation":"Later duplicate should be ignored.","observedFingerprint":"` + NativeReviewCommentFingerprint(101, "Comment one.") + `"}` +
 		`]}`
 	got := parseNativeRepairResults(stdout, "", fixItems)
 	if len(got) != 1 || got[0].Action != "declined" || got[0].Explanation != "First valid result." {

--- a/internal/fixer/runner_forgejo_native_resolve_test.go
+++ b/internal/fixer/runner_forgejo_native_resolve_test.go
@@ -13,7 +13,13 @@ import (
 )
 
 func nativeReply(fixItemID, action string) replyExplanationEntry {
-	return replyExplanationEntry{FixItemID: fixItemID, Action: action, Explanation: "Reviewed the Forgejo native comment."}
+	updated := "u1"
+	for id, value := range map[int64]string{102: "u2", 103: "u3", 104: "u4"} {
+		if fixItemID == NativeReviewCommentFixItemID(id) {
+			updated = value
+		}
+	}
+	return replyExplanationEntry{FixItemID: fixItemID, Action: action, Explanation: "Reviewed the Forgejo native comment.", ObservedFingerprint: fixItemID + ":" + updated}
 }
 
 func nativeFixItem(commentID int64, updatedAt string) FixItem {
@@ -28,14 +34,14 @@ func nativeFixItem(commentID int64, updatedAt string) FixItem {
 	}
 }
 
-func TestRunResolveCommentsStepForgejoNativeRequiresActualPush(t *testing.T) {
+func TestRunResolveCommentsStepForgejoNativeAllowsAlreadyFixedWithoutNewPush(t *testing.T) {
 	t.Parallel()
 	github := &fakeGitHubGateway{viewResponses: []PullRequestDetail{{Number: 42, State: "OPEN", HeadSHA: "new-head"}}, nativeCommentBatches: [][]NativeReviewComment{{{ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true, Author: "alice"}}}}
 	runner := New(Options{GitHub: github})
 	checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "u1")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: false}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
 	_, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-	if err == nil || !strings.Contains(err.Error(), "actual push") {
-		t.Fatalf("runResolveCommentsStep() error = %v, want actual push requirement", err)
+	if err != nil {
+		t.Fatalf("runResolveCommentsStep() error = %v, already-fixed decisions do not require a fake commit", err)
 	}
 }
 
@@ -206,7 +212,7 @@ func TestRunResolveCommentsStepForgejoNativeClassifiesHTTPAndTimeoutErrors(t *te
 	}
 }
 
-func TestRunResolveCommentsStepForgejoNativeUnsupportedResolveRequiresManualIntervention(t *testing.T) {
+func TestRunResolveCommentsStepForgejoNativeUnsupportedResolutionRetainsFixedDecision(t *testing.T) {
 	t.Parallel()
 	for _, errValue := range []error{
 		&forge.ForgejoHTTPError{StatusCode: 404, Method: "POST", Path: "/resolve", Message: "missing"},
@@ -216,12 +222,11 @@ func TestRunResolveCommentsStepForgejoNativeUnsupportedResolveRequiresManualInte
 		runner := New(Options{GitHub: github})
 		checkpoint := fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}, FixItems: []FixItem{nativeFixItem(101, "u1")}, Validation: &ValidationResult{Passed: true, HeadSHA: "new-head"}, Push: &checkpointPush{Pushed: true}, Repair: &checkpointRepair{ReplyExplanations: []replyExplanationEntry{nativeReply(NativeReviewCommentFixItemID(101), "fixed")}}}
 		updated, err := runner.runResolveCommentsStep(context.Background(), stepInput{Project: storage.ProjectRecord{RepoPath: t.TempDir()}, Repo: "acme/looper", PRNumber: 42, Checkpoint: checkpoint})
-		var loopErr *loopError
-		if !errors.As(err, &loopErr) || loopErr.kind != FailureManualIntervention || !strings.Contains(loopErr.Error(), "requires manual intervention") {
-			t.Fatalf("runResolveCommentsStep() error = %#v, want manual intervention", err)
+		if err != nil {
+			t.Fatalf("runResolveCommentsStep() error = %v", err)
 		}
-		if updated.ResolvedComments == nil || len(updated.ResolvedComments.Items) != 1 || updated.ResolvedComments.Items[0].Status != "unsupported_remote_resolution" {
-			t.Fatalf("resolved comments = %#v, want unsupported_remote_resolution", updated.ResolvedComments)
+		if updated.ResolvedComments == nil || len(updated.ResolvedComments.Items) != 1 || updated.ResolvedComments.Items[0].Status != forgejoFixedUnresolvedStatus {
+			t.Fatalf("resolved comments = %#v, want code fixed with remote comment still open", updated.ResolvedComments)
 		}
 	}
 }

--- a/internal/fixer/runner_forgejo_native_test.go
+++ b/internal/fixer/runner_forgejo_native_test.go
@@ -50,7 +50,7 @@ func TestBuildFixerPromptAddsForgejoNativeCommentRepairResultsInstruction(t *tes
 	t.Parallel()
 
 	detail := &checkpointDetail{State: "OPEN", HeadSHA: "abc123", BaseRefName: "main", HeadRefName: "feature/fix"}
-	prompt, _ := buildFixerPrompt("project_1", customInstructionConfig(nil), "acme/looper", 42, detail, []FixItem{{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "updated-1"), Summary: "rename helper", Body: "Please rename this helper.", Path: "internal/fixer/runner.go", DiffHunk: "@@ -1,2 +1,2 @@"}}, false, config.DefaultDisclosureConfig(), "opencode", "openai/gpt-5.5")
+	prompt, _ := buildFixerPrompt("project_1", customInstructionConfig(nil), "acme/looper", 42, detail, []FixItem{{Type: "comment", ID: "c1", ThreadID: "101", Source: NativeReviewCommentSource, ProviderCommentID: 101, ObservedFingerprint: NativeReviewCommentFingerprint(101, "Please rename this helper."), Summary: "rename helper", Body: "Please rename this helper.", Path: "internal/fixer/runner.go", DiffHunk: "@@ -1,2 +1,2 @@"}}, false, config.DefaultDisclosureConfig(), "opencode", "openai/gpt-5.5")
 	for _, want := range []string{
 		"Forgejo native review comment fix item",
 		"`repair_results`",
@@ -63,7 +63,7 @@ func TestBuildFixerPromptAddsForgejoNativeCommentRepairResultsInstruction(t *tes
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)
 		}
 	}
-	if !strings.Contains(prompt, `"providerCommentId":101`) || !strings.Contains(prompt, NativeReviewCommentFingerprint(101, "updated-1")) {
+	if !strings.Contains(prompt, `"providerCommentId":101`) || !strings.Contains(prompt, NativeReviewCommentFingerprint(101, "Please rename this helper.")) {
 		t.Fatalf("prompt missing native item identifiers/fingerprint:\n%s", prompt)
 	}
 	for _, unwanted := range []string{"review_thread_replies", "threadId", "threadCommentsObserved"} {
@@ -93,8 +93,8 @@ func TestCollectFixItemsFromForgejoNativeReviewCommentPreservesNativeFields(t *t
 		"id":                  "101",
 		"databaseId":          int64(101),
 		"threadId":            "101",
-		"threadFingerprint":   NativeReviewCommentFingerprint(101, "updated-1"),
-		"observedFingerprint": NativeReviewCommentFingerprint(101, "updated-1"),
+		"threadFingerprint":   NativeReviewCommentFingerprint(101, "Please rename this helper."),
+		"observedFingerprint": NativeReviewCommentFingerprint(101, "Please rename this helper."),
 		"source":              NativeReviewCommentSource,
 		"body":                "Please rename this helper.",
 		"url":                 "https://forgejo.test/acme/looper/pulls/42#discussion_r101",
@@ -105,7 +105,7 @@ func TestCollectFixItemsFromForgejoNativeReviewCommentPreservesNativeFields(t *t
 	if len(items) != 1 {
 		t.Fatalf("len(items) = %d, want 1", len(items))
 	}
-	if got := items[0]; got.Source != NativeReviewCommentSource || got.ID != NativeReviewCommentFixItemID(101) || got.ThreadID != NativeReviewCommentThreadID(101) || got.ProviderCommentID != 101 || got.ObservedFingerprint != NativeReviewCommentFingerprint(101, "updated-1") || got.Body != "Please rename this helper." || got.DiffHunk != "@@ -1,2 +1,2 @@" || got.URL == "" {
+	if got := items[0]; got.Source != NativeReviewCommentSource || got.ID != NativeReviewCommentFixItemID(101) || got.ThreadID != NativeReviewCommentThreadID(101) || got.ProviderCommentID != 101 || got.ObservedFingerprint != NativeReviewCommentFingerprint(101, "Please rename this helper.") || got.Body != "Please rename this helper." || got.DiffHunk != "@@ -1,2 +1,2 @@" || got.URL == "" {
 		t.Fatalf("item = %#v, want forgejo native review comment fields", got)
 	}
 }
@@ -136,8 +136,8 @@ func TestCollectFixItemsAllowsForgejoNativeAndSummaryItemsToCoexist(t *testing.T
 			"id":                  NativeReviewCommentFixItemID(101),
 			"databaseId":          int64(101),
 			"threadId":            "101",
-			"threadFingerprint":   NativeReviewCommentFingerprint(101, "updated-1"),
-			"observedFingerprint": NativeReviewCommentFingerprint(101, "updated-1"),
+			"threadFingerprint":   NativeReviewCommentFingerprint(101, "Please rename this helper."),
+			"observedFingerprint": NativeReviewCommentFingerprint(101, "Please rename this helper."),
 			"source":              NativeReviewCommentSource,
 			"body":                "Please rename this helper.",
 			"url":                 "https://forgejo.test/acme/looper/pulls/42#discussion_r101",
@@ -165,7 +165,7 @@ func TestCollectFixItemsAllowsForgejoNativeAndSummaryItemsToCoexist(t *testing.T
 
 func TestRunCollectFixesStepIncludesManualForgejoNativeCommentsAndFiltersLooperAuthored(t *testing.T) {
 	t.Parallel()
-	github := &fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true}, {ProviderCommentID: 102, Body: "my own comment", Author: "looper", ObservedFingerprint: NativeReviewCommentFingerprint(102, "u2"), ResolverPresent: true}}}
+	github := &fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "fix this"), ResolverPresent: true}, {ProviderCommentID: 102, Body: "my own comment", Author: "looper", ObservedFingerprint: NativeReviewCommentFingerprint(102, "my own comment"), ResolverPresent: true}}}
 	runner := New(Options{GitHub: github})
 	checkpoint, err := runner.runCollectFixesStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()}, Loop: storage.LoopRecord{MetadataJSON: stringPtr(`{"manual":true}`)}, Repo: "acme/looper", PRNumber: 42, Checkpoint: fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}}})
 	if err != nil {
@@ -178,7 +178,7 @@ func TestRunCollectFixesStepIncludesManualForgejoNativeCommentsAndFiltersLooperA
 
 func TestRunCollectFixesStepAllowsRepairWhenNativeResolverMissing(t *testing.T) {
 	t.Parallel()
-	github := &fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: false}}}
+	github := &fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "fix this"), ResolverPresent: false}}}
 	runner := New(Options{GitHub: github})
 	_, err := runner.runCollectFixesStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()}, Loop: storage.LoopRecord{MetadataJSON: stringPtr(`{"manual":true}`)}, Repo: "acme/looper", PRNumber: 42, Checkpoint: fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}}})
 	if err != nil {
@@ -189,7 +189,7 @@ func TestRunCollectFixesStepAllowsRepairWhenNativeResolverMissing(t *testing.T) 
 func TestRunCollectFixesStepDoesNotRequireResolveCapabilityToRepair(t *testing.T) {
 	t.Parallel()
 	github := &capabilityProbeGitHub{
-		fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true}}},
+		fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "fix this"), ResolverPresent: true}}},
 		state:             forge.ProbeStateUnknown,
 	}
 	runner := New(Options{GitHub: github})

--- a/internal/fixer/runner_forgejo_native_test.go
+++ b/internal/fixer/runner_forgejo_native_test.go
@@ -176,17 +176,17 @@ func TestRunCollectFixesStepIncludesManualForgejoNativeCommentsAndFiltersLooperA
 	}
 }
 
-func TestRunCollectFixesStepFailsUnsupportedWhenNativeResolverMissing(t *testing.T) {
+func TestRunCollectFixesStepAllowsRepairWhenNativeResolverMissing(t *testing.T) {
 	t.Parallel()
 	github := &fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: false}}}
 	runner := New(Options{GitHub: github})
 	_, err := runner.runCollectFixesStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()}, Loop: storage.LoopRecord{MetadataJSON: stringPtr(`{"manual":true}`)}, Repo: "acme/looper", PRNumber: 42, Checkpoint: fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}}})
-	if err == nil || !strings.Contains(err.Error(), "unsupported") {
-		t.Fatalf("runCollectFixesStep() error = %v, want unsupported manual intervention", err)
+	if err != nil {
+		t.Fatalf("runCollectFixesStep() error = %v, remote resolution is optional", err)
 	}
 }
 
-func TestRunCollectFixesStepFailsBeforeRepairWhenResolveCapabilityUnknown(t *testing.T) {
+func TestRunCollectFixesStepDoesNotRequireResolveCapabilityToRepair(t *testing.T) {
 	t.Parallel()
 	github := &capabilityProbeGitHub{
 		fakeGitHubGateway: fakeGitHubGateway{currentUser: "looper", nativeComments: []NativeReviewComment{{ProviderCommentID: 101, Body: "fix this", Author: "alice", ObservedFingerprint: NativeReviewCommentFingerprint(101, "u1"), ResolverPresent: true}}},
@@ -194,12 +194,8 @@ func TestRunCollectFixesStepFailsBeforeRepairWhenResolveCapabilityUnknown(t *tes
 	}
 	runner := New(Options{GitHub: github})
 	_, err := runner.runCollectFixesStep(context.Background(), stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: t.TempDir()}, Loop: storage.LoopRecord{MetadataJSON: stringPtr(`{"manual":true}`)}, Repo: "acme/looper", PRNumber: 42, Checkpoint: fixerCheckpoint{Detail: &checkpointDetail{State: "OPEN"}}})
-	if err == nil || !strings.Contains(err.Error(), "resolution is unknown") {
-		t.Fatalf("runCollectFixesStep() error = %v, want unknown-capability failure", err)
-	}
-	var loopErr *loopError
-	if !errors.As(err, &loopErr) || loopErr.kind != FailureManualIntervention {
-		t.Fatalf("runCollectFixesStep() error = %#v, want manual intervention", err)
+	if err != nil {
+		t.Fatalf("runCollectFixesStep() error = %v, remote capability is checked after repair", err)
 	}
 }
 

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -7245,6 +7245,7 @@ type fakeGitHubGateway struct {
 	nativeCommentBatches  [][]NativeReviewComment
 	listNativeContextErr  error
 	listNativeErr         error
+	listNativeCalls       int
 	resolveNativeCalls    []ResolveNativeReviewCommentInput
 	resolveNativeErr      error
 }
@@ -7393,6 +7394,7 @@ func (f *fakeGitHubGateway) AddReviewThreadReply(_ context.Context, input AddRev
 }
 
 func (f *fakeGitHubGateway) ListNativeReviewComments(ctx context.Context, _ ListNativeReviewCommentsInput) ([]NativeReviewComment, error) {
+	f.listNativeCalls++
 	f.listNativeContextErr = ctx.Err()
 	if f.listNativeErr != nil {
 		return nil, f.listNativeErr

--- a/internal/forge/agent_context.go
+++ b/internal/forge/agent_context.go
@@ -1,0 +1,85 @@
+package forge
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func configuredForgejoProvider(cfg config.Config, projectID, repo string) (config.ProviderConfig, bool) {
+	for _, project := range cfg.Projects {
+		if project.ID != strings.TrimSpace(projectID) || !strings.EqualFold(strings.TrimSpace(project.Repo), strings.TrimSpace(repo)) || config.ResolvedProjectProviderKind(cfg, project) != config.ProviderKindForgejo {
+			continue
+		}
+		for _, provider := range cfg.Providers {
+			if provider.ID == project.Provider && provider.Kind == config.ProviderKindForgejo {
+				return provider, true
+			}
+		}
+	}
+	return config.ProviderConfig{}, false
+}
+
+// ConfiguredPullRequestURL supplies older checkpoints with the configured
+// Forgejo web URL. Fresh provider-returned HTML URLs take precedence at callers.
+func ConfiguredPullRequestURL(cfg config.Config, projectID, repo string, prNumber int64) string {
+	provider, ok := configuredForgejoProvider(cfg, projectID, repo)
+	if !ok {
+		return ""
+	}
+	base, err := url.Parse(provider.BaseURL)
+	if err != nil || base.Host == "" {
+		return ""
+	}
+	base.User, base.RawQuery, base.Fragment = nil, "", ""
+	return base.JoinPath(repo, "pulls", fmt.Sprint(prNumber)).String()
+}
+
+// ForgejoAgentContext describes the configured transport without reading or
+// copying credentials. Both runners use the same provider-specific read APIs.
+func ForgejoAgentContext(cfg config.Config, projectID, repo string, prNumber int64) string {
+	provider, ok := configuredForgejoProvider(cfg, projectID, repo)
+	if !ok {
+		return ""
+	}
+	prURL := ConfiguredPullRequestURL(cfg, projectID, repo, prNumber)
+	base, err := url.Parse(provider.BaseURL)
+	if err != nil || base.Host == "" {
+		return ""
+	}
+	base.User, base.RawQuery, base.Fragment = nil, "", ""
+	apiBase := strings.TrimRight(base.String(), "/") + "/api/v1"
+	apiRepo := "/repos/" + strings.Trim(repo, "/")
+	auth := ""
+	if config.EffectiveProviderAuth(provider) == config.ProviderAuthTea {
+		teaPath, login := "tea", ""
+		if provider.TeaPath != nil && strings.TrimSpace(*provider.TeaPath) != "" {
+			teaPath = strings.TrimSpace(*provider.TeaPath)
+		}
+		if provider.TeaLogin != nil {
+			login = strings.TrimSpace(*provider.TeaLogin)
+		}
+		auth = fmt.Sprintf("Read API command: %s api --login %s -i <endpoint>. Use this explicit login. tea can exit zero on HTTP errors: inspect the HTTP status printed with -i and require 2xx.", agentContextShellQuote(teaPath), agentContextShellQuote(login))
+	} else {
+		envName := ""
+		if provider.TokenEnv != nil {
+			envName = strings.TrimSpace(*provider.TokenEnv)
+		}
+		auth = fmt.Sprintf("Authentication uses the configured environment variable %q. Read it only inside your HTTP client and set the Authorization header to token plus that value. Never print its value, dump the environment, or enable shell tracing. Require an HTTP 2xx response.", envName)
+	}
+	return strings.Join([]string{
+		"Forgejo repository context: " + prURL + ". API base: " + apiBase + ".",
+		auth,
+		"Use the prepared local worktree for Git inspection and validation. Use Forgejo API reads for mutable PR context; gh commands target the wrong provider. Follow the role-specific publishing instructions for all writes.",
+		fmt.Sprintf("PR metadata: GET %s/pulls/%d (head.sha, base.sha, head.ref, base.ref, state, draft, requested_reviewers). Patch: GET %s/pulls/%d.diff. Conversation: GET %s/issues/%d/comments.", apiRepo, prNumber, apiRepo, prNumber, apiRepo, prNumber),
+		fmt.Sprintf("Native reviews: GET %s/pulls/%d/reviews, then GET %s/pulls/%d/reviews/<review_id>/comments for inline findings. These are not GitHub GraphQL threads; Forgejo currently has no supported resolve endpoint.", apiRepo, prNumber, apiRepo, prNumber),
+		"Paginate list reads with page=1&limit=50, following Link rel=next / X-Total-Pages; retain all relevant pages. A failed read is not an empty list or clean result.",
+		fmt.Sprintf("CI: GET %s/statuses/<head_sha>?sort=highestindex and retain the newest status per context. Actions: GET %s/actions/runs?head_sha=<head_sha> (do not combine event with head_sha); response.workflow_runs is an array. Use run.id for API paths, not index_in_repo or the UI run number. For each relevant newest workflow run, GET %s/actions/runs/<run_id>/jobs returns a bare array. Failed-job plaintext logs: GET %s/actions/jobs/<job_id>/logs (optional ?attempt=<attempt>). Fetch logs only for diagnostics needed in this run.", apiRepo, apiRepo, apiRepo, apiRepo),
+	}, "\n")
+}
+
+func agentContextShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/internal/forge/agent_context_test.go
+++ b/internal/forge/agent_context_test.go
@@ -1,0 +1,39 @@
+package forge
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+)
+
+func TestForgejoAgentContextUsesConfiguredTransportWithoutCredentials(t *testing.T) {
+	t.Setenv("FORGEJO_TEST_SECRET", "do-not-copy-this-token")
+	for _, tea := range []bool{false, true} {
+		provider := config.ProviderConfig{ID: "forge", Kind: config.ProviderKindForgejo, BaseURL: "https://code.example/forge", Auth: config.ProviderAuthTokenEnv, TokenEnv: stringPtr("FORGEJO_TEST_SECRET")}
+		if tea {
+			provider.Auth = config.ProviderAuthTea
+			provider.TeaLogin = stringPtr("team-main")
+			provider.TeaPath = stringPtr("/opt/Tea Tools/tea")
+		}
+		cfg := config.Config{Providers: []config.ProviderConfig{provider}, Projects: []config.ProjectRefConfig{{ID: "project", Provider: "forge", Repo: "core/looper"}}}
+		got := ForgejoAgentContext(cfg, "project", "core/looper", 42)
+		for _, required := range []string{"https://code.example/forge/core/looper/pulls/42", "/repos/core/looper/pulls/42/reviews/<review_id>/comments", "run.id", "bare array", "/actions/jobs/<job_id>/logs", "page=1&limit=50"} {
+			if !strings.Contains(got, required) {
+				t.Errorf("context missing %q: %s", required, got)
+			}
+		}
+		if strings.Contains(got, "do-not-copy-this-token") || strings.Contains(got, "gh pr") {
+			t.Errorf("context leaks credentials or GitHub command: %s", got)
+		}
+		if tea && !strings.Contains(got, "'/opt/Tea Tools/tea' api --login 'team-main' -i") {
+			t.Errorf("configured tea command missing: %s", got)
+		}
+		if !tea && !strings.Contains(got, "FORGEJO_TEST_SECRET") {
+			t.Errorf("token variable reference missing: %s", got)
+		}
+		if got := ForgejoAgentContext(cfg, "unknown", "core/looper", 42); got != "" {
+			t.Errorf("unknown project context = %q", got)
+		}
+	}
+}

--- a/internal/forge/forgejo.go
+++ b/internal/forge/forgejo.go
@@ -319,6 +319,9 @@ type PullRequest struct {
 	Labels    []Label
 	Assignees []Identity
 	Reviewers []Identity
+	// Mergeable is not a conflict verdict: Forgejo also returns false while
+	// checking mergeability, for server errors, and for work-in-progress PRs.
+	Mergeable *bool
 }
 
 type BranchRef struct {
@@ -353,16 +356,22 @@ type PullRequestReviewComment struct {
 	DiffHunk            string
 	PullRequestReviewID int64
 	Resolver            ForgejoReviewCommentResolverField
+	ReviewBody          string
+	ReviewState         string
+	ReviewCommitID      string
+	ReviewAuthor        string
 }
 
 type PullRequestReview struct {
-	ID       int64
-	State    string
-	Body     string
-	CommitID string
-	HTMLURL  string
-	User     Identity
-	Comments []PullRequestReviewComment
+	ID        int64
+	State     string
+	Body      string
+	CommitID  string
+	HTMLURL   string
+	User      Identity
+	Comments  []PullRequestReviewComment
+	Dismissed bool
+	Stale     bool
 }
 
 type UnsupportedCapabilityError struct {
@@ -631,21 +640,24 @@ func (forgejo *ForgejoClient) UpdateIssueComment(ctx context.Context, input Upda
 }
 
 func (forgejo *ForgejoClient) ListPullRequestReviewComments(ctx context.Context, number int64) ([]PullRequestReviewComment, error) {
-	var reviews []forgejoPullRequestReview
-	if err := forgejo.getPaged(ctx, forgejo.repoPath("pulls", strconv.FormatInt(number, 10), "reviews"), nil, 0, &reviews); err != nil {
+	reviews, err := forgejo.listPullRequestReviews(ctx, number, true)
+	if err != nil {
 		return nil, err
 	}
 	comments := make([]PullRequestReviewComment, 0)
 	for _, review := range reviews {
-		var output []forgejoPullRequestReviewComment
-		if err := forgejo.getPaged(ctx, forgejo.repoPath("pulls", strconv.FormatInt(number, 10), "reviews", strconv.FormatInt(review.ID, 10), "comments"), nil, 0, &output); err != nil {
-			return nil, err
-		}
-		for _, comment := range output {
-			comments = append(comments, convertPullRequestReviewComment(comment))
-		}
+		comments = append(comments, review.Comments...)
 	}
 	return comments, nil
+}
+
+// ListPullRequestReviewSummaries avoids fetching every inline comment when a
+// caller only needs reviewer identities or the latest review decisions.
+func (forgejo *ForgejoClient) ListPullRequestReviewSummaries(ctx context.Context, number int64) ([]PullRequestReview, error) {
+	if err := forgejo.requireCapability(ctx, "nativeReviews", http.MethodGet, "/repos/{owner}/{repo}/pulls/{index}/reviews"); err != nil {
+		return nil, err
+	}
+	return forgejo.listPullRequestReviews(ctx, number, false)
 }
 
 func (forgejo *ForgejoClient) ListPullRequestReviews(ctx context.Context, number int64) ([]PullRequestReview, error) {
@@ -658,6 +670,10 @@ func (forgejo *ForgejoClient) ListPullRequestReviews(ctx context.Context, number
 	if err := forgejo.requireCapability(ctx, "nativeReviews", http.MethodGet, "/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments"); err != nil {
 		return nil, err
 	}
+	return forgejo.listPullRequestReviews(ctx, number, true)
+}
+
+func (forgejo *ForgejoClient) listPullRequestReviews(ctx context.Context, number int64, includeComments bool) ([]PullRequestReview, error) {
 	var output []forgejoPullRequestReview
 	if err := forgejo.getPaged(ctx, forgejo.repoPath("pulls", strconv.FormatInt(number, 10), "reviews"), nil, 0, &output); err != nil {
 		return nil, err
@@ -665,7 +681,7 @@ func (forgejo *ForgejoClient) ListPullRequestReviews(ctx context.Context, number
 	reviews := make([]PullRequestReview, 0, len(output))
 	for _, review := range output {
 		converted := convertPullRequestReview(review)
-		if len(converted.Comments) == 0 {
+		if includeComments && len(converted.Comments) == 0 && (review.CommentsCount == nil || *review.CommentsCount > 0) {
 			var comments []forgejoPullRequestReviewComment
 			if err := forgejo.getPaged(ctx, forgejo.repoPath("pulls", strconv.FormatInt(number, 10), "reviews", strconv.FormatInt(review.ID, 10), "comments"), nil, 0, &comments); err != nil {
 				return nil, err
@@ -674,9 +690,24 @@ func (forgejo *ForgejoClient) ListPullRequestReviews(ctx context.Context, number
 				converted.Comments = append(converted.Comments, convertPullRequestReviewComment(comment))
 			}
 		}
+		for index := range converted.Comments {
+			comment := &converted.Comments[index]
+			comment.PullRequestReviewID = converted.ID
+			comment.ReviewBody = converted.Body
+			comment.ReviewState = converted.State
+			comment.ReviewCommitID = converted.CommitID
+			comment.ReviewAuthor = converted.User.Login
+		}
 		reviews = append(reviews, converted)
 	}
 	return reviews, nil
+}
+
+func (forgejo *ForgejoClient) DismissPullRequestReview(ctx context.Context, number, reviewID int64, message string) error {
+	if err := outboundguard.Validate(outboundguard.Field{Name: "review dismissal message", Text: message}); err != nil {
+		return err
+	}
+	return forgejo.do(ctx, http.MethodPost, forgejo.repoPath("pulls", strconv.FormatInt(number, 10), "reviews", strconv.FormatInt(reviewID, 10), "dismissals"), nil, map[string]any{"message": message, "priors": false}, nil)
 }
 
 func (forgejo *ForgejoClient) CreatePullRequestReview(ctx context.Context, input CreatePullRequestReviewInput) (PullRequestReview, error) {
@@ -979,6 +1010,7 @@ type forgejoPullRequest struct {
 	Labels    []forgejoLabel `json:"labels"`
 	Assignees []forgejoUser  `json:"assignees"`
 	Reviewers []forgejoUser  `json:"requested_reviewers"`
+	Mergeable *bool          `json:"mergeable"`
 }
 
 type forgejoBranch struct {
@@ -1038,13 +1070,16 @@ type forgejoPullRequestReviewComment struct {
 }
 
 type forgejoPullRequestReview struct {
-	ID       int64                             `json:"id"`
-	State    string                            `json:"state"`
-	Body     string                            `json:"body"`
-	CommitID string                            `json:"commit_id"`
-	HTMLURL  string                            `json:"html_url"`
-	User     forgejoUser                       `json:"user"`
-	Comments []forgejoPullRequestReviewComment `json:"comments"`
+	ID            int64                             `json:"id"`
+	State         string                            `json:"state"`
+	Body          string                            `json:"body"`
+	CommitID      string                            `json:"commit_id"`
+	HTMLURL       string                            `json:"html_url"`
+	User          forgejoUser                       `json:"user"`
+	Comments      []forgejoPullRequestReviewComment `json:"comments"`
+	CommentsCount *int                              `json:"comments_count"`
+	Dismissed     bool                              `json:"dismissed"`
+	Stale         bool                              `json:"stale"`
 }
 
 func convertIssue(input forgejoIssue) Issue {
@@ -1052,7 +1087,7 @@ func convertIssue(input forgejoIssue) Issue {
 }
 
 func convertPullRequest(input forgejoPullRequest) PullRequest {
-	return PullRequest{Number: input.Number, Title: input.Title, Body: input.Body, State: input.State, IsDraft: input.Draft, HTMLURL: input.HTMLURL, UpdatedAt: input.UpdatedAt, User: convertUser(input.User), Head: convertBranch(input.Head), Base: convertBranch(input.Base), Labels: convertLabels(input.Labels), Assignees: convertUsers(input.Assignees), Reviewers: convertUsers(input.Reviewers)}
+	return PullRequest{Number: input.Number, Title: input.Title, Body: input.Body, State: input.State, IsDraft: input.Draft, HTMLURL: input.HTMLURL, UpdatedAt: input.UpdatedAt, User: convertUser(input.User), Head: convertBranch(input.Head), Base: convertBranch(input.Base), Labels: convertLabels(input.Labels), Assignees: convertUsers(input.Assignees), Reviewers: convertUsers(input.Reviewers), Mergeable: input.Mergeable}
 }
 
 func convertPullRequestReview(input forgejoPullRequestReview) PullRequestReview {
@@ -1060,7 +1095,11 @@ func convertPullRequestReview(input forgejoPullRequestReview) PullRequestReview 
 	for _, comment := range input.Comments {
 		comments = append(comments, convertPullRequestReviewComment(comment))
 	}
-	return PullRequestReview{ID: input.ID, State: normalizeForgejoReviewState(input.State), Body: input.Body, CommitID: input.CommitID, HTMLURL: input.HTMLURL, User: convertUser(input.User), Comments: comments}
+	state := normalizeForgejoReviewState(input.State)
+	if input.Dismissed {
+		state = "DISMISSED"
+	}
+	return PullRequestReview{ID: input.ID, State: state, Body: input.Body, CommitID: input.CommitID, HTMLURL: input.HTMLURL, User: convertUser(input.User), Comments: comments, Dismissed: input.Dismissed, Stale: input.Stale}
 }
 
 func normalizeForgejoReviewEvent(event string) string {

--- a/internal/forge/forgejo.go
+++ b/internal/forge/forgejo.go
@@ -294,15 +294,16 @@ type UpdateCommentInput struct {
 }
 
 type Issue struct {
-	Number    int64
-	Title     string
-	Body      string
-	State     string
-	HTMLURL   string
-	UpdatedAt string
-	User      Identity
-	Labels    []Label
-	Assignees []Identity
+	Number        int64
+	IsPullRequest bool
+	Title         string
+	Body          string
+	State         string
+	HTMLURL       string
+	UpdatedAt     string
+	User          Identity
+	Labels        []Label
+	Assignees     []Identity
 }
 
 type PullRequest struct {
@@ -985,15 +986,16 @@ type forgejoLabel struct {
 }
 
 type forgejoIssue struct {
-	Number    int64          `json:"number"`
-	Title     string         `json:"title"`
-	Body      string         `json:"body"`
-	State     string         `json:"state"`
-	HTMLURL   string         `json:"html_url"`
-	UpdatedAt string         `json:"updated_at"`
-	User      forgejoUser    `json:"user"`
-	Labels    []forgejoLabel `json:"labels"`
-	Assignees []forgejoUser  `json:"assignees"`
+	Number      int64          `json:"number"`
+	PullRequest *struct{}      `json:"pull_request"`
+	Title       string         `json:"title"`
+	Body        string         `json:"body"`
+	State       string         `json:"state"`
+	HTMLURL     string         `json:"html_url"`
+	UpdatedAt   string         `json:"updated_at"`
+	User        forgejoUser    `json:"user"`
+	Labels      []forgejoLabel `json:"labels"`
+	Assignees   []forgejoUser  `json:"assignees"`
 }
 
 type forgejoPullRequest struct {
@@ -1083,7 +1085,7 @@ type forgejoPullRequestReview struct {
 }
 
 func convertIssue(input forgejoIssue) Issue {
-	return Issue{Number: input.Number, Title: input.Title, Body: input.Body, State: input.State, HTMLURL: input.HTMLURL, UpdatedAt: input.UpdatedAt, User: convertUser(input.User), Labels: convertLabels(input.Labels), Assignees: convertUsers(input.Assignees)}
+	return Issue{Number: input.Number, IsPullRequest: input.PullRequest != nil, Title: input.Title, Body: input.Body, State: input.State, HTMLURL: input.HTMLURL, UpdatedAt: input.UpdatedAt, User: convertUser(input.User), Labels: convertLabels(input.Labels), Assignees: convertUsers(input.Assignees)}
 }
 
 func convertPullRequest(input forgejoPullRequest) PullRequest {

--- a/internal/forge/forgejo_checks.go
+++ b/internal/forge/forgejo_checks.go
@@ -1,0 +1,146 @@
+package forge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// CommitCheck is the current status of an external check or Forgejo Actions
+// workflow for one commit. URLs and descriptions are diagnostic context; the
+// provider's state is the authority for whether CI is failing.
+type CommitCheck struct {
+	ID          int64
+	Name        string
+	State       string
+	Description string
+	URL         string
+	ActionRunID int64
+}
+
+// ListCommitChecks selects the newest status for each context, and the newest
+// Actions run for each workflow/event/ref. Historical failures must not keep a
+// PR in the fixer queue after a successful rerun on the same commit.
+func (forgejo *ForgejoClient) ListCommitChecks(ctx context.Context, sha string) ([]CommitCheck, error) {
+	sha = strings.TrimSpace(sha)
+	if sha == "" {
+		return nil, nil
+	}
+	var statuses []forgejoCommitStatus
+	if err := forgejo.getPaged(ctx, forgejo.repoPath("statuses", url.PathEscape(sha)), url.Values{"sort": {"highestindex"}}, 0, &statuses); err != nil {
+		return nil, err
+	}
+	latest := make(map[string]forgejoCommitStatus)
+	for _, status := range statuses {
+		prior, found := latest[status.Context]
+		if !found || status.ID > prior.ID {
+			latest[status.Context] = status
+		}
+	}
+	checks := make([]CommitCheck, 0, len(latest))
+	statusURLs := make(map[string]bool)
+	for _, status := range latest {
+		checks = append(checks, CommitCheck{ID: status.ID, Name: status.Context, State: strings.ToUpper(status.Status), Description: status.Description, URL: status.TargetURL})
+		if status.TargetURL != "" {
+			statusURLs[status.TargetURL] = true
+		}
+	}
+	runs, err := forgejo.listCommitActionRuns(ctx, sha)
+	if err != nil {
+		// Older instances and repositories with Actions disabled can still use
+		// external status checks. Authentication and transport errors are not
+		// interpreted as an absence of CI.
+		var httpErr *ForgejoHTTPError
+		if !errors.As(err, &httpErr) || (httpErr.StatusCode != http.StatusNotFound && httpErr.StatusCode != http.StatusMethodNotAllowed) {
+			return nil, err
+		}
+	}
+	for _, run := range runs {
+		if statusURLs[run.HTMLURL] {
+			continue
+		}
+		name := strings.TrimSpace(run.WorkflowID)
+		if name == "" {
+			name = run.Title
+		}
+		if name == "" {
+			name = "Forgejo Actions"
+		}
+		checks = append(checks, CommitCheck{ID: run.ID, Name: name, State: strings.ToUpper(run.Status), Description: run.Title, URL: run.HTMLURL, ActionRunID: run.ID})
+	}
+	sort.Slice(checks, func(i, j int) bool {
+		if checks[i].Name == checks[j].Name {
+			return checks[i].ID < checks[j].ID
+		}
+		return checks[i].Name < checks[j].Name
+	})
+	return checks, nil
+}
+
+func (forgejo *ForgejoClient) listCommitActionRuns(ctx context.Context, sha string) ([]forgejoActionRun, error) {
+	latest := make(map[string]forgejoActionRun)
+	for page := 1; ; page++ {
+		// Do not combine event and head_sha filters: deployed Forgejo versions
+		// can incorrectly return no runs when both filters are supplied.
+		query := url.Values{"head_sha": {sha}, "page": {strconv.Itoa(page)}, "limit": {"50"}}
+		response, err := forgejo.doRaw(ctx, http.MethodGet, forgejo.repoPath("actions", "runs"), query, nil)
+		if err != nil {
+			return nil, err
+		}
+		var output struct {
+			Runs       *[]forgejoActionRun `json:"workflow_runs"`
+			TotalCount int                 `json:"total_count"`
+		}
+		if err := json.Unmarshal(response.body, &output); err != nil {
+			return nil, fmt.Errorf("forgejo API decode action runs: %w", err)
+		}
+		if output.Runs == nil {
+			return nil, fmt.Errorf("forgejo API decode action runs: missing workflow_runs array")
+		}
+		for _, run := range *output.Runs {
+			if !strings.EqualFold(run.CommitSHA, sha) {
+				continue
+			}
+			key := strings.Join([]string{run.WorkflowID, run.Event, run.PrettyRef}, "\x00")
+			if run.WorkflowID == "" {
+				key = strconv.FormatInt(run.ID, 10)
+			}
+			if prior, found := latest[key]; !found || run.ID > prior.ID {
+				latest[key] = run
+			}
+		}
+		if !hasNextPage(response.header, page) && (len(*output.Runs) == 0 || page*50 >= output.TotalCount) {
+			break
+		}
+	}
+	runs := make([]forgejoActionRun, 0, len(latest))
+	for _, run := range latest {
+		runs = append(runs, run)
+	}
+	return runs, nil
+}
+
+type forgejoCommitStatus struct {
+	ID          int64  `json:"id"`
+	Context     string `json:"context"`
+	Status      string `json:"status"`
+	Description string `json:"description"`
+	TargetURL   string `json:"target_url"`
+}
+
+type forgejoActionRun struct {
+	ID         int64  `json:"id"`
+	WorkflowID string `json:"workflow_id"`
+	CommitSHA  string `json:"commit_sha"`
+	Event      string `json:"event"`
+	PrettyRef  string `json:"prettyref"`
+	Status     string `json:"status"`
+	Title      string `json:"title"`
+	HTMLURL    string `json:"html_url"`
+}

--- a/internal/forge/forgejo_checks_test.go
+++ b/internal/forge/forgejo_checks_test.go
@@ -1,0 +1,103 @@
+package forge
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestForgejoCommitChecksUseLatestStatesAcrossPages(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "token super-secret" {
+			t.Errorf("authorization = %q", r.Header.Get("Authorization"))
+		}
+		switch r.URL.Path {
+		case "/api/v1/repos/acme/looper/statuses/head":
+			if r.URL.Query().Get("sort") != "highestindex" {
+				t.Error("status discovery must include successes and failures in descending ID order")
+			}
+			if r.URL.Query().Get("page") == "1" {
+				w.Header().Set("X-Total-Pages", "2")
+				_, _ = w.Write([]byte(`[{"id":4,"context":"unit","status":"success"},{"id":3,"context":"lint","status":"failure","description":"lint failed in app.go","target_url":"https://ci.test/lint"}]`))
+			} else {
+				_, _ = w.Write([]byte(`[{"id":2,"context":"unit","status":"failure"}]`))
+			}
+		case "/api/v1/repos/acme/looper/actions/runs":
+			if r.URL.Query().Get("head_sha") != "head" || r.URL.Query().Get("event") != "" {
+				t.Errorf("action query = %s", r.URL.RawQuery)
+			}
+			if r.URL.Query().Get("page") == "1" {
+				w.Header().Set("Link", `</api/v1/repos/acme/looper/actions/runs?page=2>; rel="next"`)
+				_, _ = w.Write([]byte(`{"workflow_runs":[{"id":100,"index_in_repo":9,"workflow_id":"ci.yml","commit_sha":"head","status":"success","event":"push","prettyref":"feature","html_url":"https://forge.test/actions/runs/9"},{"id":200,"workflow_id":"other.yml","commit_sha":"another-head","status":"failure"}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"workflow_runs":[{"id":99,"workflow_id":"ci.yml","commit_sha":"head","status":"failure","event":"push","prettyref":"feature"},{"id":98,"workflow_id":"deploy.yml","commit_sha":"head","status":"failure","event":"push","prettyref":"feature","title":"Deploy failed","html_url":"https://forge.test/actions/runs/8"}]}`))
+			}
+		default:
+			t.Errorf("unexpected request %s", r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	checks, err := newForgejoTestClient(t, server.URL).ListCommitChecks(context.Background(), "head")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(checks) != 4 {
+		t.Fatalf("checks = %#v, want current status per context/workflow", checks)
+	}
+	if checks[0].Name != "ci.yml" || checks[0].State != "SUCCESS" || checks[0].ActionRunID != 100 {
+		t.Errorf("action rerun = %#v, want success and API ID 100, not display index 9", checks[0])
+	}
+	if checks[1].Name != "deploy.yml" || checks[1].State != "FAILURE" || checks[1].Description != "Deploy failed" {
+		t.Errorf("failed action = %#v", checks[1])
+	}
+	if checks[2].Name != "lint" || checks[2].URL != "https://ci.test/lint" || checks[2].Description != "lint failed in app.go" {
+		t.Errorf("external failure diagnostics = %#v", checks[2])
+	}
+	if checks[3].Name != "unit" || checks[3].State != "SUCCESS" {
+		t.Errorf("status rerun = %#v, historical failure must not remain actionable", checks[3])
+	}
+}
+
+func TestForgejoCommitChecksDoNotHidePermissionOrTransportErrors(t *testing.T) {
+	t.Parallel()
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.URL.Path, "/statuses/") {
+					_, _ = w.Write([]byte(`[{"id":1,"context":"unit","status":"failure"}]`))
+					return
+				}
+				w.WriteHeader(code)
+			}))
+			defer server.Close()
+			checks, err := newForgejoTestClient(t, server.URL).ListCommitChecks(context.Background(), "head")
+			if code == http.StatusNotFound || code == http.StatusMethodNotAllowed {
+				if err != nil || len(checks) != 1 || checks[0].State != "FAILURE" {
+					t.Fatalf("checks = %#v, %v; unavailable Actions must preserve external checks", checks, err)
+				}
+				return
+			}
+			var httpErr *ForgejoHTTPError
+			if !errors.As(err, &httpErr) || httpErr.StatusCode != code {
+				t.Fatalf("error = %v, want HTTP %d", err, code)
+			}
+		})
+	}
+}
+
+func TestForgejoPullRequestRetainsUnknownMergeability(t *testing.T) {
+	t.Parallel()
+	no, yes := false, true
+	for _, mergeable := range []*bool{nil, &no, &yes} {
+		got := convertPullRequest(forgejoPullRequest{State: "open", Mergeable: mergeable}).Mergeable
+		if got != mergeable {
+			t.Fatalf("Mergeable = %v, want original tri-state %v", got, mergeable)
+		}
+	}
+}

--- a/internal/forge/forgejo_merge.go
+++ b/internal/forge/forgejo_merge.go
@@ -1,0 +1,56 @@
+package forge
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type RepositoryMergeSettings struct {
+	AllowMergeCommit bool `json:"allow_merge_commits"`
+	AllowSquashMerge bool `json:"allow_squash_merge"`
+	AllowRebaseMerge bool `json:"allow_rebase"`
+}
+
+type BranchProtection struct {
+	Protected           bool     `json:"protected"`
+	EnableStatusCheck   bool     `json:"enable_status_check"`
+	StatusCheckContexts []string `json:"status_check_contexts"`
+}
+
+func (forgejo *ForgejoClient) GetRepositoryMergeSettings(ctx context.Context) (RepositoryMergeSettings, error) {
+	var settings RepositoryMergeSettings
+	err := forgejo.do(ctx, http.MethodGet, forgejo.repoPath(), nil, nil, &settings)
+	return settings, err
+}
+
+func (forgejo *ForgejoClient) GetBranchProtection(ctx context.Context, branch string) (BranchProtection, error) {
+	var protection BranchProtection
+	err := forgejo.do(ctx, http.MethodGet, forgejo.repoPath("branches", url.PathEscape(strings.TrimSpace(branch))), nil, nil, &protection)
+	return protection, err
+}
+
+func (forgejo *ForgejoClient) EnableAutoMerge(ctx context.Context, number int64, strategy, headSHA string) error {
+	if strings.TrimSpace(headSHA) == "" {
+		return fmt.Errorf("Forgejo auto-merge requires the reviewed head commit")
+	}
+	switch strategy {
+	case "merge", "squash", "rebase":
+	default:
+		return fmt.Errorf("unsupported Forgejo auto-merge strategy %q", strategy)
+	}
+	if err := forgejo.requireCapability(ctx, "autoMerge", http.MethodPost, "/repos/{owner}/{repo}/pulls/{index}/merge"); err != nil {
+		return err
+	}
+	// Forgejo's scheduled merge ignores head_commit_id, including when the head
+	// changes after scheduling. Use only immediate merge, where the server checks
+	// this expected commit and required checks. The reviewer publish checkpoint
+	// owns retries while CI is pending; no server-side merge is left queued.
+	return forgejo.do(ctx, http.MethodPost, forgejo.repoPath("pulls", strconv.FormatInt(number, 10), "merge"), nil, map[string]any{
+		"Do": strategy, "head_commit_id": strings.TrimSpace(headSHA), "merge_when_checks_succeed": false,
+		"force_merge": false, "delete_branch_after_merge": false,
+	}, nil)
+}

--- a/internal/forge/types.go
+++ b/internal/forge/types.go
@@ -78,7 +78,7 @@ func StaticCapabilities(kind ProviderKind) (Capabilities, bool) {
 	case ProviderKindGitHub:
 		return Capabilities{Issues: true, PullRequests: true, Labels: true, Assignees: true, Comments: true, Identity: true, Diffs: true, NativeReviews: true, ReviewRequests: true, AutoMerge: true, Webhooks: true, ReviewCommentResolution: ReviewCommentResolutionNative, ReviewDiscovery: ReviewDiscoveryReviewRequest, ReviewPublish: ReviewPublishNative, ThreadResolution: ThreadResolutionNative, WorkerClaim: WorkerClaimAssignSelf, Webhook: WebhookNative}, true
 	case ProviderKindForgejo:
-		return Capabilities{Issues: true, PullRequests: true, Labels: true, Assignees: true, Comments: true, Identity: true, Diffs: true, NativeReviews: true, ReviewRequests: true, AutoMerge: false, Webhooks: false, ReviewCommentResolution: ReviewCommentResolutionManualOnly, Dependencies: false, ReviewDiscovery: ReviewDiscoveryReviewRequest, ReviewPublish: ReviewPublishNative, ThreadResolution: ThreadResolutionDisabled, WorkerClaim: WorkerClaimPreAssigned, Webhook: WebhookPolling}, true
+		return Capabilities{Issues: true, PullRequests: true, Labels: true, Assignees: true, Comments: true, Identity: true, Diffs: true, NativeReviews: true, ReviewRequests: true, AutoMerge: true, Webhooks: false, ReviewCommentResolution: ReviewCommentResolutionManualOnly, Dependencies: false, ReviewDiscovery: ReviewDiscoveryReviewRequest, ReviewPublish: ReviewPublishNative, ThreadResolution: ThreadResolutionDisabled, WorkerClaim: WorkerClaimPreAssigned, Webhook: WebhookPolling}, true
 	case ProviderKindPlane:
 		// Plane is a task-source: it owns issues/labels/comments/assignees but
 		// has no pull requests, diffs, or native reviews (those are delegated to

--- a/internal/infra/github/gateway.go
+++ b/internal/infra/github/gateway.go
@@ -2485,7 +2485,9 @@ var reviewMarkerRE = regexp.MustCompile(`<!--\s*looper:review\s+([^>]*)-->`)
 // marker grammar and event policy as publish verification. Both GitHub GraphQL
 // and native review payloads are accepted. A valid review of the current head
 // prevents an older review from authorizing another full pass on that head.
-func ReviewEngagementHead(reviews []map[string]any, loopID, headSHA, login string, allowed []string, allowCleanComment bool) string {
+// allowBlockingComment is exclusively the Forgejo self-review transport fallback;
+// GitHub callers leave it false and retain their existing outcome/event policy.
+func ReviewEngagementHead(reviews []map[string]any, loopID, headSHA, login string, allowed []string, allowCleanComment, allowBlockingComment bool) string {
 	login = normalizeReviewMarkerLogin(strings.TrimPrefix(strings.TrimSpace(login), "@"))
 	if login == "" || strings.TrimSpace(loopID) == "" || strings.TrimSpace(headSHA) == "" {
 		return ""
@@ -2513,7 +2515,11 @@ func ReviewEngagementHead(reviews []map[string]any, loopID, headSHA, login strin
 			if marker.ID != wantID && !strings.HasPrefix(marker.ID, wantID+":") {
 				continue
 			}
-			if marker.Head != sha || !reviewMarkerEventAllowedForOutcome(marker.Outcome, event, allowed, allowCleanComment) {
+			eventAllowed := reviewMarkerEventAllowedForOutcome(marker.Outcome, event, allowed, allowCleanComment)
+			if allowBlockingComment && marker.Outcome == "blocking" && event == "COMMENT" && reviewEventAllowed(event, allowed) {
+				eventAllowed = true
+			}
+			if marker.Head != sha || !eventAllowed {
 				continue
 			}
 			if sha == strings.TrimSpace(headSHA) {

--- a/internal/infra/github/gateway_test.go
+++ b/internal/infra/github/gateway_test.go
@@ -2970,8 +2970,30 @@ func TestReviewEngagementDoesNotRecoverOldHeadWhenCurrentHeadAlreadyReviewed(t *
 	old := map[string]any{"user": map[string]any{"login": "bob"}, "state": "CHANGES_REQUESTED", "commit_id": "old", "body": "<!-- looper:review id=reviewer:loop head=old outcome=blocking -->"}
 	current := map[string]any{"user": map[string]any{"login": "bob"}, "state": "CHANGES_REQUESTED", "commit_id": "new", "body": "<!-- looper:review id=reviewer:loop head=new outcome=blocking -->"}
 	for _, reviews := range [][]map[string]any{{old, current}, {current, old}} {
-		if got := ReviewEngagementHead(reviews, "loop", "new", "bob", []string{"COMMENT", "REQUEST_CHANGES"}, false); got != "" {
+		if got := ReviewEngagementHead(reviews, "loop", "new", "bob", []string{"COMMENT", "REQUEST_CHANGES"}, false, false); got != "" {
 			t.Fatalf("current head granted full follow-up via %q", got)
 		}
+	}
+}
+
+func TestReviewEngagementSelfBlockingFallbackStillMatchesAuthorAndHead(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, author, commit, markerHead string
+		allow                            bool
+		want                             string
+	}{
+		{name: "explicit Forgejo fallback", author: "bob", commit: "old", markerHead: "old", allow: true, want: "old"},
+		{name: "GitHub policy unchanged", author: "bob", commit: "old", markerHead: "old"},
+		{name: "wrong review author", author: "alice", commit: "old", markerHead: "old", allow: true},
+		{name: "marker does not match reviewed commit", author: "bob", commit: "old", markerHead: "other", allow: true},
+		{name: "current head already reviewed", author: "bob", commit: "new", markerHead: "new", allow: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reviews := []map[string]any{{"user": map[string]any{"login": tc.author}, "state": "COMMENTED", "commit_id": tc.commit, "body": "<!-- looper:review id=reviewer:loop head=" + tc.markerHead + " outcome=blocking -->"}}
+			if got := ReviewEngagementHead(reviews, "loop", "new", "bob", []string{"COMMENT", "REQUEST_CHANGES"}, true, tc.allow); got != tc.want {
+				t.Fatalf("engagement = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/projects/catalog_test.go
+++ b/internal/projects/catalog_test.go
@@ -312,9 +312,9 @@ func TestMaterializeCatalogAppliesAndValidatesForgejoRoleProfile(t *testing.T) {
 		t.Fatalf("materialized coordinator = %#v, want Forgejo coordinator and dependency gates disabled", coordinator)
 	}
 
-	incompatibleMetadata := `{"provider":"forgejo-main","repo":"core/odcrew","roles":{"reviewer":{"autoMerge":{"enabled":true}}},"source":"api"}`
+	incompatibleMetadata := `{"provider":"forgejo-main","repo":"core/odcrew","roles":{"reviewer":{"behavior":{"threadResolution":{"enabled":true}}}},"source":"api"}`
 	_, err = MaterializeCatalog(global, []storage.ProjectRecord{{ID: "odcrew", MetadataJSON: &incompatibleMetadata}})
-	if err == nil || !strings.Contains(err.Error(), "autoMerge.enabled") {
+	if err == nil || !strings.Contains(err.Error(), "threadResolution.enabled") {
 		t.Fatalf("MaterializeCatalog() error = %v, want incompatible Forgejo role rejection", err)
 	}
 }

--- a/internal/projects/reviewer_automerge_validation.go
+++ b/internal/projects/reviewer_automerge_validation.go
@@ -28,6 +28,9 @@ func (s *Service) validateReviewerAutoMergeForProject(ctx context.Context, proje
 		if project.ID != projectID || config.ResolvedProjectProviderKind(cfg, project) != config.ProviderKindForgejo {
 			continue
 		}
+		if roles.Reviewer.Behavior.PublishMode == config.ReviewerPublishModeSummaryComment {
+			return reviewerAutoMergeValidationError(projectRepoLabel(repo, projectID), `publishMode "summary_comment" cannot submit the native APPROVE review auto-merge requires`)
+		}
 		for _, provider := range cfg.Providers {
 			if provider.ID != project.Provider {
 				continue

--- a/internal/projects/reviewer_automerge_validation.go
+++ b/internal/projects/reviewer_automerge_validation.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/forge"
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/reviewer/automerge"
 )
@@ -22,14 +23,37 @@ func (s *Service) validateReviewerAutoMergeForProject(ctx context.Context, proje
 	if autoMergeCfg.Scope != config.ReviewerAutoMergeScopeLooperOnly {
 		return reviewerAutoMergeValidationError(projectRepoLabel(repo, projectID), fmt.Sprintf("scope %q is unsupported in v1", autoMergeCfg.Scope))
 	}
-	if s.GetRepositorySettings == nil || (autoMergeCfg.RequireBranchProtection && s.GetBranchProtection == nil) {
+	getSettings, getProtection := s.GetRepositorySettings, s.GetBranchProtection
+	for _, project := range cfg.Projects {
+		if project.ID != projectID || config.ResolvedProjectProviderKind(cfg, project) != config.ProviderKindForgejo {
+			continue
+		}
+		for _, provider := range cfg.Providers {
+			if provider.ID != project.Provider {
+				continue
+			}
+			client, err := forge.NewForgejoClientFromConfig(provider, strings.TrimSpace(stringValue(repo)))
+			if err != nil {
+				return err
+			}
+			getSettings = func(ctx context.Context, _ githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+				settings, err := client.GetRepositoryMergeSettings(ctx)
+				return githubinfra.RepositorySettings{AllowSquashMerge: settings.AllowSquashMerge, AllowMergeCommit: settings.AllowMergeCommit, AllowRebaseMerge: settings.AllowRebaseMerge, AllowAutoMerge: true}, err
+			}
+			getProtection = func(ctx context.Context, input githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+				branch, err := client.GetBranchProtection(ctx, input.Branch)
+				return githubinfra.BranchProtection{Enabled: branch.Protected, HasRequiredChecks: branch.Protected && branch.EnableStatusCheck && len(branch.StatusCheckContexts) > 0, RequiredChecks: branch.StatusCheckContexts}, err
+			}
+		}
+	}
+	if getSettings == nil || (autoMergeCfg.RequireBranchProtection && getProtection == nil) {
 		return reviewerAutoMergeValidationError(projectRepoLabel(repo, projectID), "GitHub auto-merge validation is not configured")
 	}
 	repoName := strings.TrimSpace(stringValue(repo))
 	if repoName == "" {
 		return reviewerAutoMergeValidationError(projectID, "GitHub repo is unknown")
 	}
-	settings, err := s.GetRepositorySettings(ctx, githubinfra.RepositorySettingsInput{Repo: repoName})
+	settings, err := getSettings(ctx, githubinfra.RepositorySettingsInput{Repo: repoName})
 	if err != nil {
 		return fmt.Errorf("read repo settings for %s: %w", repoName, err)
 	}
@@ -52,7 +76,7 @@ func (s *Service) validateReviewerAutoMergeForProject(ctx context.Context, proje
 		if branch == "" {
 			return reviewerAutoMergeValidationError(repoName, "default branch is unknown")
 		}
-		protection, err := s.GetBranchProtection(ctx, githubinfra.BranchProtectionInput{Repo: repoName, Branch: branch})
+		protection, err := getProtection(ctx, githubinfra.BranchProtectionInput{Repo: repoName, Branch: branch})
 		if err != nil {
 			return fmt.Errorf("read branch protection for %s@%s: %w", repoName, branch, err)
 		}

--- a/internal/projects/reviewer_automerge_validation_test.go
+++ b/internal/projects/reviewer_automerge_validation_test.go
@@ -2,6 +2,9 @@ package projects
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +13,65 @@ import (
 	githubinfra "github.com/nexu-io/looper/internal/infra/github"
 	"github.com/nexu-io/looper/internal/storage"
 )
+
+func TestServiceSyncConfiguredForgejoAutoMergeUsesProviderPolicy(t *testing.T) {
+	t.Setenv("FORGEJO_PROJECT_MERGE_TOKEN", "test")
+	for _, tc := range []struct {
+		name                      string
+		protected, checks, squash bool
+		want                      string
+	}{
+		{"opt in", true, true, true, ""},
+		{"missing protection", false, true, true, "default branch protection"},
+		{"status checks disabled", true, false, true, "default branch protection"},
+		{"strategy disabled", true, true, false, "strategy"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				switch r.URL.Path {
+				case "/api/v1/repos/core/looper":
+					_ = json.NewEncoder(w).Encode(map[string]any{"allow_squash_merge": tc.squash})
+				case "/api/v1/repos/core/looper/branches/main":
+					_ = json.NewEncoder(w).Encode(map[string]any{"protected": tc.protected, "enable_status_check": tc.checks, "status_check_contexts": []string{"unit"}})
+				default:
+					t.Errorf("unexpected provider request %s %s", r.Method, r.URL)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			tokenEnv, enabled := "FORGEJO_PROJECT_MERGE_TOKEN", true
+			cfg.Providers = []config.ProviderConfig{{ID: "fj", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: &tokenEnv}}
+			cfg.Projects = []config.ProjectRefConfig{{ID: "looper", Name: "Looper", Provider: "fj", Repo: "core/looper", RepoPath: t.TempDir(), Roles: &config.PartialRoleConfigs{Reviewer: &config.PartialReviewerRoleConfig{AutoMerge: &config.PartialReviewerAutoMergeConfig{Enabled: &enabled}}}}}
+			config.ApplyForgejoProjectProfile(&cfg.Projects[0])
+			coordinator := openCoordinator(t)
+			repos := storage.NewRepositories(coordinator.DB())
+			service := &Service{DB: coordinator.DB(), Repos: repos}
+			err = service.SyncConfigured(context.Background(), cfg, time.Now())
+			if tc.want != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("SyncConfigured = %v, want %s", err, tc.want)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if requests != 2 {
+				t.Fatalf("provider reads = %d, want repo + branch", requests)
+			}
+			project, err := repos.Projects.GetByID(context.Background(), "looper")
+			if err != nil || project == nil {
+				t.Fatalf("configured project = %#v, %v", project, err)
+			}
+		})
+	}
+}
 
 func TestValidateReviewerAutoMergeForProjectFailureModes(t *testing.T) {
 	t.Parallel()

--- a/internal/projects/reviewer_automerge_validation_test.go
+++ b/internal/projects/reviewer_automerge_validation_test.go
@@ -134,6 +134,25 @@ func TestValidateReviewerAutoMergeForProjectFailureModes(t *testing.T) {
 	}
 }
 
+func TestValidateReviewerAutoMergeRejectsForgejoSummaryComment(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	tokenEnv := "FORGEJO_TOKEN"
+	cfg.Roles.Reviewer.AutoMerge.Enabled = true
+	cfg.Roles.Reviewer.Behavior.PublishMode = config.ReviewerPublishModeSummaryComment
+	cfg.Providers = []config.ProviderConfig{{ID: "fj", Kind: config.ProviderKindForgejo, BaseURL: "https://forgejo.example.test", TokenEnv: &tokenEnv}}
+	cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Name: "Looper", Provider: "fj", Repo: "acme/looper", RepoPath: t.TempDir()}}
+	repo := "acme/looper"
+	err = (&Service{}).validateReviewerAutoMergeForProject(context.Background(), "project_1", &repo, "main", cfg)
+	if err == nil || !strings.Contains(err.Error(), `publishMode "summary_comment"`) {
+		t.Fatalf("validateReviewerAutoMergeForProject() error = %v, want summary_comment rejection", err)
+	}
+}
+
 func TestServiceAddProjectValidatesReviewerAutoMerge(t *testing.T) {
 	t.Parallel()
 

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -5888,7 +5888,11 @@ func (r *Runner) maybePublishCriteriaAnchoredCleanReview(ctx context.Context, in
 	if resolvePullRequestPhase(detail.Labels) == "spec" {
 		return nil, nil
 	}
-	if r.effectiveReviewEvents(input.Project.ID, input.Loop.MetadataJSON).Clean != config.ReviewerReviewEventApprove {
+	reviewEvents := r.effectiveReviewEvents(input.Project.ID, input.Loop.MetadataJSON)
+	if r.commentOnlyCompletionForProject(input.Project.ID, reviewEvents) {
+		return nil, nil
+	}
+	if reviewEvents.Clean != config.ReviewerReviewEventApprove {
 		return nil, nil
 	}
 	autoMergeCfg := r.reviewerAutoMergeConfigForProject(input.Project.ID)

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -608,6 +608,8 @@ type reviewerCheckpoint struct {
 }
 
 type checkpointDetail struct {
+	URL                string                     `json:"url,omitempty"`
+	ChecksSummary      string                     `json:"checksSummary,omitempty"`
 	Title              string                     `json:"title,omitempty"`
 	State              string                     `json:"state,omitempty"`
 	IsDraft            bool                       `json:"isDraft,omitempty"`
@@ -2705,7 +2707,7 @@ func (r *Runner) skipMissingPullRequest(ctx context.Context, input stepInput, ch
 }
 
 func checkpointDetailFromDetail(detail PullRequestDetail) *checkpointDetail {
-	return &checkpointDetail{Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, Author: detail.Author, ReviewRequests: cloneStrings(detail.ReviewRequests), ReviewRequestUsers: cloneGitHubUsers(detail.ReviewRequestUsers), HasConflicts: detail.HasConflicts, Comments: cloneObjectSlice(detail.Comments), IssueComments: cloneObjectSlice(detail.IssueComments), Reviews: cloneObjectSlice(detail.Reviews)}
+	return &checkpointDetail{URL: detail.URL, ChecksSummary: detail.ChecksSummary, Title: detail.Title, State: detail.State, IsDraft: detail.IsDraft, ReviewDecision: detail.ReviewDecision, Labels: cloneStrings(detail.Labels), HeadSHA: detail.HeadSHA, BaseSHA: detail.BaseSHA, HeadRefName: detail.HeadRefName, BaseRefName: detail.BaseRefName, Author: detail.Author, ReviewRequests: cloneStrings(detail.ReviewRequests), ReviewRequestUsers: cloneGitHubUsers(detail.ReviewRequestUsers), HasConflicts: detail.HasConflicts, Comments: cloneObjectSlice(detail.Comments), IssueComments: cloneObjectSlice(detail.IssueComments), Reviews: cloneObjectSlice(detail.Reviews)}
 }
 
 func (r *Runner) runFilterStep(ctx context.Context, input stepInput) (reviewerCheckpoint, error) {
@@ -5175,8 +5177,26 @@ func (r *Runner) runPublishStep(ctx context.Context, input stepInput) (reviewerC
 				return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
 			}
 			if reviewRequestsKnownAbsent(detail.ReviewRequests, normalizeLogin(currentLogin)) {
-				checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", input.Repo, input.PRNumber)
-				return checkpoint, nil
+				approvedPendingMerge := false
+				if r.forgejoProject(input.Project.ID) && r.reviewerAutoMergeConfigForProject(input.Project.ID).Enabled {
+					// Forgejo consumes the request when this pending review submits
+					// APPROVE. A publish retry may finish that same head's merge,
+					// without admitting a new review or rerunning the agent.
+					marker, err := r.verifyAgentNativeReviewMarker(ctx, input, pending.HeadSHA, pending.IdempotencyKey, cleanReviewAuthorLogin(checkpoint, detail))
+					if err != nil {
+						return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+					}
+					if cleanApprovedReviewMarker(marker) {
+						if err := validateCleanApprovedReviewMarkerBody(marker, cleanReviewAuthorLogin(checkpoint, detail)); err != nil {
+							return checkpoint, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+						}
+						approvedPendingMerge = true
+					}
+				}
+				if !approvedPendingMerge {
+					checkpoint.SkipReason = fmt.Sprintf("Skipped pull request %s#%d because current user is not requested for review", input.Repo, input.PRNumber)
+					return checkpoint, nil
+				}
 			}
 		}
 		if !isManualReviewerLoop(input.Loop) && domain.IsAutoLaneHeld(domain.LoopTypeReviewer, detail.Labels) {
@@ -5935,8 +5955,12 @@ func (r *Runner) publishCriteriaApprovedReview(ctx context.Context, input stepIn
 		if _, err := r.reviewerPublishFreshDetailForMutation(ctx, input, "enabling auto-merge"); err != nil {
 			return nil, err
 		}
-		if err := r.github.EnableAutoMerge(ctx, githubinfra.EnableAutoMergeInput{Repo: input.Repo, PRNumber: input.PRNumber, Strategy: decision.Strategy, HeadSHA: pending.HeadSHA, CWD: input.Project.RepoPath}); err != nil && !isAlreadyEnabledAutoMergeError(err) {
-			return nil, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+		if err := r.github.EnableAutoMerge(ctx, githubinfra.EnableAutoMergeInput{Repo: input.Repo, PRNumber: input.PRNumber, Strategy: decision.Strategy, HeadSHA: pending.HeadSHA, CWD: input.Project.RepoPath}); err != nil {
+			// Forgejo uses immediate, head-bound merge. It cannot treat a
+			// server-side scheduled/"already enabled" response as completion.
+			if r.forgejoProject(input.Project.ID) || !isAlreadyEnabledAutoMergeError(err) {
+				return nil, &loopError{message: err.Error(), kind: FailureRetryableAfterResume}
+			}
 		}
 		return &criteriaPublishResult{reviewEvent: marker.Event, marker: marker}, nil
 	}
@@ -6861,37 +6885,20 @@ func renderReviewerSummaryComment(summary forge.ReviewerSummary, visibleSummary 
 		return "", err
 	}
 	visibleSummary = strings.TrimSpace(visibleSummary)
-	open := 0
-	resolved := 0
-	superseded := 0
-	lines := []string{"## Reviewer Summary", fmt.Sprintf("Review round: %d", summary.ReviewRoundID)}
+	lines := []string{}
 	if visibleSummary != "" {
-		lines = append(lines, "", visibleSummary)
+		lines = append(lines, visibleSummary)
 	}
 	for _, item := range summary.Items {
-		switch item.Status {
-		case forge.ReviewItemStatusOpen:
-			open++
-		case forge.ReviewItemStatusResolved:
-			resolved++
-		case forge.ReviewItemStatusSuperseded:
-			superseded++
+		if item.Status != forge.ReviewItemStatusOpen {
+			continue
+		}
+		lines = append(lines, "", "### "+item.Title, "", item.Body)
+		if len(item.Files) > 0 {
+			lines = append(lines, "", "Files: "+strings.Join(item.Files, ", "))
 		}
 	}
-	lines = append(lines, "", fmt.Sprintf("Open: %d · Resolved: %d · Superseded: %d", open, resolved, superseded))
-	if open > 0 {
-		lines = append(lines, "", "### Open items")
-		for _, item := range summary.Items {
-			if item.Status != forge.ReviewItemStatusOpen {
-				continue
-			}
-			line := fmt.Sprintf("- **%s** `%s`", item.ReviewItemID, item.Title)
-			if len(item.Files) > 0 {
-				line += fmt.Sprintf(" (%s)", strings.Join(item.Files, ", "))
-			}
-			lines = append(lines, line, "  "+item.Body)
-		}
-	}
+
 	return strings.Join(lines, "\n") + "\n\n" + marker, nil
 }
 
@@ -9588,11 +9595,11 @@ func fixerDeclineAdjudicationContract() string {
 	return `Fixer decline adjudication: a validated Fixer declined reply on an existing Looper-authored review thread is a scope dispute, not dismissal authority. Do not open a duplicate thread for the same finding. Adjudicate on the existing thread only: (1) accept the decline when the item is out of scope (leave the thread for later resolution ownership — do not invent a new thread), (2) reject the decline with new concrete authority evidence and keep the thread unresolved so Fixer remains eligible, or (3) disposition needs_human when judgment is required. A second attempted fix to the same subsystem, or a repeated reviewer–fixer scope conflict without new evidence, must be needs_human — not another automatic argument round.`
 }
 
-func buildReviewerMinimalPRSeed(repo string, prNumber int64, checkpoint reviewerCheckpoint, scope config.ReviewerScope) string {
+func buildReviewerMinimalPRSeed(repo string, prNumber int64, checkpoint reviewerCheckpoint, scope config.ReviewerScope, configuredURL string) string {
 	seed := map[string]any{
 		"repo":           repo,
 		"pr_number":      prNumber,
-		"url":            seededPullRequestURL(repo, prNumber),
+		"url":            firstNonEmpty(configuredURL, seededPullRequestURL(repo, prNumber)),
 		"head_sha":       snapshotHeadSHA(checkpoint),
 		"expected_state": "OPEN",
 		"expected_draft": false,
@@ -9602,6 +9609,9 @@ func buildReviewerMinimalPRSeed(repo string, prNumber int64, checkpoint reviewer
 		},
 	}
 	if checkpoint.Detail != nil {
+		if checkpoint.Detail.URL != "" {
+			seed["url"] = checkpoint.Detail.URL
+		}
 		seed["base_ref"] = checkpoint.Detail.BaseRefName
 		seed["head_ref"] = checkpoint.Detail.HeadRefName
 		seed["expected_state"] = firstNonEmpty(strings.ToUpper(strings.TrimSpace(checkpoint.Detail.State)), "OPEN")
@@ -9674,9 +9684,10 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	if phase == "spec" {
 		phaseInstruction = "This is a spec review. Focus on scope, correctness, feasibility, risks, and validation. Do not review implementation details beyond whether the spec is actionable."
 	}
-	forgejoNative := reviewerProjectProviderKind(instructionConfig, projectID) == config.ProviderKindForgejo && !commentOnlyPublish
+	isForgejo := reviewerProjectProviderKind(instructionConfig, projectID) == config.ProviderKindForgejo
+	forgejoNative := isForgejo && !commentOnlyPublish
 	forgeName := "GitHub"
-	if forgejoNative {
+	if isForgejo {
 		forgeName = "Forgejo"
 	}
 	currentHeadSHA := snapshotHeadSHA(checkpoint)
@@ -9684,7 +9695,7 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	laterPass := isRepairFrontierPass(lastPublishedHeadSHA, currentHeadSHA)
 	publishInstruction := fmt.Sprintf("For actionable must_fix findings, you must publish the %s review yourself by calling looper's enforced review-submit wrapper from the shell (inline comments only for must_fix). For no-actionable-finding results, follow the clean-result publishing instructions for this run. After the agent step, finish with `__LOOPER_RESULT__` JSON that includes `summary`, optional `outcome`, and `findings` using the same disposition fields as comment-only (`disposition`, `severity`, `scopeBasis`, `scopeEvidence`, `title`, `body`, optional `path`/`line`). Looper **does** parse this findings list: `follow_up` is retained locally only and must not be submitted; `needs_human` parks the pair and must not be submitted as change-request comments. Do not smuggle follow_up/needs_human into unstructured top-level review body prose as the only carrier of a blocking finding.", forgeName)
 	if looperCLIPath == "" {
-		publishInstruction = "A trusted Looper CLI review-submit wrapper is unavailable for this run, so fail closed: do not publish any GitHub review, do not add or remove any GitHub reaction, and exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
+		publishInstruction = fmt.Sprintf("A trusted Looper CLI review-submit wrapper is unavailable for this run, so fail closed: do not publish any %s review, do not add or remove any %s reaction, and exit non-zero with the exact message `trusted looper review submit wrapper unavailable`.", forgeName, forgeName)
 	}
 	outcomeInstruction := "Use outcome=clean only when there are no must_fix findings, outcome=non_blocking for must_fix feedback that should not block merge, and outcome=blocking for must_fix findings that should block merge. Legacy outcome=actionable may be treated as comment-only compatibility, but prefer non_blocking or blocking. For no-actionable-finding results, follow the clean-result instructions for this run and finish with a completion summary that starts with `No actionable findings`."
 	cleanResultCompletionInstruction := "Group findings only when they share the same root cause; keep unrelated concerns as separate findings. Accumulate every independent in-scope must_fix before publishing — do not intentionally defer an already observed in-scope issue. The publication budget limits review publications, not findings per publication. If there is no concrete must_fix feedback, follow the clean-result instructions for this run and finish successfully with a summary beginning `No actionable findings`. Do not invent feedback."
@@ -9702,7 +9713,13 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		cleanResultCompletionInstruction = "Group findings only when they share the same root cause; keep unrelated concerns separate. Accumulate every independent in-scope must_fix before finalizing. If there is no concrete must_fix feedback, start the final summary with `No actionable findings`. Do not invent feedback."
 		fetchContract = "Provider-supplied Forgejo review context: Looper fetched PR metadata and diff before invoking you. Use the prepared local worktree plus the supplied metadata/diff as the review context; do not use GitHub CLI/API commands or native review/thread features."
 	}
-	parts := []string{fmt.Sprintf("Review pull request %s#%d.", repo, prNumber), buildReviewerMinimalPRSeed(repo, prNumber, checkpoint, scope), fetchContract, "Phase: " + phase, phaseInstruction, reviewerScopeInstruction(scope), publishInstruction, fmt.Sprintf("Review idempotency marker prefix: <!-- looper:review id=%s head=%s outcome=clean|non_blocking|blocking -->", idempotencyKey, currentHeadSHA), outcomeInstruction, "Run ID for logging only, not for idempotency: " + runID}
+	parts := []string{fmt.Sprintf("Review pull request %s#%d.", repo, prNumber), buildReviewerMinimalPRSeed(repo, prNumber, checkpoint, scope, forge.ConfiguredPullRequestURL(instructionConfig, projectID, repo, prNumber)), fetchContract, "Phase: " + phase, phaseInstruction, reviewerScopeInstruction(scope), publishInstruction, fmt.Sprintf("Review idempotency marker prefix: <!-- looper:review id=%s head=%s outcome=clean|non_blocking|blocking -->", idempotencyKey, currentHeadSHA), outcomeInstruction, "Run ID for logging only, not for idempotency: " + runID}
+	if providerContext := forge.ForgejoAgentContext(instructionConfig, projectID, repo, prNumber); providerContext != "" {
+		parts = append(parts, providerContext)
+	}
+	if checkpoint.Detail != nil && checkpoint.Detail.ChecksSummary != "" && (checkpoint.Snapshot == nil || checkpoint.Snapshot.ChecksSummary == "") {
+		parts = append(parts, "Checks: "+checkpoint.Detail.ChecksSummary)
+	}
 	if laterPass {
 		parts = append(parts, fmt.Sprintf("Last reviewed head SHA: %s", lastPublishedHeadSHA), fmt.Sprintf("Current head SHA for this pass: %s", currentHeadSHA), repairFrontierPassContract(lastPublishedHeadSHA, currentHeadSHA, commentOnlyPublish))
 	}
@@ -9735,12 +9752,18 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	cleanNoopInstruction := "For no-actionable-finding results when the clean review policy is COMMENT, do not submit a clean COMMENT or APPROVE review; finish successfully with the `No actionable findings` summary only. After Looper validates that no clean review marker was required for this run, the runner will reconcile the clean-signal +1 reaction."
 	cleanInstruction := cleanNoopInstruction
 	if autoMergeEnabled && phase != "spec" {
-		cleanInstruction = "For no-actionable-finding results on this implementation PR, do not submit a clean GitHub review yourself. Finish successfully with a summary beginning `No actionable findings`; the runner will verify the linked issue's acceptance criteria and decide whether to publish APPROVE, COMMENT, or no clean review."
+		cleanInstruction = "For no-actionable-finding results on this implementation PR, do not submit a clean review yourself. Finish successfully with a summary beginning `No actionable findings`; the runner will verify the linked issue's acceptance criteria and decide whether to publish APPROVE, COMMENT, or no clean review."
 	}
 	if looperCLIPath == "" {
 		cleanInstruction = "For no-actionable-finding results, do not use the clean COMMENT no-op path and do not finish successfully because the trusted review-submit wrapper is unavailable; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
 	}
 	blockingInstruction := "Submit blocking and non-blocking finding reviews as COMMENT."
+	threadSemantics := "Inline review comments posted through the PR review `comments` array create resolvable GitHub review threads. Top-level review bodies and issue comments are not resolvable; use the review body only for clean summaries or a short overview of already-submitted inline must_fix findings."
+	inlineRequirement := "Resolvable inline review comments are required for code-anchored actionable feedback: when a finding refers to specific changed lines and you can identify the changed file path plus RIGHT/LEFT line numbers from the diff, submit it as an inline review comment in the PR review `comments` array, not in the review body and not as a separate issue/PR conversation comment."
+	if forgejoNative {
+		threadSemantics = "Inline comments remain native Forgejo review comments. The current Forgejo instance has no supported resolve endpoint; do not claim comments were resolved or attempt GitHub thread APIs. Use the review body only for clean prose or a short overview of inline must_fix findings."
+		inlineRequirement = "Native inline review comments are required for code-anchored actionable feedback. Submit each finding in the PR review `comments` array at its changed-file anchor, not in the review body or a separate conversation comment."
+	}
 	specLabelInstruction := "Do not transition spec-review labels yourself. Looper may transition spec-review labels only after it validates a matching APPROVED clean review marker for the current head."
 	policyFlags := fmt.Sprintf("--clean-review-event %s --blocking-review-event %s", reviewEvents.Clean, reviewEvents.Blocking)
 	reviewerModeFlag := ""
@@ -9757,9 +9780,17 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 	}
 	if reviewEvents.Blocking == config.ReviewerReviewEventRequestChanges {
 		blockingInstruction = "If the review has blocking findings, submit REQUEST_CHANGES with outcome=blocking. If findings are non-blocking, submit COMMENT with outcome=non_blocking. Never submit REQUEST_CHANGES for non-blocking findings."
+		if forgejoNative {
+			blockingInstruction += " For a Forgejo PR authored by the authenticated user, the trusted wrapper downgrades REQUEST_CHANGES to COMMENT while retaining outcome=blocking and inline findings; use the wrapper normally and preserve that blocking outcome."
+		}
 		actionableReviewSubmitCommand = fmt.Sprintf("`%s review submit %s#%d --event COMMENT --commit-id %s%s %s` for non-blocking findings or `%s review submit %s#%d --event REQUEST_CHANGES --commit-id %s%s %s` for blocking findings", looperCLICommand, repo, prNumber, snapshotHeadSHA(checkpoint), reviewerModeFlag, policyFlags, looperCLICommand, repo, prNumber, snapshotHeadSHA(checkpoint), reviewerModeFlag, policyFlags)
 	}
 	existingMarkerEventInstruction := "Idempotency outcome matching is strict: only treat an existing `outcome=clean` marker as satisfied when it is on a COMMENTED review if clean policy is COMMENT, or on an APPROVED review if clean policy is APPROVE. A COMMENTED `outcome=clean` marker is also valid when the authenticated GitHub user authored the pull request and the trusted wrapper downgraded self-approval. Only treat an existing `outcome=blocking` marker as satisfied when it is on a CHANGES_REQUESTED review if blocking policy is REQUEST_CHANGES. Treat `outcome=non_blocking` or legacy `outcome=actionable` markers as satisfied only when they are on a COMMENTED review. Ignore matching markers on disallowed review states and publish the correct review for this run instead."
+	if forgejoNative {
+		cleanInstruction = strings.ReplaceAll(cleanInstruction, "authenticated GitHub user", "authenticated Forgejo user")
+		cleanInstruction = strings.ReplaceAll(cleanInstruction, "because GitHub rejects self-approval", "because Forgejo rejects self-approval")
+		existingMarkerEventInstruction = "The trusted wrapper verifies native Forgejo marker id, head, outcome and review state. Blocking REQUEST_CHANGES and clean APPROVE reviews may use the verified self-authored COMMENT fallback; the original outcome is preserved. A remote inline comment remaining open is not evidence that its finding remains unfixed: inspect the current code and Fixer evidence."
+	}
 	reviewRequestInstruction := fmt.Sprintf("Before posting, confirm the current %s user is still requested for review. If not requested, do not post a review; exit non-zero with the exact message `review request removed before publish`.", forgeName)
 	if manual {
 		reviewRequestInstruction = "This is a manual reviewer run, so a current-user review request is not required before posting."
@@ -9799,7 +9830,7 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		anchorInstruction = "Before posting, validate every inline review comment against the supplied Forgejo diff and local worktree. Preserve exact changed-file anchors. If a must_fix location is not exactly on the supplied diff, attach it to the nearest anchorable changed-file location. Do not downgrade must_fix findings to a top-level review-body item; every must_fix must remain an inline comment."
 	}
 	if looperCLIPath == "" {
-		githubOperationContract = "GitHub operation contract: a trusted Looper CLI path was not detected for this reviewer run, so you cannot safely publish a GitHub review. Do not call PATH-based `looper`, repository-local `go run ./cmd/looper`, `gh api repos/.../pulls/.../reviews`, or `gh pr review` directly; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`."
+		githubOperationContract = fmt.Sprintf("%s operation contract: a trusted Looper CLI path was not detected for this reviewer run, so review publication is unavailable. Do not call PATH-based `looper`, repository-local `go run ./cmd/looper`, or the provider review API directly; exit non-zero with the exact message `trusted looper review submit wrapper unavailable`.", forgeName)
 		submitPayloadInstruction = ""
 	}
 	reviewPassContract := "Review pass contract: complete one full review pass before publishing. Collect PR metadata, changed-file list, live diffs, prior unresolved feedback, and necessary surrounding context; then scan every changed file/range in scope. Do not stop after the first issue. If an in-scope must_fix issue is visible in the current PR head and review context, include it in this review rather than deferring it to a later pass."
@@ -9817,7 +9848,7 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		"Finalization gate before submit: verify that the scoped changed files/ranges were reviewed, all observed in-scope must_fix findings are included in this publication, repeated patterns are consolidated only for a shared root cause, non-blocking/nit feedback is not escalated, every published comment has disposition=must_fix with scopeBasis/scopeEvidence plus concrete evidence and a suggested fix, and the review outcome matches the highest published severity.",
 		freshnessInstruction,
 		reviewRequestInstruction,
-		"Review body style contract: the visible body must be human-authored review prose only. Never post terminal/tool output, ANSI escape sequences, file-read traces, command logs, JSON parsing artifacts, or your internal scratch work as the GitHub review body. If you have actionable findings but do not have concrete actionable prose yet, exit non-zero instead of posting logs. For a clean APPROVE review, write the required author mention, change/verification summary, and warm acknowledgement; never use an LGTM, empty, or disclosure-only clean body as a fallback.",
+		"Review body style contract: the visible body must be human-authored review prose only. Never post terminal/tool output, ANSI escape sequences, file-read traces, command logs, JSON parsing artifacts, or your internal scratch work as the review body. If you have actionable findings but do not have concrete actionable prose yet, exit non-zero instead of posting logs. For a clean APPROVE review, write the required author mention, change/verification summary, and warm acknowledgement; never use an LGTM, empty, or disclosure-only clean body as a fallback.",
 		"Shell payload safety contract: never build review JSON inside a double-quoted shell string because Markdown backticks and dollar expressions can execute or expand. Serialize the payload with a JSON-aware tool or pass a literal single-quoted heredoc to the trusted review-submit wrapper.",
 		"Worktree hygiene contract: do not create review payload or scratch files inside the managed worktree (including top-level `/.looper-review-*.json`). Pipe review JSON via a literal single-quoted heredoc on stdin, or write temporary files only under an OS temp directory outside the worktree.",
 		"Content safety recovery contract: if `looper review submit` fails with an outbound content safety gate rejection, rewrite the rejected body/comments/paths in plain prose without secret-shaped env assignments, credential URLs, env dumps, or high-entropy tokens, then resubmit in the same session; do not exit non-zero solely because of that rejection, and never paste the rejected value into logs, prompts, or the next payload.",
@@ -9836,9 +9867,9 @@ func buildReviewPromptWithInstructions(projectID string, instructionConfig confi
 		"Cross-cutting or otherwise unanchorable must_fix findings still require an inline comment on a representative changed-file location; do not submit them as body-only top-level feedback.",
 		"Flag vague unlocated must_fix feedback as a follow-up quality-gating failure; every must_fix must be an inline comment with an exact file, section, symbol, or behavior reference.",
 		"Do not repeat the overall body/summary as a comment; comments must add distinct actionable feedback.",
-		"Resolvable inline review comments are required for code-anchored actionable feedback: when a finding refers to specific changed lines and you can identify the changed file path plus RIGHT/LEFT line numbers from the diff, submit it as an inline review comment in the PR review `comments` array, not in the review body and not as a separate issue/PR conversation comment.",
-		"Inline review comments posted through the PR review `comments` array create resolvable GitHub review threads. Top-level review bodies and issue comments are not resolvable; use the review body only for clean summaries or a short overview of already-submitted inline must_fix findings.",
-		"For non-blocking or blocking must_fix reviews, the review body should be a short overview plus markers/disclosure; every must_fix finding must live in inline `comments` so maintainers can resolve them individually.",
+		inlineRequirement,
+		threadSemantics,
+		"For non-blocking or blocking must_fix reviews, the review body should be a short overview plus markers/disclosure; every must_fix finding must live in inline `comments` so maintainers can address them individually.",
 		"For multiline inline comments, `start_line`/`start_side` must identify the first line and `line`/`side` the last line; omit `start_line`/`start_side` for single-line comments.",
 		"Write substantially more detail than a brief summary; every comment should explain the problem, why it matters, and the concrete change to make.",
 		"A comment is invalid if it only names a category (for example, 'gaps around X', 'issues with Y', or 'concerns about Z'), says only 'add tests' without naming the behavior and where the test belongs, lacks a concrete location or section reference, asks a question without proposing a resolution path, or compresses multiple unrelated concerns into one vague summary.",

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -164,6 +164,7 @@ type PullRequestSummary struct {
 
 type PullRequestDetail struct {
 	Number             int64
+	URL                string
 	Title              string
 	Body               string
 	State              string
@@ -270,7 +271,10 @@ type VerifyReviewMarkerInput struct {
 	AllowedReviewEvents []ReviewEvent
 	AuthorLogin         string
 	AllowCleanComment   bool
-	CWD                 string
+	// Forgejo rejects self-authored change requests; the trusted wrapper keeps
+	// outcome=blocking and publishes COMMENT for this transport fallback only.
+	AllowBlockingComment bool
+	CWD                  string
 }
 
 type ReviewMarkerResult struct {
@@ -1534,7 +1538,8 @@ func (r *Runner) backfillPublishedHeadFromLooperReview(ctx context.Context, proj
 			return "", err
 		}
 		policy := r.effectiveReviewEvents(project.ID, loop.MetadataJSON)
-		return looperReviewEngagementHead(reviews, currentLogin, loop.ID, detail.HeadSHA, r.allowedReviewEventsForPolicy(policy), sameReviewAuthorLogin(currentLogin, detail.Author)), nil
+		selfAuthored := sameReviewAuthorLogin(currentLogin, detail.Author)
+		return looperReviewEngagementHead(reviews, currentLogin, loop.ID, detail.HeadSHA, r.allowedReviewEventsForPolicy(policy), selfAuthored, selfAuthored && r.forgejoProject(project.ID)), nil
 	})
 	if err != nil || engagedHead == "" {
 		return loop, err
@@ -1583,12 +1588,12 @@ func (r *Runner) reviewsForEngagementBackfill(ctx context.Context, project stora
 	return refreshed.Reviews, nil
 }
 
-func looperReviewEngagementHead(reviews []map[string]any, login, loopID, currentHeadSHA string, allowedEvents []ReviewEvent, allowCleanComment bool) string {
+func looperReviewEngagementHead(reviews []map[string]any, login, loopID, currentHeadSHA string, allowedEvents []ReviewEvent, allowCleanComment, allowBlockingComment bool) string {
 	events := make([]string, len(allowedEvents))
 	for i, event := range allowedEvents {
 		events[i] = string(event)
 	}
-	return githubinfra.ReviewEngagementHead(reviews, loopID, currentHeadSHA, login, events, allowCleanComment)
+	return githubinfra.ReviewEngagementHead(reviews, loopID, currentHeadSHA, login, events, allowCleanComment, allowBlockingComment)
 }
 
 func (r *Runner) findReviewerLoopsByPR(ctx context.Context, projectID, repo string, prNumber int64) ([]storage.LoopRecord, error) {
@@ -5464,7 +5469,8 @@ func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepIn
 	marker := agentNativeReviewMarker(input.Loop.ID, headSHA, idempotencyKey)
 	allowedEvents := r.allowedReviewEventsForPolicy(r.effectiveReviewEvents(input.Project.ID, input.Loop.MetadataJSON))
 	allowCleanComment := sameReviewAuthorLogin(currentLogin, prAuthorLogin)
-	found, err := r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: marker, AllowedReviewEvents: allowedEvents, AuthorLogin: currentLogin, AllowCleanComment: allowCleanComment, CWD: input.Project.RepoPath})
+	allowBlockingComment := allowCleanComment && r.forgejoProject(input.Project.ID)
+	found, err := r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: marker, AllowedReviewEvents: allowedEvents, AuthorLogin: currentLogin, AllowCleanComment: allowCleanComment, AllowBlockingComment: allowBlockingComment, CWD: input.Project.RepoPath})
 	if err != nil || found.Found {
 		return found, err
 	}
@@ -5473,12 +5479,12 @@ func (r *Runner) verifyAgentNativeReviewMarker(ctx context.Context, input stepIn
 		return found, nil
 	}
 	bareLoopMarker := agentNativeBareLoopReviewMarker(input.Loop.ID, headSHA)
-	found, err = r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: bareLoopMarker, AllowedReviewEvents: allowedEvents, AuthorLogin: currentLogin, AllowCleanComment: allowCleanComment, CWD: input.Project.RepoPath})
+	found, err = r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: bareLoopMarker, AllowedReviewEvents: allowedEvents, AuthorLogin: currentLogin, AllowCleanComment: allowCleanComment, AllowBlockingComment: allowBlockingComment, CWD: input.Project.RepoPath})
 	if err != nil || found.Found {
 		return found, err
 	}
 	loopMarker := agentNativeLoopReviewMarker(input.Loop.ID, headSHA)
-	found, err = r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: loopMarker, AllowedReviewEvents: allowedEvents, AuthorLogin: currentLogin, AllowCleanComment: allowCleanComment, CWD: input.Project.RepoPath})
+	found, err = r.github.FindReviewMarker(ctx, VerifyReviewMarkerInput{Repo: input.Repo, PRNumber: input.PRNumber, Marker: loopMarker, AllowedReviewEvents: allowedEvents, AuthorLogin: currentLogin, AllowCleanComment: allowCleanComment, AllowBlockingComment: allowBlockingComment, CWD: input.Project.RepoPath})
 	if err != nil || found.Found {
 		return found, err
 	}

--- a/internal/reviewer/runner_engagement_backfill_test.go
+++ b/internal/reviewer/runner_engagement_backfill_test.go
@@ -15,12 +15,17 @@ import (
 )
 
 func TestDiscoverPullRequestsRequeuesLooperEngagedFollowUpAfterCurrentHeadSkip(t *testing.T) {
-	for _, recovered := range []bool{false, true} {
-		name := "missing publication"
-		if recovered {
-			name = "already recovered publication"
-		}
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range []struct {
+		name                     string
+		recovered, forgejo, self bool
+	}{
+		{"missing publication", false, false, false},
+		{"already recovered publication", true, false, false},
+		{"Forgejo missing publication", false, true, false},
+		{"Forgejo already recovered publication", true, true, false},
+		{"Forgejo self blocking COMMENT", false, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			fixture := newRunnerFixture(t)
 			const loopID = "loop_follow_engaged_without_metadata"
@@ -36,12 +41,33 @@ func TestDiscoverPullRequestsRequeuesLooperEngagedFollowUpAfterCurrentHeadSkip(t
 				}},
 			}
 			agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings", Stdout: `__LOOPER_RESULT__={"summary":"posted clean follow-up review"}`, ParseStatus: "parsed"}}}
-			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}, ReviewEvents: config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventRequestChanges}, LoopConfig: testReviewerLoopConfig()})
+			options := Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: true, Labels: []string{}, LabelMode: config.LabelModeAll}, ReviewEvents: config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventComment, Blocking: config.ReviewerReviewEventRequestChanges}, LoopConfig: testReviewerLoopConfig()}
+			if tc.forgejo {
+				cfg, err := config.DefaultConfig(t.TempDir())
+				if err != nil {
+					t.Fatal(err)
+				}
+				cfg.Providers = []config.ProviderConfig{{ID: "fj", Kind: config.ProviderKindForgejo, BaseURL: "https://code.example", TokenEnv: stringPtr("FORGEJO_TOKEN")}}
+				cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Provider: "fj", Repo: "acme/looper"}}
+				cfg.Roles.Reviewer.Discovery.AutoDiscovery = true
+				cfg.Roles.Reviewer.Discovery.Triggers.RequireReviewRequest = true
+				cfg.Roles.Reviewer.Discovery.Triggers.Labels = []string{}
+				cfg.Roles.Reviewer.Discovery.Triggers.EnableSelfReview = tc.self
+				cfg.Roles.Reviewer.Behavior.ReviewEvents = options.ReviewEvents
+				cfg.Roles.Reviewer.Behavior.Loop = testReviewerLoopConfig()
+				options.CustomInstructions = &cfg
+				github.comments = []map[string]any{{"body": "Old finding, explicitly fixed by the fixer", "isResolved": false}}
+				if tc.self {
+					github.author = "bob"
+					github.reviews[0]["state"] = "COMMENTED"
+				}
+			}
+			runner := New(options)
 			nowISO := fixture.nowISO()
 			repo := "acme/looper"
 			prNumber := int64(42)
 			metadata := `{"followUpdates":true,"lastFilterSkip":{"kind":"not_requested","headSha":"new-head","reviewerLogin":"bob"},"loop":{"enabled":true,"iterationCount":1,"iterationsByHead":{"old-head":1}}}`
-			if recovered {
+			if tc.recovered {
 				metadata = strings.Replace(metadata, `"followUpdates":true`, `"followUpdates":true,"lastPublishedHeadSha":"old-head"`, 1)
 			}
 			loop := storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &prNumber, Status: "completed", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
@@ -74,6 +100,15 @@ func TestDiscoverPullRequestsRequeuesLooperEngagedFollowUpAfterCurrentHeadSkip(t
 			}
 			if processed.Status != "success" || len(agent.starts) != 1 {
 				t.Fatalf("ProcessClaimedItem() = %#v, agent starts = %d; want full follow-up review", processed, len(agent.starts))
+			}
+			if tc.forgejo && (github.listReviewThreadsCalls != 0 || len(github.resolveThreadCalls) != 0) {
+				t.Fatal("Forgejo follow-up attempted unsupported thread resolution")
+			}
+			if tc.forgejo {
+				repeated, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo})
+				if err != nil || len(repeated.QueueItems) != 0 {
+					t.Fatalf("same-head rediscovery = %#v, %v; want no duplicate review", repeated, err)
+				}
 			}
 
 		})

--- a/internal/reviewer/runner_engagement_backfill_test.go
+++ b/internal/reviewer/runner_engagement_backfill_test.go
@@ -252,13 +252,13 @@ func TestLooperReviewEngagementHeadMatchesPublishVerifierGates(t *testing.T) {
 	canonicalClean := "<!-- looper:review id=reviewer:" + loopID + " head=old-head outcome=clean -->"
 
 	// Policy: COMMENTED+blocking is only valid when REQUEST_CHANGES is not required.
-	if got := looperReviewEngagementHead(withState("COMMENTED", canonicalBlocking), "bob", loopID, "new-head", allowedRC, false); got != "" {
+	if got := looperReviewEngagementHead(withState("COMMENTED", canonicalBlocking), "bob", loopID, "new-head", allowedRC, false, false); got != "" {
 		t.Fatalf("COMMENTED+blocking under REQUEST_CHANGES policy = %q, want empty", got)
 	}
-	if got := looperReviewEngagementHead(withState("COMMENTED", canonicalBlocking), "bob", loopID, "new-head", allowedComment, false); got != "old-head" {
+	if got := looperReviewEngagementHead(withState("COMMENTED", canonicalBlocking), "bob", loopID, "new-head", allowedComment, false, false); got != "old-head" {
 		t.Fatalf("COMMENTED+blocking under COMMENT policy = %q, want old-head", got)
 	}
-	if got := looperReviewEngagementHead(marker(canonicalBlocking), "bob", loopID, "new-head", allowedRC, false); got != "old-head" {
+	if got := looperReviewEngagementHead(marker(canonicalBlocking), "bob", loopID, "new-head", allowedRC, false, false); got != "old-head" {
 		t.Fatalf("CHANGES_REQUESTED+blocking = %q, want old-head", got)
 	}
 
@@ -268,21 +268,21 @@ func TestLooperReviewEngagementHeadMatchesPublishVerifierGates(t *testing.T) {
 		"<!-- looper:review-extra id=reviewer:" + loopID + " head=old-head outcome=blocking -->",
 		"<!-- looper:review id=reviewer:" + loopID + " head=old-head outcome=BLOCKING -->",
 	} {
-		if got := looperReviewEngagementHead(marker(body), "bob", loopID, "new-head", allowedRC, false); got != "" {
+		if got := looperReviewEngagementHead(marker(body), "bob", loopID, "new-head", allowedRC, false, false); got != "" {
 			t.Fatalf("noncanonical body %q engagement head = %q, want empty", body, got)
 		}
 	}
 
 	// Human-body quality belongs to publish validation, not engagement authority.
-	if got := looperReviewEngagementHead(withState("APPROVED", canonicalClean), "bob", loopID, "new-head", allowedApprove, false); got != "old-head" {
+	if got := looperReviewEngagementHead(withState("APPROVED", canonicalClean), "bob", loopID, "new-head", allowedApprove, false, false); got != "old-head" {
 		t.Fatalf("APPROVED clean marker-only = %q, want old-head engagement", got)
 	}
 
-	if got := looperReviewEngagementHead(withState("COMMENTED", canonicalClean), "bob", loopID, "new-head", allowedApprove, true); got != "old-head" {
+	if got := looperReviewEngagementHead(withState("COMMENTED", canonicalClean), "bob", loopID, "new-head", allowedApprove, true, false); got != "old-head" {
 		t.Fatalf("self-approval clean marker-only = %q, want old-head engagement", got)
 	}
 	// COMMENT clean policy does not require body validation.
-	if got := looperReviewEngagementHead(withState("COMMENTED", canonicalClean), "bob", loopID, "new-head", allowedComment, false); got != "old-head" {
+	if got := looperReviewEngagementHead(withState("COMMENTED", canonicalClean), "bob", loopID, "new-head", allowedComment, false, false); got != "old-head" {
 		t.Fatalf("COMMENT policy clean = %q, want old-head", got)
 	}
 

--- a/internal/reviewer/runner_forgejo_automerge_test.go
+++ b/internal/reviewer/runner_forgejo_automerge_test.go
@@ -166,3 +166,42 @@ func TestForgejoAutoMergePublishRetryRetainsApprovalAndRejectsHeadDrift(t *testi
 		})
 	}
 }
+
+func TestForgejoSummaryCommentCleanPublishSkipsAutoMergeNativeReview(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	github := &fakeGitHubGateway{labels: []string{"looper:review"}, reviewRequests: []string{}, currentLogin: "reviewer"}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings","outcome":"clean","findings":[]}`, ParseStatus: "parsed"}}}
+	cfg := reviewerAutoMergeTestConfig(t)
+	cfg.Providers = []config.ProviderConfig{{ID: "fj", Kind: config.ProviderKindForgejo, BaseURL: "https://code.example", TokenEnv: stringPtr("FORGEJO_TOKEN")}}
+	cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Provider: "fj", Repo: "acme/looper", RepoPath: "/tmp/repos/looper"}}
+	cfg.Roles.Reviewer.Discovery.Triggers.RequireReviewRequest = false
+	cfg.Roles.Reviewer.Discovery.Triggers.Labels = []string{"looper:review"}
+	cfg.Roles.Reviewer.Behavior.PublishMode = config.ReviewerPublishModeSummaryComment
+	cfg.Roles.Reviewer.Behavior.ReviewEvents.Clean = config.ReviewerReviewEventApprove
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CustomInstructions: cfg, DiscoveryPolicy: DiscoveryPolicy{AutoDiscovery: true, IncludeDrafts: false, RequireReviewRequest: false, Labels: []string{"looper:review"}, LabelMode: config.LabelModeAll}, LoopConfig: testReviewerLoopConfig(), ReviewEvents: cfg.Roles.Reviewer.Behavior.ReviewEvents})
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: "acme/looper"}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNextOfType() = (%#v, %v), want claimed reviewer item", claim, err)
+	}
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success", result)
+	}
+	if len(github.issueCommentCalls) != 1 {
+		t.Fatalf("issueCommentCalls = %#v, want the configured summary comment", github.issueCommentCalls)
+	}
+	if len(github.submitReviewCalls) != 0 {
+		t.Fatalf("submitReviewCalls = %#v, want no native review under summary_comment", github.submitReviewCalls)
+	}
+	if len(github.enableAutoMergeCalls) != 0 {
+		t.Fatalf("enableAutoMergeCalls = %#v, want no auto-merge without a native APPROVE", github.enableAutoMergeCalls)
+	}
+}

--- a/internal/reviewer/runner_forgejo_automerge_test.go
+++ b/internal/reviewer/runner_forgejo_automerge_test.go
@@ -1,0 +1,168 @@
+package reviewer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/forge"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/reviewer/criteria"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+// The live Forgejo merge endpoint checks required CI and the supplied head only
+// for immediate merges. It consumes the review request when approval is submitted.
+type forgejoImmediateMergeGateway struct {
+	*fakeGitHubGateway
+	checksReady       bool
+	changeHeadAtMerge bool
+	loseMergeResponse bool
+	mergedHeads       []string
+}
+
+func (g *forgejoImmediateMergeGateway) SubmitReview(ctx context.Context, input githubinfra.SubmitReviewInput) error {
+	if err := g.fakeGitHubGateway.SubmitReview(ctx, input); err != nil {
+		return err
+	}
+	g.reviewRequests = []string{}
+	row := g.reviews[len(g.reviews)-1]
+	row["commit_id"] = input.CommitID
+	return nil
+}
+
+func (g *forgejoImmediateMergeGateway) EnableAutoMerge(_ context.Context, input githubinfra.EnableAutoMergeInput) error {
+	g.enableAutoMergeCalls = append(g.enableAutoMergeCalls, input)
+	if g.changeHeadAtMerge {
+		g.viewHeadSHA = "changed-head"
+	}
+	if !g.checksReady {
+		return &forge.ForgejoHTTPError{StatusCode: http.StatusMethodNotAllowed, Message: "PR is not ready to be merged: required CI is pending"}
+	}
+	if input.HeadSHA != firstNonEmpty(g.viewHeadSHA, "abc123") {
+		return &forge.ForgejoHTTPError{StatusCode: http.StatusConflict, Message: "head out of date"}
+	}
+	g.mergedHeads = append(g.mergedHeads, input.HeadSHA)
+	if g.loseMergeResponse {
+		g.viewState = "CLOSED"
+		return fmt.Errorf("connection reset after merge response")
+	}
+	return nil
+}
+
+func TestForgejoAutoMergePublishRetryRetainsApprovalAndRejectsHeadDrift(t *testing.T) {
+	for _, mode := range []string{"CI succeeds", "approval removed before retry", "head changes before retry", "head changes during merge request", "merge response lost", "merge response lost then head changes"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRunnerFixture(t)
+			gateway := &forgejoImmediateMergeGateway{fakeGitHubGateway: &fakeGitHubGateway{
+				author: "octocat", currentLogin: "reviewer", reviewMarkerMissing: true, reviewRequests: []string{"reviewer"},
+				labels: []string{"looper:worker-ready"}, viewBody: "Closes #358", viewDiff: "diff --git a/app.go b/app.go\n@@ -1 +1 @@\n-old\n+new\n",
+				issueDetail: githubinfra.IssueDetail{Number: 358, Body: "## Acceptance criteria\n- ship app change\n", Labels: []string{"triaged"}},
+			}}
+			cfg := reviewerAutoMergeTestConfig(t)
+			cfg.Providers = []config.ProviderConfig{{ID: "fj", Kind: config.ProviderKindForgejo, BaseURL: "https://code.example", TokenEnv: stringPtr("FORGEJO_TOKEN")}}
+			cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Provider: "fj", Repo: "acme/looper"}}
+			cfg.Roles.Reviewer.Discovery.Triggers.RequireReviewRequest = true
+			cfg.Roles.Reviewer.Discovery.Triggers.Labels = nil
+			cfg.Roles.Reviewer.Behavior.Loop = testReviewerLoopConfig()
+			agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "No actionable findings", Stdout: `__LOOPER_RESULT__={"summary":"No actionable findings"}`, ParseStatus: "parsed"}}}
+			runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: gateway, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, CustomInstructions: cfg, CriteriaVerifier: stubCriteriaVerifier{responses: map[criteria.AcceptanceCriterion]criteria.CriterionAssessment{"ship app change": {Verdict: criteria.VerdictPass, Justification: "present in diff", Evidence: []criteria.Evidence{{FilePath: "app.go", StartLine: 1, EndLine: 1}}}}}})
+			ctx := context.Background()
+			repo, number, metadata := "acme/looper", int64(42), `{"followUpdates":true,"loop":{"enabled":true}}`
+			loop := storage.LoopRecord{ID: "loop_forgejo_ci", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Repo: &repo, PRNumber: &number, Status: "queued", MetadataJSON: &metadata, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+			if err := fixture.repos.Loops.Upsert(ctx, loop); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := runner.enqueue(ctx, enqueueInput{ProjectID: loop.ProjectID, LoopID: loop.ID, Repo: repo, PRNumber: number}); err != nil {
+				t.Fatal(err)
+			}
+			claimAndProcess := func() ProcessResult {
+				t.Helper()
+				claim, err := fixture.repos.Queue.ClaimNextOfType(ctx, fixture.nowISO(), "reviewer-worker", "reviewer")
+				if err != nil || claim == nil {
+					t.Fatalf("claim = %#v, %v", claim, err)
+				}
+				result, err := runner.ProcessClaimedItem(ctx, *claim)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return result
+			}
+			first := claimAndProcess()
+			if first.Status != "failed" || first.FailureKind != FailureRetryableAfterResume || len(gateway.enableAutoMergeCalls) != 1 || len(gateway.mergedHeads) != 0 {
+				t.Fatalf("pending CI = %#v, merge attempts=%d, merged=%v", first, len(gateway.enableAutoMergeCalls), gateway.mergedHeads)
+			}
+			persisted, err := fixture.repos.Loops.GetByID(ctx, loop.ID)
+			if err != nil || persisted == nil || strings.Contains(derefString(persisted.MetadataJSON), "lastPublishedHeadSha") {
+				t.Fatalf("merge failure recorded publish success: %#v, %v", persisted, err)
+			}
+			prior, err := fixture.repos.Runs.GetByID(ctx, first.RunID)
+			if err != nil || prior == nil {
+				t.Fatalf("first run = %#v, %v", prior, err)
+			}
+			pending := parseCheckpoint(prior.CheckpointJSON)
+			if pending.PendingReview == nil || !pending.PendingReview.CleanNoop || pending.PendingReview.HeadSHA != "abc123" || derefString(prior.LastCompletedStep) != string(stepReview) {
+				t.Fatalf("lost publish checkpoint: %#v", pending)
+			}
+			gateway.checksReady = true
+			if mode == "head changes before retry" {
+				gateway.viewHeadSHA = "changed-head"
+			}
+			if mode == "approval removed before retry" {
+				gateway.reviews = nil
+			}
+			gateway.changeHeadAtMerge = mode == "head changes during merge request"
+			gateway.loseMergeResponse = strings.HasPrefix(mode, "merge response lost")
+			fixture.advance(time.Hour)
+			second := claimAndProcess()
+			if len(agent.starts) != 1 || len(gateway.submitReviewCalls) != 1 {
+				t.Fatalf("retry reran review: agents=%d approvals=%d", len(agent.starts), len(gateway.submitReviewCalls))
+			}
+			switch mode {
+			case "CI succeeds":
+				if second.Status != "success" || len(gateway.enableAutoMergeCalls) != 2 || len(gateway.mergedHeads) != 1 || gateway.mergedHeads[0] != "abc123" {
+					t.Fatalf("CI completion = %#v, attempts=%d merged=%v", second, len(gateway.enableAutoMergeCalls), gateway.mergedHeads)
+				}
+			case "head changes before retry":
+				if second.Status != "skipped" || !strings.Contains(second.Summary, "head changed") || len(gateway.enableAutoMergeCalls) != 1 || len(gateway.mergedHeads) != 0 {
+					t.Fatalf("head drift = %#v, attempts=%d merged=%v", second, len(gateway.enableAutoMergeCalls), gateway.mergedHeads)
+				}
+			case "approval removed before retry":
+				if second.Status != "skipped" || !strings.Contains(second.Summary, "not requested") || len(gateway.enableAutoMergeCalls) != 1 || len(gateway.mergedHeads) != 0 {
+					t.Fatalf("removed approval authorized a merge: %#v, attempts=%d merged=%v", second, len(gateway.enableAutoMergeCalls), gateway.mergedHeads)
+				}
+			case "head changes during merge request":
+				if second.Status != "failed" || !strings.Contains(second.Summary, "head out of date") || len(gateway.enableAutoMergeCalls) != 2 || len(gateway.mergedHeads) != 0 {
+					t.Fatalf("atomic head rejection = %#v, attempts=%d merged=%v", second, len(gateway.enableAutoMergeCalls), gateway.mergedHeads)
+				}
+			case "merge response lost", "merge response lost then head changes":
+				if second.Status != "failed" || len(gateway.mergedHeads) != 1 {
+					t.Fatalf("lost response = %#v, merged=%v", second, gateway.mergedHeads)
+				}
+				if mode == "merge response lost then head changes" {
+					gateway.viewHeadSHA = "changed-head"
+				}
+				fixture.advance(time.Minute)
+				third := claimAndProcess()
+				if third.Status != "skipped" || len(gateway.enableAutoMergeCalls) != 2 || len(gateway.submitReviewCalls) != 1 || len(agent.starts) != 1 {
+					t.Fatalf("merged PR retry = %#v, attempts=%d approvals=%d agents=%d", third, len(gateway.enableAutoMergeCalls), len(gateway.submitReviewCalls), len(agent.starts))
+				}
+				if mode == "merge response lost then head changes" && !strings.Contains(third.Summary, "head changed") {
+					t.Fatalf("new head falsely accepted old approval: %#v", third)
+				}
+			}
+			persisted, err = fixture.repos.Loops.GetByID(ctx, loop.ID)
+			if err != nil || persisted == nil {
+				t.Fatalf("final loop = %#v, %v", persisted, err)
+			}
+			if strings.Contains(derefString(persisted.MetadataJSON), `"lastPublishedHeadSha":"changed-head"`) {
+				t.Fatalf("unreviewed head recorded as published: %s", derefString(persisted.MetadataJSON))
+			}
+		})
+	}
+}

--- a/internal/reviewer/runner_forgejo_context_test.go
+++ b/internal/reviewer/runner_forgejo_context_test.go
@@ -1,0 +1,87 @@
+package reviewer
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/disclosure"
+	"github.com/nexu-io/looper/internal/forge"
+)
+
+func TestForgejoReviewerPromptUsesPersistedURLAndConfiguredTransport(t *testing.T) {
+	t.Parallel()
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Providers = []config.ProviderConfig{{ID: "fj", Kind: config.ProviderKindForgejo, BaseURL: "https://code.example/forge", Auth: config.ProviderAuthTea, TeaPath: stringPtr("/opt/tea"), TeaLogin: stringPtr("team-login")}}
+	cfg.Projects = []config.ProjectRefConfig{{ID: "p", Provider: "fj", Repo: "core/looper"}}
+	for _, legacy := range []bool{false, true} {
+		for _, actualURL := range []string{"", "https://canonical.example/prefix/core/looper/pulls/42"} {
+			checkpoint := reviewerCheckpoint{Detail: checkpointDetailFromDetail(PullRequestDetail{URL: actualURL, HeadSHA: "abc123", ChecksSummary: "unit: FAILURE"}), Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}
+			encoded, err := json.Marshal(checkpoint)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var resumed reviewerCheckpoint
+			if err := json.Unmarshal(encoded, &resumed); err != nil {
+				t.Fatal(err)
+			}
+			prompt, _ := buildReviewPromptWithInstructions("p", cfg, "core/looper", 42, resumed, "run", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove, Blocking: config.ReviewerReviewEventRequestChanges}, false, true, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "codex", "", "/opt/looper", false, legacy, "")
+			wantURL := actualURL
+			if wantURL == "" {
+				wantURL = "https://code.example/forge/core/looper/pulls/42"
+			}
+			for _, required := range []string{`"url": "` + wantURL + `"`, "'/opt/tea' api --login 'team-login' -i", "unit: FAILURE"} {
+				if !strings.Contains(prompt, required) {
+					t.Errorf("legacy=%v url=%s missing %q", legacy, actualURL, required)
+				}
+			}
+			if !legacy && !strings.Contains(prompt, disclosure.Slogan) {
+				t.Error("native review prompt lost the shared GitHub disclosure slogan")
+			}
+			for _, forbidden := range []string{"https://github.com/core/looper/pull/42", "gh pr view", "gh api graphql"} {
+				if strings.Contains(prompt, forbidden) {
+					t.Errorf("Forgejo prompt contains %q", forbidden)
+				}
+			}
+			if !legacy && (!strings.Contains(prompt, "downgrades REQUEST_CHANGES to COMMENT while retaining outcome=blocking") || strings.Contains(prompt, "Resolvable inline review comments are required")) {
+				t.Error("native prompt lost self-blocking fallback or requires unsupported resolve")
+			}
+		}
+	}
+}
+
+func TestForgejoReviewerLegacyCommentHasHumanProseAndSharedDisclosure(t *testing.T) {
+	t.Parallel()
+	summary := forge.NewReviewerSummary(4, []forge.ReviewItem{
+		{ReviewItemID: "R-001", Status: forge.ReviewItemStatusOpen, Title: "Retain the discount", Body: "The price calculation drops the discount; apply it before rounding.", Files: []string{"price.go"}, LastSeenRoundID: 4},
+		{ReviewItemID: "R-002", Status: forge.ReviewItemStatusResolved, Title: "Historical finding", Body: "Already fixed.", LastSeenRoundID: 3},
+	})
+	body, err := renderReviewerSummaryComment(summary, "I found one price calculation issue.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stamper := disclosure.Stamper{Config: config.DefaultDisclosureConfig(), Agent: "codex"}
+	body = stamper.Markdown(body, "reviewer", disclosure.ChannelIssueComment)
+	visible := reviewHumanVisibleBody(body)
+	for _, required := range []string{"I found one price calculation issue.", "Retain the discount", "apply it before rounding", "price.go"} {
+		if !strings.Contains(visible, required) {
+			t.Errorf("visible comment missing %q: %s", required, visible)
+		}
+	}
+	for _, forbidden := range []string{"Reviewer Summary", "Review round", "Open items", "Resolved", "R-001", "Historical finding", "schema_version"} {
+		if strings.Contains(visible, forbidden) {
+			t.Errorf("protocol leaked to visible comment %q: %s", forbidden, visible)
+		}
+	}
+	if !strings.Contains(body, stamper.MarkdownStamp("reviewer")) || !strings.Contains(body, "runner=reviewer · agent=codex · "+disclosure.Slogan) {
+		t.Fatalf("GitHub disclosure missing: %s", body)
+	}
+	parsed, err := forge.ParseReviewerSummary(body)
+	if err != nil || parsed.ReviewRoundID != 4 || len(parsed.Items) != 2 || parsed.Items[1].Status != forge.ReviewItemStatusResolved {
+		t.Fatalf("hidden legacy protocol = %#v, %v", parsed, err)
+	}
+}

--- a/internal/reviewer/runner_forgejo_self_review_test.go
+++ b/internal/reviewer/runner_forgejo_self_review_test.go
@@ -1,0 +1,93 @@
+package reviewer
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestVerifyAgentNativeReviewMarkerScopesBlockingCommentFallbackToForgejoAuthor(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		kind   config.ProviderKind
+		author string
+		allow  bool
+	}{
+		{name: "Forgejo self review", kind: config.ProviderKindForgejo, author: "Reviewer", allow: true},
+		{name: "Forgejo other author", kind: config.ProviderKindForgejo, author: "alice"},
+		{name: "Forgejo missing author", kind: config.ProviderKindForgejo},
+		{name: "GitHub self review retains event policy", kind: config.ProviderKindGitHub, author: "reviewer"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg.Providers = []config.ProviderConfig{{ID: "provider", Kind: tc.kind}}
+			cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Repo: "acme/looper", Provider: "provider"}}
+			github := &fakeGitHubGateway{currentLogin: "reviewer", reviewMarkerMissing: true}
+			runner := New(Options{GitHub: github, CustomInstructions: &cfg})
+			input := stepInput{Project: storage.ProjectRecord{ID: "project_1", RepoPath: "/repo"}, Loop: storage.LoopRecord{ID: "loop"}, Repo: "acme/looper", PRNumber: 42}
+			found, err := runner.verifyAgentNativeReviewMarker(context.Background(), input, "head", "", tc.author)
+			if err != nil || found.Found {
+				t.Fatalf("verify = %#v, %v; want no matching marker", found, err)
+			}
+			if len(github.reviewMarkerInputs) != 3 {
+				t.Fatalf("marker lookups = %d, want all supported marker forms", len(github.reviewMarkerInputs))
+			}
+			for _, lookup := range github.reviewMarkerInputs {
+				if lookup.AllowBlockingComment != tc.allow || lookup.AuthorLogin != "reviewer" || !strings.Contains(lookup.Marker, "head=head") {
+					t.Fatalf("lookup = %#v; want current author/head and blocking fallback %t", lookup, tc.allow)
+				}
+			}
+		})
+	}
+}
+
+func TestForgejoSelfBlockingReviewBackfillsEngagementWithoutChangingGitHubPolicy(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		kind   config.ProviderKind
+		author string
+		want   string
+	}{
+		{name: "Forgejo self review", kind: config.ProviderKindForgejo, author: "reviewer", want: "old-head"},
+		{name: "Forgejo other author", kind: config.ProviderKindForgejo, author: "alice"},
+		{name: "GitHub self review", kind: config.ProviderKindGitHub, author: "reviewer"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newRunnerFixture(t)
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg.Providers = []config.ProviderConfig{{ID: "provider", Kind: tc.kind}}
+			cfg.Projects = []config.ProjectRefConfig{{ID: "project_1", Repo: "acme/looper", Provider: "provider"}}
+			cfg.Roles.Reviewer.Behavior.ReviewEvents.Blocking = config.ReviewerReviewEventRequestChanges
+			runner := New(Options{Repos: fixture.repos, CustomInstructions: &cfg})
+			meta := `{"followUpdates":true,"loop":{"enabled":true}}`
+			loop := storage.LoopRecord{ID: "self-review-loop", Seq: 1, ProjectID: "project_1", Type: "reviewer", TargetType: "pull_request", Status: "completed", MetadataJSON: &meta, CreatedAt: fixture.nowISO(), UpdatedAt: fixture.nowISO()}
+			if err := fixture.repos.Loops.Upsert(context.Background(), loop); err != nil {
+				t.Fatal(err)
+			}
+			detail := PullRequestDetail{Number: 42, HeadSHA: "new-head", Author: tc.author, Reviews: []map[string]any{{
+				"user": map[string]any{"login": "reviewer"}, "state": "COMMENTED", "commit_id": "old-head",
+				"body": "<!-- looper:review id=reviewer:self-review-loop head=old-head outcome=blocking -->",
+			}}}
+			updated, err := runner.backfillPublishedHeadFromLooperReview(context.Background(), storage.ProjectRecord{ID: "project_1"}, loop, detail, "reviewer")
+			if err != nil {
+				t.Fatal(err)
+			}
+			metadata := parseJSONObject(updated.MetadataJSON)
+			got, _ := metadata["lastPublishedHeadSha"].(string)
+			if got != tc.want {
+				t.Fatalf("engaged head = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -8789,7 +8789,7 @@ func TestBuildReviewPromptForgejoNativeKeepsMustFixInline(t *testing.T) {
 func TestBuildReviewerMinimalPRSeedUsesEnterpriseHost(t *testing.T) {
 	t.Parallel()
 
-	seed := buildReviewerMinimalPRSeed("ghe.example.com/acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, config.ReviewerScopeFullPR)
+	seed := buildReviewerMinimalPRSeed("ghe.example.com/acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{HeadSHA: "abc123"}}, config.ReviewerScopeFullPR, "")
 	if !strings.Contains(seed, "\"url\": \"https://ghe.example.com/acme/looper/pull/42\"") {
 		t.Fatalf("seed = %q, want enterprise host PR URL", seed)
 	}
@@ -8831,31 +8831,49 @@ func TestBuildReviewPromptRequiresHumanCleanApproveBodyMentioningAuthor(t *testi
 
 func TestBuildReviewPromptOmitsSubmitPathInstructionWhenTrustedWrapperUnavailable(t *testing.T) {
 	t.Parallel()
+	for _, provider := range []string{"GitHub", "Forgejo"} {
+		t.Run(provider, func(t *testing.T) {
+			cfg, err := config.DefaultConfig(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if provider == "Forgejo" {
+				cfg.Providers = []config.ProviderConfig{{ID: "fj", Kind: config.ProviderKindForgejo, BaseURL: "https://code.example", TokenEnv: stringPtr("FORGEJO_TOKEN")}}
+				cfg.Projects = []config.ProjectRefConfig{{ID: "p", Provider: "fj", Repo: "acme/looper"}}
+			}
+			prompt, _ := buildReviewPromptWithInstructions("p", cfg, "acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{Title: "Spec PR", HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove, Blocking: config.ReviewerReviewEventComment}, false, true, "", config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "", false, false, "")
 
-	prompt := buildReviewPrompt("acme/looper", 42, reviewerCheckpoint{Snapshot: &checkpointSnapshot{Title: "Spec PR", HeadSHA: "abc123"}}, "run_1", "reviewer:loop:abc123", config.ReviewerReviewEventsConfig{Clean: config.ReviewerReviewEventApprove, Blocking: config.ReviewerReviewEventComment}, false, config.ReviewerScopeChangedRanges, config.DefaultDisclosureConfig(), "opencode", "", "")
-
-	if !strings.Contains(prompt, "trusted looper review submit wrapper unavailable") {
-		t.Fatalf("prompt missing trusted wrapper unavailable failure instruction:\n%s", prompt)
-	}
-	for _, want := range []string{
-		"do not publish any GitHub review",
-		"do not add or remove any GitHub reaction",
-	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("prompt missing wrapper-unavailable failure guard %q:\n%s", want, prompt)
-		}
-	}
-	for _, forbidden := range []string{
-		"When submitting through",
-		"'' review submit",
-		" review submit acme/looper#42",
-		"You must publish the GitHub review yourself by calling looper's enforced review-submit wrapper",
-		"finish successfully with the `No actionable findings` summary only",
-		"finish successfully with a summary beginning `No actionable findings`",
-	} {
-		if strings.Contains(prompt, forbidden) {
-			t.Fatalf("prompt contains unavailable submit-path instruction %q:\n%s", forbidden, prompt)
-		}
+			if !strings.Contains(prompt, "trusted looper review submit wrapper unavailable") {
+				t.Fatalf("prompt missing trusted wrapper unavailable failure instruction:\n%s", prompt)
+			}
+			for _, want := range []string{
+				"do not publish any " + provider + " review",
+				"do not add or remove any " + provider + " reaction",
+			} {
+				if !strings.Contains(prompt, want) {
+					t.Fatalf("prompt missing wrapper-unavailable failure guard %q:\n%s", want, prompt)
+				}
+			}
+			for _, forbidden := range []string{
+				"When submitting through",
+				"'' review submit",
+				" review submit acme/looper#42",
+				"You must publish the GitHub review yourself by calling looper's enforced review-submit wrapper",
+				"finish successfully with the `No actionable findings` summary only",
+				"finish successfully with a summary beginning `No actionable findings`",
+			} {
+				if strings.Contains(prompt, forbidden) {
+					t.Fatalf("prompt contains unavailable submit-path instruction %q:\n%s", forbidden, prompt)
+				}
+			}
+			if provider == "Forgejo" {
+				for _, forbidden := range []string{"GitHub operation contract", "gh api", "gh pr"} {
+					if strings.Contains(prompt, forbidden) {
+						t.Fatalf("Forgejo wrapper-unavailable prompt contains %q", forbidden)
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -2461,7 +2461,7 @@ func (a fixerGitHubAdapter) ListNativeReviewComments(ctx context.Context, input 
 				URL:                 comment.HTMLURL,
 				Path:                comment.Path,
 				DiffHunk:            comment.DiffHunk,
-				ObservedFingerprint: fixer.NativeReviewCommentFingerprint(comment.ID, comment.UpdatedAt),
+				ObservedFingerprint: fixer.NativeReviewCommentFingerprint(comment.ID, comment.Body),
 				ResolverPresent:     comment.Resolver.Present,
 				IsResolved:          comment.Resolver.Value != nil,
 				Author:              comment.User.Login,

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -702,9 +702,15 @@ func forgeLabelNames(labels []forge.Label) []string {
 	return names
 }
 
-func forgeReviewContext(ctx context.Context, client *forge.ForgejoClient, pr forge.PullRequest, compatibilityFallback bool) ([]string, []networkpolicy.GitHubUser, []map[string]any, string, error) {
+func forgeReviewContext(ctx context.Context, client *forge.ForgejoClient, pr forge.PullRequest, compatibilityFallback bool, includeComments bool) ([]string, []networkpolicy.GitHubUser, []map[string]any, string, error) {
 	requested := pr.Reviewers
-	reviews, err := client.ListPullRequestReviews(ctx, pr.Number)
+	var reviews []forge.PullRequestReview
+	var err error
+	if includeComments {
+		reviews, err = client.ListPullRequestReviews(ctx, pr.Number)
+	} else {
+		reviews, err = client.ListPullRequestReviewSummaries(ctx, pr.Number)
+	}
 	if err != nil {
 		var capabilityErr *forge.UnsupportedCapabilityError
 		if !compatibilityFallback || !errors.As(err, &capabilityErr) {
@@ -712,31 +718,73 @@ func forgeReviewContext(ctx context.Context, client *forge.ForgejoClient, pr for
 		}
 	}
 	objects := make([]map[string]any, 0, len(reviews))
-	latestStates := map[string]string{}
+	latestVotes := map[string]forge.PullRequestReview{}
 	for _, review := range reviews {
 		objects = append(objects, map[string]any{
-			"id":     review.ID,
-			"author": map[string]any{"login": review.User.Login},
-			"body":   review.Body,
-			"state":  review.State,
-			"commit": map[string]any{"oid": review.CommitID},
-			"url":    review.HTMLURL,
+			"id":        review.ID,
+			"author":    map[string]any{"login": review.User.Login},
+			"body":      review.Body,
+			"state":     review.State,
+			"commit":    map[string]any{"oid": review.CommitID},
+			"url":       review.HTMLURL,
+			"comments":  forgeReviewCommentsToObjects(review.Comments),
+			"dismissed": review.Dismissed,
+			"stale":     review.Stale,
 		})
-		if login := strings.ToLower(strings.TrimSpace(review.User.Login)); login != "" {
-			latestStates[login] = review.State
+		if login := strings.ToLower(strings.TrimSpace(review.User.Login)); login != "" && (review.State == "CHANGES_REQUESTED" || review.State == "APPROVED") && !review.Dismissed {
+			if prior, found := latestVotes[login]; !found || review.ID > prior.ID {
+				latestVotes[login] = review
+			}
 		}
 	}
 	decision := ""
-	for _, state := range latestStates {
-		if state == "CHANGES_REQUESTED" {
+	for _, review := range latestVotes {
+		if review.State == "CHANGES_REQUESTED" {
 			decision = "CHANGES_REQUESTED"
 			break
 		}
-		if state == "APPROVED" {
+		if review.State == "APPROVED" {
 			decision = "APPROVED"
 		}
 	}
 	return forgeIdentityLogins(requested), forgeNetworkPolicyUsers(requested), objects, decision, nil
+}
+
+func forgeReviewCommentsToObjects(comments []forge.PullRequestReviewComment) []map[string]any {
+	objects := make([]map[string]any, 0, len(comments))
+	for _, comment := range comments {
+		objects = append(objects, map[string]any{
+			"id": comment.ID, "body": comment.Body, "author": map[string]any{"login": comment.User.Login},
+			"url": comment.HTMLURL, "path": comment.Path, "diffHunk": comment.DiffHunk,
+			"isResolved": comment.Resolver.Value != nil, "updatedAt": comment.UpdatedAt,
+		})
+	}
+	return objects
+}
+
+func forgeReviewContextComments(reviews []map[string]any) []map[string]any {
+	var comments []map[string]any
+	for _, review := range reviews {
+		state, _ := review["state"].(string)
+		if state == "PENDING" || state == "DISMISSED" {
+			continue
+		}
+		inline, _ := review["comments"].([]map[string]any)
+		comments = append(comments, inline...)
+	}
+	return comments
+}
+
+func forgeChecksToObjects(checks []forge.CommitCheck) []map[string]any {
+	objects := make([]map[string]any, 0, len(checks))
+	for _, check := range checks {
+		objects = append(objects, map[string]any{
+			"id": check.ID, "name": check.Name, "state": check.State,
+			"description": check.Description, "url": check.URL, "detailsUrl": check.URL,
+			"actionRunId": check.ActionRunID,
+		})
+	}
+	return objects
 }
 
 func forgejoSummaryCommentMode(cfg *config.Config, repo, cwd string) bool {
@@ -1138,11 +1186,15 @@ func (a reviewerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input r
 		}
 		result := make([]reviewer.PullRequestSummary, 0, len(pullRequests))
 		for _, pr := range pullRequests {
-			requests, requestUsers, reviews, decision, err := forgeReviewContext(ctx, client, pr, forgejoSummaryCommentMode(a.config, input.Repo, input.CWD))
+			requests, requestUsers, reviews, decision, err := forgeReviewContext(ctx, client, pr, forgejoSummaryCommentMode(a.config, input.Repo, input.CWD), false)
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: decision, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, BaseSHA: pr.Base.SHA, Author: pr.User.Login, ReviewRequests: requests, ReviewRequestUsers: requestUsers, Reviews: reviews})
+			conflicted, err := forgejoPullRequestHasConflicts(ctx, a.config, input.Repo, input.CWD, pr)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: decision, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, BaseSHA: pr.Base.SHA, HasConflicts: conflicted, Author: pr.User.Login, ReviewRequests: requests, ReviewRequestUsers: requestUsers, Reviews: reviews})
 		}
 		return result, nil
 	}
@@ -1171,11 +1223,15 @@ func (a reviewerGitHubAdapter) ListReviewRequestedPullRequests(ctx context.Conte
 		}
 		result := make([]reviewer.PullRequestSummary, 0, len(pullRequests))
 		for _, pr := range pullRequests {
-			requests, requestUsers, reviews, decision, err := forgeReviewContext(ctx, client, pr, forgejoSummaryCommentMode(a.config, input.Repo, input.CWD))
+			requests, requestUsers, reviews, decision, err := forgeReviewContext(ctx, client, pr, forgejoSummaryCommentMode(a.config, input.Repo, input.CWD), false)
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: decision, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, BaseSHA: pr.Base.SHA, Author: pr.User.Login, ReviewRequests: requests, ReviewRequestUsers: requestUsers, Reviews: reviews})
+			conflicted, err := forgejoPullRequestHasConflicts(ctx, a.config, input.Repo, input.CWD, pr)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: decision, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, BaseSHA: pr.Base.SHA, HasConflicts: conflicted, Author: pr.User.Login, ReviewRequests: requests, ReviewRequestUsers: requestUsers, Reviews: reviews})
 		}
 		return result, nil
 	}
@@ -1236,11 +1292,19 @@ func (a reviewerGitHubAdapter) ViewPullRequest(ctx context.Context, input review
 		if err != nil {
 			return reviewer.PullRequestDetail{}, err
 		}
-		requests, requestUsers, reviews, decision, err := forgeReviewContext(ctx, client, pr, forgejoSummaryCommentMode(a.config, input.Repo, input.CWD))
+		requests, requestUsers, reviews, decision, err := forgeReviewContext(ctx, client, pr, forgejoSummaryCommentMode(a.config, input.Repo, input.CWD), true)
 		if err != nil {
 			return reviewer.PullRequestDetail{}, err
 		}
-		return reviewer.PullRequestDetail{Number: pr.Number, Title: pr.Title, Body: pr.Body, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: decision, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, BaseSHA: pr.Base.SHA, HeadRefName: pr.Head.Name, BaseRefName: pr.Base.Name, Author: pr.User.Login, ReviewRequests: requests, ReviewRequestUsers: requestUsers, Diff: diff, IssueComments: forgeCommentsToObjects(comments), Reviews: reviews}, nil
+		checks, err := client.ListCommitChecks(ctx, pr.Head.SHA)
+		if err != nil {
+			return reviewer.PullRequestDetail{}, err
+		}
+		conflicted, err := forgejoPullRequestHasConflicts(ctx, a.config, input.Repo, input.CWD, pr)
+		if err != nil {
+			return reviewer.PullRequestDetail{}, err
+		}
+		return reviewer.PullRequestDetail{Number: pr.Number, URL: pr.HTMLURL, Title: pr.Title, Body: pr.Body, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: decision, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, BaseSHA: pr.Base.SHA, HeadRefName: pr.Head.Name, BaseRefName: pr.Base.Name, Author: pr.User.Login, ReviewRequests: requests, ReviewRequestUsers: requestUsers, HasConflicts: conflicted, ChecksSummary: summarizeCheckStates(forgeChecksToObjects(checks)), Comments: forgeReviewContextComments(reviews), Diff: diff, IssueComments: forgeCommentsToObjects(comments), Reviews: reviews}, nil
 	}
 	if a.gateway == nil {
 		return reviewer.PullRequestDetail{}, fmt.Errorf("github gateway is not configured")
@@ -1410,12 +1474,15 @@ func findForgejoNativeReviewMarker(reviews []forge.PullRequestReview, input revi
 		if !ok {
 			continue
 		}
+		if review.CommitID != "" && !strings.EqualFold(strings.TrimSpace(review.CommitID), marker.Head) {
+			continue
+		}
 		author := strings.TrimSpace(review.User.Login)
 		if expectedAuthor != "" && strings.ToLower(author) != expectedAuthor {
 			continue
 		}
 		event := forgejoReviewEventFromState(review.State)
-		if !forgejoNativeReviewMarkerEventAllowed(marker.Outcome, event, input.AllowedReviewEvents, input.AllowCleanComment) {
+		if !forgejoNativeReviewMarkerEventAllowed(marker.Outcome, event, input.AllowedReviewEvents, input.AllowCleanComment, input.AllowBlockingComment) {
 			continue
 		}
 		inlineBodies := make([]string, 0, len(review.Comments))
@@ -1445,8 +1512,8 @@ func forgejoReviewEventFromState(state string) reviewer.ReviewEvent {
 // forgejoNativeReviewMarkerEventAllowed mirrors github.reviewMarkerEventAllowedForOutcome so
 // outcome=clean requires APPROVE when that event is allowed, outcome=blocking requires
 // REQUEST_CHANGES when allowed, and COMMENT only matches non-blocking/actionable (or the
-// explicit clean-comment self-approval fallback).
-func forgejoNativeReviewMarkerEventAllowed(outcome string, event reviewer.ReviewEvent, allowed []reviewer.ReviewEvent, allowCleanComment bool) bool {
+// explicit self-authored COMMENT transport fallbacks).
+func forgejoNativeReviewMarkerEventAllowed(outcome string, event reviewer.ReviewEvent, allowed []reviewer.ReviewEvent, allowCleanComment, allowBlockingComment bool) bool {
 	if event == "" {
 		return false
 	}
@@ -1466,6 +1533,9 @@ func forgejoNativeReviewMarkerEventAllowed(outcome string, event reviewer.Review
 		}
 		return event == reviewer.ReviewEventComment
 	case "blocking":
+		if allowBlockingComment && event == reviewer.ReviewEventComment {
+			return true
+		}
 		if forgejoReviewEventAllowed(reviewer.ReviewEventRequestChanges, allowed) {
 			return event == reviewer.ReviewEventRequestChanges
 		}
@@ -2183,7 +2253,15 @@ func (a fixerGitHubAdapter) ViewPullRequest(ctx context.Context, input fixer.Vie
 		if err != nil {
 			return fixer.PullRequestDetail{}, failureclass.WithBoundary(err, failureclass.BoundaryGitHubAPI)
 		}
-		return fixer.PullRequestDetail{Number: pr.Number, State: pr.State, IsDraft: pr.IsDraft, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, HeadRefName: pr.Head.Name, BaseRefName: pr.Base.Name, BaseSHA: pr.Base.SHA, IssueComments: forgeCommentsToObjects(comments), Author: pr.User.Login}, nil
+		checks, err := client.ListCommitChecks(ctx, pr.Head.SHA)
+		if err != nil {
+			return fixer.PullRequestDetail{}, failureclass.WithBoundary(err, failureclass.BoundaryGitHubAPI)
+		}
+		conflicted, err := forgejoPullRequestHasConflicts(ctx, a.config, input.Repo, input.CWD, pr)
+		if err != nil {
+			return fixer.PullRequestDetail{}, err
+		}
+		return fixer.PullRequestDetail{Number: pr.Number, URL: pr.HTMLURL, State: pr.State, IsDraft: pr.IsDraft, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, HeadRefName: pr.Head.Name, BaseRefName: pr.Base.Name, BaseSHA: pr.Base.SHA, IssueComments: forgeCommentsToObjects(comments), Checks: forgeChecksToObjects(checks), HasConflicts: conflicted, Author: pr.User.Login}, nil
 	}
 	detail, err := a.gateway.ViewPullRequestForFixer(ctx, githubinfra.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
 	if err != nil {
@@ -2374,6 +2452,10 @@ func (a fixerGitHubAdapter) ListNativeReviewComments(ctx context.Context, input 
 				IsResolved:          comment.Resolver.Value != nil,
 				Author:              comment.User.Login,
 				UpdatedAt:           comment.UpdatedAt,
+				ReviewBody:          comment.ReviewBody,
+				ReviewState:         comment.ReviewState,
+				ReviewCommitID:      comment.ReviewCommitID,
+				ReviewAuthor:        comment.ReviewAuthor,
 			})
 		}
 		return out, nil
@@ -2489,10 +2571,30 @@ func (a fixerGitHubAdapter) RemovePullRequestLabels(ctx context.Context, input f
 }
 
 func (a fixerGitHubAdapter) AddPullRequestReviewers(ctx context.Context, input fixer.PullRequestReviewersInput) error {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
+		if err != nil {
+			return err
+		}
+		return addForgejoPullRequestReviewers(ctx, client, a.config, input.Repo, input.PRNumber, input.Reviewers, input.CWD)
+	}
 	return a.gateway.AddPullRequestReviewers(ctx, githubinfra.PullRequestReviewersInput{Repo: input.Repo, PRNumber: input.PRNumber, Reviewers: input.Reviewers, CWD: input.CWD})
 }
 
 func (a fixerGitHubAdapter) ListPullRequestReviews(ctx context.Context, input fixer.ViewPullRequestInput) ([]fixer.ReviewSummary, error) {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		reviews, err := client.ListPullRequestReviewSummaries(ctx, input.PRNumber)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]fixer.ReviewSummary, 0, len(reviews))
+		for _, review := range reviews {
+			out = append(out, fixer.ReviewSummary{ID: review.ID, State: review.State, Author: review.User.Login, Body: review.Body})
+		}
+		return out, nil
+	}
 	reviews, err := a.gateway.ListPullRequestReviews(ctx, githubinfra.ViewPullRequestInput{Repo: input.Repo, PRNumber: input.PRNumber, CWD: input.CWD})
 	if err != nil {
 		return nil, err
@@ -2505,6 +2607,12 @@ func (a fixerGitHubAdapter) ListPullRequestReviews(ctx context.Context, input fi
 }
 
 func (a fixerGitHubAdapter) DismissReview(ctx context.Context, input fixer.DismissReviewInput) error {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
+		if err != nil {
+			return err
+		}
+		return client.DismissPullRequestReview(ctx, input.PRNumber, input.ReviewID, input.Message)
+	}
 	return a.gateway.DismissReview(ctx, githubinfra.DismissReviewInput{Repo: input.Repo, PRNumber: input.PRNumber, ReviewID: input.ReviewID, Message: input.Message, CWD: input.CWD})
 }
 

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -863,6 +863,41 @@ func forgeClientForLocation[T any](cfg *config.Config, repo string, cwd []string
 	return byRepo(cfg, repo)
 }
 
+// forgejoClientForIssueLookup binds ViewIssue to the referenced repository.
+// CWD still disambiguates same-slug projects, but a closing reference such as
+// Fixes other/repo#123 must not reuse the PR project's client.
+func forgejoClientForIssueLookup(cfg *config.Config, repo, cwd string) (*forge.ForgejoClient, bool, error) {
+	repo = strings.TrimSpace(repo)
+	cwd = strings.TrimSpace(cwd)
+	if cwd != "" {
+		project, provider, ok, err := forgejoProjectProviderForCWD(cfg, cwd)
+		if err != nil {
+			return nil, false, err
+		}
+		if ok {
+			projectRepo := strings.TrimSpace(project.Repo)
+			if repo == "" || strings.EqualFold(projectRepo, repo) {
+				client, err := forge.NewForgejoClientFromConfig(provider, projectRepo)
+				if err != nil {
+					return nil, true, err
+				}
+				return client, true, nil
+			}
+			client, ok, err := forgejoClientForRepo(cfg, repo)
+			if ok || err != nil {
+				return client, ok, err
+			}
+			return nil, true, &forge.ForgejoHTTPError{
+				Method:     http.MethodGet,
+				Path:       "issues",
+				StatusCode: http.StatusNotFound,
+				Message:    fmt.Sprintf("cross-repository issue %s is not bound to a configured Forgejo project", repo),
+			}
+		}
+	}
+	return forgeClientForLocation(cfg, repo, []string{cwd}, forgejoClientForCWD, forgejoClientForRepo)
+}
+
 func (a plannerGitHubAdapter) ListOpenIssues(ctx context.Context, input planner.ListOpenIssuesInput) ([]planner.IssueSummary, error) {
 	if client, ok, err := a.plane(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
@@ -1331,7 +1366,7 @@ func (a reviewerGitHubAdapter) LoadPullRequestReviews(ctx context.Context, input
 }
 
 func (a reviewerGitHubAdapter) ViewIssue(ctx context.Context, input githubinfra.ViewIssueInput) (githubinfra.IssueDetail, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
+	if client, ok, err := forgejoClientForIssueLookup(a.config, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return githubinfra.IssueDetail{}, err
 		}

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1339,7 +1339,7 @@ func (a reviewerGitHubAdapter) ViewIssue(ctx context.Context, input githubinfra.
 		if err != nil {
 			return githubinfra.IssueDetail{}, err
 		}
-		return githubinfra.IssueDetail{Number: issue.Number, Title: issue.Title, Body: issue.Body, URL: issue.HTMLURL, State: issue.State, Labels: forgeLabelNames(issue.Labels), Assignees: forgeIdentityLogins(issue.Assignees), Author: issue.User.Login}, nil
+		return githubinfra.IssueDetail{IsPullRequest: issue.IsPullRequest, Number: issue.Number, Title: issue.Title, Body: issue.Body, URL: issue.HTMLURL, State: issue.State, Labels: forgeLabelNames(issue.Labels), Assignees: forgeIdentityLogins(issue.Assignees), Author: issue.User.Login}, nil
 	}
 	if a.gateway == nil {
 		return githubinfra.IssueDetail{}, fmt.Errorf("github gateway is not configured")
@@ -1348,10 +1348,24 @@ func (a reviewerGitHubAdapter) ViewIssue(ctx context.Context, input githubinfra.
 }
 
 func (a reviewerGitHubAdapter) GetRepositorySettings(ctx context.Context, input githubinfra.RepositorySettingsInput) (githubinfra.RepositorySettings, error) {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
+		if err != nil {
+			return githubinfra.RepositorySettings{}, err
+		}
+		settings, err := client.GetRepositoryMergeSettings(ctx)
+		return githubinfra.RepositorySettings{AllowSquashMerge: settings.AllowSquashMerge, AllowMergeCommit: settings.AllowMergeCommit, AllowRebaseMerge: settings.AllowRebaseMerge, AllowAutoMerge: true}, err
+	}
 	return a.gateway.GetRepositorySettings(ctx, input)
 }
 
 func (a reviewerGitHubAdapter) GetBranchProtection(ctx context.Context, input githubinfra.BranchProtectionInput) (githubinfra.BranchProtection, error) {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
+		if err != nil {
+			return githubinfra.BranchProtection{}, err
+		}
+		branch, err := client.GetBranchProtection(ctx, input.Branch)
+		return githubinfra.BranchProtection{Enabled: branch.Protected, HasRequiredChecks: branch.Protected && branch.EnableStatusCheck && len(branch.StatusCheckContexts) > 0, RequiredChecks: branch.StatusCheckContexts}, err
+	}
 	return a.gateway.GetBranchProtection(ctx, input)
 }
 
@@ -1746,11 +1760,11 @@ func (a reviewerGitHubAdapter) SubmitReview(ctx context.Context, input githubinf
 }
 
 func (a reviewerGitHubAdapter) EnableAutoMerge(ctx context.Context, input githubinfra.EnableAutoMergeInput) error {
-	if _, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
+	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("forgejo provider capability autoMerge is unsupported")
+		return client.EnableAutoMerge(ctx, input.PRNumber, string(input.Strategy), input.HeadSHA)
 	}
 	return a.gateway.EnableAutoMerge(ctx, input)
 }
@@ -2496,15 +2510,12 @@ func (a fixerGitHubAdapter) AddReviewThreadReply(ctx context.Context, input fixe
 }
 
 func (a fixerGitHubAdapter) CompareCommits(ctx context.Context, input fixer.CompareCommitsInput) (fixer.CompareCommitsResult, error) {
-	if client, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
+	if _, ok, err := a.forgejo(ctx, input.Repo, input.CWD); ok || err != nil {
 		if err != nil {
 			return fixer.CompareCommitsResult{}, err
 		}
-		out, err := client.CompareBranches(ctx, forge.CompareBranchesInput{Base: input.Base, Head: input.Head})
-		if err != nil {
-			return fixer.CompareCommitsResult{}, err
-		}
-		return fixer.CompareCommitsResult{Status: out.Status}, nil
+		status, err := forgejoCompareCommits(ctx, a.config, input.Repo, input.CWD, input.Base, input.Head)
+		return fixer.CompareCommitsResult{Status: status}, err
 	}
 	out, err := a.gateway.CompareCommits(ctx, githubinfra.CompareCommitsInput{Repo: input.Repo, Base: input.Base, Head: input.Head, CWD: input.CWD})
 	if err != nil {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -1225,11 +1225,10 @@ func (a reviewerGitHubAdapter) ListOpenPullRequests(ctx context.Context, input r
 			if err != nil {
 				return nil, err
 			}
-			conflicted, err := forgejoPullRequestHasConflicts(ctx, a.config, input.Repo, input.CWD, pr)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: decision, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, BaseSHA: pr.Base.SHA, HasConflicts: conflicted, Author: pr.User.Login, ReviewRequests: requests, ReviewRequestUsers: requestUsers, Reviews: reviews})
+			// Exact merge-tree checks stay on ViewPullRequest. List runs before
+			// eligibility filtering, and one mergeable=false draft whose commits
+			// cannot be fetched or merge-tree'd must not abort the whole list.
+			result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: decision, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, BaseSHA: pr.Base.SHA, Author: pr.User.Login, ReviewRequests: requests, ReviewRequestUsers: requestUsers, Reviews: reviews})
 		}
 		return result, nil
 	}
@@ -1262,11 +1261,10 @@ func (a reviewerGitHubAdapter) ListReviewRequestedPullRequests(ctx context.Conte
 			if err != nil {
 				return nil, err
 			}
-			conflicted, err := forgejoPullRequestHasConflicts(ctx, a.config, input.Repo, input.CWD, pr)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: decision, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, BaseSHA: pr.Base.SHA, HasConflicts: conflicted, Author: pr.User.Login, ReviewRequests: requests, ReviewRequestUsers: requestUsers, Reviews: reviews})
+			// Exact merge-tree checks stay on ViewPullRequest. List runs before
+			// eligibility filtering, and one mergeable=false draft whose commits
+			// cannot be fetched or merge-tree'd must not abort the whole list.
+			result = append(result, reviewer.PullRequestSummary{Number: pr.Number, Title: pr.Title, State: pr.State, IsDraft: pr.IsDraft, ReviewDecision: decision, Labels: forgeLabelNames(pr.Labels), HeadSHA: pr.Head.SHA, BaseSHA: pr.Base.SHA, Author: pr.User.Login, ReviewRequests: requests, ReviewRequestUsers: requestUsers, Reviews: reviews})
 		}
 		return result, nil
 	}

--- a/internal/runtime/scheduler_forgejo_ancestry.go
+++ b/internal/runtime/scheduler_forgejo_ancestry.go
@@ -1,0 +1,51 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/infra/shell"
+)
+
+func forgejoCompareCommits(ctx context.Context, cfg *config.Config, repo, cwd, base, head string) (string, error) {
+	base, head = strings.TrimSpace(base), strings.TrimSpace(head)
+	if base != "" && strings.EqualFold(base, head) {
+		return "identical", nil
+	}
+	gitPath, cwd, err := forgejoGitLocation(cfg, repo, cwd)
+	if err != nil {
+		return "", err
+	}
+	if err := ensureForgejoCommits(ctx, gitPath, cwd, []string{base, head}); err != nil {
+		return "", withForgejoConflictBoundary(err)
+	}
+	for i, pair := range [][2]string{{base, head}, {head, base}} {
+		result, err := shell.Run(ctx, shell.Options{Command: gitPath, CWD: cwd, Args: []string{"merge-base", "--is-ancestor", pair[0], pair[1]}})
+		if err == nil {
+			if i == 0 {
+				return "ahead", nil
+			}
+			return "behind", nil
+		}
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		var commandErr *shell.CommandExecutionError
+		if !errors.As(err, &commandErr) || result.ExitCode != 1 {
+			return "", withForgejoConflictBoundary(fmt.Errorf("compare Forgejo commit ancestry: %w", err))
+		}
+	}
+	// A shallow boundary hides parents even when both exact commit objects are
+	// present. Positive ancestry is conclusive; two negative answers are not.
+	result, err := shell.Run(ctx, shell.Options{Command: gitPath, CWD: cwd, Args: []string{"rev-parse", "--is-shallow-repository"}})
+	if err != nil {
+		return "", withForgejoConflictBoundary(fmt.Errorf("inspect Forgejo ancestry history: %w", err))
+	}
+	if strings.TrimSpace(result.Stdout) != "false" {
+		return "", withForgejoConflictBoundary(fmt.Errorf("Forgejo commit ancestry is inconclusive in a shallow repository; fetch complete history before retrying"))
+	}
+	return "diverged", nil
+}

--- a/internal/runtime/scheduler_forgejo_ancestry_test.go
+++ b/internal/runtime/scheduler_forgejo_ancestry_test.go
@@ -1,0 +1,114 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/fixer"
+	"github.com/nexu-io/looper/internal/loops/failureclass"
+)
+
+func TestForgejoCompareCommitsUsesAncestryInsteadOfCompareCount(t *testing.T) {
+	t.Setenv("FORGEJO_COMPARE_TOKEN", "test")
+	cwd, mainHead, fixedHead, _ := forgejoConflictRepo(t)
+	initial := strings.TrimSpace(forgejoMergeTestRunGit(t, cwd, "merge-base", mainHead, fixedHead))
+	tree := strings.TrimSpace(forgejoMergeTestRunGit(t, cwd, "rev-parse", fixedHead+"^{tree}"))
+	descendant := strings.TrimSpace(forgejoMergeTestRunGit(t, cwd, "commit-tree", tree, "-p", fixedHead, "-m", "unrelated follow-up"))
+	apiCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		apiCalls++
+		// Real Forgejo Compare schema cannot distinguish ahead from diverged.
+		_, _ = w.Write([]byte(`{"commits":[{"sha":"commit"}],"files":[],"total_commits":1}`))
+	}))
+	defer server.Close()
+	cfg := config.Config{Providers: []config.ProviderConfig{{ID: "forge", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: stringPtr("FORGEJO_COMPARE_TOKEN")}}, Projects: []config.ProjectRefConfig{{ID: "p", Provider: "forge", Repo: "core/looper", RepoPath: cwd}}}
+	adapter := fixerGitHubAdapter{config: &cfg}
+	for _, tc := range []struct{ name, base, head, want string }{
+		{"same head", fixedHead, fixedHead, "identical"},
+		{"ahead", initial, fixedHead, "ahead"},
+		{"unrelated later commit retains fix", fixedHead, descendant, "ahead"},
+		{"rewound before fix", fixedHead, initial, "behind"},
+		{"force-push removes fix", fixedHead, mainHead, "diverged"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := adapter.CompareCommits(context.Background(), fixer.CompareCommitsInput{Repo: "core/looper", CWD: cwd, Base: tc.base, Head: tc.head})
+			if err != nil || result.Status != tc.want {
+				t.Fatalf("compare = %#v, %v; want %s", result, err, tc.want)
+			}
+		})
+	}
+	if apiCalls != 0 {
+		t.Fatalf("Compare API calls = %d; total_commits is not ancestry evidence", apiCalls)
+	}
+}
+
+func TestForgejoCompareCommitsFetchesWithoutChangingCallerAndRejectsShallowGuess(t *testing.T) {
+	t.Parallel()
+	source, mainHead, feature, _ := forgejoConflictRepo(t)
+	initial := strings.TrimSpace(forgejoMergeTestRunGit(t, source, "merge-base", mainHead, feature))
+	for _, shallow := range []bool{false, true} {
+		root := t.TempDir()
+		caller := filepath.Join(root, "caller")
+		if shallow {
+			forgejoMergeTestRunGit(t, root, "clone", "--depth=1", "file://"+source, caller)
+		} else {
+			forgejoMergeTestMustMkdirAll(t, caller)
+			forgejoMergeTestRunGit(t, caller, "init", "-b", "main")
+			forgejoMergeTestRunGit(t, caller, "remote", "add", "origin", source)
+			forgejoMergeTestRunGit(t, caller, "fetch", "origin", initial)
+			forgejoMergeTestRunGit(t, caller, "reset", "--hard", initial)
+		}
+		forgejoMergeTestWriteFile(t, filepath.Join(caller, "README.md"), "staged caller change\n")
+		forgejoMergeTestRunGit(t, caller, "add", "README.md")
+		forgejoMergeTestWriteFile(t, filepath.Join(caller, "README.md"), "unstaged caller change\n")
+		forgejoMergeTestWriteFile(t, filepath.Join(caller, "untracked.txt"), "keep me\n")
+		forgejoMergeTestWriteFile(t, filepath.Join(caller, ".git", "FETCH_HEAD"), "keep fetch marker\n")
+		before := mergeConflictCallerSnapshot(t, caller)
+		cfg := config.Config{Projects: []config.ProjectRefConfig{{Repo: "core/looper", RepoPath: caller}}}
+		status, err := forgejoCompareCommits(context.Background(), &cfg, "core/looper", "", initial, mainHead)
+		if shallow {
+			if err == nil || status != "" || !strings.Contains(err.Error(), "shallow repository") {
+				t.Fatalf("shallow result = %q, %v; must not falsely report divergence", status, err)
+			}
+		} else if err != nil || status != "ahead" {
+			t.Fatalf("fetched ancestry = %q, %v", status, err)
+		}
+		if after := mergeConflictCallerSnapshot(t, caller); after != before {
+			t.Fatalf("ancestry changed caller: before=%s, after=%s", before, after)
+		}
+		for _, sha := range []string{initial, mainHead} {
+			forgejoMergeTestRunGit(t, caller, "cat-file", "-e", sha+"^{commit}")
+		}
+	}
+}
+
+func TestForgejoCompareCommitsPreservesLocalAndFetchFailures(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, script string
+		want         failureclass.Kind
+	}{
+		{"SSH connection closes", "#!/bin/sh\ncase \"$1\" in\ncat-file) while read object; do echo \"$object missing\"; done;;\nfetch) echo 'Connection closed by 172.16.1.8 port 22' >&2; exit 128;;\nesac\n", failureclass.RetryableTransient},
+		{"missing configured git", "", failureclass.NonRetryable},
+		{"merge-base fails", "#!/bin/sh\ncase \"$1\" in\ncat-file) while read object; do echo \"$object commit\"; done;;\n*) echo 'unsupported Git operation' >&2; exit 129;;\nesac\n", failureclass.NonRetryable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gitPath := filepath.Join(t.TempDir(), "missing-git")
+			if tc.script != "" {
+				gitPath = forgejoMergeTestWriteFakeGit(t, tc.script)
+			}
+			cfg := config.Config{Tools: config.ToolPathsConfig{GitPath: &gitPath}}
+			status, err := forgejoCompareCommits(context.Background(), &cfg, "core/looper", t.TempDir(), strings.Repeat("a", 40), strings.Repeat("b", 40))
+			var boundaryErr *failureclass.BoundaryError
+			if status != "" || !errors.As(err, &boundaryErr) || failureclass.Classify(err, failureclass.Context{Runner: failureclass.RunnerFixer, Boundary: failureclass.BoundaryGitHubAPI}) != tc.want {
+				t.Fatalf("ancestry failure = %q, %v; want %s", status, err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/scheduler_forgejo_automerge_test.go
+++ b/internal/runtime/scheduler_forgejo_automerge_test.go
@@ -182,3 +182,66 @@ func TestForgejoMergeAdapterDoesNotScheduleAndRejectsChangedHead(t *testing.T) {
 		t.Fatalf("new-head merge: queued=%d merged=%d", scheduled, merged)
 	}
 }
+
+func TestForgejoViewIssueRoutesCrossRepoLookupAwayFromCWD(t *testing.T) {
+	t.Setenv("FORGEJO_ISSUE_TOKEN", "test")
+	var requested []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.Path)
+		switch r.URL.Path {
+		case "/swagger.v1.json":
+			_, _ = w.Write([]byte(`{"paths":{}}`))
+		case "/api/v1/repos/other/repo/issues/123":
+			_, _ = w.Write([]byte(`{"number":123,"title":"linked","state":"open","body":"Acceptance criteria","html_url":"https://code.example/other/repo/issues/123","labels":[{"name":"looper:worker-ready"}]}`))
+		case "/api/v1/repos/core/looper/issues/123":
+			t.Errorf("used CWD repo for cross-repo issue lookup")
+			_, _ = w.Write([]byte(`{"number":123,"title":"wrong-repo","state":"open"}`))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	cwd := t.TempDir()
+	cfg := config.Config{
+		Providers: []config.ProviderConfig{{ID: "forge", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: stringPtr("FORGEJO_ISSUE_TOKEN")}},
+		Projects: []config.ProjectRefConfig{
+			{ID: "pr-project", Provider: "forge", Repo: "core/looper", RepoPath: cwd},
+			{ID: "issue-project", Provider: "forge", Repo: "other/repo", RepoPath: t.TempDir()},
+		},
+	}
+	adapter := reviewerGitHubAdapter{config: &cfg}
+	issue, err := adapter.ViewIssue(context.Background(), githubinfra.ViewIssueInput{Repo: "other/repo", IssueNumber: 123, CWD: cwd})
+	if err != nil {
+		t.Fatalf("ViewIssue() error = %v", err)
+	}
+	if issue.Number != 123 || issue.Title != "linked" || issue.URL != "https://code.example/other/repo/issues/123" {
+		t.Fatalf("ViewIssue() = %#v, want other/repo#123", issue)
+	}
+	for _, path := range requested {
+		if path == "/api/v1/repos/core/looper/issues/123" {
+			t.Fatalf("requested = %#v, CWD repo must not supply merge-authority issue", requested)
+		}
+	}
+}
+
+func TestForgejoViewIssueRejectsUnboundCrossRepoLookup(t *testing.T) {
+	t.Setenv("FORGEJO_ISSUE_TOKEN", "test")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request %s %s", r.Method, r.URL)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"number":123,"title":"wrong-repo","state":"open"}`))
+	}))
+	defer server.Close()
+	cwd := t.TempDir()
+	cfg := config.Config{
+		Providers: []config.ProviderConfig{{ID: "forge", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: stringPtr("FORGEJO_ISSUE_TOKEN")}},
+		Projects:  []config.ProjectRefConfig{{ID: "pr-project", Provider: "forge", Repo: "core/looper", RepoPath: cwd}},
+	}
+	adapter := reviewerGitHubAdapter{config: &cfg}
+	_, err := adapter.ViewIssue(context.Background(), githubinfra.ViewIssueInput{Repo: "other/repo", IssueNumber: 123, CWD: cwd})
+	var httpErr *forge.ForgejoHTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusNotFound {
+		t.Fatalf("ViewIssue() error = %v, want HTTP 404 for unbound cross-repo lookup", err)
+	}
+}

--- a/internal/runtime/scheduler_forgejo_automerge_test.go
+++ b/internal/runtime/scheduler_forgejo_automerge_test.go
@@ -1,0 +1,184 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/forge"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/reviewer/automerge"
+)
+
+func TestForgejoAutoMergeAdapterPreservesPolicyAndReviewedHead(t *testing.T) {
+	t.Setenv("FORGEJO_MERGE_TOKEN", "test")
+	protected, statusChecks := true, true
+	contexts := []string{"unit"}
+	mergeStatus, mergeCalls := http.StatusOK, 0
+	var mergeBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/swagger.v1.json":
+			_, _ = w.Write([]byte(`{"paths":{"/repos/{owner}/{repo}/pulls/{index}/merge":{"post":{}}}}`))
+		case "/api/v1/repos/core/looper":
+			_, _ = w.Write([]byte(`{"allow_merge_commits":true,"allow_rebase":false,"allow_squash_merge":true}`))
+		case "/api/v1/repos/core/looper/branches/release/next":
+			if r.URL.EscapedPath() != "/api/v1/repos/core/looper/branches/release%2Fnext" {
+				t.Errorf("branch path = %s", r.URL.EscapedPath())
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"protected": protected, "enable_status_check": statusChecks, "status_check_contexts": contexts})
+		case "/api/v1/repos/core/looper/pulls/42/merge":
+			if r.Method != http.MethodPost {
+				t.Errorf("merge method = %s", r.Method)
+			}
+			mergeCalls++
+			if err := json.NewDecoder(r.Body).Decode(&mergeBody); err != nil {
+				t.Error(err)
+			}
+			w.WriteHeader(mergeStatus)
+		case "/api/v1/repos/core/looper/issues/1":
+			_, _ = w.Write([]byte(`{"number":1,"state":"open","body":"Acceptance criteria","html_url":"https://code.example/core/looper/issues/1"}`))
+		case "/api/v1/repos/core/looper/issues/2":
+			_, _ = w.Write([]byte(`{"number":2,"state":"open","pull_request":{"url":"api-url"}}`))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	cfg := config.Config{Providers: []config.ProviderConfig{{ID: "forge", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: stringPtr("FORGEJO_MERGE_TOKEN")}}, Projects: []config.ProjectRefConfig{{ID: "p", Provider: "forge", Repo: "core/looper", RepoPath: t.TempDir()}}}
+	adapter := reviewerGitHubAdapter{config: &cfg} // No GitHub gateway: every operation must route to Forgejo.
+	ctx := context.Background()
+	settings, err := adapter.GetRepositorySettings(ctx, githubinfra.RepositorySettingsInput{Repo: "core/looper"})
+	if err != nil || !settings.AllowAutoMerge || !settings.AllowSquashMerge || !settings.AllowMergeCommit || settings.AllowRebaseMerge {
+		t.Fatalf("settings = %#v, %v", settings, err)
+	}
+	policy := config.ReviewerAutoMergeConfig{Enabled: true, Scope: config.ReviewerAutoMergeScopeLooperOnly, Strategy: config.ReviewerAutoMergeStrategySquash, RequireBranchProtection: true}
+	pr := automerge.PRSnapshot{Labels: []string{"looper:ready"}, HasTrackedIssueLink: true}
+	for _, tc := range []struct {
+		name              string
+		protected, checks bool
+		contexts          []string
+		want              automerge.RefusalReason
+	}{
+		{"protected with required check", true, true, []string{"unit"}, ""},
+		{"unprotected", false, true, []string{"unit"}, automerge.RefusalReasonNoBranchProtection},
+		{"checks disabled", true, false, []string{"unit"}, automerge.RefusalReasonNoBranchProtection},
+		{"no required contexts", true, true, nil, automerge.RefusalReasonNoBranchProtection},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			protected, statusChecks, contexts = tc.protected, tc.checks, tc.contexts
+			branch, err := adapter.GetBranchProtection(ctx, githubinfra.BranchProtectionInput{Repo: "core/looper", Branch: "release/next"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			decision := automerge.Decide(pr, policy, automerge.BranchProtectionSnapshot{Exists: branch.Enabled, HasRequiredChecks: branch.HasRequiredChecks}, automerge.RepoSettingsSnapshot{AllowSquashMerge: settings.AllowSquashMerge, AllowAutoMerge: settings.AllowAutoMerge})
+			if decision.Reason != tc.want {
+				t.Fatalf("decision = %#v, want reason %s", decision, tc.want)
+			}
+		})
+	}
+	for _, strategy := range []config.ReviewerAutoMergeStrategy{config.ReviewerAutoMergeStrategyMerge, config.ReviewerAutoMergeStrategySquash, config.ReviewerAutoMergeStrategyRebase} {
+		if err := adapter.EnableAutoMerge(ctx, githubinfra.EnableAutoMergeInput{Repo: "core/looper", PRNumber: 42, Strategy: strategy, HeadSHA: "reviewed-head"}); err != nil {
+			t.Fatal(err)
+		}
+		if len(mergeBody) != 5 || mergeBody["Do"] != string(strategy) || mergeBody["head_commit_id"] != "reviewed-head" || mergeBody["merge_when_checks_succeed"] != false || mergeBody["force_merge"] != false || mergeBody["delete_branch_after_merge"] != false {
+			t.Fatalf("unsafe merge payload = %#v", mergeBody)
+		}
+	}
+	before := mergeCalls
+	if err := adapter.EnableAutoMerge(ctx, githubinfra.EnableAutoMergeInput{Repo: "core/looper", PRNumber: 42, Strategy: config.ReviewerAutoMergeStrategySquash}); err == nil || mergeCalls != before {
+		t.Fatalf("missing reviewed head err = %v, calls = %d", err, mergeCalls)
+	}
+	for _, code := range []int{http.StatusForbidden, http.StatusNotFound, http.StatusConflict, http.StatusInternalServerError} {
+		mergeStatus = code
+		err := adapter.EnableAutoMerge(ctx, githubinfra.EnableAutoMergeInput{Repo: "core/looper", PRNumber: 42, Strategy: config.ReviewerAutoMergeStrategySquash, HeadSHA: "reviewed-head"})
+		var httpErr *forge.ForgejoHTTPError
+		if !errors.As(err, &httpErr) || httpErr.StatusCode != code {
+			t.Fatalf("merge status %d err = %v", code, err)
+		}
+	}
+	for _, number := range []int64{1, 2} {
+		issue, err := adapter.ViewIssue(ctx, githubinfra.ViewIssueInput{Repo: "core/looper", IssueNumber: number})
+		if err != nil || issue.IsPullRequest != (number == 2) {
+			t.Fatalf("issue %d = %#v, %v", number, issue, err)
+		}
+	}
+}
+
+func TestForgejoMergeAdapterDoesNotScheduleAndRejectsChangedHead(t *testing.T) {
+	t.Setenv("FORGEJO_IMMEDIATE_MERGE_TOKEN", "test")
+	head, checksReady, scheduled, merged := "reviewed-head", false, 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/swagger.v1.json":
+			_, _ = w.Write([]byte(`{"paths":{"/repos/{owner}/{repo}/pulls/{index}/merge":{"post":{}}}}`))
+		case "/api/v1/repos/core/looper/pulls/42":
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": 42, "state": "open", "head": map[string]any{"sha": head}})
+		case "/api/v1/repos/core/looper/pulls/42/merge":
+			var payload struct {
+				Head     string `json:"head_commit_id"`
+				Schedule bool   `json:"merge_when_checks_succeed"`
+				Force    bool   `json:"force_merge"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Error(err)
+			}
+			if payload.Force {
+				t.Error("merge request bypasses server protection")
+			}
+			// Forgejo v16.0.3 pull.go schedules before passing HeadCommitID to
+			// Merge; services/automerge later merges with an empty expected head.
+			if payload.Schedule {
+				scheduled++
+				w.WriteHeader(http.StatusCreated)
+				return
+			}
+			if !checksReady {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			if payload.Head != head {
+				w.WriteHeader(http.StatusConflict)
+				return
+			}
+			merged++
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	cfg := config.Config{Providers: []config.ProviderConfig{{ID: "fj", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: stringPtr("FORGEJO_IMMEDIATE_MERGE_TOKEN")}}, Projects: []config.ProjectRefConfig{{ID: "p", Provider: "fj", Repo: "core/looper", RepoPath: t.TempDir()}}}
+	adapter := reviewerGitHubAdapter{config: &cfg}
+	input := githubinfra.EnableAutoMergeInput{Repo: "core/looper", PRNumber: 42, Strategy: config.ReviewerAutoMergeStrategySquash, HeadSHA: head}
+	requireStatus := func(want int) {
+		t.Helper()
+		err := adapter.EnableAutoMerge(context.Background(), input)
+		var httpErr *forge.ForgejoHTTPError
+		if !errors.As(err, &httpErr) || httpErr.StatusCode != want {
+			t.Fatalf("merge = %v, want HTTP %d", err, want)
+		}
+	}
+	requireStatus(http.StatusMethodNotAllowed)
+	// A later push must never inherit the earlier merge decision, including
+	// when the caller inspected the old head immediately before the request.
+	head, checksReady = "unreviewed-new-head", true
+	requireStatus(http.StatusConflict)
+	if scheduled != 0 || merged != 0 {
+		t.Fatalf("old decision caused remote action: queued=%d merged=%d", scheduled, merged)
+	}
+	// A separately authorized new-head decision can use the same transport.
+	input.HeadSHA = head
+	if err := adapter.EnableAutoMerge(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	if scheduled != 0 || merged != 1 {
+		t.Fatalf("new-head merge: queued=%d merged=%d", scheduled, merged)
+	}
+}

--- a/internal/runtime/scheduler_forgejo_ci_test.go
+++ b/internal/runtime/scheduler_forgejo_ci_test.go
@@ -87,8 +87,8 @@ func TestForgejoAdaptersExposeConflictsChecksAndNativeReviewHandoff(t *testing.T
 		t.Fatalf("review detail = %#v, %v", review, err)
 	}
 	prs, err := reviewerAdapter.ListOpenPullRequests(ctx, reviewer.ListOpenPullRequestsInput{Repo: "acme/looper", CWD: cwd})
-	if err != nil || len(prs) != 1 || !prs[0].HasConflicts || inlineReads != 1 {
-		t.Fatalf("discovery = %#v, %v; inline reads = %d, want no extra inline fetch", prs, err, inlineReads)
+	if err != nil || len(prs) != 1 || prs[0].HasConflicts || inlineReads != 1 {
+		t.Fatalf("discovery = %#v, %v; inline reads = %d, want listed PR without list-time conflict check", prs, err, inlineReads)
 	}
 	fixerAdapter := fixerGitHubAdapter{config: &cfg}
 	fix, err := fixerAdapter.ViewPullRequest(ctx, fixer.ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42, CWD: cwd})

--- a/internal/runtime/scheduler_forgejo_ci_test.go
+++ b/internal/runtime/scheduler_forgejo_ci_test.go
@@ -1,0 +1,124 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/fixer"
+	"github.com/nexu-io/looper/internal/reviewer"
+)
+
+func TestForgejoAdaptersExposeConflictsChecksAndNativeReviewHandoff(t *testing.T) {
+	t.Setenv("FORGEJO_TOKEN", "secret")
+	cwd, baseSHA, headSHA, cleanSHA := forgejoConflictRepo(t)
+	inlineReads := 0
+	requested := false
+	dismissed := false
+	marker := "<!-- looper:review id=reviewer:loop:" + headSHA + " head=" + headSHA + " outcome=blocking -->"
+	pr := map[string]any{
+		"number": 42, "title": "Fix me", "state": "open", "mergeable": false,
+		"html_url": "https://forge.test/acme/looper/pulls/42",
+		"head":     map[string]any{"sha": headSHA, "ref": "feature"}, "base": map[string]any{"sha": baseSHA, "ref": "main"},
+		"user": map[string]any{"login": "author"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/swagger.v1.json":
+			_, _ = w.Write([]byte(`{"paths":{"/repos/{owner}/{repo}/pulls/{index}/reviews":{"get":{},"post":{}},"/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments":{"get":{}},"/repos/{owner}/{repo}/pulls/{index}/requested_reviewers":{"post":{}}}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/looper/pulls/42":
+			_ = json.NewEncoder(w).Encode(pr)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/looper/pulls":
+			_ = json.NewEncoder(w).Encode([]any{pr})
+		case r.URL.Path == "/api/v1/repos/acme/looper/pulls/42.diff":
+			_, _ = w.Write([]byte("diff --git a/app.go b/app.go\n"))
+		case r.URL.Path == "/api/v1/repos/acme/looper/issues/42/comments":
+			_ = json.NewEncoder(w).Encode([]any{})
+		case r.URL.Path == "/api/v1/repos/acme/looper/pulls/42/reviews":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": 8, "state": "REQUEST_CHANGES", "body": marker, "commit_id": headSHA, "comments_count": 1, "user": map[string]any{"login": "reviewer"}},
+				{"id": 9, "state": "COMMENT", "body": "Follow-up", "comments_count": 0, "user": map[string]any{"login": "reviewer"}},
+				{"id": 10, "state": "APPROVED", "dismissed": true, "comments_count": 0, "user": map[string]any{"login": "another-reviewer"}},
+			})
+		case r.URL.Path == "/api/v1/repos/acme/looper/pulls/42/reviews/8/comments":
+			inlineReads++
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": 101, "body": "Fix discount", "path": "app.go", "diff_hunk": "@@ -1 +1 @@", "updated_at": "2026-09-06T00:00:00Z", "user": map[string]any{"login": "reviewer"}, "resolver": nil}})
+		case strings.HasPrefix(r.URL.Path, "/api/v1/repos/acme/looper/statuses/"):
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": 1, "context": "unit", "status": "failure", "description": "price expected 80, got 20", "target_url": "https://ci.test/unit"}})
+		case r.URL.Path == "/api/v1/repos/acme/looper/actions/runs":
+			_ = json.NewEncoder(w).Encode(map[string]any{"workflow_runs": []any{}})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/repos/acme/looper/pulls/42/requested_reviewers":
+			var body struct {
+				Reviewers []string `json:"reviewers"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || len(body.Reviewers) != 1 || body.Reviewers[0] != "reviewer" {
+				t.Errorf("review request body = %#v, %v", body, err)
+			}
+			requested = true
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/repos/acme/looper/pulls/42/reviews/8/dismissals":
+			var body struct {
+				Message string `json:"message"`
+				Priors  bool   `json:"priors"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Message != "Finding withdrawn" || body.Priors {
+				t.Errorf("dismissal body = %#v, %v", body, err)
+			}
+			dismissed = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 8, "dismissed": true})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	cfg := config.Config{
+		Providers: []config.ProviderConfig{{ID: "forgejo", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: stringPtr("FORGEJO_TOKEN")}},
+		Projects:  []config.ProjectRefConfig{{ID: "project", Provider: "forgejo", Repo: "acme/looper", RepoPath: cwd}},
+	}
+	ctx := context.Background()
+	reviewerAdapter := reviewerGitHubAdapter{config: &cfg}
+	review, err := reviewerAdapter.ViewPullRequest(ctx, reviewer.ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42, CWD: cwd})
+	if err != nil || !review.HasConflicts || !strings.Contains(review.ChecksSummary, "FAILURE") || review.URL != pr["html_url"] || review.ReviewDecision != "CHANGES_REQUESTED" || len(review.Comments) != 1 {
+		t.Fatalf("review detail = %#v, %v", review, err)
+	}
+	prs, err := reviewerAdapter.ListOpenPullRequests(ctx, reviewer.ListOpenPullRequestsInput{Repo: "acme/looper", CWD: cwd})
+	if err != nil || len(prs) != 1 || !prs[0].HasConflicts || inlineReads != 1 {
+		t.Fatalf("discovery = %#v, %v; inline reads = %d, want no extra inline fetch", prs, err, inlineReads)
+	}
+	fixerAdapter := fixerGitHubAdapter{config: &cfg}
+	fix, err := fixerAdapter.ViewPullRequest(ctx, fixer.ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42, CWD: cwd})
+	if err != nil || !fix.HasConflicts || fix.URL != pr["html_url"] || len(fix.Checks) != 1 || fix.Checks[0]["state"] != "FAILURE" || fix.Checks[0]["url"] != "https://ci.test/unit" || fix.Checks[0]["description"] != "price expected 80, got 20" {
+		t.Fatalf("fix detail = %#v, %v", fix, err)
+	}
+	comments, err := fixerAdapter.ListNativeReviewComments(ctx, fixer.ListNativeReviewCommentsInput{Repo: "acme/looper", PRNumber: 42, CWD: cwd})
+	if err != nil || len(comments) != 1 || comments[0].ReviewBody != marker || comments[0].ReviewState != "CHANGES_REQUESTED" || comments[0].ReviewAuthor != "reviewer" || comments[0].ReviewCommitID != headSHA || comments[0].IsResolved {
+		t.Fatalf("native comments = %#v, %v", comments, err)
+	}
+	reviews, err := fixerAdapter.ListPullRequestReviews(ctx, fixer.ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42, CWD: cwd})
+	if err != nil || len(reviews) != 3 || reviews[2].State != "DISMISSED" || inlineReads != 2 {
+		t.Fatalf("reviews = %#v, %v; inline reads = %d", reviews, err, inlineReads)
+	}
+	if err := fixerAdapter.AddPullRequestReviewers(ctx, fixer.PullRequestReviewersInput{Repo: "acme/looper", PRNumber: 42, Reviewers: []string{"reviewer"}, CWD: cwd}); err != nil || !requested {
+		t.Fatalf("re-request = %v, requested = %v", err, requested)
+	}
+	if err := fixerAdapter.DismissReview(ctx, fixer.DismissReviewInput{Repo: "acme/looper", PRNumber: 42, ReviewID: 8, Message: "Finding withdrawn", CWD: cwd}); err != nil || !dismissed {
+		t.Fatalf("dismiss = %v, dismissed = %v", err, dismissed)
+	}
+	// The same remote false can mean CHECKING, ERROR or WIP. When the exact
+	// commits merge cleanly neither runner should advertise a conflict.
+	pr["head"] = map[string]any{"sha": cleanSHA, "ref": "clean"}
+	cleanReview, err := reviewerAdapter.ViewPullRequest(ctx, reviewer.ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42, CWD: cwd})
+	if err != nil || cleanReview.HasConflicts {
+		t.Fatalf("false mergeability on clean reviewer PR = %#v, %v", cleanReview, err)
+	}
+	cleanFix, err := fixerAdapter.ViewPullRequest(ctx, fixer.ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42, CWD: cwd})
+	if err != nil || cleanFix.HasConflicts {
+		t.Fatalf("false mergeability on clean fixer PR = %#v, %v", cleanFix, err)
+	}
+
+}

--- a/internal/runtime/scheduler_forgejo_conflicts.go
+++ b/internal/runtime/scheduler_forgejo_conflicts.go
@@ -20,26 +20,9 @@ func forgejoPullRequestHasConflicts(ctx context.Context, cfg *config.Config, rep
 	// Forgejo's mergeable=false also includes CHECKING, server-side ERROR and
 	// WIP. Only an actual merge of the exact base/head commits can establish a
 	// conflict; the check never checks out or merges into the caller's worktree.
-	cwd = strings.TrimSpace(cwd)
-	if cwd == "" && cfg != nil {
-		for _, project := range cfg.Projects {
-			if strings.EqualFold(strings.TrimSpace(project.Repo), strings.TrimSpace(repo)) {
-				if cwd != "" {
-					return false, failureclass.WithBoundary(fmt.Errorf("merge conflict check for %s requires an unambiguous project path", repo), failureclass.BoundaryGitLocal)
-				}
-				cwd = strings.TrimSpace(project.RepoPath)
-			}
-		}
-	}
-	if cwd == "" {
-		return false, failureclass.WithBoundary(fmt.Errorf("merge conflict check for %s requires project repo path", repo), failureclass.BoundaryGitLocal)
-	}
-	gitPath := ""
-	if cfg != nil {
-		gitPath = derefString(cfg.Tools.GitPath)
-	}
-	if strings.TrimSpace(gitPath) == "" {
-		gitPath = "git"
+	gitPath, cwd, err := forgejoGitLocation(cfg, repo, cwd)
+	if err != nil {
+		return false, err
 	}
 	conflicted, err := forgejoHasMergeConflicts(ctx, gitPath, cwd, pr.Base.SHA, pr.Head.SHA)
 	// Preserve remote fetch failures and keep transient local launch pressure retryable.
@@ -60,35 +43,8 @@ func withForgejoConflictBoundary(err error) error {
 // It requires Git's merge-tree --write-tree support (Git 2.38 or later).
 func forgejoHasMergeConflicts(ctx context.Context, gitPath, repoPath, baseSHA, headSHA string) (bool, error) {
 	commits := []string{strings.TrimSpace(baseSHA), strings.TrimSpace(headSHA)}
-	for _, sha := range commits {
-		if len(sha) != 40 && len(sha) != 64 {
-			return false, fmt.Errorf("merge conflict check requires full base and head commit IDs")
-		}
-		if _, err := hex.DecodeString(sha); err != nil {
-			return false, fmt.Errorf("merge conflict check requires hexadecimal commit IDs: %w", err)
-		}
-	}
-	missing, err := missingForgejoMergeCommits(ctx, gitPath, repoPath, commits)
-	if err != nil {
+	if err := ensureForgejoCommits(ctx, gitPath, repoPath, commits); err != nil {
 		return false, err
-	}
-	if len(missing) > 0 {
-		// Empty refmap and no FETCH_HEAD write keep the caller's refs unchanged.
-		args := append([]string{"fetch", "--no-write-fetch-head", "--no-tags", "--refmap=", "origin"}, missing...)
-		if _, err := shell.Run(ctx, shell.Options{Command: gitPath, CWD: repoPath, Args: args}); err != nil {
-			boundary := failureclass.BoundaryGitRemote
-			if shell.IsStartFailure(err) && !shell.IsTransientStartFailure(err) {
-				boundary = failureclass.BoundaryGitLocal
-			}
-			return false, failureclass.WithBoundary(fmt.Errorf("fetch commits for merge conflict check: %w", err), boundary)
-		}
-		missing, err = missingForgejoMergeCommits(ctx, gitPath, repoPath, commits)
-		if err != nil {
-			return false, err
-		}
-		if len(missing) > 0 {
-			return false, fmt.Errorf("merge conflict check commits still unavailable after fetch: %s", strings.Join(missing, ", "))
-		}
 	}
 	result, err := shell.Run(ctx, shell.Options{Command: gitPath, CWD: repoPath, Args: []string{"merge-tree", "--write-tree", commits[0], commits[1]}})
 	if err == nil {
@@ -104,7 +60,41 @@ func forgejoHasMergeConflicts(ctx context.Context, gitPath, repoPath, baseSHA, h
 	return false, fmt.Errorf("check merge conflicts: %w", err)
 }
 
-func missingForgejoMergeCommits(ctx context.Context, gitPath, repoPath string, commits []string) ([]string, error) {
+func ensureForgejoCommits(ctx context.Context, gitPath, repoPath string, commits []string) error {
+	for _, sha := range commits {
+		if len(sha) != 40 && len(sha) != 64 {
+			return fmt.Errorf("Forgejo commit inspection requires full base and head commit IDs")
+		}
+		if _, err := hex.DecodeString(sha); err != nil {
+			return fmt.Errorf("Forgejo commit inspection requires hexadecimal commit IDs: %w", err)
+		}
+	}
+	missing, err := missingForgejoCommits(ctx, gitPath, repoPath, commits)
+	if err != nil {
+		return err
+	}
+	if len(missing) > 0 {
+		// Empty refmap and no FETCH_HEAD write keep the caller's refs unchanged.
+		args := append([]string{"fetch", "--no-write-fetch-head", "--no-tags", "--refmap=", "origin"}, missing...)
+		if _, err := shell.Run(ctx, shell.Options{Command: gitPath, CWD: repoPath, Args: args}); err != nil {
+			boundary := failureclass.BoundaryGitRemote
+			if shell.IsStartFailure(err) && !shell.IsTransientStartFailure(err) {
+				boundary = failureclass.BoundaryGitLocal
+			}
+			return failureclass.WithBoundary(fmt.Errorf("fetch commits for Forgejo commit inspection: %w", err), boundary)
+		}
+		missing, err = missingForgejoCommits(ctx, gitPath, repoPath, commits)
+		if err != nil {
+			return err
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("Forgejo commit inspection commits still unavailable after fetch: %s", strings.Join(missing, ", "))
+		}
+	}
+	return nil
+}
+
+func missingForgejoCommits(ctx context.Context, gitPath, repoPath string, commits []string) ([]string, error) {
 	// Batch-check reports a missing object on stdout with exit zero. Ordinary
 	// git failures (bad CWD, permissions, unavailable binary) remain errors and
 	// do not incorrectly trigger a fetch or become a conflict verdict.
@@ -138,4 +128,29 @@ func missingForgejoMergeCommits(ctx context.Context, gitPath, repoPath string, c
 		}
 	}
 	return missing, nil
+}
+
+func forgejoGitLocation(cfg *config.Config, repo, cwd string) (gitPath, location string, err error) {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" && cfg != nil {
+		for _, project := range cfg.Projects {
+			if strings.EqualFold(strings.TrimSpace(project.Repo), strings.TrimSpace(repo)) {
+				if cwd != "" {
+					return "", "", failureclass.WithBoundary(fmt.Errorf("merge conflict check for %s requires an unambiguous project path", repo), failureclass.BoundaryGitLocal)
+				}
+				cwd = strings.TrimSpace(project.RepoPath)
+			}
+		}
+	}
+	if cwd == "" {
+		return "", "", failureclass.WithBoundary(fmt.Errorf("merge conflict check for %s requires project repo path", repo), failureclass.BoundaryGitLocal)
+	}
+	gitPath = ""
+	if cfg != nil {
+		gitPath = derefString(cfg.Tools.GitPath)
+	}
+	if strings.TrimSpace(gitPath) == "" {
+		gitPath = "git"
+	}
+	return gitPath, cwd, nil
 }

--- a/internal/runtime/scheduler_forgejo_conflicts.go
+++ b/internal/runtime/scheduler_forgejo_conflicts.go
@@ -1,0 +1,141 @@
+package runtime
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/forge"
+	"github.com/nexu-io/looper/internal/infra/shell"
+	"github.com/nexu-io/looper/internal/loops/failureclass"
+)
+
+func forgejoPullRequestHasConflicts(ctx context.Context, cfg *config.Config, repo, cwd string, pr forge.PullRequest) (bool, error) {
+	if pr.Mergeable == nil || *pr.Mergeable || !strings.EqualFold(pr.State, "open") {
+		return false, nil
+	}
+	// Forgejo's mergeable=false also includes CHECKING, server-side ERROR and
+	// WIP. Only an actual merge of the exact base/head commits can establish a
+	// conflict; the check never checks out or merges into the caller's worktree.
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" && cfg != nil {
+		for _, project := range cfg.Projects {
+			if strings.EqualFold(strings.TrimSpace(project.Repo), strings.TrimSpace(repo)) {
+				if cwd != "" {
+					return false, failureclass.WithBoundary(fmt.Errorf("merge conflict check for %s requires an unambiguous project path", repo), failureclass.BoundaryGitLocal)
+				}
+				cwd = strings.TrimSpace(project.RepoPath)
+			}
+		}
+	}
+	if cwd == "" {
+		return false, failureclass.WithBoundary(fmt.Errorf("merge conflict check for %s requires project repo path", repo), failureclass.BoundaryGitLocal)
+	}
+	gitPath := ""
+	if cfg != nil {
+		gitPath = derefString(cfg.Tools.GitPath)
+	}
+	if strings.TrimSpace(gitPath) == "" {
+		gitPath = "git"
+	}
+	conflicted, err := forgejoHasMergeConflicts(ctx, gitPath, cwd, pr.Base.SHA, pr.Head.SHA)
+	// Preserve remote fetch failures and keep transient local launch pressure retryable.
+	return conflicted, withForgejoConflictBoundary(err)
+}
+
+func withForgejoConflictBoundary(err error) error {
+	boundary := failureclass.BoundaryGitLocal
+	if shell.IsTransientStartFailure(err) {
+		boundary = failureclass.BoundaryGitRemote
+	}
+	return failureclass.WithBoundary(err, boundary)
+}
+
+// forgejoHasMergeConflicts checks exact commits without checking out branches or
+// touching the caller's index, worktree, refs, or merge state. Missing commits
+// are fetched into the object database; merge-tree may also write tree objects.
+// It requires Git's merge-tree --write-tree support (Git 2.38 or later).
+func forgejoHasMergeConflicts(ctx context.Context, gitPath, repoPath, baseSHA, headSHA string) (bool, error) {
+	commits := []string{strings.TrimSpace(baseSHA), strings.TrimSpace(headSHA)}
+	for _, sha := range commits {
+		if len(sha) != 40 && len(sha) != 64 {
+			return false, fmt.Errorf("merge conflict check requires full base and head commit IDs")
+		}
+		if _, err := hex.DecodeString(sha); err != nil {
+			return false, fmt.Errorf("merge conflict check requires hexadecimal commit IDs: %w", err)
+		}
+	}
+	missing, err := missingForgejoMergeCommits(ctx, gitPath, repoPath, commits)
+	if err != nil {
+		return false, err
+	}
+	if len(missing) > 0 {
+		// Empty refmap and no FETCH_HEAD write keep the caller's refs unchanged.
+		args := append([]string{"fetch", "--no-write-fetch-head", "--no-tags", "--refmap=", "origin"}, missing...)
+		if _, err := shell.Run(ctx, shell.Options{Command: gitPath, CWD: repoPath, Args: args}); err != nil {
+			boundary := failureclass.BoundaryGitRemote
+			if shell.IsStartFailure(err) && !shell.IsTransientStartFailure(err) {
+				boundary = failureclass.BoundaryGitLocal
+			}
+			return false, failureclass.WithBoundary(fmt.Errorf("fetch commits for merge conflict check: %w", err), boundary)
+		}
+		missing, err = missingForgejoMergeCommits(ctx, gitPath, repoPath, commits)
+		if err != nil {
+			return false, err
+		}
+		if len(missing) > 0 {
+			return false, fmt.Errorf("merge conflict check commits still unavailable after fetch: %s", strings.Join(missing, ", "))
+		}
+	}
+	result, err := shell.Run(ctx, shell.Options{Command: gitPath, CWD: repoPath, Args: []string{"merge-tree", "--write-tree", commits[0], commits[1]}})
+	if err == nil {
+		return false, nil
+	}
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	var commandErr *shell.CommandExecutionError
+	if errors.As(err, &commandErr) && result.ExitCode == 1 {
+		return true, nil
+	}
+	return false, fmt.Errorf("check merge conflicts: %w", err)
+}
+
+func missingForgejoMergeCommits(ctx context.Context, gitPath, repoPath string, commits []string) ([]string, error) {
+	// Batch-check reports a missing object on stdout with exit zero. Ordinary
+	// git failures (bad CWD, permissions, unavailable binary) remain errors and
+	// do not incorrectly trigger a fetch or become a conflict verdict.
+	result, err := shell.Run(ctx, shell.Options{
+		Command: gitPath, CWD: repoPath,
+		Args:  []string{"cat-file", "--batch-check=%(objectname) %(objecttype)"},
+		Stdin: strings.Join(commits, "\n") + "\n",
+		Env:   map[string]string{"GIT_NO_LAZY_FETCH": "1"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("inspect commits for merge conflict check: %w", err)
+	}
+	lines := strings.Split(strings.TrimSpace(result.Stdout), "\n")
+	if len(lines) != len(commits) {
+		return nil, fmt.Errorf("inspect commits for merge conflict check: unexpected cat-file output")
+	}
+	var missing []string
+	for i, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || !strings.EqualFold(fields[0], commits[i]) {
+			return nil, fmt.Errorf("inspect commits for merge conflict check: unexpected cat-file output")
+		}
+		switch fields[1] {
+		case "commit":
+		case "missing":
+			if len(missing) == 0 || missing[0] != commits[i] {
+				missing = append(missing, commits[i])
+			}
+		default:
+			return nil, fmt.Errorf("merge conflict check object %s is %s, want commit", commits[i], fields[1])
+		}
+	}
+	return missing, nil
+}

--- a/internal/runtime/scheduler_forgejo_conflicts_test.go
+++ b/internal/runtime/scheduler_forgejo_conflicts_test.go
@@ -1,0 +1,182 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/fixer"
+	"github.com/nexu-io/looper/internal/forge"
+	"github.com/nexu-io/looper/internal/loops/failureclass"
+	"github.com/nexu-io/looper/internal/reviewer"
+)
+
+func TestForgejoConflictProcessLaunchFailuresPreserveRetryPolicy(t *testing.T) {
+	t.Parallel()
+	for _, operation := range []string{"inspect commits for merge conflict check", "check merge conflicts"} {
+		for _, tc := range []struct {
+			name     string
+			errno    syscall.Errno
+			boundary failureclass.Boundary
+			kind     failureclass.Kind
+		}{
+			{"EAGAIN", syscall.EAGAIN, failureclass.BoundaryGitRemote, failureclass.RetryableTransient},
+			{"ENOMEM", syscall.ENOMEM, failureclass.BoundaryGitRemote, failureclass.RetryableTransient},
+			{"EMFILE", syscall.EMFILE, failureclass.BoundaryGitRemote, failureclass.RetryableTransient},
+			{"ENFILE", syscall.ENFILE, failureclass.BoundaryGitRemote, failureclass.RetryableTransient},
+			{"ETXTBSY", syscall.ETXTBSY, failureclass.BoundaryGitRemote, failureclass.RetryableTransient},
+			{"ENOENT", syscall.ENOENT, failureclass.BoundaryGitLocal, failureclass.NonRetryable},
+			{"EACCES", syscall.EACCES, failureclass.BoundaryGitLocal, failureclass.NonRetryable},
+		} {
+			t.Run(operation+"/"+tc.name, func(t *testing.T) {
+				// Match shell.Run's wrapped start error, retaining the underlying
+				// errno through the cat-file / merge-tree operation context.
+				err := withForgejoConflictBoundary(fmt.Errorf("%s: %w", operation, fmt.Errorf("start command: %w", &os.PathError{Op: "fork/exec", Path: "/configured/git", Err: tc.errno})))
+				var boundaryErr *failureclass.BoundaryError
+				if !errors.As(err, &boundaryErr) || boundaryErr.Boundary != tc.boundary {
+					t.Fatalf("boundary = %v; want %s", err, tc.boundary)
+				}
+				for _, runner := range []failureclass.RunnerKind{failureclass.RunnerReviewer, failureclass.RunnerFixer} {
+					if got := failureclass.Classify(err, failureclass.Context{Runner: runner, Boundary: failureclass.BoundaryGitHubAPI}); got != tc.kind {
+						t.Fatalf("%s launch classification = %s, want %s", runner, got, tc.kind)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestForgejoConflictAdapterFailuresKeepOperationBoundary(t *testing.T) {
+	t.Setenv("FORGEJO_CONFLICT_TOKEN", "test-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/swagger.v1.json":
+			_, _ = w.Write([]byte(`{"paths":{"/repos/{owner}/{repo}/pulls/{index}/reviews":{"get":{}},"/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments":{"get":{}}}}`))
+		case strings.HasSuffix(r.URL.Path, "/pulls/42"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": 42, "state": "open", "mergeable": false, "head": map[string]any{"sha": strings.Repeat("a", 40)}, "base": map[string]any{"sha": strings.Repeat("b", 40)}})
+		case strings.HasSuffix(r.URL.Path, ".diff"):
+			_, _ = w.Write([]byte("diff --git a/app.go b/app.go\n"))
+		case strings.HasSuffix(r.URL.Path, "/actions/runs"):
+			_, _ = w.Write([]byte(`{"workflow_runs":[]}`))
+		default:
+			_, _ = w.Write([]byte(`[]`))
+		}
+	}))
+	defer server.Close()
+	for _, tc := range []struct {
+		name, script string
+		boundary     failureclass.Boundary
+		kind         failureclass.Kind
+	}{
+		{"remote fetch closes", "#!/bin/sh\ncase \"$1\" in\ncat-file) while read object; do echo \"$object missing\"; done;;\nfetch) echo 'Connection closed by 172.16.1.8 port 22' >&2; exit 128;;\n*) exit 129;;\nesac\n", failureclass.BoundaryGitRemote, failureclass.RetryableTransient},
+		{"missing configured Git", "", failureclass.BoundaryGitLocal, failureclass.NonRetryable},
+		{"unsupported merge-tree", "#!/bin/sh\ncase \"$1\" in\ncat-file) while read object; do echo \"$object commit\"; done;;\nmerge-tree) echo 'unknown option write-tree' >&2; exit 129;;\n*) exit 129;;\nesac\n", failureclass.BoundaryGitLocal, failureclass.NonRetryable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gitPath := filepath.Join(t.TempDir(), "missing-git")
+			if tc.script != "" {
+				gitPath = forgejoMergeTestWriteFakeGit(t, tc.script)
+			}
+			cwd := t.TempDir()
+			cfg := config.Config{
+				Tools:     config.ToolPathsConfig{GitPath: &gitPath},
+				Providers: []config.ProviderConfig{{ID: "forgejo", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: stringPtr("FORGEJO_CONFLICT_TOKEN")}},
+				Projects:  []config.ProjectRefConfig{{ID: "project", Provider: "forgejo", Repo: "acme/looper", RepoPath: cwd}},
+			}
+			for _, runner := range []failureclass.RunnerKind{failureclass.RunnerReviewer, failureclass.RunnerFixer} {
+				t.Run(string(runner), func(t *testing.T) {
+					var err error
+					if runner == failureclass.RunnerReviewer {
+						_, err = (reviewerGitHubAdapter{config: &cfg}).ViewPullRequest(context.Background(), reviewer.ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42, CWD: cwd})
+					} else {
+						_, err = (fixerGitHubAdapter{config: &cfg}).ViewPullRequest(context.Background(), fixer.ViewPullRequestInput{Repo: "acme/looper", PRNumber: 42, CWD: cwd})
+					}
+					var boundaryErr *failureclass.BoundaryError
+					if !errors.As(err, &boundaryErr) || boundaryErr.Boundary != tc.boundary {
+						t.Fatalf("adapter error = %v; want explicit %s boundary", err, tc.boundary)
+					}
+					if got := failureclass.Classify(err, failureclass.Context{Runner: runner, Step: "discover_pr", Boundary: failureclass.BoundaryGitHubAPI}); got != tc.kind {
+						t.Fatalf("adapter→failureclass = %s, want %s: %v", got, tc.kind, err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestForgejoConflictChecksRespectGitConfigurationAndUnknownState(t *testing.T) {
+	t.Parallel()
+	cwd, base, head, _ := forgejoConflictRepo(t)
+	missingGit := filepath.Join(t.TempDir(), "missing-configured-git")
+	cfg := config.Config{Tools: config.ToolPathsConfig{GitPath: &missingGit}, Projects: []config.ProjectRefConfig{{Repo: "acme/looper", RepoPath: cwd}}}
+	no, yes := false, true
+	for _, mergeable := range []*bool{nil, &yes} {
+		got, err := forgejoPullRequestHasConflicts(context.Background(), &cfg, "acme/looper", "", forge.PullRequest{State: "open", Mergeable: mergeable})
+		if err != nil || got {
+			t.Fatalf("unknown/true mergeability = %v, %v; must not invoke Git", got, err)
+		}
+	}
+	pr := forge.PullRequest{State: "open", Mergeable: &no, Head: forge.BranchRef{SHA: head}, Base: forge.BranchRef{SHA: base}}
+	if got, err := forgejoPullRequestHasConflicts(context.Background(), &cfg, "acme/looper", "", pr); err == nil || got || !strings.Contains(err.Error(), missingGit) {
+		t.Fatalf("configured Git unavailable = %v, %v; want configured-path error, not conflict", got, err)
+	}
+	cfg.Tools.GitPath = nil
+	if got, err := forgejoPullRequestHasConflicts(context.Background(), &cfg, "acme/looper", "", pr); err != nil || !got {
+		t.Fatalf("project CWD fallback = %v, %v; want confirmed conflict", got, err)
+	}
+}
+
+func forgejoConflictRepo(t *testing.T) (cwd, base, conflictedHead, cleanHead string) {
+	t.Helper()
+	cwd = t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = cwd
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(cwd, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git("init", "-b", "main")
+	git("config", "user.name", "Looper Test")
+	git("config", "user.email", "test@example.com")
+	git("config", "commit.gpgsign", "false")
+	write("README.md", "original\n")
+	git("add", ".")
+	git("commit", "-m", "initial")
+	initial := git("rev-parse", "HEAD")
+	git("checkout", "-b", "feature")
+	write("README.md", "feature\n")
+	git("add", ".")
+	git("commit", "-m", "feature")
+	conflictedHead = git("rev-parse", "HEAD")
+	git("checkout", "-b", "clean", initial)
+	write("new.txt", "independent change\n")
+	git("add", ".")
+	git("commit", "-m", "clean feature")
+	cleanHead = git("rev-parse", "HEAD")
+	git("checkout", "main")
+	write("README.md", "main\n")
+	git("add", ".")
+	git("commit", "-m", "base advances")
+	base = git("rev-parse", "HEAD")
+	return cwd, base, conflictedHead, cleanHead
+}

--- a/internal/runtime/scheduler_forgejo_conflicts_test.go
+++ b/internal/runtime/scheduler_forgejo_conflicts_test.go
@@ -136,6 +136,55 @@ func TestForgejoConflictChecksRespectGitConfigurationAndUnknownState(t *testing.
 	}
 }
 
+func TestForgejoListPullRequestsDefersExactConflictChecks(t *testing.T) {
+	t.Setenv("FORGEJO_CONFLICT_TOKEN", "test-token")
+	missingGit := filepath.Join(t.TempDir(), "missing-configured-git")
+	requestedReviewer := map[string]any{"id": 7, "login": "reviewer"}
+	draft := map[string]any{
+		"number": 1, "title": "WIP", "state": "open", "draft": true, "mergeable": false,
+		"head":                map[string]any{"sha": strings.Repeat("a", 40), "ref": "wip"},
+		"base":                map[string]any{"sha": strings.Repeat("b", 40), "ref": "main"},
+		"user":                map[string]any{"login": "alice"},
+		"requested_reviewers": []map[string]any{requestedReviewer},
+	}
+	ready := map[string]any{
+		"number": 2, "title": "Ready", "state": "open", "mergeable": true,
+		"head":                map[string]any{"sha": strings.Repeat("c", 40), "ref": "ready"},
+		"base":                map[string]any{"sha": strings.Repeat("b", 40), "ref": "main"},
+		"user":                map[string]any{"login": "bob"},
+		"requested_reviewers": []map[string]any{requestedReviewer},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/swagger.v1.json":
+			_, _ = w.Write([]byte(`{"paths":{"/repos/{owner}/{repo}/pulls/{index}/reviews":{"get":{}},"/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments":{"get":{}},"/repos/{owner}/{repo}/pulls/{index}/requested_reviewers":{"post":{}}}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/looper/pulls":
+			_ = json.NewEncoder(w).Encode([]any{draft, ready})
+		default:
+			_ = json.NewEncoder(w).Encode([]any{})
+		}
+	}))
+	defer server.Close()
+	cwd := t.TempDir()
+	cfg := config.Config{
+		Tools:     config.ToolPathsConfig{GitPath: &missingGit},
+		Providers: []config.ProviderConfig{{ID: "forgejo", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: stringPtr("FORGEJO_CONFLICT_TOKEN")}},
+		Projects:  []config.ProjectRefConfig{{ID: "project", Provider: "forgejo", Repo: "acme/looper", RepoPath: cwd}},
+	}
+	adapter := reviewerGitHubAdapter{config: &cfg}
+	ctx := context.Background()
+	assertListed := func(t *testing.T, prs []reviewer.PullRequestSummary, err error) {
+		t.Helper()
+		if err != nil || len(prs) != 2 || prs[0].Number != 1 || !prs[0].IsDraft || prs[1].Number != 2 || prs[0].HasConflicts || prs[1].HasConflicts {
+			t.Fatalf("listed = %#v, %v; want both PRs without aborting on the mergeable=false draft", prs, err)
+		}
+	}
+	open, err := adapter.ListOpenPullRequests(ctx, reviewer.ListOpenPullRequestsInput{Repo: "acme/looper", CWD: cwd})
+	assertListed(t, open, err)
+	requested, err := adapter.ListReviewRequestedPullRequests(ctx, reviewer.ListReviewRequestedPullRequestsInput{Repo: "acme/looper", CWD: cwd, Reviewer: "reviewer"})
+	assertListed(t, requested, err)
+}
+
 func forgejoConflictRepo(t *testing.T) (cwd, base, conflictedHead, cleanHead string) {
 	t.Helper()
 	cwd = t.TempDir()

--- a/internal/runtime/scheduler_forgejo_live_test.go
+++ b/internal/runtime/scheduler_forgejo_live_test.go
@@ -1,0 +1,599 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/config"
+	"github.com/nexu-io/looper/internal/fixer"
+	"github.com/nexu-io/looper/internal/forge"
+	githubinfra "github.com/nexu-io/looper/internal/infra/github"
+	"github.com/nexu-io/looper/internal/reviewer"
+)
+
+// TestForgejoLiveProviderContracts is a transport/adapter test, not a reviewer
+// policy bypass or an agent E2E. It creates two PRs and three unique branches.
+// The extra merge opt-in permits protection of, and immediate merge into, only
+// its own base branch. Existing reviewer policy is covered by offline tests.
+//
+// Required: LOOPER_FORGEJO_LIVE_CONTRACTS=1, LOOPER_FORGEJO_LIVE_BASE_URL,
+// LOOPER_FORGEJO_LIVE_REPO, LOOPER_FORGEJO_LIVE_TEA_LOGIN.
+// Optional: LOOPER_FORGEJO_LIVE_TEA_PATH, LOOPER_FORGEJO_LIVE_MERGE=1.
+// Run with -v -count=1 -timeout=15m to retain resource IDs and cleanup proof.
+// Closed PRs and statuses on test commits remain as audit history.
+func TestForgejoLiveProviderContracts(t *testing.T) {
+	if os.Getenv("LOOPER_FORGEJO_LIVE_CONTRACTS") != "1" {
+		t.Skip("set LOOPER_FORGEJO_LIVE_CONTRACTS=1 and explicit Forgejo target/login to create live test resources")
+	}
+	required := func(name string) string {
+		t.Helper()
+		value := strings.TrimSpace(os.Getenv(name))
+		if value == "" {
+			t.Fatalf("%s is required for live writes", name)
+		}
+		return value
+	}
+	baseURL := strings.TrimRight(required("LOOPER_FORGEJO_LIVE_BASE_URL"), "/")
+	repo := required("LOOPER_FORGEJO_LIVE_REPO")
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" || url.PathEscape(repo) != strings.ReplaceAll(repo, "/", "%2F") || strings.Contains(repo, "..") {
+		t.Fatal("LOOPER_FORGEJO_LIVE_REPO must be an explicit owner/repository slug")
+	}
+	login := required("LOOPER_FORGEJO_LIVE_TEA_LOGIN")
+	teaPath := strings.TrimSpace(os.Getenv("LOOPER_FORGEJO_LIVE_TEA_PATH"))
+	if teaPath == "" {
+		teaPath = "tea"
+	}
+	teaPath, err := exec.LookPath(teaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	var nonce [6]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		t.Fatal(err)
+	}
+	f := &forgejoLiveFixture{t: t, ctx: ctx, repo: repo, tea: teaPath, login: login, gitPath: gitPath,
+		prefix: "looper-provider-contract-" + time.Now().UTC().Format("20060102T150405") + "-" + hex.EncodeToString(nonce[:]),
+		dir:    t.TempDir(), merge: os.Getenv("LOOPER_FORGEJO_LIVE_MERGE") == "1"}
+	f.base, f.clean, f.conflict = f.prefix+"-base", f.prefix+"-clean", f.prefix+"-conflict"
+	source, caller := filepath.Join(f.dir, "source"), filepath.Join(f.dir, "caller")
+	cfg := config.Config{
+		Tools:     config.ToolPathsConfig{GitPath: &gitPath},
+		Providers: []config.ProviderConfig{{ID: "live", Kind: config.ProviderKindForgejo, BaseURL: baseURL, Auth: config.ProviderAuthTea, TeaLogin: &login, TeaPath: &teaPath}},
+		Projects:  []config.ProjectRefConfig{{ID: "live", Provider: "live", Repo: repo, RepoPath: caller}},
+	}
+	client, ok, err := forgejoClientForRepo(&cfg, repo)
+	if err != nil || !ok {
+		t.Fatalf("configured Forgejo tea provider: matched=%v err=%v", ok, err)
+	}
+	actor, err := client.CurrentUser(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.actor = actor.Login
+	var metadata struct {
+		FullName      string                           `json:"full_name"`
+		SSHURL        string                           `json:"ssh_url"`
+		DefaultBranch string                           `json:"default_branch"`
+		AllowMerge    bool                             `json:"allow_merge_commits"`
+		AllowSquash   bool                             `json:"allow_squash_merge"`
+		AllowRebase   bool                             `json:"allow_rebase"`
+		Permissions   struct{ Admin, Push, Pull bool } `json:"permissions"`
+	}
+	f.mustAPI(http.MethodGet, "", nil, &metadata, http.StatusOK)
+	if metadata.FullName != repo || !metadata.Permissions.Push || !metadata.Permissions.Pull || (f.merge && !metadata.Permissions.Admin) {
+		t.Fatalf("target/permissions unsuitable: repo=%q permissions=%+v merge=%v", metadata.FullName, metadata.Permissions, f.merge)
+	}
+	if err := forgejoLiveValidateSSHURL(metadata.SSHURL, repo); err != nil {
+		t.Fatal(err)
+	}
+	if metadata.DefaultBranch == "" {
+		t.Fatal("repository has no existing default branch; this test never seeds a repository")
+	}
+	f.unchanged = map[string]string{metadata.DefaultBranch: f.branch(metadata.DefaultBranch).Commit.ID}
+	if metadata.DefaultBranch != "main" {
+		var main forgejoLiveBranch
+		status, err := f.api(ctx, http.MethodGet, "/branches/main", nil, &main)
+		if err != nil || (status != http.StatusOK && status != http.StatusNotFound) {
+			t.Fatalf("read main baseline: HTTP %d, %v", status, err)
+		}
+		if status == http.StatusOK {
+			f.unchanged["main"] = main.Commit.ID
+		}
+	}
+	for branch, sha := range f.unchanged {
+		if sha == "" {
+			t.Fatalf("empty baseline SHA for %s", branch)
+		}
+		t.Logf("baseline repo=%s branch=%s sha=%s actor=%s prefix=%s", repo, branch, sha, actor.Login, f.prefix)
+	}
+	for _, branch := range []string{f.base, f.clean, f.conflict} {
+		f.mustAPI(http.MethodGet, "/branches/"+url.PathEscape(branch), nil, nil, http.StatusNotFound)
+	}
+	f.mustAPI(http.MethodGet, "/branch_protections/"+url.PathEscape(f.base), nil, nil, http.StatusNotFound)
+	// Register before any write so a lost creation response is still cleaned up.
+	t.Cleanup(f.cleanup)
+	for _, path := range []string{source, caller} {
+		f.runGit(f.dir, "init", "-b", "local-caller", path)
+		f.runGit(path, "config", "user.name", "Looper Provider Contract")
+		f.runGit(path, "config", "user.email", "looper-provider-contract@example.invalid")
+		f.runGit(path, "config", "commit.gpgsign", "false")
+		f.runGit(path, "config", "core.hooksPath", filepath.Join(f.dir, "no-hooks"))
+		f.runGit(path, "remote", "add", "origin", metadata.SSHURL)
+		f.runGit(path, "fetch", "--no-tags", "origin", "refs/heads/"+metadata.DefaultBranch+":refs/remotes/origin/baseline")
+		f.runGit(path, "checkout", "-B", "local-caller", "refs/remotes/origin/baseline")
+		if actual := f.runGit(path, "rev-parse", "HEAD"); actual != f.unchanged[metadata.DefaultBranch] {
+			t.Fatalf("default branch changed during fixture preparation: %s", actual)
+		}
+	}
+	// The adapters must preserve a dirty caller, including its refs and FETCH_HEAD.
+	forgejoMergeTestWriteFile(t, filepath.Join(caller, "README.md"), "local staged work\n")
+	f.runGit(caller, "add", "README.md")
+	forgejoMergeTestWriteFile(t, filepath.Join(caller, "README.md"), "local unstaged work\n")
+	forgejoMergeTestWriteFile(t, filepath.Join(caller, "untracked.txt"), "local untracked work\n")
+	forgejoMergeTestWriteFile(t, filepath.Join(caller, ".git", "FETCH_HEAD"), "local fetch marker\n")
+	before := mergeConflictCallerSnapshot(t, caller)
+	assertCaller := func() {
+		t.Helper()
+		if after := mergeConflictCallerSnapshot(t, caller); before != after {
+			t.Fatal("Forgejo adapter changed caller branch, refs, index, worktree, or FETCH_HEAD")
+		}
+		if _, err := os.Stat(filepath.Join(caller, ".git", "MERGE_HEAD")); !os.IsNotExist(err) {
+			t.Fatalf("caller merge state changed: %v", err)
+		}
+	}
+	fixtureFile := f.prefix + ".txt"
+	f.runGit(source, "checkout", "-b", f.base)
+	initial := f.commit(source, fixtureFile, "original\n")
+	f.runGit(source, "checkout", "-b", f.conflict, initial)
+	conflictSHA := f.commit(source, fixtureFile, "conflicting head\n")
+	f.runGit(source, "checkout", f.base)
+	baseSHA := f.commit(source, fixtureFile, "advanced base\n")
+	f.runGit(source, "checkout", "-b", f.clean)
+	cleanSHA := f.commit(source, f.prefix+"-clean.txt", "clean head\n")
+	for _, branch := range []string{f.base, f.conflict, f.clean} {
+		f.push(source, branch)
+	}
+	createPR := func(head string) int64 {
+		t.Helper()
+		pr, err := client.CreatePullRequest(ctx, forge.CreatePullRequestInput{Title: "Looper provider contract: " + strings.TrimPrefix(head, f.prefix+"-"), Body: "Temporary live provider contract fixture. Only its unique test base may be merged; no reviewer policy assertion or production branch mutation.", Head: head, Base: f.base})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("created PR=%d url=%s base=%s head=%s", pr.Number, pr.HTMLURL, f.base, head)
+		return pr.Number
+	}
+	conflictPR, cleanPR := createPR(f.conflict), createPR(f.clean)
+	reviewAdapter, fixAdapter := reviewerGitHubAdapter{config: &cfg}, fixerGitHubAdapter{config: &cfg}
+	for _, tc := range []struct {
+		number int64
+		sha    string
+		want   bool
+	}{{conflictPR, conflictSHA, true}, {cleanPR, cleanSHA, false}} {
+		f.await("PR head/base and conflict state", func() bool {
+			pr, err := reviewAdapter.ViewPullRequest(ctx, reviewer.ViewPullRequestInput{Repo: repo, PRNumber: tc.number, CWD: caller})
+			if err != nil {
+				t.Fatal(err)
+			}
+			return pr.HeadSHA == tc.sha && pr.BaseSHA == baseSHA && pr.HasConflicts == tc.want
+		})
+		fix, err := fixAdapter.ViewPullRequest(ctx, fixer.ViewPullRequestInput{Repo: repo, PRNumber: tc.number, CWD: caller})
+		if err != nil || fix.HeadSHA != tc.sha || fix.BaseSHA != baseSHA || fix.HasConflicts != tc.want {
+			t.Fatalf("fixer PR %d: detail=%+v err=%v", tc.number, fix, err)
+		}
+		assertCaller()
+		t.Logf("adapters PR=%d head=%s base=%s HasConflicts=%v caller unchanged", tc.number, tc.sha, baseSHA, tc.want)
+	}
+	settings, err := reviewAdapter.GetRepositorySettings(ctx, githubinfra.RepositorySettingsInput{Repo: repo})
+	if err != nil || !settings.AllowAutoMerge || settings.AllowMergeCommit != metadata.AllowMerge || settings.AllowSquashMerge != metadata.AllowSquash || settings.AllowRebaseMerge != metadata.AllowRebase {
+		t.Fatalf("repository merge settings=%+v err=%v", settings, err)
+	}
+	assertProtection := func(branch string) {
+		t.Helper()
+		raw := f.branch(branch)
+		got, err := reviewAdapter.GetBranchProtection(ctx, githubinfra.BranchProtectionInput{Repo: repo, Branch: branch})
+		if err != nil || got.Enabled != raw.Protected || got.HasRequiredChecks != (raw.EnableStatusCheck && len(raw.StatusCheckContexts) > 0) {
+			t.Fatalf("effective branch protection %s: adapter=%+v raw=%+v err=%v", branch, got, raw, err)
+		}
+		t.Logf("branch protection branch=%s protected=%v required_contexts=%v", branch, raw.Protected, raw.StatusCheckContexts)
+	}
+	assertProtection(metadata.DefaultBranch)
+	assertProtection(f.base)
+	checkName := f.prefix + "/required"
+	checkURL := baseURL + "/" + repo + "/pulls/" + strconv.FormatInt(cleanPR, 10)
+	statusID := f.status(cleanSHA, checkName, "failure", "intentional live contract failure", checkURL)
+	assertStatus := func(sha, state, description string, id int64) {
+		t.Helper()
+		checks, err := client.ListCommitChecks(ctx, sha)
+		if err != nil {
+			t.Fatal(err)
+		}
+		count := 0
+		for _, check := range checks {
+			if check.Name == checkName {
+				count++
+				if check.ID != id || check.State != state || check.Description != description || check.URL != checkURL {
+					t.Fatalf("current check lost latest state/diagnostics: %+v", check)
+				}
+			}
+		}
+		if count != 1 {
+			t.Fatalf("current context count=%d, want one after status deduplication", count)
+		}
+		fix, err := fixAdapter.ViewPullRequest(ctx, fixer.ViewPullRequestInput{Repo: repo, PRNumber: cleanPR, CWD: caller})
+		if err != nil || fix.HeadSHA != sha {
+			t.Fatalf("fixer current head=%s err=%v", fix.HeadSHA, err)
+		}
+		count = 0
+		for _, check := range fix.Checks {
+			if check["name"] == checkName {
+				count++
+				if check["state"] != state || check["description"] != description || check["url"] != checkURL {
+					t.Fatalf("fixer check diagnostics=%+v", check)
+				}
+			}
+		}
+		if count != 1 {
+			t.Fatalf("fixer context count=%d, want one", count)
+		}
+		review, err := reviewAdapter.ViewPullRequest(ctx, reviewer.ViewPullRequestInput{Repo: repo, PRNumber: cleanPR, CWD: caller})
+		if err != nil || review.HeadSHA != sha || !strings.Contains(review.ChecksSummary, state) || review.URL != checkURL || fix.URL != checkURL {
+			t.Fatalf("reviewer check/URL mapping: head=%s checks=%q URL=%q err=%v", review.HeadSHA, review.ChecksSummary, review.URL, err)
+		}
+		assertCaller()
+	}
+	assertStatus(cleanSHA, "FAILURE", "intentional live contract failure", statusID)
+	merge := githubinfra.EnableAutoMergeInput{Repo: repo, PRNumber: cleanPR, Strategy: config.ReviewerAutoMergeStrategyMerge, HeadSHA: cleanSHA}
+	requireMergeStatus := func(want int) {
+		t.Helper()
+		err := reviewAdapter.EnableAutoMerge(ctx, merge)
+		var httpErr *forge.ForgejoHTTPError
+		if !errors.As(err, &httpErr) || httpErr.StatusCode != want {
+			t.Fatalf("immediate merge expected head=%s: err=%v, want HTTP %d", merge.HeadSHA, err, want)
+		}
+		if actual := f.branch(f.base).Commit.ID; actual != baseSHA {
+			t.Fatalf("rejected merge changed own base: got %s want %s", actual, baseSHA)
+		}
+		t.Logf("immediate merge rejected PR=%d expected_head=%s HTTP=%d own base unchanged", cleanPR, merge.HeadSHA, want)
+	}
+	if f.merge {
+		if !settings.AllowMergeCommit || f.branch(f.base).Protected {
+			t.Fatal("merge fixture requires merge commits and an initially unprotected unique base")
+		}
+		f.protection = true
+		f.mustAPI(http.MethodPost, "/branch_protections", map[string]any{"rule_name": f.base, "apply_to_admins": true, "enable_push": true, "enable_status_check": true, "status_check_contexts": []string{checkName}}, nil, http.StatusCreated)
+		raw := f.branch(f.base)
+		if !raw.Protected || !raw.EnableStatusCheck || !reflect.DeepEqual(raw.StatusCheckContexts, []string{checkName}) {
+			t.Fatalf("own required CI protection not effective: %+v", raw)
+		}
+		assertProtection(f.base)
+		requireMergeStatus(http.StatusMethodNotAllowed) // Scheduling would return 201 and fail here.
+	}
+	successID := f.status(cleanSHA, checkName, "success", "live contract passed", checkURL)
+	if successID <= statusID {
+		t.Fatalf("status history IDs did not advance: %d -> %d", statusID, successID)
+	}
+	assertStatus(cleanSHA, "SUCCESS", "live contract passed", successID)
+	var history []struct {
+		ID      int64  `json:"id"`
+		Context string `json:"context"`
+	}
+	f.mustAPI(http.MethodGet, "/statuses/"+cleanSHA+"?limit=50&page=1&sort=highestindex", nil, &history, http.StatusOK)
+	found := map[int64]bool{}
+	for _, status := range history {
+		if status.Context == checkName {
+			found[status.ID] = true
+		}
+	}
+	if !found[statusID] || !found[successID] {
+		t.Fatal("live status history does not contain both failure and success")
+	}
+	if !f.merge {
+		t.Log("immediate merge contract skipped; set LOOPER_FORGEJO_LIVE_MERGE=1 as an additional explicit opt-in")
+		return
+	}
+	merge.HeadSHA = baseSHA // Wrong existing commit, with required CI now successful.
+	requireMergeStatus(http.StatusConflict)
+	newHead := f.commit(source, f.prefix+"-clean.txt", "separately authorized new head\n")
+	f.push(source, f.clean)
+	f.await("updated PR head", func() bool {
+		pr, err := client.ViewPullRequest(ctx, cleanPR)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pr.Head.SHA == newHead
+	})
+	newStatusID := f.status(newHead, checkName, "success", "new head live contract passed", checkURL)
+	assertStatus(newHead, "SUCCESS", "new head live contract passed", newStatusID)
+	merge.HeadSHA = cleanSHA // The previously authorized head must not authorize this push.
+	requireMergeStatus(http.StatusConflict)
+	// This direct transport call is authorized by the second live-test opt-in
+	// for this exact new fixture commit. It does not assert reviewer eligibility.
+	merge.HeadSHA = newHead
+	if err := reviewAdapter.EnableAutoMerge(ctx, merge); err != nil {
+		t.Fatal(err)
+	}
+	var merged forgejoLivePR
+	f.mustAPI(http.MethodGet, fmt.Sprintf("/pulls/%d", cleanPR), nil, &merged, http.StatusOK)
+	if !merged.Merged || merged.State != "closed" || merged.Base.Ref != f.base || merged.Head.SHA != newHead {
+		t.Fatalf("immediate merge result=%+v", merged)
+	}
+	mergedBase := f.branch(f.base).Commit.ID
+	f.runGit(source, "fetch", "--no-tags", "--no-write-fetch-head", "origin", mergedBase)
+	f.runGit(source, "merge-base", "--is-ancestor", newHead, mergedBase)
+	assertCaller()
+	t.Logf("merged only own base PR=%d reviewed_head=%s base=%s before=%s after=%s", cleanPR, newHead, f.base, baseSHA, mergedBase)
+}
+
+type forgejoLiveBranch struct {
+	Name                string   `json:"name"`
+	Protected           bool     `json:"protected"`
+	EnableStatusCheck   bool     `json:"enable_status_check"`
+	StatusCheckContexts []string `json:"status_check_contexts"`
+	Commit              struct {
+		ID string `json:"id"`
+	} `json:"commit"`
+}
+
+type forgejoLivePR struct {
+	Number int64  `json:"number"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+	Merged bool   `json:"merged"`
+	User   struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	Base struct{ Ref, SHA string } `json:"base"`
+	Head struct{ Ref, SHA string } `json:"head"`
+}
+
+type forgejoLiveFixture struct {
+	t                                             *testing.T
+	ctx                                           context.Context
+	repo, tea, login, gitPath, actor, prefix, dir string
+	base, clean, conflict                         string
+	merge, protection                             bool
+	unchanged                                     map[string]string
+}
+
+// Fixture-only REST setup/cleanup. All assertions exercise the production
+// client/adapters. tea holds credentials; neither config files nor tokens are read.
+func (f *forgejoLiveFixture) api(ctx context.Context, method, suffix string, payload, out any) (int, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	args := []string{"api", "--login", f.login, "-i", "-X", method, "/repos/" + f.repo + suffix}
+	var input []byte
+	if payload != nil {
+		var err error
+		input, err = json.Marshal(payload)
+		if err != nil {
+			return 0, err
+		}
+		args = append(args, "-d", "@-")
+	}
+	cmd := exec.CommandContext(ctx, f.tea, args...)
+	cmd.Stdin = bytes.NewReader(input)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	// tea can exit zero on HTTP errors. Require an actual final status line.
+	status := 0
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && strings.HasPrefix(fields[0], "HTTP/") {
+			status, _ = strconv.Atoi(fields[1])
+		}
+	}
+	if err != nil || status < 100 {
+		return status, fmt.Errorf("tea fixture %s %s: process=%v HTTP=%d", method, suffix, err, status)
+	}
+	if out != nil && status >= 200 && status < 300 {
+		if err := json.Unmarshal(stdout.Bytes(), out); err != nil {
+			return status, fmt.Errorf("tea fixture %s %s returned invalid JSON: %w", method, suffix, err)
+		}
+	}
+	return status, nil
+}
+
+func (f *forgejoLiveFixture) mustAPI(method, suffix string, payload, out any, want int) {
+	f.t.Helper()
+	status, err := f.api(f.ctx, method, suffix, payload, out)
+	if err != nil || status != want {
+		f.t.Fatalf("fixture %s %s: HTTP=%d err=%v, want %d", method, suffix, status, err, want)
+	}
+}
+
+func (f *forgejoLiveFixture) branch(name string) forgejoLiveBranch {
+	f.t.Helper()
+	var branch forgejoLiveBranch
+	f.mustAPI(http.MethodGet, "/branches/"+url.PathEscape(name), nil, &branch, http.StatusOK)
+	return branch
+}
+
+func (f *forgejoLiveFixture) runGit(cwd string, args ...string) string {
+	f.t.Helper()
+	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, f.gitPath, args...)
+	cmd.Dir = cwd
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		f.t.Fatalf("fixture git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func (f *forgejoLiveFixture) commit(cwd, name, body string) string {
+	f.t.Helper()
+	forgejoMergeTestWriteFile(f.t, filepath.Join(cwd, name), body)
+	f.runGit(cwd, "add", "--", name)
+	f.runGit(cwd, "commit", "-m", "test: "+f.prefix)
+	return f.runGit(cwd, "rev-parse", "HEAD")
+}
+
+func (f *forgejoLiveFixture) push(cwd, branch string) {
+	f.t.Helper()
+	if branch != f.base && branch != f.clean && branch != f.conflict {
+		f.t.Fatalf("refusing fixture push outside exact owned branches: %s", branch)
+	}
+	f.runGit(cwd, "push", "origin", "refs/heads/"+branch+":refs/heads/"+branch)
+	f.t.Logf("pushed own branch=%s sha=%s", branch, f.runGit(cwd, "rev-parse", branch))
+}
+
+func (f *forgejoLiveFixture) status(sha, name, state, description, targetURL string) int64 {
+	f.t.Helper()
+	var status struct {
+		ID int64 `json:"id"`
+	}
+	f.mustAPI(http.MethodPost, "/statuses/"+sha, map[string]string{"context": name, "state": state, "description": description, "target_url": targetURL}, &status, http.StatusCreated)
+	f.t.Logf("created status id=%d sha=%s context=%s state=%s", status.ID, sha, name, state)
+	return status.ID
+}
+
+func (f *forgejoLiveFixture) await(what string, ready func() bool) {
+	f.t.Helper()
+	deadline := time.Now().Add(45 * time.Second)
+	for !ready() {
+		if time.Now().After(deadline) {
+			f.t.Fatalf("timed out waiting for %s", what)
+		}
+		select {
+		case <-f.ctx.Done():
+			f.t.Fatal(f.ctx.Err())
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func (f *forgejoLiveFixture) cleanup() {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	call := func(method, path string, payload, out any, allowed ...int) bool {
+		status, err := f.api(ctx, method, path, payload, out)
+		for _, want := range allowed {
+			if err == nil && status == want {
+				return true
+			}
+		}
+		f.t.Errorf("CLEANUP FAILED %s %s HTTP=%d err=%v; prefix=%s", method, path, status, err, f.prefix)
+		return false
+	}
+	// Query the exact base to recover a PR even if its creation response was lost.
+	for page := 1; ; page++ {
+		var prs []forgejoLivePR
+		path := fmt.Sprintf("/pulls?state=all&base=%s&limit=50&page=%d", url.QueryEscape(f.base), page)
+		if !call(http.MethodGet, path, nil, &prs, http.StatusOK) || len(prs) == 0 {
+			break
+		}
+		for _, pr := range prs {
+			if pr.Base.Ref != f.base || (pr.Head.Ref != f.clean && pr.Head.Ref != f.conflict) || pr.User.Login != f.actor || pr.Title != "Looper provider contract: "+strings.TrimPrefix(pr.Head.Ref, f.prefix+"-") {
+				f.t.Errorf("CLEANUP ownership mismatch for PR=%d; left untouched", pr.Number)
+				continue
+			}
+			path := fmt.Sprintf("/pulls/%d", pr.Number)
+			if !pr.Merged && pr.State == "open" {
+				if f.merge {
+					call(http.MethodDelete, path+"/merge", nil, nil, http.StatusNoContent, http.StatusNotFound)
+				}
+				call(http.MethodPatch, path, map[string]string{"state": "closed"}, nil, http.StatusCreated, http.StatusOK)
+			}
+			var final forgejoLivePR
+			if call(http.MethodGet, path, nil, &final, http.StatusOK) {
+				if final.State != "closed" {
+					f.t.Errorf("CLEANUP PR=%d remains %s", pr.Number, final.State)
+				} else {
+					f.t.Logf("cleanup PR=%d state=%s merged=%v", pr.Number, final.State, final.Merged)
+				}
+			}
+		}
+	}
+	if f.protection {
+		path := "/branch_protections/" + url.PathEscape(f.base)
+		call(http.MethodDelete, path, nil, nil, http.StatusNoContent, http.StatusNotFound)
+		if call(http.MethodGet, path, nil, nil, http.StatusNotFound) {
+			f.t.Logf("cleanup protection=%s absent (HTTP 404)", f.base)
+		}
+	}
+	for _, branch := range []string{f.clean, f.conflict, f.base} {
+		path := "/branches/" + url.PathEscape(branch)
+		call(http.MethodDelete, path, nil, nil, http.StatusNoContent, http.StatusNotFound)
+		if call(http.MethodGet, path, nil, nil, http.StatusNotFound) {
+			f.t.Logf("cleanup branch=%s absent (HTTP 404)", branch)
+		}
+	}
+	for branch, before := range f.unchanged {
+		var after forgejoLiveBranch
+		if call(http.MethodGet, "/branches/"+url.PathEscape(branch), nil, &after, http.StatusOK) {
+			if after.Commit.ID != before {
+				f.t.Errorf("protected baseline branch %s changed: before=%s after=%s", branch, before, after.Commit.ID)
+			} else {
+				f.t.Logf("cleanup baseline branch=%s before=%s after=%s unchanged", branch, before, after.Commit.ID)
+			}
+		}
+	}
+}
+
+func forgejoLiveValidateSSHURL(raw, repo string) error {
+	if strings.HasPrefix(raw, "git@") {
+		host, path, ok := strings.Cut(strings.TrimPrefix(raw, "git@"), ":")
+		if ok && host != "" && !strings.ContainsAny(host, "/ \t\r\n") && strings.TrimSuffix(strings.TrimPrefix(path, "/"), ".git") == repo {
+			return nil
+		}
+	}
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Scheme == "ssh" && parsed.Hostname() != "" && parsed.User != nil && parsed.User.Username() == "git" && parsed.RawQuery == "" && parsed.Fragment == "" && strings.TrimSuffix(strings.TrimPrefix(parsed.Path, "/"), ".git") == repo {
+		if _, hasPassword := parsed.User.Password(); !hasPassword {
+			return nil
+		}
+	}
+	return fmt.Errorf("repository ssh_url must be a Git SSH URL for the exact configured repository %s", repo)
+}
+
+func TestForgejoLiveFixtureUsesHTTPStatusAndExactSSHRepository(t *testing.T) {
+	tea := writeFakeTeaBinary(t, "https://forge.example", "live-test", map[string]fakeTeaAPIRoute{
+		"GET /repos/core/sandbox/branches/missing": {Status: "HTTP/2.0 404 Not Found", Body: `{"message":"missing"}`},
+	})
+	f := forgejoLiveFixture{tea: tea, login: "live-test", repo: "core/sandbox"}
+	status, err := f.api(context.Background(), http.MethodGet, "/branches/missing", nil, nil)
+	if err != nil || status != http.StatusNotFound {
+		t.Fatalf("tea exits zero on an HTTP error: status=%d err=%v", status, err)
+	}
+	for _, tc := range []struct {
+		url   string
+		valid bool
+	}{
+		{"ssh://git@ssh.forge.example/core/sandbox.git", true},
+		{"git@ssh.forge.example:core/sandbox.git", true},
+		{"ssh://git@ssh.forge.example:2222/core/sandbox.git", true},
+		{"ssh://git@ssh.forge.example/core/production.git", false},
+		{"git@ssh.forge.example:core/production.git", false},
+		{"ssh://git:credential@ssh.forge.example/core/sandbox.git", false},
+		{"https://forge.example/core/sandbox.git", false},
+		{"ext::unexpected command", false},
+	} {
+		if err := forgejoLiveValidateSSHURL(tc.url, "core/sandbox"); (err == nil) != tc.valid {
+			t.Errorf("SSH repository validation for %q: %v, want valid=%v", tc.url, err, tc.valid)
+		}
+	}
+}

--- a/internal/runtime/scheduler_forgejo_merge_test.go
+++ b/internal/runtime/scheduler_forgejo_merge_test.go
@@ -1,0 +1,161 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestForgejoHasMergeConflictsFetchesExactObjectsWithoutChangingCaller(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	source, remote, caller := filepath.Join(root, "source"), filepath.Join(root, "remote.git"), filepath.Join(root, "caller")
+	forgejoMergeTestMustMkdirAll(t, source)
+	forgejoMergeTestRunGit(t, source, "init", "-b", "main")
+	forgejoMergeTestConfigureRepo(t, source)
+	forgejoMergeTestWriteFile(t, filepath.Join(source, "README.md"), "original\n")
+	forgejoMergeTestRunGit(t, source, "add", ".")
+	forgejoMergeTestRunGit(t, source, "commit", "-m", "initial")
+	initial := strings.TrimSpace(forgejoMergeTestRunGit(t, source, "rev-parse", "HEAD"))
+	forgejoMergeTestRunGit(t, root, "clone", "--bare", source, remote)
+	forgejoMergeTestRunGit(t, root, "clone", remote, caller)
+	forgejoMergeTestRunGit(t, source, "remote", "add", "origin", remote)
+	for _, branch := range []string{"feature", "clean"} {
+		forgejoMergeTestRunGit(t, source, "checkout", "-b", branch, initial)
+		path := "README.md"
+		if branch == "clean" {
+			path = "new.txt"
+		}
+		forgejoMergeTestWriteFile(t, filepath.Join(source, path), branch+" change\n")
+		forgejoMergeTestRunGit(t, source, "add", ".")
+		forgejoMergeTestRunGit(t, source, "commit", "-m", branch)
+		forgejoMergeTestRunGit(t, source, "push", "origin", branch)
+	}
+	head := strings.TrimSpace(forgejoMergeTestRunGit(t, source, "rev-parse", "feature"))
+	clean := strings.TrimSpace(forgejoMergeTestRunGit(t, source, "rev-parse", "clean"))
+	forgejoMergeTestRunGit(t, source, "checkout", "main")
+	forgejoMergeTestWriteFile(t, filepath.Join(source, "README.md"), "main change\n")
+	forgejoMergeTestRunGit(t, source, "add", ".")
+	forgejoMergeTestRunGit(t, source, "commit", "-m", "base advances")
+	forgejoMergeTestRunGit(t, source, "push", "origin", "main")
+	base := strings.TrimSpace(forgejoMergeTestRunGit(t, source, "rev-parse", "HEAD"))
+
+	// Deliberately dirty both the index and working tree, and retain FETCH_HEAD.
+	forgejoMergeTestWriteFile(t, filepath.Join(caller, "README.md"), "staged local work\n")
+	forgejoMergeTestRunGit(t, caller, "add", "README.md")
+	forgejoMergeTestWriteFile(t, filepath.Join(caller, "README.md"), "unstaged local work\n")
+	forgejoMergeTestWriteFile(t, filepath.Join(caller, "untracked.txt"), "keep me\n")
+	forgejoMergeTestWriteFile(t, filepath.Join(caller, ".git", "FETCH_HEAD"), "caller fetch marker\n")
+	before := mergeConflictCallerSnapshot(t, caller)
+	for _, tc := range []struct {
+		name, head string
+		want       bool
+	}{{"clean", clean, false}, {"conflict", head, true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := forgejoHasMergeConflicts(context.Background(), "git", caller, base, tc.head)
+			if err != nil || got != tc.want {
+				t.Fatalf("HasMergeConflicts = %v, %v; want %v", got, err, tc.want)
+			}
+			if after := mergeConflictCallerSnapshot(t, caller); after != before {
+				t.Fatalf("caller changed:\nbefore=%s\nafter=%s", before, after)
+			}
+		})
+	}
+	// Once the exact objects are cached, remote unavailability must not matter.
+	forgejoMergeTestRunGit(t, caller, "remote", "set-url", "origin", filepath.Join(root, "unavailable.git"))
+	if got, err := forgejoHasMergeConflicts(context.Background(), "git", caller, base, head); err != nil || !got {
+		t.Fatalf("cached merge check = %v, %v; must not fetch existing objects", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(caller, ".git", "MERGE_HEAD")); !os.IsNotExist(err) {
+		t.Fatalf("MERGE_HEAD exists after read-only check: %v", err)
+	}
+	if got, err := forgejoHasMergeConflicts(context.Background(), "git", caller, base, strings.Repeat("1", 40)); err == nil || got {
+		t.Fatalf("missing commit with failed fetch = %v, %v; want error, not conflict", got, err)
+	}
+}
+
+func TestForgejoHasMergeConflictsDoesNotTurnGitFailuresIntoConflicts(t *testing.T) {
+	t.Parallel()
+	sha := strings.Repeat("a", 40)
+	for _, tc := range []struct{ name, script string }{
+		{"inspect failure", "#!/bin/sh\necho 'cannot read repository' >&2\nexit 128\n"},
+		{"unsupported merge-tree", "#!/bin/sh\nif [ \"$1\" = cat-file ]; then while read object; do echo \"$object commit\"; done; exit 0; fi\necho 'unknown option write-tree' >&2\nexit 129\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gitPath := forgejoMergeTestWriteFakeGit(t, tc.script)
+			got, err := forgejoHasMergeConflicts(context.Background(), gitPath, t.TempDir(), sha, sha)
+			if err == nil || got {
+				t.Fatalf("HasMergeConflicts = %v, %v; want Git error", got, err)
+			}
+		})
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got, err := forgejoHasMergeConflicts(ctx, "git", t.TempDir(), sha, sha); err == nil || got {
+		t.Fatalf("cancelled check = %v, %v; want error", got, err)
+	}
+}
+
+func mergeConflictCallerSnapshot(t *testing.T, cwd string) string {
+	t.Helper()
+	return strings.Join([]string{
+		forgejoMergeTestRunGit(t, cwd, "symbolic-ref", "HEAD"), forgejoMergeTestRunGit(t, cwd, "rev-parse", "HEAD"),
+		forgejoMergeTestRunGit(t, cwd, "for-each-ref", "--format=%(refname) %(objectname)"),
+		forgejoMergeTestRunGit(t, cwd, "ls-files", "--stage"), forgejoMergeTestRunGit(t, cwd, "status", "--porcelain=v1"),
+		forgejoMergeTestReadFile(t, filepath.Join(cwd, "README.md")), forgejoMergeTestReadFile(t, filepath.Join(cwd, "untracked.txt")),
+		forgejoMergeTestReadFile(t, filepath.Join(cwd, ".git", "FETCH_HEAD")),
+	}, "\n")
+}
+
+func forgejoMergeTestRunGit(t *testing.T, cwd string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = cwd
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+func forgejoMergeTestConfigureRepo(t *testing.T, cwd string) {
+	t.Helper()
+	forgejoMergeTestRunGit(t, cwd, "config", "user.name", "Looper Test")
+	forgejoMergeTestRunGit(t, cwd, "config", "user.email", "test@example.com")
+	forgejoMergeTestRunGit(t, cwd, "config", "commit.gpgsign", "false")
+}
+
+func forgejoMergeTestMustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func forgejoMergeTestWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func forgejoMergeTestReadFile(t *testing.T, path string) string {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(contents)
+}
+
+func forgejoMergeTestWriteFakeGit(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "git")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/runtime/scheduler_forgejo_native_test.go
+++ b/internal/runtime/scheduler_forgejo_native_test.go
@@ -72,6 +72,40 @@ func TestFindForgejoNativeReviewMarkerEnforcesOutcomeSpecificEvents(t *testing.T
 	}
 }
 
+func TestFindForgejoNativeReviewMarkerAcceptsOnlyExplicitSelfBlockingFallback(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, reviewAuthor, markerHead, commitHead string
+		allow, wantFound                           bool
+	}{
+		{name: "self transport fallback", reviewAuthor: "reviewer", markerHead: "head", commitHead: "head", allow: true, wantFound: true},
+		{name: "no self transport allowance", reviewAuthor: "reviewer", markerHead: "head", commitHead: "head"},
+		{name: "wrong review author", reviewAuthor: "other", markerHead: "head", commitHead: "head", allow: true},
+		{name: "wrong marker head", reviewAuthor: "reviewer", markerHead: "old", commitHead: "old", allow: true},
+		{name: "review commit differs from marker", reviewAuthor: "reviewer", markerHead: "head", commitHead: "old", allow: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reviews := []forge.PullRequestReview{{
+				ID: 1, State: "COMMENTED", CommitID: tc.commitHead,
+				Body:     "Blocking finding\n<!-- looper:review id=reviewer:loop:head head=" + tc.markerHead + " outcome=blocking -->",
+				User:     forge.Identity{Login: tc.reviewAuthor},
+				Comments: []forge.PullRequestReviewComment{{Body: "Return the discounted total."}},
+			}}
+			found := findForgejoNativeReviewMarker(reviews, reviewer.VerifyReviewMarkerInput{
+				Marker: "looper:review id=reviewer:loop:head head=head", AuthorLogin: "reviewer",
+				AllowedReviewEvents:  []reviewer.ReviewEvent{reviewer.ReviewEventComment, reviewer.ReviewEventRequestChanges},
+				AllowBlockingComment: tc.allow,
+			})
+			if found.Found != tc.wantFound {
+				t.Fatalf("marker = %#v, want Found=%t", found, tc.wantFound)
+			}
+			if tc.wantFound && (found.Event != reviewer.ReviewEventComment || found.Outcome != "blocking" || len(found.InlineCommentBodies) != 1) {
+				t.Fatalf("self review lost its blocking finding: %#v", found)
+			}
+		})
+	}
+}
+
 func TestReviewerForgejoAdapterNativeDiscoveryContextPublishAndRetry(t *testing.T) {
 	t.Setenv("FORGEJO_TOKEN", "secret")
 	marker := "<!-- looper:review id=reviewer:loop:head-42 head=head-42 outcome=blocking -->"
@@ -79,6 +113,10 @@ func TestReviewerForgejoAdapterNativeDiscoveryContextPublishAndRetry(t *testing.
 	publishCalls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/statuses/"):
+			_ = json.NewEncoder(w).Encode([]any{})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/actions/runs"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"workflow_runs": []any{}})
 		case r.URL.Path == "/swagger.v1.json":
 			_, _ = w.Write([]byte(`{"paths":{"/repos/{owner}/{repo}/pulls/{index}/requested_reviewers":{"post":{}},"/repos/{owner}/{repo}/pulls/{index}/reviews":{"get":{},"post":{}},"/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments":{"get":{}}}}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/user":

--- a/internal/runtime/scheduler_forgejo_test.go
+++ b/internal/runtime/scheduler_forgejo_test.go
@@ -683,9 +683,9 @@ func TestFixerGitHubAdapterForgejoSummaryCommentNoResolveFlow(t *testing.T) {
 	if err := adapter.RemovePullRequestLabels(ctx, fixer.PullRequestLabelsInput{Repo: "acme/looper", PRNumber: 42, Labels: []string{"looper:fix"}, CWD: repoPath}); err != nil {
 		t.Fatalf("RemovePullRequestLabels() error = %v", err)
 	}
-	compare, err := adapter.CompareCommits(ctx, fixer.CompareCommitsInput{Repo: "acme/looper", Base: "base123", Head: "abc123", CWD: repoPath})
-	if err != nil || compare.Status != "ahead" {
-		t.Fatalf("CompareCommits() = %#v, %v; want ahead", compare, err)
+	compare, err := adapter.CompareCommits(ctx, fixer.CompareCommitsInput{Repo: "acme/looper", Base: "abc123", Head: "abc123", CWD: repoPath})
+	if err != nil || compare.Status != "identical" {
+		t.Fatalf("CompareCommits() = %#v, %v; want identical", compare, err)
 	}
 	if _, err := adapter.ListReviewThreads(ctx, fixer.ListReviewThreadsInput{Repo: "acme/looper", PRNumber: 42, CWD: repoPath}); err == nil || !strings.Contains(err.Error(), "does not support native review threads") {
 		t.Fatalf("ListReviewThreads() error = %v, want Forgejo unsupported native review threads", err)

--- a/internal/runtime/scheduler_forgejo_test.go
+++ b/internal/runtime/scheduler_forgejo_test.go
@@ -748,7 +748,7 @@ func TestFixerGitHubAdapterForgejoListNativeReviewComments(t *testing.T) {
 	if len(comments) != 3 {
 		t.Fatalf("comments = %#v, want 3", comments)
 	}
-	if got := comments[0]; got.ObservedFingerprint != fixer.NativeReviewCommentFingerprint(101, "2026-07-01T00:00:00Z") || got.ResolverPresent || got.IsResolved {
+	if got := comments[0]; got.ObservedFingerprint != fixer.NativeReviewCommentFingerprint(101, "Open comment") || got.ResolverPresent || got.IsResolved {
 		t.Fatalf("comments[0] = %#v, want absent resolver preserved as open", got)
 	}
 	if got := comments[1]; !got.ResolverPresent || got.IsResolved {
@@ -756,6 +756,57 @@ func TestFixerGitHubAdapterForgejoListNativeReviewComments(t *testing.T) {
 	}
 	if got := comments[2]; !got.ResolverPresent || !got.IsResolved || got.Author != "carol" {
 		t.Fatalf("comments[2] = %#v, want resolved comment with author preserved", got)
+	}
+}
+
+func TestFixerGitHubAdapterForgejoNativeFingerprintTracksBodyInsteadOfPushTimestamp(t *testing.T) {
+	t.Setenv("FORGEJO_TOKEN", "secret")
+	// Forgejo 16 live PR 25/comment 2433 changed only updated_at after a
+	// fixer push. The comment body and original review anchors stayed unchanged.
+	comment := map[string]any{
+		"id": 2433, "body": "Return the final price after subtracting the discount.\n\n<!-- looper:stamp v=1 -->",
+		"user": map[string]any{"login": "reviewer", "id": 1}, "resolver": nil,
+		"pull_request_review_id": 41, "created_at": "2026-09-06T11:09:23Z", "updated_at": "2026-09-06T11:09:23Z",
+		"path": "price.py", "commit_id": "0168818d2a7e524c3204841196c7f05ccf6e8787", "original_commit_id": "",
+		"diff_hunk": "@@ -0,0 +1,3 @@\n+def discounted_price(price, discount_percent):\n+    return price * discount_percent / 100",
+		"position":  3, "original_position": 0, "extra_lines_count": 0,
+		"html_url": "https://forge.example/acme/looper/pulls/25#issuecomment-2433", "pull_request_url": "https://forge.example/acme/looper/pulls/25",
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/looper/pulls/25/reviews":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": 41, "state": "COMMENT", "comments_count": 1, "commit_id": comment["commit_id"], "user": comment["user"]}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/looper/pulls/25/reviews/41/comments":
+			_ = json.NewEncoder(w).Encode([]map[string]any{comment})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	cfg := config.Config{
+		Providers: []config.ProviderConfig{{ID: "forgejo", Kind: config.ProviderKindForgejo, BaseURL: server.URL, TokenEnv: stringPtr("FORGEJO_TOKEN")}},
+		Projects:  []config.ProjectRefConfig{{ID: "project", Provider: "forgejo", Repo: "acme/looper", RepoPath: t.TempDir()}},
+	}
+	adapter := fixerGitHubAdapter{config: &cfg}
+	read := func() fixer.NativeReviewComment {
+		t.Helper()
+		comments, err := adapter.ListNativeReviewComments(context.Background(), fixer.ListNativeReviewCommentsInput{Repo: "acme/looper", PRNumber: 25})
+		if err != nil || len(comments) != 1 {
+			t.Fatalf("native REST comment: count=%d err=%v", len(comments), err)
+		}
+		return comments[0]
+	}
+	beforePush := read()
+	comment["updated_at"] = "2026-09-06T11:12:03Z"
+	afterPush := read()
+	if afterPush.UpdatedAt == beforePush.UpdatedAt || afterPush.Body != beforePush.Body || afterPush.ObservedFingerprint != beforePush.ObservedFingerprint {
+		t.Fatalf("push-only metadata caused content drift: before=%+v after=%+v", beforePush, afterPush)
+	}
+	comment["body"] = beforePush.Body + "\nAlso preserve decimal prices."
+	afterEdit := read()
+	if afterEdit.UpdatedAt != afterPush.UpdatedAt || afterEdit.ObservedFingerprint == afterPush.ObservedFingerprint {
+		t.Fatalf("body edit with unchanged timestamp did not cause content drift: before=%+v after=%+v", afterPush, afterEdit)
 	}
 }
 

--- a/internal/runtime/scheduler_forgejo_test.go
+++ b/internal/runtime/scheduler_forgejo_test.go
@@ -382,6 +382,10 @@ func TestReviewerGitHubAdapterForgejoCommentOnlyFlow(t *testing.T) {
 	var comparePath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/statuses/"):
+			_ = json.NewEncoder(w).Encode([]any{})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/actions/runs"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"workflow_runs": []any{}})
 		case r.Method == http.MethodGet && r.URL.Path == "/swagger.v1.json":
 			_, _ = w.Write([]byte(`{"paths":{}}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/looper/pulls":
@@ -581,6 +585,10 @@ func TestFixerGitHubAdapterForgejoSummaryCommentNoResolveFlow(t *testing.T) {
 	var removedLabelPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/statuses/"):
+			_ = json.NewEncoder(w).Encode([]any{})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/actions/runs"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"workflow_runs": []any{}})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/user":
 			_ = json.NewEncoder(w).Encode(map[string]any{"id": 7, "login": "fixer-bot"})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repos/acme/looper/pulls":

--- a/scripts/forgejo-review-fix-smoke.py
+++ b/scripts/forgejo-review-fix-smoke.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+"""Opt-in live Forgejo/Codex lifecycle check using an existing tea login.
+
+Creates and closes one test PR; uses only its own branch, label, daemon and DB.
+Requires go, git, tea, python3 and an authenticated codex. Run --help for usage.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import signal
+import socket
+import sqlite3
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def execute(argv, *, cwd=None, env=None, timeout=300):
+    result = subprocess.run([str(a) for a in argv], cwd=cwd, env=env,
+                            text=True, capture_output=True, timeout=timeout)
+    if result.returncode:
+        raise RuntimeError(f"{argv[0]} exited {result.returncode}: {result.stderr[-1600:]}")
+    return result.stdout
+
+
+def save(path, value):
+    path.write_text(json.dumps(value, indent=2, ensure_ascii=False) + "\n")
+
+
+class Smoke:
+    def __init__(self, args):
+        self.args = args
+        self.run_id = time.strftime("%Y%m%d-%H%M%S", time.gmtime()) + f"-{os.getpid()}"
+        self.branch = "looper-smoke-" + self.run_id
+        self.label_name = "looper-smoke:" + self.run_id
+        self.out = Path(args.output or ROOT / "dist" / self.branch).resolve()
+        self.out.mkdir(parents=True, exist_ok=False)
+        self.checkout = self.out / "repo"
+        self.bin_dir = self.out / "bin"
+        self.bin_dir.mkdir()
+        # Keep vendor/tea authentication in the current HOME. All Looper runtime
+        # paths are explicit; inherited Looper overrides must not select another DB.
+        self.env = {k: v for k, v in os.environ.items() if not k.startswith("LOOPER_")}
+        self.env.update(GIT_TERMINAL_PROMPT="0", GCM_INTERACTIVE="Never")
+        self.pr_number = None
+        self.label_id = None
+        self.label_attempted = False
+        self.pr_attempted = False
+        self.pushed = False
+        self.proc = None
+        self.session_id = None
+        self.log = None
+        self.cfg = None
+        self.default_branch = None
+        self.initial_default_sha = None
+        self.evidence = {"run_id": self.run_id, "repo": args.repo, "base_url": args.base_url,
+                         "branch": self.branch, "label_name": self.label_name}
+
+    def tea(self, path, method="GET", body=None, *, missing_ok=False, include_headers=False):
+        argv = ["tea", "api", "--login", self.args.tea_login, "-i", "-X", method, path]
+        if body is not None:
+            argv += ["-d", "@-"]
+        result = subprocess.run(argv, input=None if body is None else json.dumps(body),
+                                text=True, capture_output=True, env=self.env, timeout=60)
+        codes = re.findall(r"HTTP/\S+\s+(\d+)", result.stderr)
+        if missing_ok and not result.returncode and codes and codes[-1] == "404":
+            return None
+        # tea can exit zero for HTTP failures. Never interpret those as success.
+        if result.returncode or not codes or not codes[-1].startswith("2"):
+            raise RuntimeError(f"tea {method} {path}: HTTP {codes}, exit {result.returncode}")
+        value = json.loads(result.stdout) if result.stdout.strip() else None
+        return (value, result.stderr) if include_headers else value
+
+    def remote(self, suffix, method="GET", body=None, *, missing_ok=False):
+        return self.tea(f"repos/{self.args.repo}/{suffix}", method, body, missing_ok=missing_ok)
+
+    def remote_list(self, suffix):
+        items = []
+        page = 1
+        separator = "&" if "?" in suffix else "?"
+        while True:
+            batch, headers = self.tea(
+                f"repos/{self.args.repo}/{suffix}{separator}limit=50&page={page}", include_headers=True)
+            if not isinstance(batch, list):
+                raise RuntimeError(f"expected a paginated array from {suffix}")
+            items.extend(batch)
+            # Some Forgejo list endpoints ignore page/limit and return the
+            # entire collection. Follow the same Link contract as the client.
+            total_pages = re.findall(r"^x-total-pages:\s*(\d+)\s*$", headers, re.I | re.M)
+            has_next = (page < int(total_pages[-1]) if total_pages else
+                        any(re.search(r'rel\s*=\s*"?next\b', line, re.I)
+                            for line in headers.splitlines() if line.lower().startswith("link:")))
+            if not has_next:
+                return items
+            page += 1
+
+    def api(self, path, body=None):
+        data = None if body is None else json.dumps(body).encode()
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{self.cfg['server']['port']}/api/v1/{path}",
+            data=data, headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(request, timeout=30) as response:
+            result = json.load(response)
+        if not result.get("ok"):
+            raise RuntimeError(f"daemon API {path} failed; inspect artifacts")
+        return result.get("data")
+
+    def git(self, *args):
+        return execute(["git", *args], cwd=self.checkout, env=self.env).strip()
+
+    def setup(self):
+        for name in ["go", "git", "tea", "codex", "python3", "ps"]:
+            if not shutil.which(name):
+                raise RuntimeError(f"required executable missing: {name}")
+        execute(["go", "build", "-o", str(self.bin_dir) + "/",
+                 "./cmd/looper", "./cmd/looperd"], cwd=ROOT, env=self.env)
+        metadata = self.tea(f"repos/{self.args.repo}")
+        expected_url = self.args.base_url.rstrip("/") + "/" + self.args.repo
+        if metadata.get("html_url", "").rstrip("/") != expected_url:
+            raise RuntimeError("tea login repository URL does not match --base-url and --repo")
+        self.default_branch = metadata["default_branch"]
+        self.initial_default_sha = self.remote("branches/" + urllib.parse.quote(self.default_branch, safe=""))["commit"]["id"]
+        self.evidence["default_branch"] = self.default_branch
+        self.evidence["initial_default_sha"] = self.initial_default_sha
+        execute(["git", "clone", metadata["ssh_url"], self.checkout], env=self.env)
+        self.git("config", "user.name", "Looper sandbox test")
+        self.git("config", "user.email", "looper-sandbox@example.com")
+        self.git("config", "commit.gpgsign", "false")
+        self.git("checkout", "-b", self.branch, self.initial_default_sha)
+        self.fixture = self.checkout / ("looper_smoke_" + self.run_id.replace("-", "_"))
+        self.fixture.mkdir()
+        (self.fixture / "price.py").write_text(
+            'def discounted_price(price, discount_percent):\n'
+            '    """Return the final price after applying a percentage discount."""\n'
+            '    return price * discount_percent / 100\n')
+        (self.fixture / "test_price.py").write_text(
+            'import unittest\nfrom price import discounted_price\n\n'
+            'class PriceTests(unittest.TestCase):\n'
+            '    def test_twenty_percent(self):\n'
+            '        self.assertEqual(discounted_price(100, 20), 80)\n'
+            '    def test_no_discount(self):\n'
+            '        self.assertEqual(discounted_price(100, 0), 100)\n'
+            '    def test_full_discount(self):\n'
+            '        self.assertEqual(discounted_price(100, 100), 0)\n')
+        # Keep the acceptance contract outside the agent's editable checkout.
+        (self.out / "test_price_contract.py").write_text((self.fixture / "test_price.py").read_text())
+        (self.fixture / ".gitignore").write_text("__pycache__/\n")
+        self.git("add", self.fixture.name)
+        self.git("commit", "-m", "test: add Forgejo review and repair fixture")
+        self.configure()
+        save(self.out / "config.json", self.cfg)
+        execute([self.bin_dir / "looper", "config", "validate", "--config", self.out / "config.json"], env=self.env)
+        save(self.out / "resources.json", self.evidence)
+        # Also attempt cleanup if the server accepted a push whose response was lost.
+        self.pushed = True
+        self.git("push", "origin", "HEAD:refs/heads/" + self.branch)
+        self.label_attempted = True
+        label = self.remote("labels", "POST", {"name": self.label_name, "color": "5319e7"})
+        self.label_id = label["id"]
+        self.evidence["label_id"] = self.label_id
+        save(self.out / "resources.json", self.evidence)
+        self.pr_attempted = True
+        pr = self.remote("pulls", "POST", {
+            "base": self.default_branch, "head": self.branch,
+            "title": "test: Forgejo native review and repair " + self.run_id,
+            "body": "Authorized Looper sandbox lifecycle test. Implement the documented final-price "
+                    "function in the new fixture directory. Its unittest contract must pass. "
+                    "Scope is only this fixture. Do not merge this PR. "
+                    "Looper will close it after testing native review, repair and follow-up review.",
+        })
+        self.pr_number = pr["number"]
+        self.evidence.update(pr_url=pr["html_url"], pr_number=self.pr_number,
+                             original_head=pr["head"]["sha"], branch=self.branch, label_id=self.label_id)
+        self.remote(f"issues/{self.pr_number}/labels", "POST", {"labels": [self.label_id]})
+        save(self.out / "resources.json", self.evidence)
+
+    def configure(self):
+        # A minimal file lets looperd merge its own defaults. `config show`
+        # reads a running daemon, so it must never bootstrap this isolated test.
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        self.cfg = {
+            "server": {"host": "127.0.0.1", "port": port, "authMode": "none"},
+            "storage": {"dbPath": str(self.out / "looper.sqlite"), "backupDir": str(self.out / "backups")},
+            "daemon": {"logDir": str(self.out / "logs"), "workingDirectory": str(self.checkout),
+                       "mode": "foreground", "shutdownTimeoutMs": 30000, "worktreeCleanup": {"enabled": False}},
+            "package": {"autoUpgradeEnabled": False},
+            "notifications": {"osascript": {"enabled": False}, "webhook": {"enabled": False}},
+            "webhook": {"enabled": False},
+            "instructions": {"enabled": False},
+            "disclosure": {"enabled": True, "includeAgent": True, "includeOS": False},
+            "providers": [{"id": "forgejo-smoke", "kind": "forgejo", "baseUrl": self.args.base_url,
+                           "auth": "tea", "teaLogin": self.args.tea_login}],
+            "projects": [{"id": "forgejo-smoke", "name": "Isolated Forgejo smoke", "repo": self.args.repo,
+                          "repoPath": str(self.checkout), "provider": "forgejo-smoke",
+                          "worktreeRoot": str(self.out / "worktrees")}],
+            "tools": {"looperPath": str(self.bin_dir / "looper")},
+            "scheduler": {"pollIntervalSeconds": 10, "discoveryCacheTtlSeconds": 1},
+            "roles": {
+                "planner": {"autoDiscovery": False}, "worker": {"autoDiscovery": False},
+                "coordinator": {"enabled": False},
+                "reviewer": {
+                    "autoMerge": {"enabled": False},
+                    "discovery": {"autoDiscovery": False, "triggers": {
+                        "enableSelfReview": True, "requireReviewRequest": False, "labels": [self.label_name]}},
+                    "behavior": {"publishMode": "single_review", "loop": {
+                        "enabledByDefault": True, "quietPeriodSeconds": 0, "minPublishIntervalSeconds": 0}}},
+                "fixer": {"autoDiscovery": False, "triggers": {"labels": [self.label_name]},
+                          "behavior": {"loop": {"quietPeriodSeconds": 0}}}},
+            "defaults": {"allowAutoCommit": True, "allowAutoPush": True, "loop": {"quietPeriodSeconds": 0}},
+            "agent": {"vendor": "codex", "nativeResume": {"enabled": False}, "timeouts": {
+                "reviewerMaxRuntimeSeconds": 600, "reviewerIdleTimeoutSeconds": 300,
+                "fixerMaxRuntimeSeconds": 600, "fixerIdleTimeoutSeconds": 300}},
+        }
+
+    def start(self):
+        save(self.out / "config.json", self.cfg)
+        self.log = (self.out / "daemon.log").open("a")
+        self.proc = subprocess.Popen([str(self.bin_dir / "looperd"), "--config", str(self.out / "config.json")],
+                                     cwd=self.checkout, env=self.env, stdout=self.log, stderr=self.log,
+                                     start_new_session=True)
+        self.session_id = self.proc.pid
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                raise RuntimeError("isolated daemon exited; inspect daemon.log")
+            try:
+                status = self.api("healthz")
+                if Path(status["storage"]["dbPath"]).resolve() != self.out / "looper.sqlite":
+                    raise RuntimeError("readiness reached a different daemon; refusing to use it")
+                return
+            except (urllib.error.URLError, TimeoutError):
+                time.sleep(0.5)
+        raise RuntimeError("isolated daemon did not become ready")
+
+    def stop(self):
+        if self.proc is not None:
+            # Agents have their own process groups inside this dedicated
+            # session. Killing only the daemon group would leave them alive.
+            self.session_processes()
+            if self.proc.poll() is None:
+                self.proc.terminate()
+            for sig, seconds in [(None, 35), (signal.SIGTERM, 5), (signal.SIGKILL, 5)]:
+                members = self.session_processes()
+                if sig is not None:
+                    for pgid in set(members.values()):
+                        # Recheck ownership immediately before signalling.
+                        if pgid in self.session_processes().values():
+                            try:
+                                os.killpg(pgid, sig)
+                            except ProcessLookupError:
+                                pass
+                deadline = time.monotonic() + seconds
+                while members and time.monotonic() < deadline:
+                    self.proc.poll()
+                    time.sleep(0.2)
+                    members = self.session_processes()
+                if not members:
+                    self.proc.wait(timeout=2)
+                    break
+            else:
+                raise RuntimeError(f"own daemon session {self.session_id} still has live processes; remote cleanup withheld")
+        self.proc = None
+        self.session_id = None
+        if self.log:
+            self.log.close()
+            self.log = None
+
+    def session_processes(self):
+        """Inspect IDs only; never match or signal other Looper/Codex by name."""
+        rows = {}
+        for line in execute(["ps", "-axo", "pid=,ppid=,pgid=,stat="], env=self.env, timeout=10).splitlines():
+            pid, parent, group, state = line.split()
+            rows[int(pid)] = (int(parent), int(group), state)
+        descendants = {self.proc.pid}
+        while True:
+            expanded = descendants | {pid for pid, row in rows.items() if row[0] in descendants}
+            if expanded == descendants:
+                break
+            descendants = expanded
+        members = {}
+        for pid, (_, group, state) in rows.items():
+            if state.startswith("Z"):
+                continue
+            try:
+                session = os.getsid(pid)
+            except ProcessLookupError:
+                continue
+            if pid in descendants and session != self.session_id:
+                raise RuntimeError(f"own child {pid} escaped daemon session; cannot confirm cleanup, remote deletion withheld")
+            if session == self.session_id:
+                members[pid] = group
+        return members
+
+    def database_state(self):
+        # Read the already isolated DB, including completed agent executions;
+        # successful skipped runs alone cannot establish that no agent reran.
+        with sqlite3.connect((self.out / "looper.sqlite").as_uri() + "?mode=ro", uri=True) as db:
+            db.row_factory = sqlite3.Row
+            return {
+                "executions": [dict(row) for row in db.execute(
+                    "SELECT id, run_id, vendor, status FROM agent_executions ORDER BY id")],
+                "queue": [dict(row) for row in db.execute(
+                    "SELECT id, loop_id, status FROM queue_items ORDER BY id")],
+            }
+
+    def wait_runs(self, predicate, phase):
+        deadline = time.monotonic() + self.args.timeout
+        last = None
+        while time.monotonic() < deadline:
+            runs = self.api("runs")["items"]
+            loops = self.api("loops")
+            save(self.out / (phase + "-runs.json"), runs)
+            save(self.out / (phase + "-loops.json"), loops)
+            state = [(r["id"], r["status"]) for r in runs]
+            if state != last:
+                print(phase, state, flush=True)
+                last = state
+            if any(r["status"] in {"failed", "cancelled", "interrupted", "parse_failed"} for r in runs):
+                raise RuntimeError(f"{phase}: run failed; inspect saved runs/daemon log")
+            if predicate(runs):
+                return runs
+            time.sleep(3)
+        raise RuntimeError(f"{phase} timed out; inspect artifacts")
+
+    def snapshot(self):
+        pr = self.remote(f"pulls/{self.pr_number}")
+        reviews = self.remote_list(f"pulls/{self.pr_number}/reviews")
+        comments = self.remote_list(f"issues/{self.pr_number}/comments")
+        return {"pr": pr, "reviews": reviews, "comments": comments}
+
+    @staticmethod
+    def message_state(snapshot):
+        return {kind: sorted((entry["id"], entry["body"]) for entry in snapshot[kind])
+                for kind in ["reviews", "comments"]}
+
+    def wait_restart_stable(self, before, before_runs, before_db):
+        before_ids = {run["id"] for run in before_runs}
+        stable_window = 2 * self.cfg["scheduler"]["pollIntervalSeconds"] + 2
+        stable_since = None
+        last_state = None
+        deadline = time.monotonic() + self.args.timeout
+        while time.monotonic() < deadline:
+            runs = self.api("runs")["items"]
+            database = self.database_state()
+            after = self.snapshot()
+            save(self.out / "restart-runs.json", runs)
+            save(self.out / "restart-database.json", database)
+            save(self.out / "restart-snapshot.json", after)
+            if (before["pr"]["head"]["sha"] != after["pr"]["head"]["sha"]
+                    or self.message_state(before) != self.message_state(after)):
+                raise RuntimeError("restart changed head or review/fixer messages")
+            if database["executions"] != before_db["executions"]:
+                raise RuntimeError("restart started another agent execution")
+            if not before_ids.issubset({run["id"] for run in runs}):
+                raise RuntimeError("restart lost prior runs")
+            if any(run["status"] in {"failed", "cancelled", "interrupted", "parse_failed"} for run in runs):
+                raise RuntimeError("restart produced a terminal run failure")
+            extra = [run for run in runs if run["id"] not in before_ids]
+            for run in extra:
+                if run["status"] == "success" and not json.loads(run.get("checkpointJson") or "{}").get("skipReason"):
+                    raise RuntimeError("restart produced new work without an explicit skipped checkpoint")
+            quiet = (all(run["status"] == "success" for run in runs)
+                     and all(row["status"] in {"completed", "cancelled"} for row in database["queue"]))
+            state = ([run["id"] for run in runs], database["queue"])
+            if not quiet or state != last_state:
+                stable_since = time.monotonic() if quiet else None
+            elif stable_since is not None and time.monotonic() - stable_since >= stable_window:
+                self.evidence["restart_skipped_only_runs"] = [run["id"] for run in extra]
+                if extra:
+                    print("restart allowed skipped-only runs (no agent execution):", len(extra), flush=True)
+                return runs, after
+            last_state = state
+            time.sleep(3)
+        raise RuntimeError("restart did not reach a stable empty queue; inspect artifacts")
+
+    def run(self):
+        self.setup()
+        print("PR", self.evidence["pr_url"], "artifacts", self.out, flush=True)
+        self.start()
+        # No force bypass: exercises the actual provider-aware manual entrypoint.
+        loop = self.api("loops", {"projectId": "forgejo-smoke", "type": "reviewer",
+                                 "targetType": "pull_request", "repo": self.args.repo,
+                                 "prNumber": self.pr_number, "metadata": {"manual": True}})
+        self.wait_runs(lambda runs: any(r["loopId"] == loop["id"] and r["status"] == "success"
+                                       for r in runs), "manual-review")
+        first = self.snapshot()
+        actionable = [r for r in first["reviews"] if re.search(r"outcome=(blocking|non_blocking)", r["body"])]
+        if not actionable:
+            raise RuntimeError("reviewer did not publish an actionable native review for the known bug")
+        native_comments = []
+        for review in actionable:
+            # Forgejo returns the complete review's comments here; this endpoint
+            # has no page/limit parameters and repeats its result if given them.
+            native_comments += self.remote(f"pulls/{self.pr_number}/reviews/{review['id']}/comments")
+        if not native_comments:
+            raise RuntimeError("actionable native review has no inline findings")
+        save(self.out / "initial-native.json", {"snapshot": first, "inline_comments": native_comments})
+        self.stop()
+        self.cfg["roles"]["reviewer"]["discovery"]["autoDiscovery"] = True
+        self.cfg["roles"]["fixer"]["autoDiscovery"] = True
+        self.start()
+
+        def converged(runs):
+            if not runs or any(r["status"] not in {"success"} for r in runs):
+                return False
+            snap = self.snapshot()
+            head = snap["pr"]["head"]["sha"]
+            if head == self.evidence["original_head"]:
+                return False
+            clean = [r for r in snap["reviews"] if "outcome=clean" in r["body"] and r.get("commit_id") == head]
+            if clean and all(row["status"] in {"completed", "cancelled"} for row in self.database_state()["queue"]):
+                save(self.out / "converged.json", snap)
+                return True
+            return False
+
+        before_runs = self.wait_runs(converged, "automatic-repair-and-review")
+        before = self.snapshot()
+        before_db = self.database_state()
+        save(self.out / "before-restart-database.json", before_db)
+        fixer_loops = {loop["id"] for loop in self.api("loops")["items"]
+                       if loop["type"] == "fixer" and not json.loads(loop.get("metadataJson") or "{}").get("manual")}
+        fixed_ids = set()
+        for run in before_runs:
+            if run["loopId"] not in fixer_loops:
+                continue
+            checkpoint = json.loads(run.get("checkpointJson") or "{}")
+            if not checkpoint.get("validation", {}).get("passed") or not checkpoint.get("push", {}).get("pushed"):
+                continue
+            native = {item["id"]: item["providerCommentId"] for item in checkpoint.get("fixItems", [])
+                      if item.get("source") == "forgejo_review_comment"}
+            fixed_ids.update(native[item["fixItemId"]] for item in checkpoint.get("resolvedComments", {}).get("items", [])
+                             if item.get("status") == "fixed_unresolved" and item.get("fixItemId") in native)
+        if not {comment["id"] for comment in native_comments}.issubset(fixed_ids):
+            raise RuntimeError("missing successful automatic native fixer validation/push/acknowledgement checkpoint")
+        self.stop()
+        self.start()
+        runs, after = self.wait_restart_stable(before, before_runs, before_db)
+        self.stop()
+        fixer_comments = [c for c in after["comments"] if "runner=fixer" in c["body"]]
+        if not fixer_comments:
+            raise RuntimeError("no common fixer acknowledgement/disclosure was published")
+        remaining = []
+        for review in actionable:
+            remaining += self.remote(f"pulls/{self.pr_number}/reviews/{review['id']}/comments")
+        by_id = {c["id"]: c for c in remaining}
+        if any(c["id"] not in by_id or by_id[c["id"]].get("resolver") is not None
+               for c in native_comments):
+            raise RuntimeError("native findings were deleted or remotely resolved during the no-resolve test")
+        save(self.out / "final-native-comments.json", remaining)
+        if not any("code fixed; comment remains open" in c["body"] for c in fixer_comments):
+            raise RuntimeError("fixer did not describe the code fix and still-open comment accurately")
+        for body in [r["body"] for r in after["reviews"]] + [c["body"] for c in fixer_comments]:
+            visible = re.sub(r"<!--.*?-->", "", body, flags=re.S)
+            if "Reviewer Summary" in visible or "Looper Forgejo Fixer Summary" in visible:
+                raise RuntimeError("legacy protocol title leaked into visible message")
+            if ("🔁 Powered by " not in body or "agent=codex" not in body
+                    or "An autonomous AI dev team for your GitHub repos." not in body):
+                raise RuntimeError("message does not use the shared Codex disclosure")
+        final_head = after["pr"]["head"]["sha"]
+        self.git("fetch", "origin", final_head)
+        self.git("checkout", "--detach", final_head)
+        result = subprocess.run([sys.executable, "-m", "unittest", "discover", "-s", self.fixture.name, "-v"],
+                                cwd=self.checkout, env=self.env, text=True, capture_output=True, timeout=60)
+        (self.out / "fixture-test.log").write_text(result.stdout + result.stderr)
+        if result.returncode:
+            raise RuntimeError("pushed fixture tests fail; inspect fixture-test.log")
+        contract_env = dict(self.env, PYTHONPATH=str(self.fixture))
+        contract = subprocess.run([sys.executable, "-m", "unittest", "discover", "-s", str(self.out),
+                                   "-p", "test_price_contract.py", "-v"],
+                                  cwd=self.out, env=contract_env, text=True, capture_output=True, timeout=60)
+        (self.out / "fixture-contract.log").write_text(contract.stdout + contract.stderr)
+        if contract.returncode:
+            raise RuntimeError("pushed code fails the original acceptance contract; inspect fixture-contract.log")
+        self.evidence.update(final_head=final_head, native_reviews=len(after["reviews"]),
+                             fixer_comments=len(fixer_comments), open_native_findings=len(native_comments),
+                             restart_stable=True, fixture_tests="passed")
+        save(self.out / "result.json", self.evidence)
+
+    def cleanup(self):
+        errors = []
+        try:
+            self.stop()
+        except Exception as error:
+            save(self.out / "cleanup.json", {"errors": [str(error)], "remote_cleanup_withheld": True,
+                                             "resources": self.evidence})
+            raise RuntimeError("cannot confirm own processes stopped; remote cleanup withheld, see cleanup.json") from error
+        # A successful POST may lose its response. Find only this run's exact
+        # unique name/head before deciding there is nothing left to clean.
+        try:
+            if self.label_attempted and self.label_id is None:
+                matches = [label for label in self.remote_list("labels") if label["name"] == self.label_name]
+                if len(matches) > 1:
+                    raise RuntimeError("multiple labels match this run; refusing ambiguous cleanup")
+                if matches:
+                    self.label_id = matches[0]["id"]
+                    self.evidence["label_id"] = self.label_id
+            if self.pr_attempted and self.pr_number is None:
+                matches = [pr for pr in self.remote_list("pulls?state=all")
+                           if pr["head"]["ref"] == self.branch
+                           and pr["head"].get("repo", {}).get("full_name") == self.args.repo]
+                if len(matches) > 1:
+                    raise RuntimeError("multiple PRs match this run; refusing ambiguous cleanup")
+                if matches:
+                    self.pr_number = matches[0]["number"]
+                    self.evidence.update(pr_number=self.pr_number, pr_url=matches[0]["html_url"])
+        except Exception as error:
+            save(self.out / "cleanup.json", {"errors": [str(error)], "remote_cleanup_withheld": True,
+                                             "resources": self.evidence})
+            raise RuntimeError("could not recover this run's resource IDs; cleanup withheld, see cleanup.json") from error
+        actions = []
+        if self.pr_number:
+            actions.append((f"pulls/{self.pr_number}", "PATCH", {"state": "closed"}))
+        if self.pushed:
+            actions.append((f"branches/{self.branch}", "DELETE", None))
+        if self.label_id:
+            actions.append((f"labels/{self.label_id}", "DELETE", None))
+        for path, method, body in actions:
+            try:
+                self.remote(path, method, body, missing_ok=True)
+            except Exception as error:
+                errors.append(str(error))
+        if self.default_branch and self.initial_default_sha:
+            try:
+                current = self.remote("branches/" + urllib.parse.quote(self.default_branch, safe=""))["commit"]["id"]
+                if current != self.initial_default_sha:
+                    errors.append("default branch changed during test; inspect external activity")
+            except Exception as error:
+                errors.append(str(error))
+        for path in ([f"branches/{self.branch}"] if self.pushed else []) + ([f"labels/{self.label_id}"] if self.label_id else []):
+            try:
+                if self.remote(path, missing_ok=True) is not None:
+                    errors.append("test resource remains: " + path)
+            except Exception as error:
+                errors.append(str(error))
+        if self.pr_number:
+            try:
+                pr = self.remote(f"pulls/{self.pr_number}", missing_ok=True)
+                if pr and (pr["state"] != "closed" or pr.get("merged")):
+                    errors.append("test PR was not closed unmerged")
+            except Exception as error:
+                errors.append(str(error))
+        save(self.out / "cleanup.json", {"errors": errors, "resources": self.evidence})
+        if errors:
+            raise RuntimeError("cleanup needs attention; see cleanup.json")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--repo", required=True, help="Explicit sandbox owner/repo (writes test PR/branch/label)")
+    parser.add_argument("--tea-login", required=True)
+    parser.add_argument("--output", help="New artifact directory; defaults to dist/looper-smoke-<run>")
+    parser.add_argument("--timeout", type=int, default=1200, help="Maximum seconds per lifecycle phase")
+    args = parser.parse_args()
+    if not re.fullmatch(r"[^/\s]+/[^/\s]+", args.repo):
+        parser.error("--repo must be owner/repo")
+    if args.timeout <= 0:
+        parser.error("--timeout must be positive")
+    smoke = Smoke(args)
+    def interrupted(_signum, _frame):
+        raise KeyboardInterrupt
+    signal.signal(signal.SIGTERM, interrupted)
+    try:
+        smoke.run()
+    finally:
+        smoke.cleanup()
+    print("PASS", smoke.evidence["pr_url"], smoke.out, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/looper/references/config.md
+++ b/skills/looper/references/config.md
@@ -174,13 +174,16 @@ Forgejo validation notes:
 - Forgejo uses polling only; omit project `webhook.mode` and keep `network.mode` off.
 - The provider profile disables unsupported GitHub-shaped defaults. Explicit opt-ins to Forgejo-unsupported behavior fail fast.
 
-Forgejo MVP role limits:
+Forgejo role support:
 
 - planner and worker are supported
 - worker only processes issues already assigned to the current Forgejo user; it does not self-assign
-- reviewer discovers by labels and publishes a top-level Reviewer Summary PR comment; default normal-review label is `looper:review`, while spec PRs use `looper:spec-reviewing`
-- fixer consumes open items from the Reviewer Summary and publishes a top-level Fixer Summary PR comment; it does not resolve native review threads
-- coordinator, auto-merge, native reviews, review requests, thread resolution, routed network mode, and webhooks are unsupported for Forgejo
+- reviewer defaults to native review requests and `single_review` publication; configured labels are an additional discovery source. Explicitly permitted self-review uses `COMMENT` when Forgejo rejects the author's `APPROVE` or `REQUEST_CHANGES` event.
+- fixer automatically consumes native findings and legacy summary items, including the same account's Looper reviewer findings. It repairs, validates, pushes, and publishes the common fixer message without requiring a resolve API; acknowledged unchanged findings do not repeat after restart. Remote comments remain open.
+- both native and `summary_comment` compatibility modes use the GitHub message templates and disclosure, without visible protocol titles or round metadata.
+- reviewer auto-merge defaults off. Explicit opt-in retains clean review, Looper scope, linked issue / criteria, strategy and protection requirements. Self-review `COMMENT` does not authorize merge. Forgejo uses an immediate request bound to the reviewed head and existing bounded retries, not the server's unguarded scheduled-merge queue.
+- current-head commit statuses and Actions are available to reviewer/fixer. Exact conflict and ancestry checks require Git 2.38+ and sufficient repository history.
+- coordinator, review-thread resolution, GitHub's same-head decline adjudication, routed network mode, and webhooks remain unsupported for Forgejo.
 
 ## Role model guidance
 


### PR DESCRIPTION
# Summary

Forgejo native review findings can now drive an automatic reviewer → fixer → follow-up reviewer loop even though Forgejo has no review-thread resolve API. Successfully repaired comments remain open remotely, receive an accurate repair acknowledgement, and do not cause repeated repairs after polling or restart.

- Route manual review/fix and hold checks through the project provider, including dynamically registered projects. Collect current-head commit statuses, Actions results, native review provenance, PR URLs, and Forgejo-specific agent context.
- Process native inline findings, including trusted findings from an explicitly allowed same-account Looper reviewer. Preserve deferred/declined decisions, publication retries, mixed legacy/native rounds, edited feedback, and force-push handling.
- Reuse the GitHub reviewer/fixer renderers and the existing `🔁 Powered by Looper · runner=reviewer · agent=codex · An autonomous AI dev team for your GitHub repos.` footer. Remove the visible `Reviewer Summary` and `Looper Forgejo Fixer Summary` titles; the fixer reports `code fixed; comment remains open`.
- Support explicitly enabled auto-merge through existing scope, linked-issue, criteria, review, and branch-protection policies. Merge immediately against the reviewed head; retry through the existing reviewer publish checkpoint when checks are pending. Auto-merge remains off by default.
- Add executable sandbox checks and [configuration, migration, design, and acceptance documentation](https://github.com/nexu-io/looper/blob/2ca4a4f57d91928367c65c3b6471b01154b5e519/docs/DESIGN-forgejo-reviewer-fixer.md).

## Authority and trade-offs

The agent's structured findings and `repair_results` remain the authority for review and repair decisions; Git ancestry, comment fingerprints, and request SHA checks only detect input drift, while merge authorization also requires the existing explicit configuration and repository policies.

- **Remove the resolve prerequisite; reuse existing checkpoints/evidence.** `fixed_unresolved` distinguishes repaired code from an open remote comment. Persist the fingerprint the agent actually observed so retries cannot apply an old decision to edited feedback. The cost is a new value in existing evidence and checkpoint compatibility across discovery, retries, and rendering. Simply removing the resolve gate would repeatedly repair open comments; ignoring all open comments would lose new, edited, or deferred feedback. No new database schema or second ledger is introduced.
- **Hash the raw comment body instead of trusting `updated_at`.** Live Forgejo pushes changed only the timestamp and caused false drift. The existing fingerprint now uses comment ID plus raw-body SHA-256. Old timestamp checkpoints safely recollect once; actual body edits cause reassessment. Removing the comparison could reuse stale decisions, while duplicating full bodies increases checkpoint/prompt size. No additional persisted field is needed for the hash.
- **Publish before recording discovery-suppression evidence.** The common acknowledgement is the only remote repair feedback without resolve/reply. Reorder existing steps so failed/lost publication is retried without repeating the agent or push; keep the already-observed reviewer round through mixed-round publication. This costs ordering and snapshot-lifetime contracts, rather than a new pending-publication state or message ledger.
- **Use exact Git conflict and ancestry checks.** Forgejo `mergeable=false` also covers checking/error/WIP, and Compare lacks GitHub's ancestry status. Local Git 2.38+ queries and narrowly fetching missing objects cost computation and possible fetch failures; ambiguous shallow history fails explicitly. They preserve refs, index, worktree, and FETCH_HEAD. Boolean mapping or commit counts cannot provide the required answers.
- **Keep same-account COMMENT fallback scoped.** Forgejo rejects REQUEST_CHANGES on one's own PR. Preserve the structured blocking outcome using COMMENT only for already-authorized self-review, with a shared non-persistent compatibility argument in publishing and recovery. The cost is keeping those event checks aligned; accepting arbitrary COMMENT reviews would weaken existing policies.
- **Delete server-scheduled merge dependence.** Forgejo 16.0.3 queued merges do not retain or check the reviewed SHA. Immediate merges use `head_commit_id` and `merge_when_checks_succeed=false`; existing bounded publication retries handle CI rejection. The cost is provider settings/protection mapping and resuming the same checkpoint after an approval consumes its review request. No new merge queue, authorization state, or force-merge path is added.

# Testing

- [x] `go test ./...`
- [x] Additional targeted checks: `gofmt -l .`, `go vet ./...`, and `go build ./...`; focused provider, runtime, reviewer, fixer, API, CLI, configuration, and project tests; three independent implementation review gates and final structure review.
- [x] Contract/invariant coverage: real-Git conflict/ancestry and dirty-worktree preservation; native repair → acknowledgement → SQLite reopen; timestamp-only changes versus same-timestamp body edits; old checkpoints; new/edited findings and divergent heads; mixed rounds; deferred/declined handling; HTTP 503/lost-response replay; current-head CI and immediate-merge retry/head guards.
- [x] Real Forgejo 16.0.3+gitea-1.22.0, `core/looper-sandbox`: [PR #28](https://code.powerformer.net/core/looper-sandbox/pulls/28) completed three actual Codex executions (review → automatic fix → clean review). The pushed commit passed all three original tests retained outside the agent workspace. A same-DB restart produced no additional run, agent execution, push, review, or acknowledgement. The native comment stayed open and both roles used the common templates.
- [x] Real provider checks on [PR #26](https://code.powerformer.net/core/looper-sandbox/pulls/26) / [#27](https://code.powerformer.net/core/looper-sandbox/pulls/27): conflict/status mapping, CI rejection (405), wrong/stale SHA rejection (409), and correct-head merge into an owned temporary base only. Test branches, labels, protection rules, and processes were cleaned; sandbox `main` was unchanged.

Validation boundaries: the initial concurrent full-test run hit an unchanged worker E2E's existing two-second localhost timeout; the full sequential rerun passed without threshold or assertion changes. The native test collector initially mishandled unpaginated endpoints; after correcting pagination, a bounded continuation reused the three completed runs to verify restart/final assertions and cleanup. This is not claimed as a zero-exit original collector run. Real Actions workflows and the full merge authorization policy were not exercised remotely; their mappings and policy behavior have contract coverage. The reusable live checks are opt-in and described in the linked document.

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [x] Daemon boot / config / runtime path risk
- [x] Worktree / repo isolation / lifecycle risk
- [x] GitHub CLI contract / auth / scope risk
- [x] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

Shared entrypoints and review/publish paths change, so GitHub contracts remain in the full suite. Provider-specific wire verification used Forgejo, not a new GitHub auth/scope/rate-limit behavior. No deployment or ordinary daemon/config change was performed. Existing Forgejo projects need no DB migration. Remote resolve, Forgejo coordinator, routed network/webhooks, and GitHub's same-head decline adjudication remain outside this implementation; immediate auto-merge retries are bounded.

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [x] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

This is a Forgejo capability-completion change. The timestamp-only input regression was reproduced against the old implementation and then covered at both REST-to-runtime and complete fixer-lifecycle boundaries.

# Regression Mapping

- PR / issue links for regression coverage:
  - [Native cycle and restart: sandbox #28](https://code.powerformer.net/core/looper-sandbox/pulls/28).
  - [Conflicts: sandbox #26](https://code.powerformer.net/core/looper-sandbox/pulls/26); [status/head-guarded temporary-base merge: sandbox #27](https://code.powerformer.net/core/looper-sandbox/pulls/27).
  - Scenario-to-behavior mapping F1–F9 and executable commands are in `docs/DESIGN-forgejo-reviewer-fixer.md`. No linked product issue.

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied
