### PR TITLE
fix: distinguish review-fix budget holds from transport failures

### DIFF
--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -605,7 +605,7 @@ func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storag
 			diagnosis.RecommendedAction = release
 		}
 		if loops.IsReviewFixBudgetHold(loop) {
-			retryable := true
+			retryable := false
 			diagnosis.FailureClass = "review_fix_budget"
 			diagnosis.Retryable = &retryable
 			diagnosis.Source = "loop"

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -604,6 +604,13 @@ func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storag
 		} else {
 			diagnosis.RecommendedAction = release
 		}
+		if loops.IsReviewFixBudgetHold(loop) {
+			retryable := true
+			diagnosis.FailureClass = "review_fix_budget"
+			diagnosis.Retryable = &retryable
+			diagnosis.Source = "loop"
+			diagnosis.Message = "review-fix publish budget exhausted"
+		}
 	}
 	// Expand <seq> before emitting JSON/human output so operators and scripts
 	// never see the literal placeholder outside writeHumanLoopInspect.

--- a/internal/cliapp/loop_diagnostics_commands.go
+++ b/internal/cliapp/loop_diagnostics_commands.go
@@ -609,7 +609,7 @@ func diagnoseLoop(loop storage.LoopRecord, run *storage.RunRecord, queue *storag
 			diagnosis.FailureClass = "review_fix_budget"
 			diagnosis.Retryable = &retryable
 			diagnosis.Source = "loop"
-			diagnosis.Message = "review-fix publish budget exhausted"
+			diagnosis.Message = "review-fix budget exhausted"
 		}
 	}
 	// Expand <seq> before emitting JSON/human output so operators and scripts

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -452,6 +452,24 @@ func TestDiagnoseLoopBudgetHoldRecommendsUnpauseStop(t *testing.T) {
 	}
 }
 
