### PR TITLE
fix: show actual queue age and eligibility in looper ps

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -2196,6 +2196,7 @@ type activeRunView struct {
 	ResumePolicy      *string            `json:"resumePolicy,omitempty"`
 	CurrentStep       *string            `json:"currentStep"`
 	StartedAt         *string            `json:"startedAt"`
+	AvailableAt       *string            `json:"availableAt,omitempty"`
 	EndedAt           *string            `json:"endedAt,omitempty"`
 	Target            activeRunTarget    `json:"target"`
 	Agent             *activeRunAgent    `json:"agent"`
@@ -3313,7 +3314,13 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 		if !ok {
 			continue
 		}
-		startedAt := firstNonEmptyString(loop.NextRunAt, stringPtrOrNil(loop.UpdatedAt), stringPtrOrNil(loop.CreatedAt))
+		// Queue creation measures this enqueue, even for an old loop or a
+		// debounce that keeps extending its eligibility time.
+		var startedAt, availableAt *string
+		if queue := latestQueueByLoopID[loop.ID]; queueIsActiveAutomation(queue) {
+			startedAt = stringPtrOrNil(queue.CreatedAt)
+			availableAt = stringPtrOrNil(queue.AvailableAt)
+		}
 		view := activeRunView{
 			Seq:         loop.Seq,
 			RunID:       nil,
@@ -3324,6 +3331,7 @@ func (h *Handler) buildActiveRunViews(ctx context.Context, includeRunningLoopsWi
 			LoopStatus:  loop.Status,
 			CurrentStep: nil,
 			StartedAt:   startedAt,
+			AvailableAt: availableAt,
 			Target:      target,
 			Agent:       nil,
 			Worktree:    nil,

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -5603,6 +5603,17 @@ func TestHandlerRunRoutesMatchFrozenSuccessArtifacts(t *testing.T) {
 
 			actual := normalizeResponseValue(parseJSONValue(t, recorder.Body.Bytes()), fixture.rootDir)
 			want := findResponseArtifactRoute(t, routes, tt.routeID)
+			if tt.routeID == "runs.active.list" {
+				// The frozen baseline predates explicit queue eligibility timing.
+				body := want.Body.(map[string]any)
+				items := body["data"].(map[string]any)["items"].([]any)
+				for _, value := range items {
+					item := value.(map[string]any)
+					if item["status"] == "queued" {
+						item["availableAt"] = "2026-04-11T12:03:00.000Z"
+					}
+				}
+			}
 			if !responseFixtureMatches(actual, want.Body) {
 				actualJSON, _ := json.MarshalIndent(actual, "", "  ")
 				wantJSON, _ := json.MarshalIndent(want.Body, "", "  ")

--- a/internal/api/queue_timing_test.go
+++ b/internal/api/queue_timing_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nexu-io/looper/internal/storage"
+)
+
+func TestHandlerActiveRunsQueueTimingSurvivesDebounce(t *testing.T) {
+	rt, cfg := startTestRuntime(t)
+	h := NewHandler(Context{Config: cfg, Runtime: rt})
+	repos := rt.Services().Repositories
+	ctx := context.Background()
+	now := time.Now().UTC()
+	created := now.Add(-24 * time.Hour).Format(time.RFC3339Nano)
+	enqueued := now.Add(-8 * time.Minute).Format(time.RFC3339Nano)
+	updated := now.Format(time.RFC3339Nano)
+	projectID, loopID := "queue_timing", "loop_queue_timing"
+	future := now.Add(2 * time.Minute).Format(time.RFC3339Nano)
+	if err := repos.Projects.Upsert(ctx, storage.ProjectRecord{ID: projectID, Name: "Timing", RepoPath: "/tmp/repos/timing", CreatedAt: created, UpdatedAt: created}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repos.Loops.Upsert(ctx, storage.LoopRecord{ID: loopID, Seq: 5015, ProjectID: projectID, Type: "worker", TargetType: "project", TargetID: &projectID, Status: "queued", NextRunAt: &future, CreatedAt: created, UpdatedAt: updated}); err != nil {
+		t.Fatal(err)
+	}
+	readItem := func() map[string]any {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/runs/active", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+		}
+		items := parseJSONMap(t, rec.Body.Bytes())["data"].(map[string]any)["items"].([]any)
+		if len(items) != 1 {
+			t.Fatalf("want one queued loop, got %v", items)
+		}
+		return items[0].(map[string]any)
+	}
+	queue := storage.QueueItemRecord{
+		ID: "queue_timing", ProjectID: &projectID, LoopID: &loopID,
+		Type: "worker", TargetType: "project", TargetID: projectID,
+		DedupeKey: "worker:queue_timing", Priority: storage.QueuePriorityWorker,
+		Status: "queued", AvailableAt: future, MaxAttempts: -1,
+		CreatedAt: enqueued, UpdatedAt: updated,
+	}
+	for _, delay := range []time.Duration{2 * time.Minute, 5 * time.Minute} {
+		queue.AvailableAt = now.Add(delay).Format(time.RFC3339Nano)
+		if err := repos.Queue.Upsert(ctx, queue); err != nil {
+			t.Fatal(err)
+		}
+		item := readItem()
+		assertEqual(t, item["startedAt"], enqueued)
+		assertEqual(t, item["availableAt"], queue.AvailableAt)
+	}
+}

--- a/internal/cliapp/human_output.go
+++ b/internal/cliapp/human_output.go
@@ -302,6 +302,7 @@ type activeRunOutput struct {
 	LastFailureReason *string `json:"lastFailureReason"`
 	CurrentStep       *string `json:"currentStep"`
 	StartedAt         *string `json:"startedAt"`
+	AvailableAt       *string `json:"availableAt"`
 	EndedAt           *string `json:"endedAt"`
 	Target            struct {
 		Label string `json:"label"`
@@ -667,10 +668,45 @@ func writeHumanActiveRuns(w io.Writer, payload json.RawMessage) error {
 		if item.LastFailureReason != nil {
 			reason = truncateCLIText(*item.LastFailureReason, 48)
 		}
-		rows = append(rows, tableRow{"#": item.Seq, "type": item.Type, "target": item.Target.Label, "step": item.CurrentStep, "agent": agentVendor(item.Agent), "pid": agentPID(item.Agent), "status": status, "age": formatRelativeAge(firstNonEmptyCLIString(item.EndedAt, item.StartedAt)), "reason": reason})
+		age := formatRelativeAge(firstNonEmptyCLIString(item.EndedAt, item.StartedAt))
+		if item.Status == "queued" && (status == "queued" || status == "backing_off") {
+			availableAt := item.AvailableAt
+			// Older daemons expose the eligibility time as startedAt.
+			// Its queue age is unknown; do not render it as a fresh enqueue.
+			if availableAt == nil {
+				age = "-"
+				availableAt = item.StartedAt
+			}
+			if timing := formatQueueWait(availableAt, time.Now()); timing != "" {
+				if reason != "" {
+					timing += "; " + reason
+				}
+				reason = timing
+			}
+		}
+		rows = append(rows, tableRow{"#": item.Seq, "type": item.Type, "target": item.Target.Label, "step": item.CurrentStep, "agent": agentVendor(item.Agent), "pid": agentPID(item.Agent), "status": status, "age": age, "reason": reason})
 	}
 	printTable(w, []string{"#", "type", "target", "step", "agent", "pid", "status", "age", "reason"}, rows)
 	return nil
+}
+
+func formatQueueWait(availableAt *string, now time.Time) string {
+	if availableAt == nil {
+		return ""
+	}
+	eligible, err := time.Parse(time.RFC3339Nano, *availableAt)
+	if err != nil {
+		return ""
+	}
+	remaining := eligible.Sub(now)
+	if remaining <= 0 {
+		return "waiting for scheduler"
+	}
+	// Round up so a task still waiting never says eligible in 0s.
+	if remaining%time.Second != 0 {
+		remaining = remaining.Truncate(time.Second) + time.Second
+	}
+	return "eligible in " + remaining.String()
 }
 
 func truncateCLIText(value string, max int) string {

--- a/internal/cliapp/queue_timing_test.go
+++ b/internal/cliapp/queue_timing_test.go
@@ -1,0 +1,81 @@
+package cliapp
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPSQueueTiming(t *testing.T) {
+	now := time.Now()
+	enqueued := now.Add(-8*time.Minute - 30*time.Second).Format(time.RFC3339Nano)
+	future := now.Add(2 * time.Minute).Format(time.RFC3339Nano)
+	due := now.Add(-time.Minute).Format(time.RFC3339Nano)
+	for _, tc := range []struct {
+		name, status, display, started, available, failure, age, reason string
+	}{
+		{"delayed", "queued", "queued", enqueued, future, "", "8m", "eligible in"},
+		{"due", "queued", "queued", enqueued, due, "", "8m", "waiting for scheduler"},
+		{"retry", "queued", "backing_off", enqueued, future, "network timeout", "8m", "eligible in"},
+		{"legacy future", "queued", "queued", future, "", "", "-", "eligible in"},
+		{"legacy due", "queued", "queued", due, "", "", "-", "waiting for scheduler"},
+		{"missing queue", "queued", "queued", "", "", "", "-", "-"},
+		{"running", "running", "running", enqueued, "", "", "8m", "-"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			item := map[string]any{"seq": 5015, "type": "fixer", "status": tc.status, "displayStatus": tc.display, "target": map[string]string{"label": "acme/repo#76"}}
+			for key, value := range map[string]string{"startedAt": tc.started, "availableAt": tc.available, "lastFailureReason": tc.failure} {
+				if value != "" {
+					item[key] = value
+				}
+			}
+			payload, err := json.Marshal(map[string]any{"items": []any{item}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var out bytes.Buffer
+			if err := writeHumanActiveRuns(&out, payload); err != nil {
+				t.Fatal(err)
+			}
+			lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+			fields := strings.Fields(lines[len(lines)-1])
+			if len(fields) < 9 || fields[7] != tc.age {
+				t.Fatalf("unexpected queue timing:\n%s", out.String())
+			}
+			reason := strings.Join(fields[8:], " ")
+			if tc.reason == "eligible in" {
+				if !strings.HasPrefix(reason, "eligible in ") {
+					t.Fatalf("missing countdown: %s", reason)
+				}
+				parts := strings.SplitN(strings.TrimPrefix(reason, "eligible in "), "; ", 2)
+				remaining, err := time.ParseDuration(parts[0])
+				if err != nil || remaining <= 0 || remaining > 2*time.Minute {
+					t.Fatalf("invalid countdown: %s", reason)
+				}
+				if tc.failure != "" && (len(parts) != 2 || parts[1] != tc.failure) {
+					t.Fatalf("missing retry reason: %s", reason)
+				}
+			} else if reason != tc.reason {
+				t.Fatalf("reason = %q, want %q", reason, tc.reason)
+			}
+		})
+	}
+}
+
+func TestFormatQueueWaitBoundary(t *testing.T) {
+	now := time.Date(2026, 9, 11, 15, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		at, want string
+	}{
+		{now.Add(time.Nanosecond).Format(time.RFC3339Nano), "eligible in 1s"},
+		{now.Add(time.Second).Format(time.RFC3339Nano), "eligible in 1s"},
+		{now.Format(time.RFC3339Nano), "waiting for scheduler"},
+		{"invalid", ""},
+	} {
+		if got := formatQueueWait(&tc.at, now); got != tc.want {
+			t.Errorf("formatQueueWait(%q) = %q, want %q", tc.at, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
# Summary

Queued loops currently pass their future eligibility timestamp to the `age` formatter, so `looper ps` repeatedly displays `<1m` even after several minutes in the queue. Use the current queue item's creation time for age and show its eligibility separately:

```text
status  age  reason
queued  8m   eligible in 1m20s
queued  9m   waiting for scheduler
```

- Keep queue age stable when debounce extends the eligibility time, including new queue items on older loops and the claimed-queue transition.
- Preserve retry errors alongside the countdown. With older daemons, show unknown queue age as `-` while interpreting their existing eligibility timestamp.
- Cover the API timestamp contract, CLI output, countdown boundaries, and legacy responses with regression tests.

The change removes the use of `nextRunAt` as an age source. The optional response field `availableAt` exposes an existing queue timestamp; its cost is keeping API and CLI projections aligned and handling responses from older daemons. Removing the misleading age alone would still leave delayed work indistinguishable from work eligible for dispatch. There is no new persisted state, scheduling gate, or change to agent authority: this is a read-only projection of the scheduler's existing queue timestamps.

# Testing

- [ ] `go test ./...` — not run locally; CI runs the full suite.
- [x] Additional targeted checks:
  - `go test ./internal/api ./internal/cliapp -run 'TestHandlerActiveRuns|TestHandlerRunRoutesMatchFrozenSuccessArtifacts|TestPS|TestFormatQueueWait' -count=1`
  - `go vet ./...`
  - `go build ./...`
  - `gofmt` on changed Go files and `git diff --check`

# E2E / Invariant Risk

- [x] No Looper E2E / invariant risk
- [ ] Daemon boot / config / runtime path risk
- [ ] Worktree / repo isolation / lifecycle risk
- [ ] GitHub CLI contract / auth / scope risk
- [ ] Resolve-comments / PR thread mutation risk
- [ ] Real sandbox GitHub behavior risk

# Regression Policy

- [x] This is not a P0/P1 bug fix
- [ ] This is a P0/P1 bug fix and includes a regression test that fails before the fix
- [ ] Cross-component lifecycle / worktree / GitHub command / daemon / resolve-comments regression is covered by a contract/invariant integration scenario
- [ ] Real GitHub auth / scope / thread mutation / rate-limit regression is covered by sandbox E2E

# Regression Mapping

- PR / issue links for regression coverage: no linked issue; reported from live `looper ps` output.
- `TestHandlerActiveRunsQueueTimingSurvivesDebounce`: an older loop and a rescheduled queue item retain the current enqueue age.
- `TestHandlerRunRoutesMatchFrozenSuccessArtifacts`: the active-run response includes eligibility for the queued/claimed transition.
- `TestPSQueueTiming` and `TestFormatQueueWaitBoundary`: delayed/due/retrying work, legacy daemon responses, and subsecond countdowns.

# Reviewer Checklist

- [x] Tests validate user-visible invariants, not only implementation details
- [x] P0/P1 regression policy requirements above are satisfied