+func TestDiagnoseLoopBudgetHoldDoesNotClassifyHistoricalGitHubTransient(t *testing.T) {
+	t.Parallel()
+	meta := `{"pauseReason":"review_fix_budget_exhausted","reviewFixBudget":{"exhaustedBy":"reviewer","pauseReason":"review_fix_budget_exhausted"}}`
+	loop := storage.LoopRecord{ID: "loop_budget", Seq: 12, Type: "reviewer", Status: "paused", MetadataJSON: &meta}
+	runMsg := "Command exited with code 1: error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com"
+	run := &storage.RunRecord{Status: "failed", ErrorMessage: &runMsg}
+	got := diagnoseLoop(loop, run, nil, parseLoopDiagnosticMetadata(loop.MetadataJSON), true)
+	if got.FailureClass != "review_fix_budget" {
+		t.Fatalf("FailureClass = %q, want review_fix_budget not historical github_transient", got.FailureClass)
+	}
+	if !strings.Contains(got.RecommendedAction, "looper unpause 12") || !strings.Contains(got.RecommendedAction, "looper stop 12") {
+		t.Fatalf("RecommendedAction = %q, want unpause/stop", got.RecommendedAction)
+	}
+	if strings.Contains(strings.ToLower(got.RecommendedAction), "github") {
+		t.Fatalf("RecommendedAction = %q, must not send operators to GitHub recovery", got.RecommendedAction)
+	}
+}
+
 func TestWriteHumanLoopInspectScopeHoldUsesRelease(t *testing.T) {
 	t.Parallel()
 	meta := `{"pauseReason":"review_scope_human_required","reviewScopeHuman":{"heldBy":"reviewer","pauseReason":"review_scope_human_required"}}`

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -427,6 +427,9 @@ func TestDiagnoseLoopBudgetHoldRecommendsUnpauseStop(t *testing.T) {
 	if strings.Contains(diagnosis.RecommendedAction, "retry") {
 		t.Fatalf("RecommendedAction = %q, must not recommend retry for budget hold", diagnosis.RecommendedAction)
 	}
+	if diagnosis.Retryable == nil || *diagnosis.Retryable {
+		t.Fatalf("Retryable = %#v, want false for operator-gated budget hold", diagnosis.Retryable)
+	}
 	handoff := reviewFixInspectHandoff(loop, parsed)
 	if handoff == nil || handoff.Kind != "review_fix_budget" {
 		t.Fatalf("handoff = %#v, want review_fix_budget", handoff)
@@ -464,6 +467,9 @@ func TestDiagnoseLoopBudgetHoldDoesNotClassifyHistoricalGitHubTransient(t *testi
 	}
 	if got.Source != "loop" || got.Message != "review-fix budget exhausted" {
 		t.Fatalf("diagnosis = %#v, want current budget hold source and message", got)
+	}
+	if got.Retryable == nil || *got.Retryable {
+		t.Fatalf("Retryable = %#v, want false not historical github_transient retryable", got.Retryable)
 	}
 	if !strings.Contains(got.RecommendedAction, "looper unpause 12") || !strings.Contains(got.RecommendedAction, "looper stop 12") {
 		t.Fatalf("RecommendedAction = %q, want unpause/stop", got.RecommendedAction)

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -462,11 +462,27 @@ func TestDiagnoseLoopBudgetHoldDoesNotClassifyHistoricalGitHubTransient(t *testi
 	if got.FailureClass != "review_fix_budget" {
 		t.Fatalf("FailureClass = %q, want review_fix_budget not historical github_transient", got.FailureClass)
 	}
+	if got.Message != "review-fix budget exhausted" {
+		t.Fatalf("Message = %q, want role-neutral review-fix budget exhausted", got.Message)
+	}
 	if !strings.Contains(got.RecommendedAction, "looper unpause 12") || !strings.Contains(got.RecommendedAction, "looper stop 12") {
 		t.Fatalf("RecommendedAction = %q, want unpause/stop", got.RecommendedAction)
 	}
 	if strings.Contains(strings.ToLower(got.RecommendedAction), "github") {
 		t.Fatalf("RecommendedAction = %q, must not send operators to GitHub recovery", got.RecommendedAction)
+	}
+}
+
+func TestDiagnoseLoopBudgetHoldMessageIsRoleNeutralForFixerExhaustion(t *testing.T) {
+	t.Parallel()
+	meta := `{"pauseReason":"sibling_review_fix_budget","reviewFixBudget":{"siblingOf":"fixer","pauseReason":"sibling_review_fix_budget"}}`
+	loop := storage.LoopRecord{ID: "loop_budget_reviewer_sibling", Seq: 4, Type: "reviewer", Status: "paused", MetadataJSON: &meta}
+	got := diagnoseLoop(loop, nil, nil, parseLoopDiagnosticMetadata(loop.MetadataJSON), true)
+	if got.FailureClass != "review_fix_budget" {
+		t.Fatalf("FailureClass = %q, want review_fix_budget", got.FailureClass)
+	}
+	if got.Message != "review-fix budget exhausted" || strings.Contains(got.Message, "publish") {
+		t.Fatalf("Message = %q, want role-neutral review-fix budget exhausted", got.Message)
 	}
 }
 

--- a/internal/cliapp/loop_diagnostics_commands_test.go
+++ b/internal/cliapp/loop_diagnostics_commands_test.go
@@ -462,8 +462,8 @@ func TestDiagnoseLoopBudgetHoldDoesNotClassifyHistoricalGitHubTransient(t *testi
 	if got.FailureClass != "review_fix_budget" {
 		t.Fatalf("FailureClass = %q, want review_fix_budget not historical github_transient", got.FailureClass)
 	}
-	if got.Message != "review-fix budget exhausted" {
-		t.Fatalf("Message = %q, want role-neutral review-fix budget exhausted", got.Message)
+	if got.Source != "loop" || got.Message != "review-fix budget exhausted" {
+		t.Fatalf("diagnosis = %#v, want current budget hold source and message", got)
 	}
 	if !strings.Contains(got.RecommendedAction, "looper unpause 12") || !strings.Contains(got.RecommendedAction, "looper stop 12") {
 		t.Fatalf("RecommendedAction = %q, want unpause/stop", got.RecommendedAction)

--- a/internal/fixer/runner_test.go
+++ b/internal/fixer/runner_test.go
@@ -6706,6 +6706,11 @@ func TestProcessClaimedItemRestartsFromDiscoverAfterRemoteHeadChangeAtPush(t *te
 		t.Fatalf("len(agent.starts) after first run = %d, want 1", len(agent.starts))
 	}
 
+	afterFailure, err := fixture.repos.Loops.GetByID(context.Background(), first.LoopID)
+	if err != nil || afterFailure == nil || loops.FixerPushCount(afterFailure.MetadataJSON) != 0 || loops.IsReviewFixBudgetHold(*afterFailure) {
+		t.Fatalf("after failed push = (%#v, %v), want zero budget consumed and no budget hold", afterFailure, err)
+	}
+
 	fixture.advance(5 * time.Second)
 	claim2, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "fixer-worker-1", "fixer")
 	if err != nil || claim2 == nil {
@@ -6717,6 +6722,10 @@ func TestProcessClaimedItemRestartsFromDiscoverAfterRemoteHeadChangeAtPush(t *te
 	}
 	if second.Status != "success" {
 		t.Fatalf("second result = %#v, want success", second)
+	}
+	afterSuccess, err := fixture.repos.Loops.GetByID(context.Background(), second.LoopID)
+	if err != nil || afterSuccess == nil || loops.FixerPushCount(afterSuccess.MetadataJSON) != 1 {
+		t.Fatalf("after successful push = (%#v, %v), want exactly one budget unit consumed", afterSuccess, err)
 	}
 	if len(agent.starts) != 2 {
 		t.Fatalf("len(agent.starts) = %d, want 2 (restart from discover)", len(agent.starts))

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -8925,14 +8925,15 @@ func (r *Runner) livePullRequestClosed(ctx context.Context, project storage.Proj
 }
 
 // viewPullRequestClosedForBudgetAdmission reports whether the PR is not open.
-// Transport failures return an error so callers can retry instead of parking.
+// Transport failures return an error tagged BoundaryGitHubAPI so claim
+// finalization classifies them as retryable instead of parking the pair.
 func (r *Runner) viewPullRequestClosedForBudgetAdmission(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64) (bool, error) {
 	if r.github == nil || strings.TrimSpace(repo) == "" || prNumber == 0 {
 		return false, nil
 	}
 	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: project.RepoPath})
 	if err != nil {
-		return false, err
+		return false, failureclass.WithBoundary(err, failureclass.BoundaryGitHubAPI)
 	}
 	return normalizePRState(detail.State) != "open", nil
 }

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1213,16 +1213,6 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		result.Skipped++
 		return nil
 	}
-	if r.shouldCreateReviewerBudgetPark(loopResult.record) {
-		activeRetry, retryErr := r.hasActiveRetryableTransientQueue(ctx, loopResult.record.ID)
-		if retryErr != nil {
-			return retryErr
-		}
-		if activeRetry {
-			result.Skipped++
-			return nil
-		}
-	}
 	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
 		return err
 	} else if parked {
@@ -2085,18 +2075,12 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if project == nil {
 		return ProcessResult{}, fmt.Errorf("project not found: %s", loop.ProjectID)
 	}
-	if r.shouldCreateReviewerBudgetPark(*loop) {
-		closed, viewErr := r.viewPullRequestClosedForBudgetAdmission(ctx, *project, derefString(loop.Repo), derefInt64(loop.PRNumber))
-		if viewErr != nil {
-			return ProcessResult{}, viewErr
+	if r.shouldCreateReviewerBudgetPark(*loop) && r.livePullRequestClosed(ctx, *project, derefString(loop.Repo), derefInt64(loop.PRNumber)) {
+		if err := r.terminateLoop(ctx, *loop, "pr_closed_or_merged"); err != nil {
+			return ProcessResult{}, err
 		}
-		if closed {
-			if err := r.terminateLoop(ctx, *loop, "pr_closed_or_merged"); err != nil {
-				return ProcessResult{}, err
-			}
-			summary := fmt.Sprintf("Skipped terminal reviewer loop %s: pr_closed_or_merged", loop.ID)
-			return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, nil
-		}
+		summary := fmt.Sprintf("Skipped terminal reviewer loop %s: pr_closed_or_merged", loop.ID)
+		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, nil
 	}
 	if err := r.revalidateRoutedReviewerClaim(ctx, *project, queueItem); err != nil {
 		var holdErr *holdSkipError
@@ -8917,45 +8901,14 @@ func (r *Runner) shouldParkReviewerBudget(loop storage.LoopRecord, checkpoint re
 }
 
 func (r *Runner) livePullRequestClosed(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64) bool {
-	closed, err := r.viewPullRequestClosedForBudgetAdmission(ctx, project, repo, prNumber)
-	if err != nil {
-		return false
-	}
-	return closed
-}
-
-// viewPullRequestClosedForBudgetAdmission reports whether the PR is not open.
-// Transport failures return an error tagged BoundaryGitHubAPI so claim
-// finalization classifies them as retryable instead of parking the pair.
-func (r *Runner) viewPullRequestClosedForBudgetAdmission(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64) (bool, error) {
 	if r.github == nil || strings.TrimSpace(repo) == "" || prNumber == 0 {
-		return false, nil
+		return false
 	}
 	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: project.RepoPath})
 	if err != nil {
-		return false, failureclass.WithBoundary(err, failureclass.BoundaryGitHubAPI)
+		return false
 	}
-	return normalizePRState(detail.State) != "open", nil
-}
-
-func (r *Runner) hasActiveRetryableTransientQueue(ctx context.Context, loopID string) (bool, error) {
-	if r.repos == nil || r.repos.Queue == nil || strings.TrimSpace(loopID) == "" {
-		return false, nil
-	}
-	item, err := r.repos.Queue.GetLatestByLoopID(ctx, loopID)
-	if err != nil {
-		return false, err
-	}
-	if item == nil {
-		return false, nil
-	}
-	switch item.Status {
-	case "queued", "running":
-	default:
-		return false, nil
-	}
-	kind := strings.TrimSpace(derefString(item.LastErrorKind))
-	return kind == string(FailureRetryableTransient) || kind == string(FailureRetryableAfterResume), nil
+	return normalizePRState(detail.State) != "open"
 }
 
 func (r *Runner) shouldCreateReviewerBudgetPark(loop storage.LoopRecord) bool {

--- a/internal/reviewer/runner.go
+++ b/internal/reviewer/runner.go
@@ -1213,6 +1213,16 @@ func (r *Runner) enqueueReviewerDiscoveryCandidate(ctx context.Context, project 
 		result.Skipped++
 		return nil
 	}
+	if r.shouldCreateReviewerBudgetPark(loopResult.record) {
+		activeRetry, retryErr := r.hasActiveRetryableTransientQueue(ctx, loopResult.record.ID)
+		if retryErr != nil {
+			return retryErr
+		}
+		if activeRetry {
+			result.Skipped++
+			return nil
+		}
+	}
 	if parked, err := r.parkReviewerBudgetIfExhausted(ctx, loopResult.record); err != nil {
 		return err
 	} else if parked {
@@ -2075,12 +2085,18 @@ func (r *Runner) ProcessClaimedItem(ctx context.Context, queueItem storage.Queue
 	if project == nil {
 		return ProcessResult{}, fmt.Errorf("project not found: %s", loop.ProjectID)
 	}
-	if r.shouldCreateReviewerBudgetPark(*loop) && r.livePullRequestClosed(ctx, *project, derefString(loop.Repo), derefInt64(loop.PRNumber)) {
-		if err := r.terminateLoop(ctx, *loop, "pr_closed_or_merged"); err != nil {
-			return ProcessResult{}, err
+	if r.shouldCreateReviewerBudgetPark(*loop) {
+		closed, viewErr := r.viewPullRequestClosedForBudgetAdmission(ctx, *project, derefString(loop.Repo), derefInt64(loop.PRNumber))
+		if viewErr != nil {
+			return ProcessResult{}, viewErr
 		}
-		summary := fmt.Sprintf("Skipped terminal reviewer loop %s: pr_closed_or_merged", loop.ID)
-		return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, nil
+		if closed {
+			if err := r.terminateLoop(ctx, *loop, "pr_closed_or_merged"); err != nil {
+				return ProcessResult{}, err
+			}
+			summary := fmt.Sprintf("Skipped terminal reviewer loop %s: pr_closed_or_merged", loop.ID)
+			return ProcessResult{LoopID: loop.ID, QueueItemID: queueItem.ID, Status: "skipped", Summary: summary}, nil
+		}
 	}
 	if err := r.revalidateRoutedReviewerClaim(ctx, *project, queueItem); err != nil {
 		var holdErr *holdSkipError
@@ -8901,14 +8917,44 @@ func (r *Runner) shouldParkReviewerBudget(loop storage.LoopRecord, checkpoint re
 }
 
 func (r *Runner) livePullRequestClosed(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64) bool {
-	if r.github == nil || strings.TrimSpace(repo) == "" || prNumber == 0 {
-		return false
-	}
-	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: project.RepoPath})
+	closed, err := r.viewPullRequestClosedForBudgetAdmission(ctx, project, repo, prNumber)
 	if err != nil {
 		return false
 	}
-	return normalizePRState(detail.State) != "open"
+	return closed
+}
+
+// viewPullRequestClosedForBudgetAdmission reports whether the PR is not open.
+// Transport failures return an error so callers can retry instead of parking.
+func (r *Runner) viewPullRequestClosedForBudgetAdmission(ctx context.Context, project storage.ProjectRecord, repo string, prNumber int64) (bool, error) {
+	if r.github == nil || strings.TrimSpace(repo) == "" || prNumber == 0 {
+		return false, nil
+	}
+	detail, err := r.github.ViewPullRequest(ctx, ViewPullRequestInput{Repo: repo, PRNumber: prNumber, CWD: project.RepoPath})
+	if err != nil {
+		return false, err
+	}
+	return normalizePRState(detail.State) != "open", nil
+}
+
+func (r *Runner) hasActiveRetryableTransientQueue(ctx context.Context, loopID string) (bool, error) {
+	if r.repos == nil || r.repos.Queue == nil || strings.TrimSpace(loopID) == "" {
+		return false, nil
+	}
+	item, err := r.repos.Queue.GetLatestByLoopID(ctx, loopID)
+	if err != nil {
+		return false, err
+	}
+	if item == nil {
+		return false, nil
+	}
+	switch item.Status {
+	case "queued", "running":
+	default:
+		return false, nil
+	}
+	kind := strings.TrimSpace(derefString(item.LastErrorKind))
+	return kind == string(FailureRetryableTransient) || kind == string(FailureRetryableAfterResume), nil
 }
 
 func (r *Runner) shouldCreateReviewerBudgetPark(loop storage.LoopRecord) bool {

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1995,6 +1995,106 @@ func TestProcessClaimedItemParksExhaustedBudgetBeforeRun(t *testing.T) {
 	}
 }
 
+func TestProcessClaimedItemDoesNotParkBudgetOnGitHubTransportFailure(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	projectID := "project_1"
+	loopID := "loop_reviewer_budget_transport"
+	metadata := `{"loop":{"iterationCount":1}}`
+	reviewer := storage.LoopRecord{ID: loopID, Seq: 1, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}
+	fixer := storage.LoopRecord{ID: "loop_fixer_budget_transport", Seq: 2, ProjectID: projectID, Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), reviewer); err != nil {
+		t.Fatalf("Loops.Upsert(reviewer) error = %v", err)
+	}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_budget_transport", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:budget-transport", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, MaxAttempts: 5, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 1
+	cfg.HITL.Enabled = false
+	agent := &fakeAgentExecutor{}
+	github := &fakeGitHubGateway{viewErrs: []error{&shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: "error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com"}}}}
+	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg})
+
+	result, err := runner.ProcessClaimedItem(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_budget_transport", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, Status: "running"})
+	if err == nil || !strings.Contains(githubinfra.ErrorMessage(err), "error connecting to api.github.com") {
+		t.Fatalf("ProcessClaimedItem() = (%#v, %v), want GitHub transport error", result, err)
+	}
+	if len(agent.starts) != 0 {
+		t.Fatalf("agent.starts = %#v, want none", agent.starts)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || updated == nil {
+		t.Fatalf("reviewer = (%#v, %v)", updated, err)
+	}
+	if updated.Status == "paused" || updated.Status == "awaiting_human" || loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("reviewer = %#v, want no budget hold after GitHub transport failure", updated)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "waiting" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer sibling = (%#v, %v), want still waiting", sibling, err)
+	}
+}
+
+func TestDiscoverPullRequestsDoesNotParkBudgetOverRetryableTransientQueue(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	projectID := "project_1"
+	loopID := "loop_reviewer_budget_discover_retry"
+	metadata := `{"followUpdates":true,"loop":{"enabled":true,"iterationCount":3}}`
+	if err := fixture.repos.Loops.Upsert(context.Background(), storage.LoopRecord{ID: loopID, Seq: 7, ProjectID: projectID, Type: "reviewer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "queued", MetadataJSON: &metadata, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Loops.Upsert() error = %v", err)
+	}
+	kind := string(FailureRetryableTransient)
+	lastErr := "Command exited with code 1: error connecting to api.github.com"
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_budget_discover_retry", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:budget-discover-retry", Priority: storage.QueuePriorityReviewer, Status: "queued", AvailableAt: nowISO, Attempts: 3, MaxAttempts: -1, LastError: &lastErr, LastErrorKind: &kind, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+		t.Fatalf("Queue.Upsert() error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	cfg.HITL.Enabled = false
+	runner := New(Options{
+		DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: &fakeGitHubGateway{currentLogin: "octocat", reviewRequests: []string{"octocat"}}, Git: &fakeGitGateway{},
+		AgentExecutor: &fakeAgentExecutor{}, Logger: fixture.logger, Now: fixture.now,
+		DiscoveryPolicy:    DiscoveryPolicy{AutoDiscovery: true, RequireReviewRequest: false, EnableSelfReview: true},
+		LoopConfig:         cfg.Roles.Reviewer.Behavior.Loop,
+		CustomInstructions: &cfg,
+	})
+
+	result, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: projectID, Repo: repo})
+	if err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	updated, err := fixture.repos.Loops.GetByID(context.Background(), loopID)
+	if err != nil || updated == nil {
+		t.Fatalf("GetByID = (%#v, %v)", updated, err)
+	}
+	if updated.Status == "paused" || loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("loop = %#v discovery=%#v, want retryable GitHub queue left running instead of budget park", updated, result)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_reviewer_budget_discover_retry")
+	if err != nil || queue == nil || queue.Status != "queued" {
+		t.Fatalf("queue = (%#v, %v), want still queued", queue, err)
+	}
+}
+
 func TestProcessClaimedItemDoesNotParkBudgetWhenClaimedAfterPRClosed(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1995,7 +1995,7 @@ func TestProcessClaimedItemParksExhaustedBudgetBeforeRun(t *testing.T) {
 	}
 }
 
-func TestProcessClaimedQueueItemDoesNotParkBudgetOnGitHubTransportFailure(t *testing.T) {
+func TestProcessClaimedQueueItemParksExhaustedBudgetDespiteGitHubTransportFailure(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repo := "acme/looper"
@@ -2013,8 +2013,7 @@ func TestProcessClaimedQueueItemDoesNotParkBudgetOnGitHubTransportFailure(t *tes
 	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
 		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
 	}
-	queueItem := storage.QueueItemRecord{ID: "queue_reviewer_budget_transport", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:budget-transport", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, MaxAttempts: -1, CreatedAt: nowISO, UpdatedAt: nowISO}
-	if err := fixture.repos.Queue.Upsert(context.Background(), queueItem); err != nil {
+	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_budget_transport", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:budget-transport", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, MaxAttempts: -1, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
 		t.Fatalf("Queue.Upsert() error = %v", err)
 	}
 	cfg, err := config.DefaultConfig(t.TempDir())
@@ -2027,9 +2026,9 @@ func TestProcessClaimedQueueItemDoesNotParkBudgetOnGitHubTransportFailure(t *tes
 	github := &fakeGitHubGateway{viewErrs: []error{&shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: "error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com"}}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg})
 
-	result, err := runner.ProcessClaimedQueueItem(context.Background(), queueItem)
-	if err == nil || !strings.Contains(githubinfra.ErrorMessage(err), "error connecting to api.github.com") {
-		t.Fatalf("ProcessClaimedQueueItem() = (%#v, %v), want GitHub transport error", result, err)
+	result, err := runner.ProcessClaimedQueueItem(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_budget_transport", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, Status: "running"})
+	if err != nil || result == nil || result.Status != "skipped" {
+		t.Fatalf("ProcessClaimedItem() = (%#v, %v), want exhausted-budget skip", result, err)
 	}
 	if len(agent.starts) != 0 {
 		t.Fatalf("agent.starts = %#v, want none", agent.starts)
@@ -2038,23 +2037,24 @@ func TestProcessClaimedQueueItemDoesNotParkBudgetOnGitHubTransportFailure(t *tes
 	if err != nil || updated == nil {
 		t.Fatalf("reviewer = (%#v, %v)", updated, err)
 	}
-	if updated.Status == "paused" || updated.Status == "awaiting_human" || loops.IsReviewFixBudgetHold(*updated) {
-		t.Fatalf("reviewer = %#v, want no budget hold after GitHub transport failure", updated)
+	if updated.Status != "paused" || !loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("reviewer = %#v, want exhausted budget held regardless of transport failure", updated)
 	}
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
-	if err != nil || sibling == nil || sibling.Status != "waiting" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
-		t.Fatalf("fixer sibling = (%#v, %v), want still waiting", sibling, err)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer sibling = (%#v, %v), want budget sibling paused", sibling, err)
 	}
-	queue, err := fixture.repos.Queue.GetByID(context.Background(), queueItem.ID)
-	if err != nil || queue == nil || queue.Status != "queued" {
-		t.Fatalf("queue = (%#v, %v), want retryable queued item, not failed/paused", queue, err)
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_reviewer_budget_transport")
+	if err != nil || queue == nil || queue.Status != "cancelled" {
+		t.Fatalf("queue = (%#v, %v), want cancelled exhausted-budget queue", queue, err)
 	}
-	if queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) {
-		t.Fatalf("queue last_error_kind = %v, want retryable_transient", queue.LastErrorKind)
+	if got := loops.ReviewerPublishCount(updated.MetadataJSON); got != 1 {
+		t.Fatalf("publish count = %d, want unchanged successful publish count", got)
 	}
+
 }
 
-func TestDiscoverPullRequestsDoesNotParkBudgetOverRetryableTransientQueue(t *testing.T) {
+func TestDiscoverPullRequestsParksExhaustedBudgetDespiteRetryableTransientQueue(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repo := "acme/looper"
@@ -2094,12 +2094,12 @@ func TestDiscoverPullRequestsDoesNotParkBudgetOverRetryableTransientQueue(t *tes
 	if err != nil || updated == nil {
 		t.Fatalf("GetByID = (%#v, %v)", updated, err)
 	}
-	if updated.Status == "paused" || loops.IsReviewFixBudgetHold(*updated) {
-		t.Fatalf("loop = %#v discovery=%#v, want retryable GitHub queue left running instead of budget park", updated, result)
+	if updated.Status != "paused" || !loops.IsReviewFixBudgetHold(*updated) {
+		t.Fatalf("loop = %#v discovery=%#v, want exhausted budget held", updated, result)
 	}
 	queue, err := fixture.repos.Queue.GetByID(context.Background(), "queue_reviewer_budget_discover_retry")
-	if err != nil || queue == nil || queue.Status != "queued" {
-		t.Fatalf("queue = (%#v, %v), want still queued", queue, err)
+	if err != nil || queue == nil || queue.Status != "cancelled" {
+		t.Fatalf("queue = (%#v, %v), want cancelled after budget park", queue, err)
 	}
 }
 
@@ -2221,6 +2221,117 @@ func TestProcessClaimedItemDoesNotParkBudgetWhenPublishClosesPR(t *testing.T) {
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
 	if err != nil || sibling == nil || sibling.Status != "waiting" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		t.Fatalf("fixer sibling = (%#v, %v), want still waiting without budget pause", sibling, err)
+	}
+}
+
+func TestProcessClaimedItemTransportRetriesDoNotConsumeBudgetThenThirdPublishParks(t *testing.T) {
+	t.Parallel()
+	fixture := newRunnerFixture(t)
+	repo := "acme/looper"
+	prNumber := int64(42)
+	nowISO := fixture.nowISO()
+	target := "pr:acme/looper:42"
+	fixer := storage.LoopRecord{ID: "loop_fixer_budget_closed_pr", Seq: 2, ProjectID: "project_1", Type: "fixer", TargetType: "pull_request", TargetID: &target, Repo: &repo, PRNumber: &prNumber, Status: "waiting", CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
+		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
+	}
+	cfg, err := config.DefaultConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("DefaultConfig() error = %v", err)
+	}
+	cfg.Roles.Reviewer.Behavior.Loop.MaxPublishesPerPR = 3
+	cfg.HITL.Enabled = false
+	github := &fakeGitHubGateway{reviewRequests: []string{"octocat"}}
+	agent := &fakeAgentExecutor{results: []AgentResult{{Status: "completed", Summary: "Please add tests", Stdout: `__LOOPER_RESULT__={"summary":"posted review"}`}}}
+	options := Options{RetryMaxAttempts: -1, DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, AllowAutoApprove: true, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg}
+	runner := New(options)
+
+	if _, err := runner.DiscoverPullRequests(context.Background(), DiscoveryInput{ProjectID: "project_1", Repo: repo}); err != nil {
+		t.Fatalf("DiscoverPullRequests() error = %v", err)
+	}
+	claim, err := fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+	if err != nil || claim == nil {
+		t.Fatalf("ClaimNext() = (%#v, %v), want claimed queue item", claim, err)
+	}
+	seed, err := fixture.repos.Loops.GetByID(context.Background(), *claim.LoopID)
+	if err != nil || seed == nil {
+		t.Fatalf("seed: %v", err)
+	}
+	seedMeta := parseJSONObject(seed.MetadataJSON)
+	loopMeta := reviewerLoopMetadata(seedMeta)
+	loopMeta["iterationCount"] = 2
+	seedMeta["loop"] = loopMeta
+	encoded, err := json.Marshal(seedMeta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed.MetadataJSON = stringPtr(string(encoded))
+	if err := fixture.repos.Loops.Upsert(context.Background(), *seed); err != nil {
+		t.Fatal(err)
+	}
+	for attempt := 0; attempt < 7; attempt++ {
+		github.viewErrs = []error{&shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: "error connecting to api.github.com"}}}
+		failed, err := runner.ProcessClaimedQueueItem(context.Background(), *claim)
+		if err != nil || failed == nil || failed.Status != "failed" || failed.FailureKind != FailureRetryableTransient {
+			t.Fatalf("attempt %d = (%#v, %v), want transient failure", attempt, failed, err)
+		}
+		fresh, err := fixture.repos.Loops.GetByID(context.Background(), seed.ID)
+		if err != nil || fresh == nil || loops.ReviewerPublishCount(fresh.MetadataJSON) != 2 || loops.IsReviewFixBudgetHold(*fresh) {
+			t.Fatalf("attempt %d loop = (%#v, %v), want unchanged 2/3 budget without hold", attempt, fresh, err)
+		}
+		sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+		if err != nil || sibling == nil || sibling.Status != "waiting" {
+			t.Fatalf("sibling after failure = (%#v, %v)", sibling, err)
+		}
+		queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+		if err != nil || queue == nil || queue.Status != "queued" {
+			t.Fatalf("retry queue = (%#v, %v)", queue, err)
+		}
+		if len(agent.starts) != 0 {
+			t.Fatalf("agent started during transport failure")
+		}
+		fixture.advance(time.Hour)
+		claim, err = fixture.repos.Queue.ClaimNextOfType(context.Background(), fixture.nowISO(), "reviewer-worker-1", "reviewer")
+		if err != nil || claim == nil {
+			t.Fatalf("retry claim = (%#v, %v)", claim, err)
+		}
+	}
+	// A new runner must preserve the persisted budget across a daemon restart.
+	runner = New(options)
+	result, err := runner.ProcessClaimedItem(context.Background(), *claim)
+	if err != nil {
+		t.Fatalf("ProcessClaimedItem() error = %v", err)
+	}
+	if result.Status != "success" {
+		t.Fatalf("result = %#v, want success after published review", result)
+	}
+	loop, err := fixture.repos.Loops.GetByID(context.Background(), result.LoopID)
+	if err != nil || loop == nil || loop.Status != "paused" || !loops.IsReviewFixBudgetHold(*loop) {
+		t.Fatalf("reviewer = (%#v, %v), want budget hold before successful claim returns", loop, err)
+	}
+	if got := loops.ReviewerPublishCount(loop.MetadataJSON); got != 3 {
+		t.Fatalf("publish count = %d, want exactly 3", got)
+	}
+	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
+	if err != nil || sibling == nil || sibling.Status != "paused" || !loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
+		t.Fatalf("fixer = (%#v, %v), want paired budget hold", sibling, err)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), claim.ID)
+	if err != nil || queue == nil || queue.Status != "cancelled" {
+		t.Fatalf("queue = (%#v, %v), want cancelled before claim returns", queue, err)
+	}
+	events, err := fixture.repos.Events.ListByEntity(context.Background(), "loop", loop.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, event := range events {
+		if event.EventType == "loop.review_fix_budget.exhausted" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("budget handoff events = %d, want 1", count)
 	}
 }
 

--- a/internal/reviewer/runner_test.go
+++ b/internal/reviewer/runner_test.go
@@ -1995,7 +1995,7 @@ func TestProcessClaimedItemParksExhaustedBudgetBeforeRun(t *testing.T) {
 	}
 }
 
-func TestProcessClaimedItemDoesNotParkBudgetOnGitHubTransportFailure(t *testing.T) {
+func TestProcessClaimedQueueItemDoesNotParkBudgetOnGitHubTransportFailure(t *testing.T) {
 	t.Parallel()
 	fixture := newRunnerFixture(t)
 	repo := "acme/looper"
@@ -2013,7 +2013,8 @@ func TestProcessClaimedItemDoesNotParkBudgetOnGitHubTransportFailure(t *testing.
 	if err := fixture.repos.Loops.Upsert(context.Background(), fixer); err != nil {
 		t.Fatalf("Loops.Upsert(fixer) error = %v", err)
 	}
-	if err := fixture.repos.Queue.Upsert(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_budget_transport", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:budget-transport", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, MaxAttempts: 5, CreatedAt: nowISO, UpdatedAt: nowISO}); err != nil {
+	queueItem := storage.QueueItemRecord{ID: "queue_reviewer_budget_transport", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, DedupeKey: "reviewer:budget-transport", Priority: storage.QueuePriorityReviewer, Status: "running", AvailableAt: nowISO, MaxAttempts: -1, CreatedAt: nowISO, UpdatedAt: nowISO}
+	if err := fixture.repos.Queue.Upsert(context.Background(), queueItem); err != nil {
 		t.Fatalf("Queue.Upsert() error = %v", err)
 	}
 	cfg, err := config.DefaultConfig(t.TempDir())
@@ -2026,9 +2027,9 @@ func TestProcessClaimedItemDoesNotParkBudgetOnGitHubTransportFailure(t *testing.
 	github := &fakeGitHubGateway{viewErrs: []error{&shell.CommandExecutionError{Message: "Command exited with code 1", Result: shell.Result{Stderr: "error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com"}}}}
 	runner := New(Options{DB: fixture.coordinator.DB(), Repos: fixture.repos, GitHub: github, Git: &fakeGitGateway{}, AgentExecutor: agent, Logger: fixture.logger, Now: fixture.now, LoopConfig: cfg.Roles.Reviewer.Behavior.Loop, CustomInstructions: &cfg})
 
-	result, err := runner.ProcessClaimedItem(context.Background(), storage.QueueItemRecord{ID: "queue_reviewer_budget_transport", ProjectID: &projectID, LoopID: &loopID, Type: "reviewer", TargetType: "pull_request", TargetID: target, Repo: &repo, PRNumber: &prNumber, Status: "running"})
+	result, err := runner.ProcessClaimedQueueItem(context.Background(), queueItem)
 	if err == nil || !strings.Contains(githubinfra.ErrorMessage(err), "error connecting to api.github.com") {
-		t.Fatalf("ProcessClaimedItem() = (%#v, %v), want GitHub transport error", result, err)
+		t.Fatalf("ProcessClaimedQueueItem() = (%#v, %v), want GitHub transport error", result, err)
 	}
 	if len(agent.starts) != 0 {
 		t.Fatalf("agent.starts = %#v, want none", agent.starts)
@@ -2043,6 +2044,13 @@ func TestProcessClaimedItemDoesNotParkBudgetOnGitHubTransportFailure(t *testing.
 	sibling, err := fixture.repos.Loops.GetByID(context.Background(), fixer.ID)
 	if err != nil || sibling == nil || sibling.Status != "waiting" || loops.IsSiblingReviewFixBudgetPause(sibling.MetadataJSON) {
 		t.Fatalf("fixer sibling = (%#v, %v), want still waiting", sibling, err)
+	}
+	queue, err := fixture.repos.Queue.GetByID(context.Background(), queueItem.ID)
+	if err != nil || queue == nil || queue.Status != "queued" {
+		t.Fatalf("queue = (%#v, %v), want retryable queued item, not failed/paused", queue, err)
+	}
+	if queue.LastErrorKind == nil || *queue.LastErrorKind != string(FailureRetryableTransient) {
+		t.Fatalf("queue last_error_kind = %v, want retryable_transient", queue.LastErrorKind)
 	}
 }
 


### PR DESCRIPTION
# Summary

An exhausted review-fix loop could be displayed as `github_transient` because diagnostics classified its last failed run rather than its current budget hold. Report `review_fix_budget`, a role-neutral reason, and the existing unpause/stop action. Run-ID diagnostics continue to describe the selected historical run.

Budget remains based on successful review publications and successful fixer pushes. A failed transport attempt does not consume a unit; an already exhausted budget still parks even if GitHub is unavailable. Preserve that rule at claim and discovery entrypoints, without adding network-dependent admission exceptions.

## Why / evidence

Incident: powerformer/vela#1956 had three successful review publications at 09:44, 10:44, and 11:07 UTC on September 10. Seven subsequent discover failures had no pending review. At 13:02 the handoff event recorded reviewer 3/3, not ten attempts. The misleading historical transport diagnosis obscured the real budget hold.

The daemon serving those runs started September 4 and remained alive until 13:01 UTC on September 10. The installed binary was replaced September 7 and embeds main revision ea9315c7. Thus the historical process predates the currently installed build. Its exact SHA and effective cap at the third publication were not recorded, so the reason that old process did not park at 11:07 cannot be established from the surviving logs. Do not attribute that historical behavior to a reproduced current counting defect.

The current runner is exercised end to end: seed two successful publications, execute seven actual failed claims with infinite retry policy, recreate the runner over the same SQLite repositories, then complete the third publication. Assert count 2 throughout failures, a retryable queue and untouched fixer, then exactly count 3, a paired hold, cancelled queue, and one handoff event before the successful claim returns. This rules out current finalization overwriting the hold on this path.

## Design trade-offs

Authority is the configured cap and persisted successful publication/push count; current hold metadata determines the loop-level diagnosis. No agent executes at the budget admission boundary, and connectivity is not the authority for whether prior successes exhausted the cap.

Deletion: remove the transport-dependent admission helper and latest-retry-queue exception introduced on this branch, including the subsequent boundary-classification patch that only supported that helper. Both entrypoints retain their existing budget enforcement. No new persisted field, validation layer, or recovery state is introduced. Production changes relative to main are confined to diagnosis; the remaining changes assert lifecycle contracts. This avoids stacking another transport-specific patch on the same budget path.

# Testing

- [x] `go test ./...`
- [x] Additional targeted checks: Go 1.22.12 `gofmt -l .` (CI formatting version), `go vet ./...`, `go build ./...`, and `git diff --check`.
- The diagnostic regression failed against the original production code; the exhausted-budget claim/discovery tests failed against this branch's earlier network-dependent implementation and pass after removing it.
- Reviewer coverage: seven transient failures consume no budget, runner recreation preserves counters, third successful publication parks immediately, identical-publication recovery does not recount, and already exhausted offline/discovery admission still parks.
- Fixer coverage: failed push consumes zero; successful retry consumes exactly one. Existing successful-push cap and checkpoint-resume tests remain in the full suite.
- Existing closed/merged PR, scope recovery, and historical run-selector tests remain passing.
- Local test/vet/build use Go 1.27. No live daemon restart or production deployment performed.

# E2E / Invariant Risk

- [ ] No Looper E2E / invariant risk
- [ ] Daemon boot / config / runtime path risk
- [x] Worktree / repo isolation / lifecycle risk
- [ ] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

Coverage crosses runner, real SQLite repositories, retry queue, and paired loop lifecycle with fake GitHub/Git boundaries. Final production changes do not alter GitHub calls, authentication, scopes, thread mutation, or rate limits; real sandbox E2E is not required.

# Regression Policy

- [ ] This is not a P0/P1 bug fix
- [x] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [x] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- PR / issue links for regression coverage:
  - Incident: https://github.com/powerformer/vela/pull/1956
  - `TestDiagnoseLoopBudgetHoldDoesNotClassifyHistoricalGitHubTransient`
  - `TestDiagnoseLoopBudgetHoldMessageIsRoleNeutralForFixerExhaustion`
  - `TestProcessClaimedItemTransportRetriesDoNotConsumeBudgetThenThirdPublishParks`
  - `TestProcessClaimedQueueItemParksExhaustedBudgetDespiteGitHubTransportFailure`
  - `TestDiscoverPullRequestsParksExhaustedBudgetDespiteRetryableTransientQueue`
  - `TestProcessClaimedItemRestartsFromDiscoverAfterRemoteHeadChangeAtPush`

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied
